### PR TITLE
Add property-based test suite

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -4,6 +4,7 @@
     "src": ["source"],
     "exclude": [
         "source/**/*.test.ts",
+        "source/**/*.property.ts",
         "source/test-libraries/**/*.ts",
         "source/packages/command-line-interface/command-line-interface.entry-point.ts",
         "source/packages/package-processor/package-processor.entry-point.ts",

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -11,6 +11,7 @@
         "subrecord",
         "kleur",
         "cmds",
-        "htpasswd"
+        "htpasswd",
+        "sonarjs"
     ]
 }

--- a/dependency-cruiser.config.js
+++ b/dependency-cruiser.config.js
@@ -7,7 +7,7 @@ const configFiles = [
 
 const entryPointFiles = ['^source/packages/.+/.+\\.entry-point\\.ts$'];
 
-const testFiles = ['\\.test\\.ts$', '^integration-tests/'];
+const testFiles = ['\\.(test|property)\\.ts$', '^integration-tests/'];
 const testLibraryFiles = ['^source/test-libraries/'];
 const excludedFiles = ['^(\\./)?integration-tests/fixtures/', '^(\\./)?target/'];
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,7 @@ export default [
     },
     {
         ...mochaConfig,
-        files: ['**/*.test.ts', 'source/test-libraries/**/*.ts', 'integration-tests/**/*.ts']
+        files: ['**/*.test.ts', '**/*.property.ts', 'source/test-libraries/**/*.ts', 'integration-tests/**/*.ts']
     },
     {
         ...nodeConfigFileConfig,
@@ -25,11 +25,17 @@ export default [
             'mocha.config.base.cjs',
             'mocha.config.unit-tests.cjs',
             'mocha.config.integration-tests.cjs',
+            'mocha.config.property-tests.cjs',
             'packtory.config.js'
         ]
     },
     {
-        files: ['mocha.config.base.cjs', 'mocha.config.unit-tests.cjs', 'mocha.config.integration-tests.cjs'],
+        files: [
+            'mocha.config.base.cjs',
+            'mocha.config.unit-tests.cjs',
+            'mocha.config.integration-tests.cjs',
+            'mocha.config.property-tests.cjs'
+        ],
         rules: {
             'import/no-commonjs': 'off',
             'import/extensions': 'off',
@@ -79,15 +85,40 @@ export default [
         }
     },
     {
-        files: ['**/*.test.ts'],
+        files: ['**/*.test.ts', '**/*.property.ts'],
         rules: {
             '@typescript-eslint/no-magic-numbers': 'off',
-            'max-lines': 'off'
+            '@typescript-eslint/explicit-function-return-type': 'off',
+            '@typescript-eslint/no-non-null-assertion': 'off',
+            '@typescript-eslint/strict-boolean-expressions': 'off',
+            'arrow-body-style': 'off',
+            complexity: 'off',
+            'id-length': 'off',
+            'max-lines': 'off',
+            'max-statements': 'off',
+            'sonarjs/different-types-comparison': 'off',
+            'sonarjs/function-return-type': 'off',
+            'sonarjs/no-alphabetical-sort': 'off',
+            'unicorn/no-array-reverse': 'off',
+            'unicorn/no-array-sort': 'off'
         },
         settings: {
             mocha: {
                 interface: 'TDD'
             }
+        }
+    },
+    {
+        files: ['**/*.property.ts'],
+        rules: {
+            '@typescript-eslint/naming-convention': 'off',
+            '@typescript-eslint/no-unnecessary-condition': 'off',
+            '@typescript-eslint/no-unsafe-argument': 'off',
+            '@stylistic/indent': 'off',
+            'functional/prefer-tacit': 'off',
+            'prefer-named-capture-group': 'off',
+            'sonarjs/no-identical-functions': 'off',
+            'unicorn/number-literal-case': 'off'
         }
     }
 ];

--- a/justfile
+++ b/justfile
@@ -32,13 +32,16 @@ lint: eslint prettier-check lint-dependencies lint-filename lint-unused-code
 
 lint-fix: eslint-fix prettier-fix
 
-test: test-unit-with-coverage test-integration
+test: test-unit-with-coverage test-unit-property test-integration
 
 test-unit:
     mocha --config mocha.config.unit-tests.cjs
 
 test-unit-with-coverage:
     c8 --config .c8rc.json mocha --config mocha.config.unit-tests.cjs
+
+test-unit-property:
+    mocha --config mocha.config.property-tests.cjs
 
 test-mutation:
     stryker run

--- a/knip.json
+++ b/knip.json
@@ -4,9 +4,11 @@
     "entry": [
         "source/packages/**/*.entry-point.ts!",
         "source/**/*.test.ts",
+        "source/**/*.property.ts",
         "integration-tests/**/*.ts",
         "dependency-cruiser.config.js",
         "mocha.config.base.cjs",
+        "mocha.config.property-tests.cjs",
         "mocha.config.unit-tests.cjs",
         "mocha.config.integration-tests.cjs",
         "packtory.config.js"

--- a/mocha.config.property-tests.cjs
+++ b/mocha.config.property-tests.cjs
@@ -1,0 +1,7 @@
+const baseConfig = require('./mocha.config.base.cjs');
+
+module.exports = {
+    ...baseConfig,
+    spec: ['./source/**/*.property.ts'],
+    timeout: 5000
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
                 "c8": "11.0.0",
                 "dependency-cruiser": "17.3.10",
                 "eslint": "10.2.1",
+                "fast-check": "4.7.0",
                 "get-port": "7.2.0",
                 "knip": "6.8.0",
                 "mocha": "11.7.5",
@@ -7648,6 +7649,29 @@
             ],
             "license": "MIT"
         },
+        "node_modules/fast-check": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+            "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "pure-rand": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=12.17.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10937,6 +10961,23 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/pure-rand": {
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+            "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.14.2",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "c8": "11.0.0",
         "dependency-cruiser": "17.3.10",
         "eslint": "10.2.1",
+        "fast-check": "4.7.0",
         "get-port": "7.2.0",
         "knip": "6.8.0",
         "mocha": "11.7.5",

--- a/source/command-line-interface/config-loader.property.ts
+++ b/source/command-line-interface/config-loader.property.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { createConfigLoader } from './config-loader.ts';
+
+function createLoader(moduleValue: unknown) {
+    return createConfigLoader({
+        currentWorkingDirectory: '/workspace',
+        importModule: async () => {
+            return moduleValue;
+        }
+    });
+}
+
+test('load() rejects malformed module export shapes', async () => {
+    await fc.assert(
+        fc.asyncProperty(
+            fc.oneof(
+                fc.boolean(),
+                fc.integer(),
+                fc.string(),
+                fc.constant(null),
+                fc.constant(undefined),
+                fc.array(fc.anything())
+            ),
+            async (moduleValue) => {
+                await assert.rejects(async () => {
+                    await createLoader(moduleValue).load();
+                }, Error);
+            }
+        )
+    );
+});
+
+test('load() rejects objects without config and buildConfig exports', async () => {
+    await fc.assert(
+        fc.asyncProperty(fc.dictionary(fc.string(), fc.anything(), { maxKeys: 4 }), async (moduleValue) => {
+            if ('config' in moduleValue || 'buildConfig' in moduleValue) {
+                return;
+            }
+
+            await assert.rejects(async () => {
+                await createLoader(moduleValue).load();
+            }, Error);
+        })
+    );
+});
+
+test('load() rejects non-function buildConfig exports when config is absent', async () => {
+    await fc.assert(
+        fc.asyncProperty(
+            fc.anything().filter((value) => {
+                return typeof value !== 'function';
+            }),
+            async (buildConfig) => {
+                await assert.rejects(async () => {
+                    await createLoader({ buildConfig }).load();
+                }, Error);
+            }
+        )
+    );
+});

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -1,0 +1,221 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import { test } from 'mocha';
+import { configToResolveAndLinkOptions } from '../packtory/map-config.ts';
+import { packtoryConfigSchema, type PacktoryConfig } from './config.ts';
+import type { AdditionalPackageJsonAttributes } from './package-json.ts';
+
+const packageNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}$/);
+const fileNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}$/);
+const dependencyNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}$/);
+const additionalAttributeKeyArbitrary = fileNameArbitrary.filter((key) => {
+    return ![
+        'dependencies',
+        'peerDependencies',
+        'devDependencies',
+        'main',
+        'name',
+        'types',
+        'type',
+        'version'
+    ].includes(key);
+});
+
+function createEntryPoint(
+    jsBaseName: string,
+    declarationBaseName: string | undefined
+): { js: string; declarationFile?: string | undefined } {
+    return declarationBaseName === undefined
+        ? { js: `${jsBaseName}.js` }
+        : { js: `${jsBaseName}.js`, declarationFile: `${declarationBaseName}.d.ts` };
+}
+
+const validConfigArbitrary = fc
+    .record({
+        packageName: packageNameArbitrary,
+        commonSourcesFolder: fc.option(fc.stringMatching(/^[a-z][\d/a-z-]{0,12}$/), { nil: undefined }),
+        packageSourcesFolder: fc.option(fc.stringMatching(/^[a-z][\d/a-z-]{0,12}$/), { nil: undefined }),
+        packageMainType: fc.option(fc.constant<'module'>('module'), { nil: undefined }),
+        commonMainType: fc.option(fc.constant<'module'>('module'), { nil: undefined }),
+        commonIncludeSourceMaps: fc.option(fc.boolean(), { nil: undefined }),
+        packageIncludeSourceMaps: fc.option(fc.boolean(), { nil: undefined }),
+        commonAdditionalAttributes: fc.dictionary(additionalAttributeKeyArbitrary, fc.jsonValue(), { maxKeys: 2 }),
+        packageAdditionalAttributes: fc.dictionary(additionalAttributeKeyArbitrary, fc.jsonValue(), { maxKeys: 2 }),
+        commonAdditionalFileName: fc.option(fileNameArbitrary, { nil: undefined }),
+        packageAdditionalFileName: fc.option(fileNameArbitrary, { nil: undefined }),
+        entryBaseName: fileNameArbitrary,
+        declarationBaseName: fc.option(fileNameArbitrary, { nil: undefined }),
+        dependencyNames: fc.uniqueArray(dependencyNameArbitrary, { maxLength: 2 })
+    })
+    .filter((config) => {
+        return (
+            (config.commonSourcesFolder !== undefined || config.packageSourcesFolder !== undefined) &&
+            config.dependencyNames.every((dependencyName) => {
+                return dependencyName !== config.packageName;
+            })
+        );
+    })
+    .map((config) => {
+        const commonPackageSettings = {
+            ...(config.commonSourcesFolder === undefined ? {} : { sourcesFolder: config.commonSourcesFolder }),
+            mainPackageJson: config.commonMainType === undefined ? {} : { type: config.commonMainType },
+            ...(config.commonIncludeSourceMaps === undefined
+                ? {}
+                : { includeSourceMapFiles: config.commonIncludeSourceMaps }),
+            ...(config.commonAdditionalFileName === undefined
+                ? {}
+                : {
+                      additionalFiles: [
+                          {
+                              sourceFilePath: `${config.commonAdditionalFileName}.txt`,
+                              targetFilePath: `${config.commonAdditionalFileName}.txt`
+                          }
+                      ]
+                  }),
+            ...(Object.keys(config.commonAdditionalAttributes).length === 0
+                ? {}
+                : {
+                      additionalPackageJsonAttributes:
+                          config.commonAdditionalAttributes as AdditionalPackageJsonAttributes
+                  })
+        };
+
+        return {
+            registrySettings: { token: 'token' },
+            commonPackageSettings,
+            packages: [
+                {
+                    name: config.packageName,
+                    entryPoints: [createEntryPoint(config.entryBaseName, config.declarationBaseName)],
+                    ...(config.packageSourcesFolder === undefined
+                        ? {}
+                        : { sourcesFolder: config.packageSourcesFolder }),
+                    mainPackageJson: config.packageMainType === undefined ? {} : { type: config.packageMainType },
+                    ...(config.packageIncludeSourceMaps === undefined
+                        ? {}
+                        : { includeSourceMapFiles: config.packageIncludeSourceMaps }),
+                    ...(config.packageAdditionalFileName === undefined
+                        ? {}
+                        : {
+                              additionalFiles: [
+                                  {
+                                      sourceFilePath: `${config.packageAdditionalFileName}.md`,
+                                      targetFilePath: `${config.packageAdditionalFileName}.md`
+                                  }
+                              ]
+                          }),
+                    ...(Object.keys(config.packageAdditionalAttributes).length === 0
+                        ? {}
+                        : {
+                              additionalPackageJsonAttributes:
+                                  config.packageAdditionalAttributes as AdditionalPackageJsonAttributes
+                          }),
+                    ...(config.dependencyNames.length === 0 ? {} : { bundleDependencies: config.dependencyNames })
+                },
+                ...config.dependencyNames.map((dependencyName) => {
+                    return {
+                        name: dependencyName,
+                        entryPoints: [{ js: `${dependencyName}.js` }],
+                        sourcesFolder: config.commonSourcesFolder ?? config.packageSourcesFolder ?? 'source',
+                        mainPackageJson: {}
+                    };
+                })
+            ]
+        };
+    });
+
+test('packtoryConfigSchema accepts generated valid config shapes unchanged', () => {
+    fc.assert(
+        fc.property(validConfigArbitrary, (config) => {
+            const typedConfig = config as unknown as PacktoryConfig;
+            const result = safeParse(packtoryConfigSchema, typedConfig);
+
+            assert.strictEqual(result.success, true);
+            if (result.success) {
+                assert.deepStrictEqual(result.data.registrySettings, typedConfig.registrySettings);
+                assert.strictEqual(result.data.packages.length, config.packages.length);
+                assert.deepStrictEqual(
+                    result.data.packages.map((entry) => {
+                        return entry.name;
+                    }),
+                    typedConfig.packages.map((entry) => {
+                        return entry.name;
+                    })
+                );
+                assert.deepStrictEqual(
+                    result.data.packages.map((entry) => {
+                        return entry.entryPoints;
+                    }),
+                    typedConfig.packages.map((entry) => {
+                        return entry.entryPoints;
+                    })
+                );
+                assert.deepStrictEqual(
+                    result.data.packages.map((entry) => {
+                        return entry.sourcesFolder;
+                    }),
+                    typedConfig.packages.map((entry) => {
+                        return entry.sourcesFolder;
+                    })
+                );
+                assert.deepStrictEqual(
+                    result.data.packages.map((entry) => {
+                        return entry.mainPackageJson;
+                    }),
+                    typedConfig.packages.map((entry) => {
+                        return entry.mainPackageJson;
+                    })
+                );
+                assert.deepStrictEqual(
+                    result.data.commonPackageSettings?.sourcesFolder,
+                    typedConfig.commonPackageSettings?.sourcesFolder
+                );
+                assert.deepStrictEqual(
+                    result.data.commonPackageSettings?.mainPackageJson,
+                    typedConfig.commonPackageSettings?.mainPackageJson
+                );
+            }
+        })
+    );
+});
+
+test('configToResolveAndLinkOptions() keeps package-specific overrides over inherited common settings', () => {
+    fc.assert(
+        fc.property(validConfigArbitrary, (config) => {
+            const typedConfig = config as unknown as PacktoryConfig;
+            const [packageConfig] = typedConfig.packages;
+            if (packageConfig === undefined) {
+                assert.fail('Expected a package configuration');
+            }
+            const existingBundles = (packageConfig.bundleDependencies ?? []).map((dependencyName) => {
+                return { name: dependencyName, contents: [] };
+            });
+
+            const result = configToResolveAndLinkOptions(
+                packageConfig.name,
+                new Map(
+                    typedConfig.packages.map((entry) => {
+                        return [entry.name, entry];
+                    })
+                ),
+                typedConfig,
+                existingBundles
+            );
+
+            const expectedSourcesFolder =
+                packageConfig.sourcesFolder ?? typedConfig.commonPackageSettings?.sourcesFolder;
+            assert.strictEqual(result.sourcesFolder, expectedSourcesFolder);
+
+            if (packageConfig.mainPackageJson === undefined) {
+                assert.deepStrictEqual(result.mainPackageJson, typedConfig.commonPackageSettings?.mainPackageJson);
+            } else {
+                assert.deepStrictEqual(result.mainPackageJson, packageConfig.mainPackageJson);
+            }
+
+            if (packageConfig.includeSourceMapFiles !== undefined) {
+                assert.strictEqual(result.includeSourceMapFiles, packageConfig.includeSourceMapFiles);
+            }
+        })
+    );
+});

