### PR TITLE
Scope noDuplicatedFiles allow-list entries to specific packages

### DIFF
--- a/integration-tests/fixtures/duplicate-files/src/pkg-c/index.js
+++ b/integration-tests/fixtures/duplicate-files/src/pkg-c/index.js
@@ -1,0 +1,3 @@
+import { sharedValue } from '../shared/util.js';
+
+export const packageCValue = `C:${sharedValue}`;

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -90,3 +90,105 @@ test('resolveAndLinkAll succeeds when duplicated files are allow-listed', async 
 
     assert.strictEqual(result.value.length, 2);
 });
+
+test('resolveAndLinkAll succeeds when a scoped allow-list entry covers all owners of the duplicated file', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const config = {
+        ...baseConfig,
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [
+                    {
+                        filePath: `${fixturePath}/src/shared/util.js`,
+                        packages: ['pkg-a', 'pkg-b']
+                    }
+                ]
+            }
+        }
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isOk) {
+        assert.fail('Scoped allow-list entry covering all owners should not fail checks');
+    }
+
+    assert.strictEqual(result.value.length, 2);
+});
+
+test('resolveAndLinkAll reports the duplicate when an owner is outside the scoped allow-list entry', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const config = {
+        ...baseConfig,
+        packages: [
+            ...baseConfig.packages,
+            {
+                name: 'pkg-c',
+                entryPoints: [{ js: path.join(fixturePath, 'src/pkg-c/index.js') }]
+            }
+        ],
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [
+                    {
+                        filePath: `${fixturePath}/src/shared/util.js`,
+                        packages: ['pkg-a', 'pkg-b']
+                    }
+                ]
+            }
+        }
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected resolveAndLinkAll to fail because pkg-c is outside the scoped allow-list entry');
+        return;
+    }
+
+    if (result.error.type === 'checks') {
+        assert.deepStrictEqual(result.error.issues, [
+            `File "${fixturePath}/src/shared/util.js" is included in multiple packages: pkg-a, pkg-b, pkg-c`
+        ]);
+    } else {
+        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+    }
+});
+
+test('resolveAndLinkAll fails validation when a scoped allow-list entry references an unknown package', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const config = {
+        ...baseConfig,
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [
+                    {
+                        filePath: `${fixturePath}/src/shared/util.js`,
+                        packages: ['pkg-a', 'ghost']
+                    }
+                ]
+            }
+        }
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected validation to fail because of the unknown package reference');
+        return;
+    }
+
+    if (result.error.type === 'config') {
+        assert.deepStrictEqual(result.error.issues, [
+            `Allow list entry for "${fixturePath}/src/shared/util.js" references unknown package "ghost"`
+        ]);
+    } else {
+        assert.fail(`Expected a config failure, but received "${result.error.type}"`);
+    }
+});

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -101,3 +101,68 @@ test('run() ignores the allow list when the rule is disabled', () => {
 
     assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
 });
+
+test('run() suppresses a duplicate when a scoped allow-list entry covers all owners', () => {
+    const result = runNoDuplicatedFilesRule(
+        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
+        {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'shared.ts', packages: ['a', 'b'] }]
+            }
+        }
+    );
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('run() reports a duplicate when a scoped allow-list entry omits one of the actual owners', () => {
+    const result = runNoDuplicatedFilesRule(
+        {
+            bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts'), createBundle('c', 'shared.ts')]
+        },
+        {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'shared.ts', packages: ['a', 'b'] }]
+            }
+        }
+    );
+
+    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b, c']);
+});
+
+test('run() does not match a scoped entry when the file path differs', () => {
+    const result = runNoDuplicatedFilesRule(
+        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
+        {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'other.ts', packages: ['a', 'b'] }]
+            }
+        }
+    );
+
+    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
+});
+
+test('run() supports a mix of plain string and scoped allow-list entries', () => {
+    const result = runNoDuplicatedFilesRule(
+        {
+            bundles: [
+                createBundle('a', 'shared.ts'),
+                createBundle('b', 'shared.ts'),
+                createBundle('c', 'license'),
+                createBundle('d', 'license')
+            ]
+        },
+        {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: ['license', { filePath: 'shared.ts', packages: ['a', 'b'] }]
+            }
+        }
+    );
+
+    assert.deepStrictEqual(result, []);
+});

