### PR TITLE
Support config file to export a sync or async function

### DIFF
--- a/source/command-line-interface/config-loader.test.ts
+++ b/source/command-line-interface/config-loader.test.ts
@@ -29,18 +29,64 @@ test('throws when the imported module is not an object', async (t) => {
     await t.throwsAsync(configLoader.load(), { message: 'Invalid config file' });
 });
 
-test('throws when the imported module is an object but has no config property', async (t) => {
+test('throws when the imported module is an object but has no config nor buildConfig property', async (t) => {
     const importModule = fake.resolves({ something: 'but not config' });
     const configLoader = configLoaderFactory({ importModule });
 
-    await t.throwsAsync(configLoader.load(), { message: 'Config file doesn’t have a named export "config"' });
+    await t.throwsAsync(configLoader.load(), {
+        message: 'Config file doesn’t have a named export "config" nor "buildConfig"'
+    });
 });
 
-test('returns the value of the config property', async (t) => {
+test('returns the value of the config property when it exists and buildConfig doesn’t exist', async (t) => {
     const importModule = fake.resolves({ config: 'the-value' });
     const configLoader = configLoaderFactory({ importModule });
 
     const result = await configLoader.load();
 
     t.is(result, 'the-value');
+});
+
+test('returns the value of the config property when it exists and buildConfig exists', async (t) => {
+    const importModule = fake.resolves({ config: 'the-value', buildConfig() {} });
+    const configLoader = configLoaderFactory({ importModule });
+
+    const result = await configLoader.load();
+
+    t.is(result, 'the-value');
+});
+
+test('throws an error when config doesn’t exist but buildConfig does but it is not a function', async (t) => {
+    const importModule = fake.resolves({ buildConfig: 'foo' });
+    const configLoader = configLoaderFactory({ importModule });
+
+    await t.throwsAsync(configLoader.load(), {
+        message: 'Named export of "buildConfig" config file is not a function'
+    });
+});
+
+test('returns the value returned by the buildConfig function when it exists and config doesn’t', async (t) => {
+    const importModule = fake.resolves({
+        buildConfig() {
+            return 'the-value-from-function';
+        }
+    });
+    const configLoader = configLoaderFactory({ importModule });
+
+    const result = await configLoader.load();
+
+    t.is(result, 'the-value-from-function');
+});
+
+test('awaits the buildConfig function when it returns a promise', async (t) => {
+    const importModule = fake.resolves({
+        async buildConfig() {
+            return 'the-value-from-async-function';
+        }
+    });
+    const configLoader = configLoaderFactory({ importModule });
+
+    const result = await configLoader.load();
+
+    t.is(result, 'the-value-from-async-function');
 });

--- a/source/command-line-interface/config-loader.ts
+++ b/source/command-line-interface/config-loader.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { isReadonlyRecord } from 'effect/Predicate';
-import { has } from 'effect/ReadonlyRecord';
+import { has, type ReadonlyRecord } from 'effect/ReadonlyRecord';
 
 export type ConfigLoaderDependencies = {
     readonly currentWorkingDirectory: string;
@@ -11,23 +11,44 @@ export type ConfigLoader = {
     load(): Promise<unknown>;
 };
 
+type UnknownFunction = (...args: unknown[]) => unknown;
+
+function isFunction(value: unknown): value is UnknownFunction {
+    return typeof value === 'function';
+}
+
 export function createConfigLoader(dependencies: ConfigLoaderDependencies): ConfigLoader {
     const { currentWorkingDirectory, importModule } = dependencies;
 
+    async function importConfigModule(): Promise<ReadonlyRecord<unknown>> {
+        const configFilePath = path.join(currentWorkingDirectory, 'packtory.config.js');
+        const module = await importModule(configFilePath);
+
+        if (!isReadonlyRecord(module)) {
+            throw new Error('Invalid config file');
+        }
+
+        return module;
+    }
+
     return {
         async load() {
-            const configFilePath = path.join(currentWorkingDirectory, 'packtory.config.js');
-            const module = await importModule(configFilePath);
+            const module = await importConfigModule();
 
-            if (!isReadonlyRecord(module)) {
-                throw new Error('Invalid config file');
+            if (has(module, 'config')) {
+                return module.config;
             }
 
-            if (!has(module, 'config')) {
-                throw new Error('Config file doesn’t have a named export "config"');
+            if (has(module, 'buildConfig')) {
+                const { buildConfig } = module;
+                if (isFunction(buildConfig)) {
+                    return buildConfig();
+                }
+
+                throw new Error('Named export of "buildConfig" config file is not a function');
             }
 
-            return module.config;
+            throw new Error('Config file doesn’t have a named export "config" nor "buildConfig"');
         }
     };
 }


### PR DESCRIPTION
This allows more ways for the user to do async stuff like reading the package.json file.