--- a/source/config/validation.property.ts
+++ b/source/config/validation.property.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { validateConfig } from './validation.ts';
+
+const packageNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}$/);
+
+function createValidPackage(name: string) {
+    return {
+        name,
+        sourcesFolder: `/src/${name}`,
+        mainPackageJson: {},
+        entryPoints: [{ js: `${name}.js` }]
+    };
+}
+
+test('validateConfig() returns Result.err for malformed non-config values', () => {
+    fc.assert(
+        fc.property(
+            fc.oneof(fc.boolean(), fc.integer(), fc.string(), fc.constant(null), fc.constant(undefined)),
+            (value) => {
+                const result = validateConfig(value);
+                assert.strictEqual(result.isErr, true);
+            }
+        )
+    );
+});
+
+test('validateConfig() rejects configs with missing bundle dependencies', () => {
+    fc.assert(
+        fc.property(packageNameArbitrary, packageNameArbitrary, (packageName, missingDependencyName) => {
+            fc.pre(packageName !== missingDependencyName);
+
+            const result = validateConfig({
+                registrySettings: { token: 'token' },
+                packages: [
+                    {
+                        ...createValidPackage(packageName),
+                        bundleDependencies: [missingDependencyName]
+                    }
+                ]
+            });
+
+            assert.strictEqual(result.isErr, true);
+        })
+    );
+});
+
+test('validateConfig() rejects duplicate package definitions and cyclic dependencies', () => {
+    fc.assert(
+        fc.property(packageNameArbitrary, packageNameArbitrary, (firstName, secondName) => {
+            fc.pre(firstName !== secondName);
+
+            const duplicateResult = validateConfig({
+                registrySettings: { token: 'token' },
+                packages: [createValidPackage(firstName), createValidPackage(firstName)]
+            });
+            assert.strictEqual(duplicateResult.isErr, true);
+
+            const cyclicResult = validateConfig({
+                registrySettings: { token: 'token' },
+                packages: [
+                    {
+                        ...createValidPackage(firstName),
+                        bundleDependencies: [secondName]
+                    },
+                    {
+                        ...createValidPackage(secondName),
+                        bundleDependencies: [firstName]
+                    }
+                ]
+            });
+            assert.strictEqual(cyclicResult.isErr, true);
+        })
+    );
+});

