### PR TITLE
Fix resolution of js files

### DIFF
--- a/integration-tests/bundler/type-roots.test.ts
+++ b/integration-tests/bundler/type-roots.test.ts
@@ -1,0 +1,58 @@
+import path from 'node:path';
+import test from 'ava';
+import { bundler } from '../../source/bundler.entry-point.js';
+import { loadPackageJson } from '../load-package-json.js';
+
+test('resolves node_modules dependencies correctly when depending on @types/* packages', async (t) => {
+    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/type-roots-node-modules');
+    const result = await bundler.build({
+        name: 'the-package-name',
+        version: '42.0.0',
+        sourcesFolder: path.join(fixture, 'src'),
+        entryPoints: [
+            { js: path.join(fixture, 'src/entry.js'), declarationFile: path.join(fixture, 'src/entry.d.ts') }
+        ],
+        mainPackageJson: await loadPackageJson(fixture)
+    });
+
+    t.deepEqual(result, {
+        packageJson: {
+            dependencies: {
+                foo: '21.0.0',
+                '@types/foo': '42.0.0'
+            },
+            main: 'entry.js',
+            name: 'the-package-name',
+            version: '42.0.0',
+            types: 'entry.d.ts',
+            type: 'module'
+        },
+        contents: [
+            {
+                kind: 'source',
+                source: '{\n    "dependencies": {\n        "@types/foo": "42.0.0",\n        "foo": "21.0.0"\n    },\n    "main": "entry.js",\n    "name": "the-package-name",\n    "type": "module",\n    "types": "entry.d.ts",\n    "version": "42.0.0"\n}',
+                targetFilePath: 'package.json'
+            },
+            {
+                kind: 'reference',
+                sourceFilePath: path.join(fixture, 'src/entry.js'),
+                targetFilePath: 'entry.js'
+            },
+            {
+                kind: 'reference',
+                sourceFilePath: path.join(fixture, 'src/foo.js'),
+                targetFilePath: 'foo.js'
+            },
+            {
+                kind: 'reference',
+                sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
+                targetFilePath: 'entry.d.ts'
+            },
+            {
+                kind: 'reference',
+                sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
+                targetFilePath: 'foo.d.ts'
+            }
+        ]
+    });
+});

--- a/integration-tests/fixtures/type-roots-node-modules/node_modules/@types/foo/index.d.ts
+++ b/integration-tests/fixtures/type-roots-node-modules/node_modules/@types/foo/index.d.ts
@@ -1,0 +1,5 @@
+export interface Foo {
+    foo: 'bar';
+}
+
+export function bar(value: unknown): Foo;

--- a/integration-tests/fixtures/type-roots-node-modules/node_modules/@types/foo/package.json
+++ b/integration-tests/fixtures/type-roots-node-modules/node_modules/@types/foo/package.json
@@ -1,0 +1,3 @@
+{
+    "types": "index.d.ts",
+}

--- a/integration-tests/fixtures/type-roots-node-modules/node_modules/foo/index.js
+++ b/integration-tests/fixtures/type-roots-node-modules/node_modules/foo/index.js
@@ -1,0 +1,3 @@
+export default {
+    bar() {}
+}

--- a/integration-tests/fixtures/type-roots-node-modules/package.json
+++ b/integration-tests/fixtures/type-roots-node-modules/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "test-fixture",
+    "version": "0.0.0-dev",
+    "dependencies": {
+        "@types/foo": "42.0.0",
+        "foo": "21.0.0"
+    },
+    "type": "module"
+}

--- a/integration-tests/fixtures/type-roots-node-modules/src/entry.d.ts
+++ b/integration-tests/fixtures/type-roots-node-modules/src/entry.d.ts
@@ -1,0 +1,1 @@
+export declare const foo: import('./foo.js').Foo;

--- a/integration-tests/fixtures/type-roots-node-modules/src/entry.js
+++ b/integration-tests/fixtures/type-roots-node-modules/src/entry.js
@@ -1,0 +1,1 @@
+import { foo } from './foo.js';

--- a/integration-tests/fixtures/type-roots-node-modules/src/foo.d.ts
+++ b/integration-tests/fixtures/type-roots-node-modules/src/foo.d.ts
@@ -1,0 +1,2 @@
+export type Bar = string;
+export type { Foo } from 'foo';

