### PR TITLE
Check pull request labels

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,20 @@
+name: Check pull request labels
+
+on:
+    pull_request:
+        types: [opened, labeled, unlabeled]
+
+jobs:
+    check-labels:
+        runs-on: ubuntu-latest
+        if: >
+            contains(github.event.pull_request.labels.*.name, 'breaking') == false &&
+            contains(github.event.pull_request.labels.*.name, 'bug') == false &&
+            contains(github.event.pull_request.labels.*.name, 'feature') == false &&
+            contains(github.event.pull_request.labels.*.name, 'enhancement') == false &&
+            contains(github.event.pull_request.labels.*.name, 'documentation') == false &&
+            contains(github.event.pull_request.labels.*.name, 'upgrade') == false &&
+            contains(github.event.pull_request.labels.*.name, 'refactor') == false &&
+            contains(github.event.pull_request.labels.*.name, 'build') == false
+        steps:
+            - run: echo "None of the required pull request labels are set" && exit 1


### PR DESCRIPTION
The same as in https://github.com/enormora/packtory/pull/37: a preparation for an upcoming integration with [pr-log](https://github.com/lo1tuma/pr-log).

Introduce a GitHub action that checks if a pull request has one of the [needed](https://github.com/lo1tuma/pr-log#github) labels set. It runs every time a pull request is [opened, labeled or unlabeled](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request).

This guarantees that no single unlabeled pull request can slip through and gets forgotten when a new changelog is generated.