--- a/source/dependency-scanner/dependency-graph.property.ts
+++ b/source/dependency-scanner/dependency-graph.property.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { Maybe } from 'true-myth';
+import {
+    createDependencyGraph,
+    mergeDependencyFiles,
+    type DependencyFiles,
+    type LocalFile
+} from './dependency-graph.ts';
+
+const filePathArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}\.js$/);
+
+const dependencyFilesArbitrary: fc.Arbitrary<DependencyFiles> = fc
+    .uniqueArray(filePathArbitrary, {
+        minLength: 1,
+        maxLength: 3
+    })
+    .chain((filePaths) => {
+        const possibleConnections = filePaths.flatMap((_, fromIndex) => {
+            return filePaths.flatMap((__, toIndex) => {
+                if (fromIndex < toIndex) {
+                    return [[fromIndex, toIndex] as const];
+                }
+
+                return [];
+            });
+        });
+
+        return fc
+            .record({
+                sourceMapFlags: fc.array(fc.boolean(), { minLength: filePaths.length, maxLength: filePaths.length }),
+                externalDependencyNames: fc.array(fc.stringMatching(/^[a-z][\da-z-]{0,7}$/), { maxLength: 3 }),
+                connections: fc.shuffledSubarray(possibleConnections)
+            })
+            .map((options) => {
+                const graph = createDependencyGraph();
+                const projectObject = {};
+
+                filePaths.forEach((filePath, index) => {
+                    graph.addDependency(filePath, {
+                        sourceMapFilePath: options.sourceMapFlags[index]
+                            ? Maybe.just(`${filePath}.map`)
+                            : Maybe.nothing(),
+                        externalDependencies: options.externalDependencyNames.filter((_, dependencyIndex) => {
+                            return dependencyIndex % filePaths.length === index % filePaths.length;
+                        }),
+                        project: {
+                            getProject() {
+                                return projectObject;
+                            }
+                        }
+                    } as never);
+                });
+
+                options.connections.forEach(([fromIndex, toIndex]) => {
+                    graph.connect(filePaths[fromIndex]!, filePaths[toIndex]!);
+                });
+
+                return graph.flatten(filePaths[0]!);
+            });
+    });
+
+const localFilesArbitrary: fc.Arbitrary<readonly LocalFile[]> = fc
+    .uniqueArray(filePathArbitrary, {
+        minLength: 1,
+        maxLength: 3
+    })
+    .map((filePaths) => {
+        return filePaths.map((filePath) => {
+            return {
+                filePath,
+                directDependencies: new Set<string>()
+            } satisfies LocalFile;
+        });
+    });
+
+test('flatten() only references known file paths or generated source-map files', () => {
+    fc.assert(
+        fc.property(dependencyFilesArbitrary, (dependencyFiles) => {
+            const filePaths = new Set(
+                dependencyFiles.localFiles.map((file) => {
+                    return file.filePath;
+                })
+            );
+
+            dependencyFiles.localFiles.forEach((file) => {
+                file.directDependencies.forEach((dependency) => {
+                    assert.ok(filePaths.has(dependency) || dependency.endsWith('.js.map'));
+                });
+            });
+
+            dependencyFiles.externalDependencies.forEach((dependency) => {
+                dependency.referencedFrom.forEach((reference) => {
+                    assert.ok(filePaths.has(reference));
+                });
+            });
+        }),
+        { numRuns: 5 }
+    );
+});
+
+test('mergeDependencyFiles() preserves uniqueness by file path', () => {
+    fc.assert(
+        fc.property(localFilesArbitrary, localFilesArbitrary, (firstLocalFiles, secondLocalFiles) => {
+            const first: DependencyFiles = {
+                localFiles: firstLocalFiles,
+                externalDependencies: new Map()
+            };
+            const second: DependencyFiles = {
+                localFiles: secondLocalFiles,
+                externalDependencies: new Map()
+            };
+
+            const merged = mergeDependencyFiles(first, second);
+            const mergedPaths = merged.localFiles.map((file) => {
+                return file.filePath;
+            });
+
+            assert.deepStrictEqual(mergedPaths, Array.from(new Set(mergedPaths)));
+        }),
+        { numRuns: 5 }
+    );
+});

--- a/source/dependency-scanner/source-file-references.property.ts
+++ b/source/dependency-scanner/source-file-references.property.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert';
+import { builtinModules } from 'node:module';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { createProject } from '../test-libraries/typescript-project.ts';
+import { getReferencedSourceFiles } from './source-file-references.ts';
+
+const builtinImportArbitrary = fc.constantFrom(
+    ...builtinModules.filter((moduleName) => {
+        return !moduleName.startsWith('_');
+    })
+);
+const unresolvedImportArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,10}$/).filter((moduleName) => {
+    return !builtinModules.includes(moduleName) && !builtinModules.includes(`node:${moduleName}`);
+});
+
+test('getReferencedSourceFiles() does not throw for builtin imports', () => {
+    fc.assert(
+        fc.property(builtinImportArbitrary, (moduleName) => {
+            const project = createProject({
+                withFiles: [{ filePath: 'main.ts', content: `import value from "${moduleName}";` }]
+            });
+
+            assert.doesNotThrow(() => {
+                getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+            });
+        })
+    );
+});
+
+test('getReferencedSourceFiles() throws for unresolved non-builtin imports', () => {
+    fc.assert(
+        fc.property(unresolvedImportArbitrary, (moduleName) => {
+            const project = createProject({
+                withFiles: [{ filePath: 'main.ts', content: `import value from "${moduleName}";` }]
+            });
+
+            assert.throws(() => {
+                getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+            }, Error);
+        })
+    );
+});