--- a/source/checks/rules/no-duplicated-files.ts
+++ b/source/checks/rules/no-duplicated-files.ts
@@ -1,5 +1,5 @@
 import type { LinkedBundle } from '../../linker/linked-bundle.ts';
-import type { ChecksSettings } from '../../config/config.ts';
+import type { AllowListEntry, ChecksSettings } from '../../config/config.ts';
 import type { CheckContext } from '../rule.ts';
 
 function collectFileOwnership(bundles: readonly LinkedBundle[]): Map<string, Set<string>> {
@@ -17,14 +17,39 @@ function collectFileOwnership(bundles: readonly LinkedBundle[]): Map<string, Set
     return fileOwnership;
 }
 
-function getAllowList(settings: ChecksSettings | undefined): ReadonlySet<string> {
+function getAllowList(settings: ChecksSettings | undefined): readonly AllowListEntry[] | undefined {
     const option = settings?.noDuplicatedFiles;
 
     if (option?.enabled !== true) {
-        return new Set();
+        return undefined;
     }
 
-    return new Set(option.allowList);
+    return option.allowList;
+}
+
+function isAllowed(
+    filePath: string,
+    owners: ReadonlySet<string>,
+    allowList: readonly AllowListEntry[] | undefined
+): boolean {
+    if (allowList === undefined) {
+        return false;
+    }
+
+    return allowList.some((entry) => {
+        if (typeof entry === 'string') {
+            return entry === filePath;
+        }
+
+        if (entry.filePath !== filePath) {
+            return false;
+        }
+
+        const allowedOwners = new Set(entry.packages);
+        return Array.from(owners).every((owner) => {
+            return allowedOwners.has(owner);
+        });
+    });
 }
 
 export function isNoDuplicatedFilesRuleEnabled(settings: ChecksSettings | undefined): boolean {
@@ -46,7 +71,7 @@ export function runNoDuplicatedFilesRule(
     const allowList = getAllowList(settings);
 
     for (const [filePath, owners] of fileOwnership.entries()) {
-        if (owners.size > 1 && !allowList.has(filePath)) {
+        if (owners.size > 1 && !isAllowed(filePath, owners, allowList)) {
             const ownerList = Array.from(owners)
                 .toSorted((left, right) => {
                     return left.localeCompare(right);

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -94,3 +94,83 @@ test(
         expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
     })
 );
+
+test(
+    'allow list: validation succeeds with a scoped entry naming two packages',
+    checkValidationSuccess({
+        schema: checksSchema,
+        data: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
+            }
+        },
+        expectedData: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
+            }
+        }
+    })
+);
+
+test(
+    'allow list: validation succeeds with a mix of plain string and scoped entries',
+    checkValidationSuccess({
+        schema: checksSchema,
+        data: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: ['LICENSE', { filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
+            }
+        },
+        expectedData: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: ['LICENSE', { filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
+            }
+        }
+    })
+);
+
+test(
+    'allow list: validation fails when a scoped entry has fewer than two packages',
+    checkValidationFailure({
+        schema: checksSchema,
+        data: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a'] }]
+            }
+        },
+        expectedMessages: ['at noDuplicatedFiles.allowList[0].packages: array must contain at least 2 elements']
+    })
+);
+
+test(
+    'allow list: validation fails when a scoped entry omits filePath',
+    checkValidationFailure({
+        schema: checksSchema,
+        data: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ packages: ['a', 'b'] }]
+            }
+        },
+        expectedMessages: ['at noDuplicatedFiles.allowList[0]: invalid value doesn’t match expected union']
+    })
+);
+
+test(
+    'allow list: validation fails when a scoped entry has an unknown extra property',
+    checkValidationFailure({
+        schema: checksSchema,
+        data: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'], extra: true }]
+            }
+        },
+        expectedMessages: ['at noDuplicatedFiles.allowList[0]: invalid value doesn’t match expected union']
+    })
+);

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,9 +1,18 @@
 import { z } from 'zod/mini';
 import { nonEmptyStringSchema } from './base-validations.ts';
 