--- a/integration-tests/fixtures/type-roots-node-modules/src/foo.js
+++ b/integration-tests/fixtures/type-roots-node-modules/src/foo.js
@@ -1,0 +1,2 @@
+import { bar } from 'foo';
+export const foo = bar('foo');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@effect/schema": "0.60.4",
                 "@topcli/spinner": "2.1.2",
+                "@ts-morph/common": "0.22.0",
                 "cmd-ts": "0.13.0",
                 "effect": "2.1.1",
                 "kleur": "4.1.5",
@@ -1030,13 +1031,13 @@
             }
         },
         "node_modules/@ts-morph/common": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
-            "integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.22.0.tgz",
+            "integrity": "sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==",
             "dependencies": {
-                "fast-glob": "^3.2.12",
-                "minimatch": "^7.4.3",
-                "mkdirp": "^2.1.6",
+                "fast-glob": "^3.3.2",
+                "minimatch": "^9.0.3",
+                "mkdirp": "^3.0.1",
                 "path-browserify": "^1.0.1"
             }
         },
@@ -1049,23 +1050,23 @@
             }
         },
         "node_modules/@ts-morph/common/node_modules/minimatch": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@ts-morph/common/node_modules/mkdirp": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-            "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
             "bin": {
                 "mkdirp": "dist/cjs/src/bin.js"
             },
@@ -7326,6 +7327,53 @@
             "dependencies": {
                 "@ts-morph/common": "~0.20.0",
                 "code-block-writer": "^12.0.0"
+            }
+        },
+        "node_modules/ts-morph/node_modules/@ts-morph/common": {
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.20.0.tgz",
+            "integrity": "sha512-7uKjByfbPpwuzkstL3L5MQyuXPSKdoNG93Fmi2JoDcTf3pEP731JdRFAduRVkOs8oqxPsXKA+ScrWkdQ8t/I+Q==",
+            "dependencies": {
+                "fast-glob": "^3.2.12",
+                "minimatch": "^7.4.3",
+                "mkdirp": "^2.1.6",
+                "path-browserify": "^1.0.1"
+            }
+        },
+        "node_modules/ts-morph/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/ts-morph/node_modules/minimatch": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+            "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/ts-morph/node_modules/mkdirp": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+            "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+            "bin": {
+                "mkdirp": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dependencies": {
         "@effect/schema": "0.60.4",
         "@topcli/spinner": "2.1.2",
+        "@ts-morph/common": "0.22.0",
         "cmd-ts": "0.13.0",
         "effect": "2.1.1",
         "kleur": "4.1.5",

--- a/source/bundler.entry-point.ts
+++ b/source/bundler.entry-point.ts
@@ -1,14 +1,21 @@
 import fs from 'node:fs';
 import { Project } from 'ts-morph';
+import { RealFileSystemHost } from '@ts-morph/common';
 import { createBundler } from './bundler/bundler.js';
 import { createDependencyScanner } from './dependency-scanner/scanner.js';
 import { createSourceMapFileLocator } from './dependency-scanner/source-map-file-locator.js';
 import { createTypescriptProjectAnalyzer } from './dependency-scanner/typescript-project-analyzer.js';
 import { getReferencedSourceFiles } from './dependency-scanner/source-file-references.js';
 import { createFileManager } from './artifacts/file-manager.js';
+import { createFileSystemAdapters } from './dependency-scanner/typescript-file-host.js';
 
 const fileManager = createFileManager({ hostFileSystem: fs.promises });
 const sourceMapFileLocator = createSourceMapFileLocator({ fileManager });
-const typescriptProjectAnalyzer = createTypescriptProjectAnalyzer({ Project, getReferencedSourceFiles });
+const fileSystemAdapters = createFileSystemAdapters({ fileSystemHost: new RealFileSystemHost() });
+const typescriptProjectAnalyzer = createTypescriptProjectAnalyzer({
+    Project,
+    getReferencedSourceFiles,
+    fileSystemAdapters
+});
 const dependencyScanner = createDependencyScanner({ sourceMapFileLocator, typescriptProjectAnalyzer });
 export const bundler = createBundler({ dependencyScanner });