--- a/source/dependency-scanner/source-map-file-locator.property.ts
+++ b/source/dependency-scanner/source-map-file-locator.property.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { fake } from 'sinon';
+import { Maybe } from 'true-myth';
+import { createSourceMapFileLocator, type SourceMapFileLocatorDependencies } from './source-map-file-locator.ts';
+
+function createLocator(readFileContent: string, isReadable: boolean) {
+    return createSourceMapFileLocator({
+        fileManager: {
+            readFile: fake.resolves(readFileContent),
+            checkReadability: fake.resolves({ isReadable })
+        }
+    } as unknown as SourceMapFileLocatorDependencies);
+}
+
+test('locate() returns Maybe.nothing() for malformed or missing source-map comments', async () => {
+    await fc.assert(
+        fc.asyncProperty(
+            fc.string().filter((value) => {
+                return !/^\/\/# sourceMappingURL=(?<url>.+)$/m.test(value);
+            }),
+            async (fileContent) => {
+                const result = await createLocator(fileContent, true).locate('/src/file.js');
+                assert.deepStrictEqual(result, Maybe.nothing());
+            }
+        )
+    );
+});
+
+test('locate() returns Maybe.nothing() when the referenced source-map file is unreadable', async () => {
+    await fc.assert(
+        fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
+            const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, false).locate('/src/file.js');
+            assert.deepStrictEqual(result, Maybe.nothing());
+        })
+    );
+});
+
+test('locate() returns Maybe.just() when the referenced source-map file is readable', async () => {
+    await fc.assert(
+        fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
+            const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, true).locate('/src/file.js');
+            assert.deepStrictEqual(result, Maybe.just(`/src/${mapFileName}`));
+        })
+    );
+});

--- a/source/directed-graph/graph.property.ts
+++ b/source/directed-graph/graph.property.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { createDirectedGraph, type DirectedGraph, type GraphEdge } from './graph.ts';
+
+type GraphShape = {
+    readonly nodeIds: readonly string[];
+    readonly edges: readonly GraphEdge<string>[];
+};
+
+function createGraph(shape: GraphShape): DirectedGraph<string, undefined> {
+    const graph = createDirectedGraph<string, undefined>();
+
+    shape.nodeIds.forEach((nodeId) => {
+        graph.addNode(nodeId, undefined);
+    });
+
+    shape.edges.forEach((edge) => {
+        graph.connect(edge);
+    });
+
+    return graph;
+}
+
+function getSortedEdges(graph: DirectedGraph<string, undefined>, nodeIds: readonly string[]): readonly string[] {
+    return nodeIds
+        .flatMap((nodeId) => {
+            return Array.from(graph.getAdjacentIds(nodeId), (adjacentId) => {
+                return `${nodeId}->${adjacentId}`;
+            });
+        })
+        .toSorted();
+}
+
+function createDagArbitrary(): fc.Arbitrary<GraphShape> {
+    return fc.integer({ min: 1, max: 4 }).chain((nodeCount) => {
+        const nodeIds = Array.from({ length: nodeCount }, (_, index) => {
+            return `node-${index}`;
+        });
+        const possibleEdges = nodeIds.flatMap((_, fromIndex) => {
+            return nodeIds.flatMap((__, toIndex) => {
+                if (fromIndex < toIndex && toIndex !== fromIndex + 1) {
+                    return [[fromIndex, toIndex] as const];
+                }
+
+                return [];
+            });
+        });
+
+        return fc.shuffledSubarray(possibleEdges).map((edges) => {
+            return {
+                nodeIds,
+                edges: edges.map(([fromIndex, toIndex]) => {
+                    return { from: nodeIds[fromIndex]!, to: nodeIds[toIndex]! };
+                })
+            } satisfies GraphShape;
+        });
+    });
+}
+
+function createCyclicGraphArbitrary(): fc.Arbitrary<GraphShape> {
+    return fc.integer({ min: 2, max: 4 }).map((nodeCount) => {
+        const nodeIds = Array.from({ length: nodeCount }, (_, index) => {
+            return `cycle-${index}`;
+        });
+        return {
+            nodeIds,
+            edges: nodeIds.map((nodeId, index) => {
+                return {
+                    from: nodeId,
+                    to: nodeIds[(index + 1) % nodeIds.length]!
+                };
+            })
+        } satisfies GraphShape;
+    });
+}
+
+test('reverse() preserves the edge set when applied twice and reverses all original edges', () => {
+    fc.assert(
+        fc.property(createDagArbitrary(), (shape) => {
+            const graph = createGraph(shape);
+            const reversedGraph = graph.reverse();
+            const reversedTwice = reversedGraph.reverse();
+
+            assert.deepStrictEqual(getSortedEdges(reversedTwice, shape.nodeIds), getSortedEdges(graph, shape.nodeIds));
+
+            shape.edges.forEach((edge) => {
+                assert.strictEqual(reversedGraph.hasConnection({ from: edge.to, to: edge.from }), true);
+            });
+        }),
+        { numRuns: 8 }
+    );
+});
+
+test('getTopologicalGenerations() contains every node exactly once and respects edge order for DAGs', () => {
+    fc.assert(
+        fc.property(createDagArbitrary(), (shape) => {
+            const graph = createGraph(shape);
+            const generations = graph.getTopologicalGenerations();
+            const flattened = generations.flat();
+
+            assert.deepStrictEqual(Array.from(flattened).toSorted(), Array.from(shape.nodeIds).toSorted());
+
+            const positions = new Map(
+                flattened.map((nodeId, index) => {
+                    return [nodeId, index];
+                })
+            );
+            shape.edges.forEach((edge) => {
+                assert.ok(positions.get(edge.from)! < positions.get(edge.to)!);
+            });
+        }),
+        { numRuns: 8 }
+    );
+});
+
+test('detectCycles() reports no cycles for generated DAGs', () => {
+    fc.assert(
+        fc.property(createDagArbitrary(), (shape) => {
+            const graph = createGraph(shape);
+
+            assert.deepStrictEqual(graph.detectCycles(), []);
+            assert.strictEqual(graph.isCyclic(), false);
+        }),
+        { numRuns: 8 }
+    );
+});
+
+test('detectCycles() reports at least one cycle for generated cyclic graphs', () => {
+    fc.assert(
+        fc.property(createCyclicGraphArbitrary(), (shape) => {
+            const graph = createGraph(shape);
+            const cycles = graph.detectCycles();
+
+            assert.ok(cycles.length > 0);
+            cycles.flat().forEach((nodeId) => {
+                assert.ok(shape.nodeIds.includes(nodeId));
+            });
+            assert.strictEqual(graph.isCyclic(), true);
+        }),
+        { numRuns: 8 }
+    );
+});

--- a/source/file-manager/compare.property.ts
+++ b/source/file-manager/compare.property.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import type { FileDescription } from './file-description.ts';
+import { compareFileDescriptions } from './compare.ts';
+
+const fileDescriptionArbitrary = fc.record<FileDescription>({
+    filePath: fc.string(),
+    content: fc.string(),
+    isExecutable: fc.boolean()
+});
+
+test('compareFileDescriptions() is order-insensitive for equivalent file sets', () => {
+    fc.assert(
+        fc.property(
+            fc.uniqueArray(fileDescriptionArbitrary, {
+                selector: (fileDescription) => {
+                    return fileDescription.filePath;
+                },
+                maxLength: 20
+            }),
+            (fileDescriptions) => {
+                const permutation = Array.from(fileDescriptions).reverse();
+
+                assert.deepStrictEqual(compareFileDescriptions(fileDescriptions, permutation), { status: 'equal' });
+            }
+        )
+    );
+});
+
+test('compareFileDescriptions() reports non-equal when any file content changes', () => {
+    fc.assert(
+        fc.property(
+            fc.array(fileDescriptionArbitrary, { minLength: 1, maxLength: 20 }),
+            fc.string(),
+            (fileDescriptions, suffix) => {
+                const modified = Array.from(fileDescriptions);
+                const first = modified[0]!;
+                modified[0] = {
+                    ...first,
+                    content: `${first.content}${suffix}x`
+                };
+
+                assert.deepStrictEqual(compareFileDescriptions(fileDescriptions, modified), { status: 'not-equal' });
+            }
+        )
+    );
+});