+const minScopedEntryPackages = 2;
+
+const scopedAllowListEntrySchema = z.strictObject({
+    filePath: nonEmptyStringSchema,
+    packages: z.readonly(z.array(nonEmptyStringSchema).check(z.minLength(minScopedEntryPackages)))
+});
+
+const allowListEntrySchema = z.union([nonEmptyStringSchema, scopedAllowListEntrySchema]);
+
 const noDuplicatedFilesSettingsSchema = z.strictObject({
     enabled: z.boolean(),
-    allowList: z.optional(z.readonly(z.array(nonEmptyStringSchema)))
+    allowList: z.optional(z.readonly(z.array(allowListEntrySchema)))
 });
 
 export const checksSchema = z.strictObject({

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -4,9 +4,16 @@ import type { AdditionalPackageJsonAttributes, MainPackageJson } from './package
 import type { RegistrySettings } from './registry-settings.ts';
 import type { VersioningSettings } from './versioning-settings.ts';
 
+export type ScopedAllowListEntry = {
+    readonly filePath: string;
+    readonly packages: readonly string[];
+};
+
+export type AllowListEntry = ScopedAllowListEntry | string;
+
 export type NoDuplicatedFilesSettings = {
     readonly enabled: boolean;
-    readonly allowList?: readonly string[] | undefined;
+    readonly allowList?: readonly AllowListEntry[] | undefined;
 };
 
 export type ChecksSettings = {

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -200,10 +200,135 @@ test('doesn’t report cyclic dependency issues when there is also a missing dep
     assert.deepStrictEqual(result, Result.err(['Bundle peer dependency "b" referenced in "a" does not exist']));
 });
 
+test('returns an issue when a scoped allow-list entry references an unknown package', () => {
+    const result = validateConfig({
+        registrySettings: { token: 'foo' },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'ghost'] }]
+            }
+        },
+        packages: [
+            { name: 'a', entryPoints: [{ js: 'foo' }] },
+            { name: 'b', entryPoints: [{ js: 'foo' }] }
+        ]
+    });
+
+    assert.deepStrictEqual(
+        result,
+        Result.err(['Allow list entry for "src/shared/util.ts" references unknown package "ghost"'])
+    );
+});
+
+test('returns one issue per unknown package in a scoped allow-list entry', () => {
+    const result = validateConfig({
+        registrySettings: { token: 'foo' },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['ghost', 'phantom'] }]
+            }
+        },
+        packages: [
+            { name: 'a', entryPoints: [{ js: 'foo' }] },
+            { name: 'b', entryPoints: [{ js: 'foo' }] }
+        ]
+    });
+
+    assert.deepStrictEqual(
+        result,
+        Result.err([
+            'Allow list entry for "src/shared/util.ts" references unknown package "ghost"',
+            'Allow list entry for "src/shared/util.ts" references unknown package "phantom"'
+        ])
+    );
+});
+
+test('accepts a config where checks is defined but noDuplicatedFiles is omitted', () => {
+    const result = validateConfig({
+        registrySettings: { token: 'foo' },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: {},
+        packages: [{ name: 'a', entryPoints: [{ js: 'foo' }] }]
+    });
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a config where checks.noDuplicatedFiles is defined without an allowList', () => {
+    const result = validateConfig({
+        registrySettings: { token: 'foo' },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: { noDuplicatedFiles: { enabled: true } },
+        packages: [{ name: 'a', entryPoints: [{ js: 'foo' }] }]
+    });
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('does not report unknown-package issues for plain string allow-list entries', () => {
+    const result = validateConfig({
+        registrySettings: { token: 'foo' },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: ['LICENSE']
+            }
+        },
+        packages: [{ name: 'a', entryPoints: [{ js: 'foo' }] }]
+    });
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a scoped allow-list entry when all referenced packages exist', () => {
+    const result = validateConfig({
+        registrySettings: { token: 'foo' },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
+            }
+        },
+        packages: [
+            { name: 'a', entryPoints: [{ js: 'foo' }] },
+            { name: 'b', entryPoints: [{ js: 'foo' }] }
+        ]
+    });
+
+    assert.strictEqual(result.isOk, true);
+});
+
 test('validateConfigWithoutRegistry() returns schema issues when the config is invalid', () => {
     const result = validateConfigWithoutRegistry({ not: 'valid' });
 
     assert.deepStrictEqual(result, Result.err(['invalid value doesn’t match expected union']));
+});
+
+test('validateConfigWithoutRegistry() returns an issue for unknown packages in a scoped allow-list entry', () => {
+    const result = validateConfigWithoutRegistry({
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        checks: {
+            noDuplicatedFiles: {
+                enabled: true,
+                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'ghost'] }]
+            }
+        },
+        packages: [
+            { name: 'a', entryPoints: [{ js: 'foo' }] },
+            { name: 'b', entryPoints: [{ js: 'foo' }] }
+        ]
+    });
+
+    assert.deepStrictEqual(
+        result,
+        Result.err(['Allow list entry for "src/shared/util.ts" references unknown package "ghost"'])
+    );
 });
 
 test('validateConfigWithoutRegistry() returns duplicate and missing dependency issues', () => {

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -3,6 +3,7 @@ import { safeParse } from '@schema-hub/zod-error-formatter';
 import { type DirectedGraph, createDirectedGraph } from '../directed-graph/graph.ts';
 import {
     getBundledDependencies,
+    type ChecksSettings,
     type PacktoryConfig,
     type PackageConfig,
     type PacktoryConfigWithoutRegistry
@@ -70,6 +71,28 @@ function packageListToMap(packages: readonly PackageConfig[]): Map<string, Packa
     }, new Map<string, PackageConfig>());
 }
 
