### PR TITLE
Ignore integration-tests/ directory for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": ["config:base"],
+    "ignorePaths": ["**/node_modules/**", "**/integration-tests/**"],
     "commitMessagePrefix": "⬆️ ",
     "labels": ["renovate", "upgrade"],
     "dependencyDashboard": false,


### PR DESCRIPTION
Renovate is not able to scan our repository because of this dircetory:

![2024-02-05 09 42 19 developer mend io a740680c2b30](https://github.com/enormora/packtory/assets/149248/5fb32328-df11-40e7-8e55-2f5df0319ee3)