--- a/source/file-manager/sort.property.ts
+++ b/source/file-manager/sort.property.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { sortByFilePath } from './sort.ts';
+import type { FileDescription } from './file-description.ts';
+
+const fileDescriptionArbitrary = fc.record<FileDescription>({
+    filePath: fc.string(),
+    content: fc.string(),
+    isExecutable: fc.boolean()
+});
+
+test('sortByFilePath() returns a sorted copy without losing or mutating entries', () => {
+    fc.assert(
+        fc.property(fc.array(fileDescriptionArbitrary, { maxLength: 30 }), (fileDescriptions) => {
+            const original = Array.from(fileDescriptions);
+            const result = sortByFilePath(fileDescriptions);
+
+            assert.deepStrictEqual(fileDescriptions, original);
+
+            for (let index = 1; index < result.length; index += 1) {
+                assert.ok(result[index - 1]!.filePath <= result[index]!.filePath);
+            }
+
+            const expected = Array.from(fileDescriptions).sort((left, right) => {
+                if (left.filePath < right.filePath) {
+                    return -1;
+                }
+                if (left.filePath > right.filePath) {
+                    return 1;
+                }
+                return 0;
+            });
+            assert.deepStrictEqual(result, expected);
+        })
+    );
+});
+
+test('sortByFilePath() is idempotent', () => {
+    fc.assert(
+        fc.property(fc.array(fileDescriptionArbitrary, { maxLength: 30 }), (fileDescriptions) => {
+            const sortedOnce = sortByFilePath(fileDescriptions);
+            const sortedTwice = sortByFilePath(sortedOnce);
+
+            assert.deepStrictEqual(sortedTwice, sortedOnce);
+        })
+    );
+});

--- a/source/linker/substitute-bundles.property.ts
+++ b/source/linker/substitute-bundles.property.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { createProject } from '../test-libraries/typescript-project.ts';
+import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
+import { createGraphFromResolvedBundle } from './resource-graph.ts';
+import { substituteDependencies } from './substitute-bundles.ts';
+
+const importCountArbitrary = fc.integer({ min: 0, max: 4 });
+
+function createBundleDependency(index: number): VersionedBundleWithManifest {
+    const sourceFilePath = `/dep-${index}.js`;
+
+    return {
+        contents: [
+            {
+                fileDescription: {
+                    content: '',
+                    isExecutable: false,
+                    sourceFilePath,
+                    targetFilePath: `dep-${index}.js`
+                },
+                directDependencies: new Set(),
+                isSubstituted: false,
+                isExplicitlyIncluded: false
+            }
+        ],
+        packageJson: { name: `package-${index}`, version: '1.0.0' },
+        name: `package-${index}`,
+        version: '1.0.0',
+        dependencies: {},
+        peerDependencies: {},
+        additionalAttributes: {},
+        mainFile: {
+            content: '',
+            isExecutable: false,
+            sourceFilePath,
+            targetFilePath: `dep-${index}.js`
+        },
+        typesMainFile: undefined,
+        packageType: 'module',
+        manifestFile: { content: '', isExecutable: false, filePath: 'package.json' }
+    };
+}
+
+test('substituteDependencies() only rewrites matched imports and never invents unrelated files', () => {
+    fc.assert(
+        fc.property(
+            importCountArbitrary,
+            fc.array(fc.boolean(), { minLength: 0, maxLength: 4 }),
+            (importCount, replacementFlags) => {
+                const selectedFlags = replacementFlags.slice(0, importCount);
+                const importPaths = Array.from({ length: importCount }, (_, index) => {
+                    return `/dep-${index}.js`;
+                });
+                const project = createProject({
+                    withFiles: [
+                        {
+                            filePath: '/entry.js',
+                            content: importPaths
+                                .map((filePath) => {
+                                    return `import ".${filePath}";`;
+                                })
+                                .join('\n')
+                        },
+                        ...importPaths.map((filePath) => {
+                            return { filePath, content: `export const value = "${filePath}";` };
+                        })
+                    ]
+                });
+
+                const graph = createGraphFromResolvedBundle({
+                    contents: [
+                        {
+                            fileDescription: {
+                                content: importPaths
+                                    .map((filePath) => {
+                                        return `import ".${filePath}";`;
+                                    })
+                                    .join('\n'),
+                                isExecutable: false,
+                                sourceFilePath: '/entry.js',
+                                targetFilePath: 'entry.js'
+                            },
+                            directDependencies: new Set(importPaths),
+                            project,
+                            isExplicitlyIncluded: false
+                        },
+                        ...importPaths.map((filePath) => {
+                            return {
+                                fileDescription: {
+                                    content: `export const value = "${filePath}";`,
+                                    isExecutable: false,
+                                    sourceFilePath: filePath,
+                                    targetFilePath: filePath.slice(1)
+                                },
+                                directDependencies: new Set<string>(),
+                                project,
+                                isExplicitlyIncluded: false
+                            };
+                        })
+                    ],
+                    entryPoints: [
+                        {
+                            js: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/entry.js',
+                                targetFilePath: 'entry.js'
+                            }
+                        }
+                    ],
+                    externalDependencies: new Map(),
+                    name: 'fixture'
+                });
+
+                const bundleDependencies = importPaths.flatMap((_, index) => {
+                    return (selectedFlags[index] ?? false) ? [createBundleDependency(index)] : [];
+                });
+
+                const substituted = substituteDependencies(graph, bundleDependencies);
+                const result = substituted.flatten(['/entry.js']);
+                const outputFiles = result.contents
+                    .map((entry) => {
+                        return entry.fileDescription.sourceFilePath;
+                    })
+                    .toSorted();
+
+                outputFiles.forEach((filePath) => {
+                    assert.ok(filePath === '/entry.js' || importPaths.includes(filePath));
+                });
+
+                const entryFile = result.contents.find((entry) => {
+                    return entry.fileDescription.sourceFilePath === '/entry.js';
+                });
+                if (entryFile === undefined) {
+                    assert.fail('Expected entry file to exist');
+                }
+
+                importPaths.forEach((filePath, index) => {
+                    const isSubstituted = selectedFlags[index] ?? false;
+                    if (isSubstituted) {
+                        assert.ok(entryFile.fileDescription.content.includes(`package-${index}/dep-${index}.js`));
+                        assert.strictEqual(outputFiles.includes(filePath), false);
+                    } else {
+                        assert.ok(entryFile.fileDescription.content.includes(`.${filePath}`));
+                        assert.strictEqual(outputFiles.includes(filePath), true);
+                    }
+                });
+
+                const referencedBundleDependencies = Array.from(result.linkedBundleDependencies.keys()).toSorted();
+                const expectedBundleDependencies = importPaths
+                    .flatMap((_, index) => {
+                        return (selectedFlags[index] ?? false) ? [`package-${index}`] : [];
+                    })
+                    .toSorted();
+                assert.deepStrictEqual(referencedBundleDependencies, expectedBundleDependencies);
+            }
+        ),
+        { numRuns: 30 }
+    );
+});