+function validateNoDuplicatedFilesAllowList(
+    packageConfigs: ReadonlyMap<string, PackageConfig>,
+    checks: ChecksSettings | undefined
+): readonly string[] {
+    const allowList = checks?.noDuplicatedFiles?.allowList;
+    if (allowList === undefined) {
+        return [];
+    }
+    return allowList.flatMap((entry) => {
+        if (typeof entry === 'string') {
+            return [];
+        }
+        return entry.packages
+            .filter((name) => {
+                return !packageConfigs.has(name);
+            })
+            .map((name) => {
+                return `Allow list entry for "${entry.filePath}" references unknown package "${name}"`;
+            });
+    });
+}
+
 function validateDuplicatePackages(packages: readonly PackageConfig[]): readonly string[] {
     const knownPackageNames = new Set<string>();
     const issues: string[] = [];
@@ -113,10 +136,12 @@ function validatePreGraphGeneration(
     const packtoryConfig = schemaValidationResult.data;
     const packageConfigs = packageListToMap(packtoryConfig.packages);
 
-    const missingDependenciesIssues = validateDependenciesExist(packageConfigs);
-    if (missingDependenciesIssues.length > 0) {
-        const issues = Array.from(validateDuplicatePackages(packtoryConfig.packages));
-        return Result.err([...issues, ...missingDependenciesIssues]);
+    const preGraphIssues = [
+        ...validateDependenciesExist(packageConfigs),
+        ...validateNoDuplicatedFilesAllowList(packageConfigs, packtoryConfig.checks)
+    ];
+    if (preGraphIssues.length > 0) {
+        return Result.err([...validateDuplicatePackages(packtoryConfig.packages), ...preGraphIssues]);
     }
 
     return Result.ok({
@@ -137,10 +162,12 @@ function validatePreGraphGenerationWithoutRegistry(
     const packtoryConfig = schemaValidationResult.data;
     const packageConfigs = packageListToMap(packtoryConfig.packages);
 
-    const missingDependenciesIssues = validateDependenciesExist(packageConfigs);
-    if (missingDependenciesIssues.length > 0) {
-        const issues = Array.from(validateDuplicatePackages(packtoryConfig.packages));
-        return Result.err([...issues, ...missingDependenciesIssues]);
+    const preGraphIssues = [
+        ...validateDependenciesExist(packageConfigs),
+        ...validateNoDuplicatedFilesAllowList(packageConfigs, packtoryConfig.checks)
+    ];
+    if (preGraphIssues.length > 0) {
+        return Result.err([...validateDuplicatePackages(packtoryConfig.packages), ...preGraphIssues]);
     }
 
     return Result.ok({


### PR DESCRIPTION
Allow-list entries can now be objects of the form
`{ filePath, packages: [...] }` in addition to plain strings. A scoped entry suppresses a duplicate only when the actual owners of the file are a subset of the listed packages — so an exception narrowed to [pkg-a, pkg-b] still flags the duplicate if pkg-c also pulls the file in. Plain string entries keep their global semantics.

Cross-field validation rejects scoped entries that reference unknown package names so typos fail loudly at config-load time rather than silently disabling the exception.