--- a/source/bundler/bundler.ts
+++ b/source/bundler/bundler.ts
@@ -119,7 +119,7 @@ export function createBundler(dependencies: Readonly<BundlerDependencies>): Bund
             resolveDeclarationFiles
         });
 
-        return substituteDependencies(dependencyGraph, entryPoint, bundleDependencies, resolveDeclarationFiles);
+        return substituteDependencies(dependencyGraph, entryPoint, bundleDependencies);
     }
 
     async function resolveDependenciesForAllEntrypoints(options: Readonly<ResolveOptions>): Promise<DependencyFiles> {

--- a/source/bundler/substitute-bundles.test.ts
+++ b/source/bundler/substitute-bundles.test.ts
@@ -19,7 +19,7 @@ test('doesn’t substitute anything when the given dependencies are empty', (t) 
             }
         ]
     });
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', [], false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', []);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, inputGraph.flatten('/entry.js'));
@@ -46,7 +46,7 @@ test('doesn’t substitute anything when the given dependencies has only files t
             packageJson: { name: 'the-package', version: '1' }
         }
     ];
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies, false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, inputGraph.flatten('/entry.js'));
@@ -73,7 +73,7 @@ test('doesn’t substitute anything when the given dependencies have a matching 
             packageJson: { name: 'the-package', version: '1' }
         }
     ];
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies, false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, inputGraph.flatten('/entry.js'));
@@ -100,7 +100,7 @@ test('substitutes a file that has imports statements matching the files in the g
             packageJson: { name: 'the-package', version: '1' }
         }
     ];
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies, false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, {
@@ -135,7 +135,7 @@ test('substitutes a file which matches an already substituted file from a depend
             packageJson: { name: 'the-package', version: '1' }
         }
     ];
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies, false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, {
@@ -179,7 +179,7 @@ test('merges topLevelDependencies correctly when multiple files are substituted 
             packageJson: { name: 'the-package', version: '1' }
         }
     ];
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies, false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, {
@@ -236,7 +236,7 @@ test('substitutes multiple matching files in the given dependencies', (t) => {
             packageJson: { name: 'second-package', version: '42' }
         }
     ];
-    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies, false);
+    const substitutedGraph = substituteDependencies(inputGraph, '/entry.js', bundleDependencies);
     const result = substitutedGraph.flatten('/entry.js');
 
     t.deepEqual(result, {

--- a/source/bundler/substitute-bundles.ts
+++ b/source/bundler/substitute-bundles.ts
@@ -61,8 +61,7 @@ function mergeTopLevelDependencies(
 export function substituteDependencies(
     graph: DependencyGraph,
     entryPointFile: string,
-    dependencies: readonly BundleDescription[],
-    resolveDeclarationFiles: boolean
+    dependencies: readonly BundleDescription[]
 ): DependencyGraph {
     const substitutedGraph = createDependencyGraph();
     const outstandingConnections: { from: string; to: string }[] = [];
@@ -79,7 +78,7 @@ export function substituteDependencies(
 
             if (replacements.importPathReplacements.size > 0) {
                 const substitutionContent = Maybe.just(
-                    replaceImportPaths(node.tsSourceFile, replacements.importPathReplacements, resolveDeclarationFiles)
+                    replaceImportPaths(node.tsSourceFile, replacements.importPathReplacements)
                 );
 
                 substitutedGraph.addDependency(node.filePath, {

--- a/source/dependency-scanner/typescript-file-host.test.ts
+++ b/source/dependency-scanner/typescript-file-host.test.ts
@@ -1,0 +1,259 @@
+import test from 'ava';
+import { type SinonSpy, fake } from 'sinon';
+import {
+    createFileSystemAdapters,
+    type FileSystemAdapters,
+    type FileSystemAdaptersDependencies
+} from './typescript-file-host.js';
+
+type Overrides = {
+    fileExists?: SinonSpy;
+    fileExistsSync?: SinonSpy;
+    directoryExists?: SinonSpy;
+    directoryExistsSync?: SinonSpy;
+};
+
+function fileSystemAdaptersFactory(overrides: Overrides): FileSystemAdapters {
+    const {
+        fileExists = fake(),
+        fileExistsSync = fake(),
+        directoryExists = fake(),
+        directoryExistsSync = fake()
+    } = overrides;
+    const fakeDependencies = {
+        fileSystemHost: { fileExists, fileExistsSync, directoryExistsSync, directoryExists }
+    } as unknown as FileSystemAdaptersDependencies;
+
+    return createFileSystemAdapters(fakeDependencies);
+}
+
+type WrappedFileHostMethodCallTestCase = {
+    method: 'directoryExists' | 'directoryExistsSync' | 'fileExists' | 'fileExistsSync';
+    adapter: 'fileSystemHostFilteringDeclarationFiles' | 'fileSystemHostWithoutFilter';
+    pathToCheck: string;
+    upstreamMethodReturnValue: boolean;
+    expectedResult: boolean;
+    expectedUpstreamCalls: unknown[];
+};
+
+const checkWrappedFileHostMethod = test.macro(async (t, testCase: WrappedFileHostMethodCallTestCase) => {
+    const upstreamMethod = ['fileExists', 'directoryExists'].includes(testCase.method)
+        ? fake.resolves(testCase.upstreamMethodReturnValue)
+        : fake.returns(testCase.upstreamMethodReturnValue);
+
+    const fileSystemAdapters = fileSystemAdaptersFactory({ [testCase.method]: upstreamMethod });
+    const adapter = fileSystemAdapters[testCase.adapter];
+
+    const result = await adapter[testCase.method](testCase.pathToCheck);
+
+    t.is(result, testCase.expectedResult);
+    t.deepEqual(upstreamMethod.args, testCase.expectedUpstreamCalls);
+});
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.ts',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExists',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.d.ts',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.cts',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExists',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.d.cts',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.mts',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExists',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.d.mts',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExists returns the same value from the wrapped fileSystemHost when it is not a declaration file',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExists',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.txt',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/bar.txt']]
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.ts',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExistsSync',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.d.ts',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.cts',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExistsSync',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.d.cts',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.mts',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExistsSync',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.d.mts',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns the same value from the wrapped fileSystemHost when it is not a declaration file',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExistsSync',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/bar.txt',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/bar.txt']]
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.directoryExists returns false when the path contains the segments node_modules/@types',
+    checkWrappedFileHostMethod,
+    {
+        method: 'directoryExists',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/node_modules/@types/bar',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.directoryExists returns the same value from the wrapped fileSystemHost when it doesn’t contain a type-roots path segment',
+    checkWrappedFileHostMethod,
+    {
+        method: 'directoryExists',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/node_modules/bar',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/node_modules/bar']]
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns false when the path contains the segments node_modules/@types',
+    checkWrappedFileHostMethod,
+    {
+        method: 'directoryExistsSync',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/node_modules/@types/bar',
+        upstreamMethodReturnValue: true,
+        expectedResult: false,
+        expectedUpstreamCalls: []
+    }
+);
+
+test(
+    'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns the same value from the wrapped fileSystemHost when it doesn’t contain a type-roots path segment',
+    checkWrappedFileHostMethod,
+    {
+        method: 'directoryExistsSync',
+        adapter: 'fileSystemHostFilteringDeclarationFiles',
+        pathToCheck: 'foo/node_modules/bar',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/node_modules/bar']]
+    }
+);
+
+test(
+    'fileSystemHostWithoutFilter.fileExists returns the same value from the wrapped fileSystemHost even when a declaration file is given',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExists',
+        adapter: 'fileSystemHostWithoutFilter',
+        pathToCheck: 'foo/bar.d.ts',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/bar.d.ts']]
+    }
+);
+
+test(
+    'fileSystemHostWithoutFilter.fileExistsSync returns the same value from the wrapped fileSystemHost even when a declaration file is given',
+    checkWrappedFileHostMethod,
+    {
+        method: 'fileExistsSync',
+        adapter: 'fileSystemHostWithoutFilter',
+        pathToCheck: 'foo/bar.d.ts',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/bar.d.ts']]
+    }
+);
+
+test(
+    'fileSystemHostWithoutFilter.directoryExists returns the same value from the wrapped fileSystemHost even when a type-roots path is given',
+    checkWrappedFileHostMethod,
+    {
+        method: 'directoryExists',
+        adapter: 'fileSystemHostWithoutFilter',
+        pathToCheck: 'foo/node_modules/@types/bar',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/node_modules/@types/bar']]
+    }
+);
+
+test(
+    'fileSystemHostWithoutFilter.directoryExistsSync returns the same value from the wrapped fileSystemHost even when a type-roots path is given',
+    checkWrappedFileHostMethod,
+    {
+        method: 'directoryExistsSync',
+        adapter: 'fileSystemHostWithoutFilter',
+        pathToCheck: 'foo/node_modules/@types/bar',
+        upstreamMethodReturnValue: true,
+        expectedResult: true,
+        expectedUpstreamCalls: [['foo/node_modules/@types/bar']]
+    }
+);

--- a/source/dependency-scanner/typescript-file-host.ts
+++ b/source/dependency-scanner/typescript-file-host.ts
@@ -1,0 +1,75 @@
+import type { FileSystemHost } from 'ts-morph';
+
+const declarationFileExtensions = new Set(['.d.ts', '.d.cts', '.d.mts']);
+
+function isDeclarationFile(filePath: string): boolean {
+    const lowerCasedFilePath = filePath.toLowerCase();
+
+    for (const declarationFileExtension of declarationFileExtensions) {
+        if (lowerCasedFilePath.endsWith(declarationFileExtension)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function isTypesRootFolder(directoryPath: string): boolean {
+    return directoryPath.includes('/node_modules/@types');
+}
+
+export type FileSystemAdaptersDependencies = {
+    fileSystemHost: FileSystemHost;
+};
+
+export type FileSystemAdapters = {
+    fileSystemHostWithoutFilter: FileSystemHost;
+    fileSystemHostFilteringDeclarationFiles: FileSystemHost;
+};
+
+export function createFileSystemAdapters(dependencies: FileSystemAdaptersDependencies): FileSystemAdapters {
+    const { fileSystemHost } = dependencies;
+
+    const fileSystemHostFilteringDeclarationFiles = Object.create(fileSystemHost) as FileSystemHost;
+
+    fileSystemHostFilteringDeclarationFiles.fileExists = async (filePath) => {
+        if (isDeclarationFile(filePath)) {
+            return false;
+        }
+
+        return fileSystemHost.fileExists(filePath);
+    };
+
+    // eslint-disable-next-line node/no-sync -- we need to provide this method to match the expected interface
+    fileSystemHostFilteringDeclarationFiles.fileExistsSync = (filePath) => {
+        if (isDeclarationFile(filePath)) {
+            return false;
+        }
+
+        // eslint-disable-next-line node/no-sync -- we need to provide this method to match the expected interface
+        return fileSystemHost.fileExistsSync(filePath);
+    };
+
+    fileSystemHostFilteringDeclarationFiles.directoryExists = async (directoryPath) => {
+        if (isTypesRootFolder(directoryPath)) {
+            return false;
+        }
+
+        return fileSystemHost.directoryExists(directoryPath);
+    };
+
+    // eslint-disable-next-line node/no-sync -- we need to provide this method to match the expected interface
+    fileSystemHostFilteringDeclarationFiles.directoryExistsSync = (directoryPath) => {
+        if (isTypesRootFolder(directoryPath)) {
+            return false;
+        }
+
+        // eslint-disable-next-line node/no-sync -- we need to provide this method to match the expected interface
+        return fileSystemHost.directoryExistsSync(directoryPath);
+    };
+
+    return {
+        fileSystemHostWithoutFilter: fileSystemHost,
+        fileSystemHostFilteringDeclarationFiles
+    };
+}

--- a/source/source-modifier/import-paths.test.ts
+++ b/source/source-modifier/import-paths.test.ts
@@ -12,7 +12,7 @@ test('returns source code unmodified when it doesn’t contain any import statem
     const sourceFile = project.getSourceFileOrThrow('/folder/foo.ts');
     const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(sourceFile, replacements, false);
+    const result = replaceImportPaths(sourceFile, replacements);
 
     t.is(result, 'const foo = "bar";');
 });
@@ -27,7 +27,7 @@ test('returns the source code unmodified when there are no replacements', (t) =>
     const sourceFile = project.getSourceFileOrThrow('/folder/foo.ts');
     const replacements = new Map<string, string>([]);
 
-    const result = replaceImportPaths(sourceFile, replacements, false);
+    const result = replaceImportPaths(sourceFile, replacements);
 
     t.is(result, 'const foo = "bar"; import "./bar";');
 });
@@ -42,7 +42,7 @@ test('returns the source code with the modified import statement', (t) => {
     const sourceFile = project.getSourceFileOrThrow('/folder/foo.ts');
     const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(sourceFile, replacements, false);
+    const result = replaceImportPaths(sourceFile, replacements);
 
     t.is(result, 'const foo = "bar"; import "replacement";');
 });
@@ -58,12 +58,12 @@ test('modifies only matching import statements and keeps non-matching statements
     const sourceFile = project.getSourceFileOrThrow('/folder/foo.ts');
     const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(sourceFile, replacements, false);
+    const result = replaceImportPaths(sourceFile, replacements);
 
     t.is(result, 'import "./baz"; import "replacement";');
 });
 
-test('doesn’t modify import statements in d.ts files when resolving d.ts files is disabled', (t) => {
+test('modifies import statements correctly in d.ts files', (t) => {
     const project = createProject({
         withFiles: [
             { filePath: '/folder/foo.d.ts', content: 'import "./bar";' },
@@ -73,22 +73,7 @@ test('doesn’t modify import statements in d.ts files when resolving d.ts files
     const sourceFile = project.getSourceFileOrThrow('/folder/foo.d.ts');
     const replacements = new Map<string, string>([['/folder/bar.d.ts', 'replacement']]);
 
-    const result = replaceImportPaths(sourceFile, replacements, false);
-
-    t.is(result, 'import "./bar";');
-});
-
-test('modifies import statements correctly in d.ts files when resolving d.ts files is enabled', (t) => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.d.ts', content: 'import "./bar";' },
-            { filePath: '/folder/bar.d.ts', content: 'const bar = "baz";' }
-        ]
-    });
-    const sourceFile = project.getSourceFileOrThrow('/folder/foo.d.ts');
-    const replacements = new Map<string, string>([['/folder/bar.d.ts', 'replacement']]);
-
-    const result = replaceImportPaths(sourceFile, replacements, true);
+    const result = replaceImportPaths(sourceFile, replacements);
 
     t.is(result, 'import "replacement";');
 });

--- a/source/source-modifier/import-paths.ts
+++ b/source/source-modifier/import-paths.ts
@@ -4,17 +4,13 @@ import { getSourcePathFromSourceFile } from '../dependency-scanner/typescript-pr
 
 type Replacements = ReadonlyMap<string, string>;
 
-export function replaceImportPaths(
-    sourceFile: Readonly<SourceFile>,
-    replacements: Readonly<Replacements>,
-    resolveDeclarationFiles: boolean
-): string {
+export function replaceImportPaths(sourceFile: Readonly<SourceFile>, replacements: Readonly<Replacements>): string {
     const importStringLiterals = sourceFile.getImportStringLiterals();
 
     for (const literal of importStringLiterals) {
         const sourceFileForLiteral = resolveSourceFileForLiteral(literal, sourceFile);
         if (sourceFileForLiteral !== undefined) {
-            const fullPathForLiteral = getSourcePathFromSourceFile(sourceFileForLiteral, resolveDeclarationFiles);
+            const fullPathForLiteral = getSourcePathFromSourceFile(sourceFileForLiteral);
             const replacement = replacements.get(fullPathForLiteral);
 
             if (replacement !== undefined) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,7 @@
         "noUncheckedIndexedAccess": true,
         "verbatimModuleSyntax": true,
         "outDir": "./target/build",
-        "types": []
+        "types": [],
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
The typescript resolver tries to automatically resolve the files pointing to .d.ts files or type-roots packages. Unfortunately there is no option to turn this off. Luckily ts-morph provides the option to inject a custom fileSystemHost which is used by typescript during file resolution. We can wrap the fileSystemHost with methods like `fileExists` and make declaration files invisible for typescript depending on our needs.