--- a/source/list/unique-list.property.ts
+++ b/source/list/unique-list.property.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { uniqueList } from './unique-list.ts';
+
+test('uniqueList() removes duplicates while preserving the first occurrence of each value', () => {
+    fc.assert(
+        fc.property(fc.array(fc.string(), { maxLength: 40 }), (values) => {
+            const result = uniqueList(values);
+            const expected = values.filter((value, index) => {
+                return values.indexOf(value) === index;
+            });
+
+            assert.deepStrictEqual(result, expected);
+        })
+    );
+});
+
+test('uniqueList() is idempotent', () => {
+    fc.assert(
+        fc.property(fc.array(fc.string(), { maxLength: 40 }), (values) => {
+            const uniqueOnce = uniqueList(values);
+            const uniqueTwice = uniqueList(uniqueOnce);
+
+            assert.deepStrictEqual(uniqueTwice, uniqueOnce);
+        })
+    );
+});

--- a/source/packtory/map-config.ts
+++ b/source/packtory/map-config.ts
@@ -82,7 +82,7 @@ function getRequiredValue<TValue>(value: TValue | undefined, message: string): T
 
 function resolveSourcesFolder(packageConfig: PackageConfig, packtoryConfig: PacktoryConfigWithoutRegistry): string {
     return getRequiredValue(
-        packtoryConfig.commonPackageSettings?.sourcesFolder ?? packageConfig.sourcesFolder,
+        packageConfig.sourcesFolder ?? packtoryConfig.commonPackageSettings?.sourcesFolder,
         `Config for package "${packageConfig.name}" is missing the sources folder`
     );
 }
@@ -92,7 +92,7 @@ function resolveMainPackageJson(
     packtoryConfig: PacktoryConfigWithoutRegistry
 ): MainPackageJson {
     return getRequiredValue(
-        packtoryConfig.commonPackageSettings?.mainPackageJson ?? packageConfig.mainPackageJson,
+        packageConfig.mainPackageJson ?? packtoryConfig.commonPackageSettings?.mainPackageJson,
         `Config for package "${packageConfig.name}" is missing the main package.json settings`
     );
 }

--- a/source/packtory/normalize-paths.property.ts
+++ b/source/packtory/normalize-paths.property.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert';
+import path from 'node:path';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { normalizeAdditionalFile, normalizeEntryPoint } from './normalize-paths.ts';
+
+const pathSegmentArbitrary = fc.stringMatching(/^[\w.-]+$/);
+
+const relativePathArbitrary = fc
+    .array(pathSegmentArbitrary, {
+        minLength: 1,
+        maxLength: 4
+    })
+    .map((segments) => {
+        return segments.join('/');
+    });
+
+const absolutePathArbitrary = fc.tuple(relativePathArbitrary, relativePathArbitrary).map(([folder, filePath]) => {
+    return path.join(path.sep, folder, filePath);
+});
+
+test('normalizeEntryPoint() keeps absolute paths unchanged and resolves relative paths against the source folder', () => {
+    fc.assert(
+        fc.property(
+            relativePathArbitrary,
+            relativePathArbitrary,
+            fc.option(relativePathArbitrary, { nil: undefined }),
+            (sourceFolder, js, declarationFile) => {
+                const relativeEntryPoint = declarationFile === undefined ? { js } : { js, declarationFile };
+                const normalizedRelativeEntryPoint = normalizeEntryPoint(relativeEntryPoint, sourceFolder);
+
+                assert.strictEqual(normalizedRelativeEntryPoint.js, path.join(sourceFolder, js));
+                assert.strictEqual(
+                    normalizedRelativeEntryPoint.declarationFile,
+                    declarationFile === undefined ? undefined : path.join(sourceFolder, declarationFile)
+                );
+            }
+        )
+    );
+
+    fc.assert(
+        fc.property(
+            absolutePathArbitrary,
+            relativePathArbitrary,
+            fc.option(absolutePathArbitrary, { nil: undefined }),
+            (js, sourceFolder, declarationFile) => {
+                const absoluteEntryPoint = declarationFile === undefined ? { js } : { js, declarationFile };
+                const normalizedAbsoluteEntryPoint = normalizeEntryPoint(absoluteEntryPoint, sourceFolder);
+
+                assert.strictEqual(normalizedAbsoluteEntryPoint.js, js);
+                assert.strictEqual(normalizedAbsoluteEntryPoint.declarationFile, declarationFile);
+            }
+        )
+    );
+});
+
+test('normalizeAdditionalFile() keeps the target path and resolves only the source path', () => {
+    fc.assert(
+        fc.property(
+            relativePathArbitrary,
+            relativePathArbitrary,
+            relativePathArbitrary,
+            (sourceFolder, sourceFilePath, targetFilePath) => {
+                const normalized = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
+
+                assert.deepStrictEqual(normalized, {
+                    sourceFilePath: path.join(sourceFolder, sourceFilePath),
+                    targetFilePath
+                });
+            }
+        )
+    );
+
+    fc.assert(
+        fc.property(
+            relativePathArbitrary,
+            absolutePathArbitrary,
+            relativePathArbitrary,
+            (sourceFolder, sourceFilePath, targetFilePath) => {
+                const normalized = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
+
+                assert.deepStrictEqual(normalized, {
+                    sourceFilePath,
+                    targetFilePath
+                });
+            }
+        )
+    );
+});
+
+test('normalizeEntryPoint() is idempotent once all paths are normalized', () => {
+    fc.assert(
+        fc.property(
+            absolutePathArbitrary,
+            relativePathArbitrary,
+            fc.option(relativePathArbitrary, { nil: undefined }),
+            (sourceFolder, js, declarationFile) => {
+                const entryPoint = declarationFile === undefined ? { js } : { js, declarationFile };
+                const normalizedOnce = normalizeEntryPoint(entryPoint, sourceFolder);
+                const normalizedTwice = normalizeEntryPoint(normalizedOnce, sourceFolder);
+
+                assert.deepStrictEqual(normalizedTwice, normalizedOnce);
+            }
+        )
+    );
+});
+
+test('normalizeAdditionalFile() is idempotent once the source path is normalized', () => {
+    fc.assert(
+        fc.property(
+            absolutePathArbitrary,
+            relativePathArbitrary,
+            relativePathArbitrary,
+            (sourceFolder, sourceFilePath, targetFilePath) => {
+                const normalizedOnce = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
+                const normalizedTwice = normalizeAdditionalFile(normalizedOnce, sourceFolder);
+
+                assert.deepStrictEqual(normalizedTwice, normalizedOnce);
+            }
+        )
+    );
+});

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -268,23 +268,45 @@ test('tryBuildAndPublish() returns new-version when the package already has a pu
 });
 
 test('tryBuildAndPublish() keeps the configured manual version without rebuilding on the initial publish', async () => {
-    const manualBundle = createVersionedBundle('package-a', '3.2.1');
+    const manualBundle = createVersionedBundle('package-a', '4.5.6');
     const { processor, increaseVersion, emit } = createProcessor({
         determineCurrentVersion: fake.resolves(Maybe.nothing()),
         addVersion: fake.returns(manualBundle)
     });
 
+    const buildOptions: BuildAndPublishOptions = {
+        ...createBuildAndPublishOptions(),
+        versioning: { automatic: false, version: '4.5.6' }
+    };
     const result = await processor.tryBuildAndPublish({
         linkedBundle: createLinkedBundle(),
-        buildOptions: {
-            ...createBuildAndPublishOptions(),
-            versioning: { automatic: false, version: '3.2.1' }
-        }
+        buildOptions
     });
 
     assert.deepStrictEqual(result, { bundle: manualBundle, status: 'initial-version' });
     assert.strictEqual(increaseVersion.callCount, 0);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '3.2.1' }]]);
+    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '4.5.6' }]]);
+});
+
+test('tryBuildAndPublish() keeps the current published version without rebuilding when automatic versioning is disabled', async () => {
+    const currentBundle = createVersionedBundle('package-a', '2.0.0');
+    const { processor, increaseVersion, emit } = createProcessor({
+        determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
+        addVersion: fake.returns(currentBundle)
+    });
+
+    const buildOptions: BuildAndPublishOptions = {
+        ...createBuildAndPublishOptions(),
+        versioning: { automatic: false, version: '9.9.9' }
+    };
+    const result = await processor.tryBuildAndPublish({
+        linkedBundle: createLinkedBundle(),
+        buildOptions
+    });
+
+    assert.deepStrictEqual(result, { bundle: currentBundle, status: 'new-version' });
+    assert.strictEqual(increaseVersion.callCount, 0);
+    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '2.0.0' }]]);
 });
 
 test('tryBuildAndPublish() uses minimumVersion for the first automatic publish without rebuilding', async () => {
@@ -294,12 +316,13 @@ test('tryBuildAndPublish() uses minimumVersion for the first automatic publish w
         addVersion: fake.returns(minimumVersionBundle)
     });
 
+    const buildOptions: BuildAndPublishOptions = {
+        ...createBuildAndPublishOptions(),
+        versioning: { automatic: true, minimumVersion: '1.2.3' }
+    };
     const result = await processor.tryBuildAndPublish({
         linkedBundle: createLinkedBundle(),
-        buildOptions: {
-            ...createBuildAndPublishOptions(),
-            versioning: { automatic: true, minimumVersion: '1.2.3' }
-        }
+        buildOptions
     });
 
     assert.deepStrictEqual(result, { bundle: minimumVersionBundle, status: 'initial-version' });

--- a/source/tar/extract-tar.property.ts
+++ b/source/tar/extract-tar.property.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import { extractTarEntries } from './extract-tar.ts';
+
+const nonGzipBufferArbitrary = fc.uint8Array({ maxLength: 256 }).filter((data) => {
+    return data.length < 2 || data[0] !== 0x1f || data[1] !== 0x8b;
+});
+
+test('extractTarEntries() rejects malformed non-gzip buffers explicitly', async () => {
+    await fc.assert(
+        fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
+            await assert.rejects(async () => {
+                await extractTarEntries(Buffer.from(data));
+            }, Error);
+        }),
+        { numRuns: 50 }
+    );
+});
+
+test('extractTarEntries() rejects malformed non-gzip buffers without needing exact error text', async () => {
+    await fc.assert(
+        fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
+            try {
+                const result = await extractTarEntries(Buffer.from(data));
+                assert.fail(`Expected extractTarEntries() to reject, but it returned ${result.length} entries`);
+            } catch (error: unknown) {
+                assert.ok(error instanceof Error);
+            }
+        }),
+        { numRuns: 50 }
+    );
+});

--- a/source/tar/extract-tar.test.ts
+++ b/source/tar/extract-tar.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert';
+import { Readable } from 'node:stream';
 import { test } from 'mocha';
+import sinon from 'sinon';
 import { extractTarEntries } from './extract-tar.ts';
 import { createTarballBuilder } from './tarball-builder.ts';
 
@@ -63,4 +65,79 @@ test('returns the extracted entries when the given tar buffer has files which ar
             }
         }
     ]);
+});
+
+test('rejects when the given buffer is not a valid gzip tarball', async () => {
+    await assert.rejects(async () => {
+        await extractTarEntries(Buffer.from('not-a-tarball'));
+    }, Error);
+});
+
+test('rejects with an Error when iteration throws a non-Error value', async () => {
+    const throwingStream = {
+        [Symbol.asyncIterator](): AsyncIterator<unknown> {
+            return {
+                next: async (): Promise<IteratorResult<unknown>> => {
+                    // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- This test exercises non-Error rejection normalization.
+                    throw 'boom';
+                }
+            };
+        }
+    };
+    const intermediateStream = {
+        pipe() {
+            return throwingStream;
+        }
+    };
+    const source = {
+        once() {
+            return source;
+        },
+        pipe() {
+            return intermediateStream;
+        }
+    };
+    const stub = sinon.stub(Readable, 'from').returns(source as unknown as Readable);
+
+    try {
+        await assert.rejects(async () => {
+            await extractTarEntries(Buffer.from('unused'));
+        }, /^Error: boom$/);
+    } finally {
+        stub.restore();
+    }
+});
+
+test('preserves Error instances when iteration rejects with an Error', async () => {
+    const throwingStream = {
+        [Symbol.asyncIterator](): AsyncIterator<unknown> {
+            return {
+                next: async (): Promise<IteratorResult<unknown>> => {
+                    throw new Error('boom');
+                }
+            };
+        }
+    };
+    const intermediateStream = {
+        pipe() {
+            return throwingStream;
+        }
+    };
+    const source = {
+        once() {
+            return source;
+        },
+        pipe() {
+            return intermediateStream;
+        }
+    };
+    const stub = sinon.stub(Readable, 'from').returns(source as unknown as Readable);
+
+    try {
+        await assert.rejects(async () => {
+            await extractTarEntries(Buffer.from('unused'));
+        }, /^Error: boom$/);
+    } finally {
+        stub.restore();
+    }
 });

--- a/source/tar/extract-tar.ts
+++ b/source/tar/extract-tar.ts
@@ -7,18 +7,42 @@ export type TarEntry = {
     readonly content: string;
 };
 
+function toError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
 export async function extractTarEntries(buffer: Buffer): Promise<TarEntry[]> {
     const extractStream = extract();
-    const stream = Readable.from(buffer).pipe(createGunzip()).pipe(extractStream);
-    const entries: TarEntry[] = [];
+    const source = Readable.from(buffer);
+    const gunzip = createGunzip();
+    const stream = source.pipe(gunzip).pipe(extractStream);
 
-    for await (const entry of stream) {
-        let result = '';
-        for await (const chunk of entry) {
-            result += chunk.toString();
-        }
-        entries.push({ header: entry.header, content: result });
-    }
+    return new Promise<TarEntry[]>((resolve, reject) => {
+        const rejectOnError = (error: Error): void => {
+            reject(error);
+        };
 
-    return entries;
+        source.once('error', rejectOnError);
+        gunzip.once('error', rejectOnError);
+        extractStream.once('error', rejectOnError);
+
+        // eslint-disable-next-line no-void -- The async reader resolves via resolve/reject above.
+        void (async (): Promise<void> => {
+            try {
+                const entries: TarEntry[] = [];
+
+                for await (const entry of stream) {
+                    let result = '';
+                    for await (const chunk of entry) {
+                        result += chunk.toString();
+                    }
+                    entries.push({ header: entry.header, content: result });
+                }
+
+                resolve(entries);
+            } catch (error: unknown) {
+                reject(toError(error));
+            }
+        })();
+    });
 }

--- a/source/tsconfig.sources.json
+++ b/source/tsconfig.sources.json
@@ -6,5 +6,5 @@
         "types": ["node"]
     },
     "include": ["./**/*.ts"],
-    "exclude": ["./**/*.test.ts", "./test-libraries/**/*.ts"]
+    "exclude": ["./**/*.test.ts", "./**/*.property.ts", "./test-libraries/**/*.ts"]
 }

--- a/source/tsconfig.unit-tests.json
+++ b/source/tsconfig.unit-tests.json
@@ -6,5 +6,5 @@
         "types": ["node", "mocha"]
     },
     "references": [{ "path": "./tsconfig.sources.json" }],
-    "include": ["./**/*.test.ts", "./test-libraries/**/*.ts"]
+    "include": ["./**/*.test.ts", "./**/*.property.ts", "./test-libraries/**/*.ts"]
 }

--- a/source/version-manager/manifest/builder.property.ts
+++ b/source/version-manager/manifest/builder.property.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import type { AdditionalPackageJsonAttributes } from '../../config/package-json.ts';
+import type { VersionedBundle } from '../versioned-bundle.ts';
+import { buildPackageManifest } from './builder.ts';
+
+const reservedAttributeNames = new Set([
+    'dependencies',
+    'peerDependencies',
+    'devDependencies',
+    'main',
+    'name',
+    'types',
+    'type',
+    'version'
+]);
+
+const packageNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}$/);
+const filePathArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}\.(js|d\.ts)$/);
+const versionArbitrary = fc
+    .tuple(fc.integer({ min: 0, max: 9 }), fc.integer({ min: 0, max: 9 }), fc.integer({ min: 0, max: 9 }))
+    .map(([major, minor, patch]) => {
+        return `${major}.${minor}.${patch}`;
+    });
+const dependencyRecordArbitrary = fc.dictionary(packageNameArbitrary, versionArbitrary, { maxKeys: 3 });
+const additionalAttributeKeyArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,10}$/).filter((key) => {
+    return !reservedAttributeNames.has(key);
+});
+
+const additionalAttributesArbitrary: fc.Arbitrary<AdditionalPackageJsonAttributes> = fc.dictionary(
+    additionalAttributeKeyArbitrary,
+    fc.jsonValue(),
+    { maxKeys: 3 }
+) as fc.Arbitrary<AdditionalPackageJsonAttributes>;
+
+const bundleArbitrary: fc.Arbitrary<VersionedBundle> = fc
+    .record({
+        name: packageNameArbitrary,
+        version: versionArbitrary,
+        dependencies: dependencyRecordArbitrary,
+        peerDependencies: dependencyRecordArbitrary,
+        additionalAttributes: additionalAttributesArbitrary,
+        packageType: fc.option(fc.constant<'module'>('module'), { nil: undefined }),
+        mainTargetFilePath: filePathArbitrary,
+        typesTargetFilePath: fc.option(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.d\.ts$/), { nil: undefined })
+    })
+    .filter((bundle) => {
+        return Object.keys(bundle.dependencies).every((name) => {
+            return !Object.hasOwn(bundle.peerDependencies, name);
+        });
+    })
+    .map((bundle) => {
+        return {
+            name: bundle.name,
+            version: bundle.version,
+            dependencies: bundle.dependencies,
+            peerDependencies: bundle.peerDependencies,
+            additionalAttributes: bundle.additionalAttributes,
+            contents: [],
+            mainFile: {
+                sourceFilePath: `/src/${bundle.mainTargetFilePath}`,
+                targetFilePath: bundle.mainTargetFilePath,
+                content: '',
+                isExecutable: false
+            },
+            typesMainFile:
+                bundle.typesTargetFilePath === undefined
+                    ? undefined
+                    : {
+                          sourceFilePath: `/src/${bundle.typesTargetFilePath}`,
+                          targetFilePath: bundle.typesTargetFilePath,
+                          content: '',
+                          isExecutable: false
+                      },
+            packageType: bundle.packageType
+        } satisfies VersionedBundle;
+    });
+
+test('buildPackageManifest() keeps generated manifest fields coherent with the bundle inputs', () => {
+    fc.assert(
+        fc.property(bundleArbitrary, (bundle) => {
+            const manifest = buildPackageManifest(bundle);
+
+            assert.strictEqual(manifest.name, bundle.name);
+            assert.strictEqual(manifest.version, bundle.version);
+            assert.strictEqual(manifest.main, bundle.mainFile.targetFilePath);
+            assert.strictEqual(manifest.types, bundle.typesMainFile?.targetFilePath);
+            assert.strictEqual(manifest.type, bundle.packageType);
+
+            if (Object.keys(bundle.dependencies).length === 0) {
+                assert.strictEqual('dependencies' in manifest, false);
+            } else {
+                assert.deepStrictEqual(manifest.dependencies, bundle.dependencies);
+            }
+
+            if (Object.keys(bundle.peerDependencies).length === 0) {
+                assert.strictEqual('peerDependencies' in manifest, false);
+            } else {
+                assert.deepStrictEqual(manifest.peerDependencies, bundle.peerDependencies);
+            }
+        })
+    );
+});
+
+test('buildPackageManifest() preserves additional attributes without leaking dependency groups into each other', () => {
+    fc.assert(
+        fc.property(bundleArbitrary, (bundle) => {
+            const manifest = buildPackageManifest(bundle);
+
+            Object.entries(bundle.additionalAttributes).forEach(([key, value]) => {
+                assert.deepStrictEqual(manifest[key], value);
+            });
+
+            Object.keys(bundle.dependencies).forEach((dependencyName) => {
+                assert.strictEqual(Object.hasOwn(manifest.peerDependencies ?? {}, dependencyName), false);
+            });
+            Object.keys(bundle.peerDependencies).forEach((dependencyName) => {
+                assert.strictEqual(Object.hasOwn(manifest.dependencies ?? {}, dependencyName), false);
+            });
+        })
+    );
+});

--- a/source/version-manager/manifest/serialize.property.ts
+++ b/source/version-manager/manifest/serialize.property.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert';
+import fc from 'fast-check';
+import { test } from 'mocha';
+import type { PackageJson } from 'type-fest';
+import { serializePackageJson } from './serialize.ts';
+
+type JsonPrimitive = boolean | number | string;
+type JsonValue = JsonPrimitive | readonly JsonValue[] | { readonly [key: string]: JsonValue };
+type PackageJsonLike = Readonly<Record<string, JsonValue>>;
+
+const primitiveArbitrary = fc.oneof(fc.boolean(), fc.integer(), fc.string());
+
+const jsonValueArbitrary = fc.letrec((tie) => {
+    return {
+        value: fc.oneof(
+            primitiveArbitrary,
+            fc.array(tie('value'), { maxLength: 5 }),
+            fc.dictionary(fc.string(), tie('value'), { maxKeys: 5 })
+        )
+    };
+}).value as fc.Arbitrary<JsonValue>;
+
+const packageJsonLikeArbitrary: fc.Arbitrary<PackageJsonLike> = fc.dictionary(fc.string(), jsonValueArbitrary, {
+    maxKeys: 5
+});
+
+function comparePrimitiveValues(left: JsonPrimitive, right: JsonPrimitive): number {
+    if (left < right) {
+        return -1;
+    }
+
+    if (left > right) {
+        return 1;
+    }
+
+    return 0;
+}
+
+function compareKeys(left: string, right: string): number {
+    if (left < right) {
+        return -1;
+    }
+
+    if (left > right) {
+        return 1;
+    }
+
+    return 0;
+}
+
+function canonicalizeValue(value: JsonValue): JsonValue {
+    if (Array.isArray(value)) {
+        return value
+            .map((item) => {
+                return canonicalizeValue(item);
+            })
+            .toSorted((left, right) => {
+                if (
+                    (typeof left === 'string' || typeof left === 'number' || typeof left === 'boolean') &&
+                    (typeof right === 'string' || typeof right === 'number' || typeof right === 'boolean')
+                ) {
+                    return comparePrimitiveValues(left, right);
+                }
+
+                return 0;
+            });
+    }
+
+    if (typeof value === 'object' && value !== null) {
+        return Object.fromEntries(
+            Object.entries(value)
+                .toSorted(([keyA], [keyB]) => {
+                    return compareKeys(keyA, keyB);
+                })
+                .map(([propertyName, propertyValue]) => {
+                    return [propertyName, canonicalizeValue(propertyValue)];
+                })
+        );
+    }
+
+    return value;
+}
+
+test('serializePackageJson() returns valid JSON with recursively sorted object keys', () => {
+    fc.assert(
+        fc.property(packageJsonLikeArbitrary, (value) => {
+            const result = serializePackageJson(value as PackageJson);
+            const parsed = JSON.parse(result) as JsonValue;
+
+            assert.deepStrictEqual(parsed, canonicalizeValue(value));
+        })
+    );
+});
+
+test('serializePackageJson() is stable once a package json has been serialized', () => {
+    fc.assert(
+        fc.property(packageJsonLikeArbitrary, (value) => {
+            const serialized = serializePackageJson(value as PackageJson);
+            const reparsed = JSON.parse(serialized) as PackageJsonLike;
+
+            assert.strictEqual(serializePackageJson(reparsed as PackageJson), serialized);
+        })
+    );
+});

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -17,6 +17,7 @@
     "mutate": [
         "source/**/*.ts",
         "!source/**/*.test.ts",
+        "!source/**/*.property.ts",
         "!source/test-libraries/**/*.ts",
         "!source/packages/**/*.entry-point.ts"
     ],


### PR DESCRIPTION
Add a dedicated fast-check property-test lane, move *.property.ts under the unit-test TypeScript project.

This change also fixes two production issues uncovered by the new properties:
- package-level sourcesFolder and mainPackageJson overrides were not taking precedence over commonPackageSettings in map-config
- malformed gzip/tar input in extract-tar did not consistently fail through a controlled rejected promise path