### PR TITLE
Render multi-spinner from a worker thread

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -6,9 +6,7 @@
         "source/**/*.test.ts",
         "source/**/*.property.ts",
         "source/test-libraries/**/*.ts",
-        "source/packages/command-line-interface/command-line-interface.entry-point.ts",
-        "source/packages/package-processor/package-processor.entry-point.ts",
-        "source/packages/packtory/packtory.entry-point.ts",
+        "source/**/*.entry-point.ts",
         "integration-tests/**",
         "target/**"
     ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
             - name: Install dependencies
               run: npm clean-install
             - name: Run benchmarks
-              run: npx just benchmark || true
+              run: npx just benchmark

--- a/benchmarks/benchmark-types.ts
+++ b/benchmarks/benchmark-types.ts
@@ -69,4 +69,7 @@ export type CliResponsivenessMeasurement = TinybenchMeasurement & {
     readonly frameCount: number;
     readonly p99FrameGapMs: number;
     readonly maxFrameGapMs: number;
+    readonly eventLoopHistogramP99Ms: number;
+    readonly eventLoopHistogramMaxMs: number;
+    readonly eventLoopSampledMaxBlockMs: number;
 };

--- a/benchmarks/cli-event-loop-probe.ts
+++ b/benchmarks/cli-event-loop-probe.ts
@@ -1,0 +1,56 @@
+import { writeFileSync } from 'node:fs';
+import { monitorEventLoopDelay, performance as performanceTimer } from 'node:perf_hooks';
+import { setInterval as scheduleInterval, clearInterval as cancelInterval } from 'node:timers';
+
+const histogramResolutionMs = 5;
+const fineSamplerIntervalMs = 5;
+const minimumReportableBlockMs = 50;
+const nanosecondsPerMillisecond = 1e6;
+const histogramP50 = 50;
+const histogramP90 = 90;
+const histogramP99 = 99;
+const fixedDecimals = 2;
+
+// eslint-disable-next-line node/no-process-env -- the probe runs in a CLI subprocess and uses an env var as its only configuration channel
+const outputPath = process.env.PACKTORY_BENCH_EVENT_LOOP_PROBE_OUTPUT;
+
+if (outputPath !== undefined && outputPath !== '') {
+    const histogram = monitorEventLoopDelay({ resolution: histogramResolutionMs });
+    histogram.enable();
+
+    const blocks: { readonly atMs: number; readonly gapMs: number }[] = [];
+    let lastTickAt = performanceTimer.now();
+    const fineSampler = scheduleInterval(() => {
+        const now = performanceTimer.now();
+        const gap = now - lastTickAt;
+        if (gap > minimumReportableBlockMs) {
+            blocks.push({ atMs: Math.round(now), gapMs: Math.round(gap) });
+        }
+        lastTickAt = now;
+    }, fineSamplerIntervalMs);
+    fineSampler.unref();
+
+    process.on('exit', () => {
+        cancelInterval(fineSampler);
+        histogram.disable();
+
+        const ms = (nanoseconds: number): number => {
+            return Number((nanoseconds / nanosecondsPerMillisecond).toFixed(fixedDecimals));
+        };
+
+        const payload = {
+            histogram: {
+                min: ms(histogram.min),
+                mean: ms(histogram.mean),
+                p50: ms(histogram.percentile(histogramP50)),
+                p90: ms(histogram.percentile(histogramP90)),
+                p99: ms(histogram.percentile(histogramP99)),
+                max: ms(histogram.max)
+            },
+            sampledBlocks: blocks
+        };
+
+        // eslint-disable-next-line node/no-sync -- exit handlers must be synchronous
+        writeFileSync(outputPath, JSON.stringify(payload));
+    });
+}

--- a/benchmarks/cli-publish-process.ts
+++ b/benchmarks/cli-publish-process.ts
@@ -1,8 +1,10 @@
 import path from 'node:path';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { performance as currentPerformance } from 'node:perf_hooks';
 import * as nodePty from 'node-pty';
-import { createFrameRecorder, type FrameRecorder } from './cli-spinner-metrics.ts';
+import { createFrameRecorder, type FrameRecorder, type FrameRecorderResult } from './cli-spinner-metrics.ts';
 
 const cliColumns = 120;
 const cliRows = 40;
@@ -12,9 +14,83 @@ const cliEntryPointPath = path.join(
     process.cwd(),
     'source/packages/command-line-interface/command-line-interface.entry-point.ts'
 );
+const eventLoopProbePath = path.join(process.cwd(), 'benchmarks/cli-event-loop-probe.ts');
+
+export type EventLoopProbeReport = {
+    readonly histogram: {
+        readonly min: number;
+        readonly mean: number;
+        readonly p50: number;
+        readonly p90: number;
+        readonly p99: number;
+        readonly max: number;
+    };
+    readonly sampledBlocks: readonly { readonly atMs: number; readonly gapMs: number }[];
+};
+
+export type CliPublishMeasurement = FrameRecorderResult & {
+    readonly runtimeMs: number;
+    readonly eventLoopReport: EventLoopProbeReport | undefined;
+};
+
+type CliExitEvent = {
+    readonly exitCode: number;
+    readonly signal?: number;
+};
 
 function getErrorCode(error: unknown): unknown {
     return typeof error === 'object' && error !== null ? Reflect.get(error, 'code') : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function readNumberField(record: Record<string, unknown>, fieldName: string): number {
+    const value = record[fieldName];
+    if (typeof value !== 'number') {
+        throw new TypeError(`Expected event-loop probe field "${fieldName}" to be a number`);
+    }
+    return value;
+}
+
+function parseHistogram(value: unknown): EventLoopProbeReport['histogram'] {
+    if (!isRecord(value)) {
+        throw new TypeError('Event-loop probe histogram must be an object');
+    }
+
+    return {
+        min: readNumberField(value, 'min'),
+        mean: readNumberField(value, 'mean'),
+        p50: readNumberField(value, 'p50'),
+        p90: readNumberField(value, 'p90'),
+        p99: readNumberField(value, 'p99'),
+        max: readNumberField(value, 'max')
+    };
+}
+
+function parseSampledBlocks(value: unknown): EventLoopProbeReport['sampledBlocks'] {
+    if (!Array.isArray(value)) {
+        throw new TypeError('Event-loop probe sampledBlocks must be an array');
+    }
+
+    return value.map((entry: unknown) => {
+        if (!isRecord(entry)) {
+            throw new TypeError('Event-loop probe sampled block must be an object');
+        }
+        return { atMs: readNumberField(entry, 'atMs'), gapMs: readNumberField(entry, 'gapMs') };
+    });
+}
+
+function parseEventLoopProbeReport(value: unknown): EventLoopProbeReport {
+    if (!isRecord(value)) {
+        throw new TypeError('Event-loop probe report must be an object');
+    }
+
+    return {
+        histogram: parseHistogram(value.histogram),
+        sampledBlocks: parseSampledBlocks(value.sampledBlocks)
+    };
 }
 
 export async function ensureNodePtyHelperIsExecutable(): Promise<void> {
@@ -34,57 +110,101 @@ export async function ensureNodePtyHelperIsExecutable(): Promise<void> {
     }
 }
 
+async function readEventLoopProbeReport(probeOutputPath: string): Promise<EventLoopProbeReport | undefined> {
+    try {
+        const raw = await fs.readFile(probeOutputPath, 'utf8');
+        await fs.rm(probeOutputPath, { force: true });
+        return parseEventLoopProbeReport(JSON.parse(raw));
+    } catch (error: unknown) {
+        if (getErrorCode(error) === 'ENOENT') {
+            return undefined;
+        }
+        throw error;
+    }
+}
+
+function spawnCliPublish(workingDirectory: string, probeOutputPath: string): nodePty.IPty {
+    return nodePty.spawn(
+        process.execPath,
+        [
+            '--experimental-strip-types',
+            '--enable-source-maps',
+            '--import',
+            eventLoopProbePath,
+            cliEntryPointPath,
+            'publish'
+        ],
+        {
+            cols: cliColumns,
+            rows: cliRows,
+            cwd: workingDirectory,
+            name: 'xterm-color',
+            // eslint-disable-next-line node/no-process-env -- the spawned subprocess inherits environment variables and additionally needs the probe output path
+            env: { ...process.env, PACKTORY_BENCH_EVENT_LOOP_PROBE_OUTPUT: probeOutputPath }
+        }
+    );
+}
+
+async function waitForCliExit(pty: nodePty.IPty): Promise<CliExitEvent> {
+    return new Promise<CliExitEvent>((resolve) => {
+        pty.onExit((event) => {
+            resolve(event);
+        });
+    });
+}
+
+function buildFailureError(event: CliExitEvent, outputChunks: readonly string[]): Error {
+    const outputTail = outputChunks.join('').slice(-cliOutputTailLength);
+    const failureMessage = [
+        `CLI benchmark failed with exit code ${event.exitCode},`,
+        `signal ${event.signal ?? 'none'}.`,
+        outputTail
+    ].join(' ');
+    return new Error(failureMessage);
+}
+
+type CliRunContext = {
+    readonly probeOutputPath: string;
+    readonly outputChunks: string[];
+    readonly frameRecorder: FrameRecorder;
+    readonly startedAt: number;
+    readonly pty: nodePty.IPty;
+};
+
+function startCliRun(workingDirectory: string, packageNames: readonly string[]): CliRunContext {
+    const probeOutputPath = path.join(os.tmpdir(), `packtory-bench-event-loop-${randomUUID()}.json`);
+    const outputChunks: string[] = [];
+    const frameRecorder: FrameRecorder = createFrameRecorder(packageNames);
+    const startedAt = currentPerformance.now();
+    const pty = spawnCliPublish(workingDirectory, probeOutputPath);
+
+    pty.onData((data) => {
+        outputChunks.push(data);
+        frameRecorder.recordWrite(data);
+    });
+
+    return { probeOutputPath, outputChunks, frameRecorder, startedAt, pty };
+}
+
 export async function runCliPublish(
     workingDirectory: string,
     packageNames: readonly string[]
-): Promise<{
-    runtimeMs: number;
-    allFrameGapTimestamps: readonly number[];
-    perPackageFrameGapTimestamps: ReadonlyMap<string, readonly number[]>;
-    frameCount: number;
-}> {
-    return new Promise((resolve, reject) => {
-        const outputChunks: string[] = [];
-        const frameRecorder: FrameRecorder = createFrameRecorder(packageNames);
-        const startedAt = currentPerformance.now();
-        const pty = nodePty.spawn(
-            process.execPath,
-            ['--experimental-strip-types', '--enable-source-maps', cliEntryPointPath, 'publish'],
-            {
-                cols: cliColumns,
-                rows: cliRows,
-                cwd: workingDirectory,
-                name: 'xterm-color'
-            }
-        );
+): Promise<CliPublishMeasurement> {
+    const context = startCliRun(workingDirectory, packageNames);
+    const exitEvent = await waitForCliExit(context.pty);
+    const recordedFrames = await context.frameRecorder.finish();
+    const runtimeMs = currentPerformance.now() - context.startedAt;
+    const eventLoopReport = await readEventLoopProbeReport(context.probeOutputPath);
 
-        pty.onData((data) => {
-            outputChunks.push(data);
-            frameRecorder.recordWrite(data);
-        });
+    if (exitEvent.exitCode !== 0) {
+        throw buildFailureError(exitEvent, context.outputChunks);
+    }
 
-        pty.onExit(async (event) => {
-            const recordedFrames = await frameRecorder.finish();
-            const runtimeMs = currentPerformance.now() - startedAt;
-            const outputTail = outputChunks.join('').slice(-cliOutputTailLength);
-
-            if (event.exitCode !== 0) {
-                const failureMessage = [
-                    `CLI benchmark failed with exit code ${event.exitCode},`,
-                    `signal ${event.signal ?? 'none'}.`,
-                    outputTail
-                ].join(' ');
-
-                reject(new Error(failureMessage));
-                return;
-            }
-
-            resolve({
-                runtimeMs,
-                allFrameGapTimestamps: recordedFrames.allFrameGapTimestamps,
-                perPackageFrameGapTimestamps: recordedFrames.perPackageFrameGapTimestamps,
-                frameCount: recordedFrames.allFrameGapTimestamps.length
-            });
-        });
-    });
+    return {
+        runtimeMs,
+        allFrameGaps: recordedFrames.allFrameGaps,
+        perPackageFrameGaps: recordedFrames.perPackageFrameGaps,
+        frameCount: recordedFrames.frameCount,
+        eventLoopReport
+    };
 }

--- a/benchmarks/cli-responsiveness.benchmark.ts
+++ b/benchmarks/cli-responsiveness.benchmark.ts
@@ -6,10 +6,21 @@ import { createTemporaryDirectory, removeDirectory } from './benchmark-filesyste
 import { startBenchmarkRegistry } from './benchmark-registry.ts';
 import { generateCliWorkload } from './generate-workload.ts';
 import { measureAsyncTask } from './tinybench-measurement.ts';
-import { calculateFrameGaps, collectWorstPerPackageGapMetrics } from './cli-spinner-metrics.ts';
-import { ensureNodePtyHelperIsExecutable, runCliPublish } from './cli-publish-process.ts';
+import { summarizeWorstPerPackageGaps } from './cli-spinner-metrics.ts';
+import {
+    ensureNodePtyHelperIsExecutable,
+    runCliPublish,
+    type CliPublishMeasurement,
+    type EventLoopProbeReport
+} from './cli-publish-process.ts';
 
-function createMeasuredFrameTimestampMap(packageNames: readonly string[]): Map<string, number[]> {
+type EventLoopAggregate = {
+    readonly histogramP99Ms: number;
+    readonly histogramMaxMs: number;
+    readonly sampledMaxBlockMs: number;
+};
+
+function createPerPackageGapAccumulator(packageNames: readonly string[]): Map<string, number[]> {
     return new Map(
         packageNames.map((packageName) => {
             return [packageName, [] as number[]] as const;
@@ -17,17 +28,41 @@ function createMeasuredFrameTimestampMap(packageNames: readonly string[]): Map<s
     );
 }
 
-function recordMeasuredFrames(
-    measuredPerPackageFrameTimestamps: Map<string, number[]>,
-    measurement: Awaited<ReturnType<typeof runCliPublish>>
+function appendPerPackageGaps(
+    accumulator: Map<string, number[]>,
+    perRunGaps: ReadonlyMap<string, readonly number[]>
 ): void {
-    measurement.perPackageFrameGapTimestamps.forEach((timestamps, packageName) => {
-        const packageTimestamps = measuredPerPackageFrameTimestamps.get(packageName);
+    perRunGaps.forEach((gaps, packageName) => {
+        const target = accumulator.get(packageName);
 
-        if (packageTimestamps !== undefined) {
-            packageTimestamps.push(...timestamps);
+        if (target !== undefined) {
+            target.push(...gaps);
         }
     });
+}
+
+function recordEventLoopReport(reports: EventLoopProbeReport[], report: EventLoopProbeReport | undefined): void {
+    if (report === undefined) {
+        return;
+    }
+    reports.push(report);
+}
+
+function aggregateEventLoopReports(reports: readonly EventLoopProbeReport[]): EventLoopAggregate {
+    let histogramP99Ms = 0;
+    let histogramMaxMs = 0;
+    let sampledMaxBlockMs = 0;
+
+    for (const report of reports) {
+        histogramP99Ms = Math.max(histogramP99Ms, report.histogram.p99);
+        histogramMaxMs = Math.max(histogramMaxMs, report.histogram.max);
+
+        for (const block of report.sampledBlocks) {
+            sampledMaxBlockMs = Math.max(sampledMaxBlockMs, block.gapMs);
+        }
+    }
+
+    return { histogramP99Ms, histogramMaxMs, sampledMaxBlockMs };
 }
 
 async function writeBenchmarkConfig(rootDirectory: string, configModuleText: string): Promise<void> {
@@ -52,27 +87,35 @@ async function measureCliResponsiveness(
     readonly frameCount: number;
     readonly p99FrameGapMs: number;
     readonly maxFrameGapMs: number;
+    readonly eventLoop: EventLoopAggregate;
     readonly result: Awaited<ReturnType<typeof measureAsyncTask>>;
 }> {
-    const measuredFrameGaps: number[] = [];
-    const measuredPerPackageFrameTimestamps = createMeasuredFrameTimestampMap(packageNames);
-    let latestFrameCount = 0;
-    const result = await measureAsyncTask(`publish-cli:${size}`, async () => {
-        const measurement = await runCliPublish(rootDirectory, packageNames);
+    const perPackageFrameGaps = createPerPackageGapAccumulator(packageNames);
+    const eventLoopReports: EventLoopProbeReport[] = [];
+    let totalFrameCount = 0;
+    let observedAnyGap = false;
 
-        measuredFrameGaps.push(...calculateFrameGaps(measurement.allFrameGapTimestamps));
-        recordMeasuredFrames(measuredPerPackageFrameTimestamps, measurement);
-        latestFrameCount = measurement.frameCount;
+    const result = await measureAsyncTask(`publish-cli:${size}`, async () => {
+        const measurement: CliPublishMeasurement = await runCliPublish(rootDirectory, packageNames);
+
+        if (measurement.allFrameGaps.length > 0) {
+            observedAnyGap = true;
+        }
+        appendPerPackageGaps(perPackageFrameGaps, measurement.perPackageFrameGaps);
+        totalFrameCount += measurement.frameCount;
+        recordEventLoopReport(eventLoopReports, measurement.eventLoopReport);
     });
 
-    assert.ok(measuredFrameGaps.length > 0, `CLI benchmark for "${size}" did not record any frame gaps`);
+    assert.ok(observedAnyGap, `CLI benchmark for "${size}" did not record any frame gaps`);
 
-    const worstPerPackageGaps = collectWorstPerPackageGapMetrics(measuredPerPackageFrameTimestamps);
+    const worstPerPackageGaps = summarizeWorstPerPackageGaps(perPackageFrameGaps);
+    const eventLoop = aggregateEventLoopReports(eventLoopReports);
 
     return {
-        frameCount: latestFrameCount,
+        frameCount: totalFrameCount,
         p99FrameGapMs: worstPerPackageGaps.p99FrameGapMs,
         maxFrameGapMs: worstPerPackageGaps.maxFrameGapMs,
+        eventLoop,
         result
     };
 }
@@ -95,6 +138,9 @@ export async function runCliResponsivenessBenchmark(
             frameCount: measurement.frameCount,
             p99FrameGapMs: measurement.p99FrameGapMs,
             maxFrameGapMs: measurement.maxFrameGapMs,
+            eventLoopHistogramP99Ms: measurement.eventLoop.histogramP99Ms,
+            eventLoopHistogramMaxMs: measurement.eventLoop.histogramMaxMs,
+            eventLoopSampledMaxBlockMs: measurement.eventLoop.sampledMaxBlockMs,
             ...measurement.result
         };
     } finally {

--- a/benchmarks/cli-spinner-metrics.ts
+++ b/benchmarks/cli-spinner-metrics.ts
@@ -8,12 +8,15 @@ const spinnerFrames = new Set(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', 
 const packageNameCaptureIndex = 2;
 const spinnerGlyphCaptureIndex = 1;
 
+export type FrameRecorderResult = {
+    readonly allFrameGaps: readonly number[];
+    readonly perPackageFrameGaps: ReadonlyMap<string, readonly number[]>;
+    readonly frameCount: number;
+};
+
 export type FrameRecorder = {
     recordWrite: (data: string) => void;
-    finish: () => Promise<{
-        readonly allFrameGapTimestamps: readonly number[];
-        readonly perPackageFrameGapTimestamps: ReadonlyMap<string, readonly number[]>;
-    }>;
+    finish: () => Promise<FrameRecorderResult>;
 };
 
 function escapePackageName(packageName: string): string {
@@ -78,39 +81,63 @@ function collectSpinnerFramePackages(
     return matchedSpinnerLine;
 }
 
-function flushPendingPackages(
-    allFrameGapTimestamps: number[],
-    perPackageFrameGapTimestamps: Map<string, number[]>,
-    pendingFramePackages: Set<string>
-): void {
-    const timestamp = currentPerformance.now();
+type FrameRecorderState = {
+    readonly allFrameGaps: number[];
+    readonly perPackageFrameGaps: Map<string, number[]>;
+    readonly lastTimestampByPackage: Map<string, number>;
+    readonly previousGlyphByPackage: Map<string, string>;
+    readonly pendingFramePackages: Set<string>;
+    readonly spinnerLinePattern: RegExp;
+    lastFlushAtMs: number | undefined;
+    pendingFlush: boolean;
+    frameCount: number;
+};
 
-    if (pendingFramePackages.size === 0) {
-        return;
-    }
-
-    allFrameGapTimestamps.push(timestamp);
-    pendingFramePackages.forEach((packageName) => {
-        const packageTimestamps = perPackageFrameGapTimestamps.get(packageName);
-
-        if (packageTimestamps !== undefined) {
-            packageTimestamps.push(timestamp);
-        }
-    });
-    pendingFramePackages.clear();
+function createFrameRecorderState(packageNames: readonly string[]): FrameRecorderState {
+    return {
+        allFrameGaps: [],
+        perPackageFrameGaps: new Map(
+            packageNames.map((packageName) => {
+                return [packageName, [] as number[]] as const;
+            })
+        ),
+        lastTimestampByPackage: new Map<string, number>(),
+        previousGlyphByPackage: new Map<string, string>(),
+        pendingFramePackages: new Set<string>(),
+        spinnerLinePattern: createSpinnerLinePattern(packageNames),
+        lastFlushAtMs: undefined,
+        pendingFlush: false,
+        frameCount: 0
+    };
 }
 
 export function createFrameRecorder(packageNames: readonly string[]): FrameRecorder {
-    const allFrameGapTimestamps: number[] = [];
-    const perPackageFrameGapTimestamps = new Map(
-        packageNames.map((packageName) => {
-            return [packageName, [] as number[]] as const;
-        })
-    );
-    const previousGlyphByPackage = new Map<string, string>();
-    const pendingFramePackages = new Set<string>();
-    const spinnerLinePattern = createSpinnerLinePattern(packageNames);
-    let pendingFlush = false;
+    const state = createFrameRecorderState(packageNames);
+
+    function flushPending(): void {
+        if (state.pendingFramePackages.size === 0) {
+            return;
+        }
+
+        const timestamp = currentPerformance.now();
+
+        if (state.lastFlushAtMs !== undefined) {
+            state.allFrameGaps.push(timestamp - state.lastFlushAtMs);
+        }
+        state.lastFlushAtMs = timestamp;
+        state.frameCount += 1;
+
+        state.pendingFramePackages.forEach((packageName) => {
+            const gaps = state.perPackageFrameGaps.get(packageName);
+            const previous = state.lastTimestampByPackage.get(packageName);
+
+            if (gaps !== undefined && previous !== undefined) {
+                gaps.push(timestamp - previous);
+            }
+            state.lastTimestampByPackage.set(packageName, timestamp);
+        });
+        state.pendingFramePackages.clear();
+    }
 
     return {
         recordWrite(data) {
@@ -121,64 +148,49 @@ export function createFrameRecorder(packageNames: readonly string[]): FrameRecor
 
             const matchedSpinnerLine = collectSpinnerFramePackages(
                 visibleText,
-                spinnerLinePattern,
-                previousGlyphByPackage,
-                pendingFramePackages
+                state.spinnerLinePattern,
+                state.previousGlyphByPackage,
+                state.pendingFramePackages
             );
 
-            if (!matchedSpinnerLine || pendingFlush) {
+            if (!matchedSpinnerLine || state.pendingFlush) {
                 return;
             }
 
-            pendingFlush = true;
+            state.pendingFlush = true;
             scheduleImmediate(() => {
-                flushPendingPackages(allFrameGapTimestamps, perPackageFrameGapTimestamps, pendingFramePackages);
-                pendingFlush = false;
+                flushPending();
+                state.pendingFlush = false;
             });
         },
         async finish() {
-            if (pendingFlush) {
+            if (state.pendingFlush) {
                 await new Promise<void>((resolve) => {
                     scheduleImmediate(resolve);
                 });
             }
 
             return {
-                allFrameGapTimestamps,
-                perPackageFrameGapTimestamps
+                allFrameGaps: state.allFrameGaps,
+                perPackageFrameGaps: state.perPackageFrameGaps,
+                frameCount: state.frameCount
             };
         }
     };
 }
 
-export function calculateFrameGaps(timestamps: readonly number[]): readonly number[] {
-    const frameGaps: number[] = [];
-
-    for (let index = 1; index < timestamps.length; index += 1) {
-        const currentTimestamp = timestamps[index];
-        const previousTimestamp = timestamps[index - 1];
-
-        assert.ok(
-            currentTimestamp !== undefined && previousTimestamp !== undefined,
-            `Expected timestamps for frame gap index ${index}`
-        );
-        frameGaps.push(currentTimestamp - previousTimestamp);
-    }
-
-    return frameGaps;
-}
-
-export function collectWorstPerPackageGapMetrics(
-    perPackageFrameGapTimestamps: ReadonlyMap<string, readonly number[]>
-): {
+export type WorstPerPackageGapMetrics = {
     readonly p99FrameGapMs: number;
     readonly maxFrameGapMs: number;
-} {
+};
+
+export function summarizeWorstPerPackageGaps(
+    perPackageFrameGaps: ReadonlyMap<string, readonly number[]>
+): WorstPerPackageGapMetrics {
     let worstP99FrameGapMs = 0;
     let worstMaxFrameGapMs = 0;
 
-    perPackageFrameGapTimestamps.forEach((timestamps) => {
-        const gaps = calculateFrameGaps(timestamps);
+    perPackageFrameGaps.forEach((gaps) => {
         if (gaps.length === 0) {
             return;
         }

--- a/benchmarks/run-benchmarks.ts
+++ b/benchmarks/run-benchmarks.ts
@@ -42,6 +42,9 @@ function formatCliRow(measurement: CliResponsivenessMeasurement): string {
         `median ${formatMilliseconds(measurement.medianMs)}`,
         `p99 gap ${formatMilliseconds(measurement.p99FrameGapMs)}`,
         `max gap ${formatMilliseconds(measurement.maxFrameGapMs)}`,
+        `loop p99 ${formatMilliseconds(measurement.eventLoopHistogramP99Ms)}`,
+        `loop max ${formatMilliseconds(measurement.eventLoopHistogramMaxMs)}`,
+        `loop block ${formatMilliseconds(measurement.eventLoopSampledMaxBlockMs)}`,
         `frames ${measurement.frameCount}`,
         `samples ${measurement.sampleCount}`
     ].join(' ');

--- a/benchmarks/thresholds.json
+++ b/benchmarks/thresholds.json
@@ -17,8 +17,8 @@
     "responsiveness": {
         "publish-cli": {
             "intervalMs": 80,
-            "medium": { "p99Ms": 240, "maxMs": 480 },
-            "large": { "p99Ms": 240, "maxMs": 480 }
+            "medium": { "p99Ms": 120, "maxMs": 200 },
+            "large": { "p99Ms": 120, "maxMs": 200 }
         }
     }
 }

--- a/dependency-cruiser.config.js
+++ b/dependency-cruiser.config.js
@@ -5,7 +5,7 @@ const configFiles = [
     '^packtory\\.config\\.js$'
 ];
 
-const entryPointFiles = ['^source/packages/.+/.+\\.entry-point\\.ts$'];
+const entryPointFiles = ['^source/.+/.+\\.entry-point\\.ts$'];
 
 const testFiles = ['\\.(test|property)\\.ts$', '^integration-tests/'];
 const testLibraryFiles = ['^source/test-libraries/'];

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,7 @@
     "exclude": ["types"],
     "entry": [
         "benchmarks/**/*.ts",
-        "source/packages/**/*.entry-point.ts!",
+        "source/**/*.entry-point.ts!",
         "source/**/*.test.ts",
         "source/**/*.property.ts",
         "integration-tests/**/*.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
             "license": "MIT",
             "dependencies": {
                 "@schema-hub/zod-error-formatter": "0.0.11",
-                "@topcli/spinner": "4.2.1",
                 "@ts-morph/common": "0.29.0",
                 "@types/common-tags": "1.8.4",
                 "@types/libnpmpublish": "9.0.1",
@@ -2836,9 +2835,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2856,9 +2852,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2876,9 +2869,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2896,9 +2886,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2916,9 +2903,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2936,9 +2920,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2956,9 +2937,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2976,9 +2954,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3191,9 +3166,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3208,9 +3180,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3225,9 +3194,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3242,9 +3208,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3259,9 +3222,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3276,9 +3236,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3293,9 +3250,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3310,9 +3264,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3770,18 +3721,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@topcli/spinner": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@topcli/spinner/-/spinner-4.2.1.tgz",
-            "integrity": "sha512-JY+3i4ZFunrSazc6UnJfWiuTF8L357+m052Xq093H0l9w5WLZ/JTtmJZVHBi3Lptvv/X4C2u6x7r6rDJaE4BSw==",
-            "license": "MIT",
-            "dependencies": {
-                "cli-spinners": "3.4.0"
-            },
-            "engines": {
-                "node": ">=22"
             }
         },
         "node_modules/@ts-morph/common": {
@@ -4409,9 +4348,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4426,9 +4362,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4443,9 +4376,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4460,9 +4390,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4477,9 +4404,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4494,9 +4418,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4511,9 +4432,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4528,9 +4446,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6201,18 +6116,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-spinners": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
-            "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     },
     "dependencies": {
         "@schema-hub/zod-error-formatter": "0.0.11",
-        "@topcli/spinner": "4.2.1",
         "@ts-morph/common": "0.29.0",
         "@types/common-tags": "1.8.4",
         "@types/libnpmpublish": "9.0.1",

--- a/source/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/command-line-interface/spinner-boot.entry-point.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Worker as WorkerThread } from 'node:worker_threads';
+import { bootSpinnerRuntime } from './spinner-boot.ts';
+import type { SpinnerRuntime, WorkerSpawnRequest } from './spinner-worker-backend.ts';
+
+const workerModulePath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'spinner-worker.entry-point.ts');
+
+function spawnWorker(request: WorkerSpawnRequest): void {
+    const worker = new WorkerThread(workerModulePath, {
+        workerData: {
+            buffer: request.buffer,
+            slotCount: request.slotCount,
+            stdoutFileDescriptor: request.stdoutFileDescriptor
+        },
+        execArgv: ['--experimental-strip-types', '--enable-source-maps']
+    });
+    worker.unref();
+}
+
+export const bootedSpinnerRuntime: SpinnerRuntime = bootSpinnerRuntime({
+    spawnWorker,
+    initialLabel: 'packtory',
+    initialMessage: 'Starting …'
+});

--- a/source/command-line-interface/spinner-boot.test.ts
+++ b/source/command-line-interface/spinner-boot.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import { fake } from 'sinon';
+import { bootSpinnerRuntime } from './spinner-boot.ts';
+import type { WorkerSpawnRequest } from './spinner-worker-backend.ts';
+
+test('bootSpinnerRuntime spawns the worker via the supplied spawn function', () => {
+    const spawnWorker = fake();
+
+    bootSpinnerRuntime({
+        spawnWorker: (request) => {
+            spawnWorker(request);
+        },
+        initialLabel: 'lbl',
+        initialMessage: 'msg'
+    });
+
+    assert.strictEqual(spawnWorker.callCount, 1);
+    const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
+    assert.ok(request.buffer instanceof SharedArrayBuffer);
+    assert.strictEqual(typeof request.slotCount, 'number');
+});
+
+test('bootSpinnerRuntime writes the initial label and message to slot zero', () => {
+    const runtime = bootSpinnerRuntime({
+        spawnWorker: () => {
+            // noop
+        },
+        initialLabel: 'packtory',
+        initialMessage: 'Starting …'
+    });
+
+    assert.deepStrictEqual(runtime.accessors.readSlot(0), {
+        state: 'running',
+        label: 'packtory',
+        message: 'Starting …'
+    });
+});
+
+test('bootSpinnerRuntime bumps the generation of slot zero so workers pick the boot up immediately', () => {
+    const runtime = bootSpinnerRuntime({
+        spawnWorker: () => {
+            // noop
+        },
+        initialLabel: 'lbl',
+        initialMessage: 'msg'
+    });
+
+    assert.strictEqual(runtime.accessors.readSlotGeneration(0), 1);
+});
+
+test('bootSpinnerRuntime leaves all other slots empty and at generation zero', () => {
+    const runtime = bootSpinnerRuntime({
+        slotCount: 4,
+        spawnWorker: () => {
+            // noop
+        },
+        initialLabel: 'lbl',
+        initialMessage: 'msg'
+    });
+
+    for (const slotIndex of [1, 2, 3]) {
+        assert.deepStrictEqual(runtime.accessors.readSlot(slotIndex), {
+            state: 'empty',
+            label: '',
+            message: ''
+        });
+        assert.strictEqual(runtime.accessors.readSlotGeneration(slotIndex), 0);
+    }
+});
+
+test('bootSpinnerRuntime forwards runtime options like intervalMs and stdoutColumns', () => {
+    const runtime = bootSpinnerRuntime({
+        intervalMs: 25,
+        stdoutColumns: 132,
+        spawnWorker: () => {
+            // noop
+        },
+        initialLabel: 'lbl',
+        initialMessage: 'msg'
+    });
+
+    assert.strictEqual(runtime.accessors.getIntervalMs(), 25);
+    assert.strictEqual(runtime.accessors.getColumns(), 132);
+});

--- a/source/command-line-interface/spinner-boot.ts
+++ b/source/command-line-interface/spinner-boot.ts
@@ -1,0 +1,15 @@
+import { createSpinnerRuntime, type SpinnerRuntime, type SpinnerRuntimeOptions } from './spinner-worker-backend.ts';
+
+const bootSlotIndex = 0;
+
+export type SpinnerBootOptions = SpinnerRuntimeOptions & {
+    readonly initialLabel: string;
+    readonly initialMessage: string;
+};
+
+export function bootSpinnerRuntime(options: SpinnerBootOptions): SpinnerRuntime {
+    const runtime = createSpinnerRuntime(options);
+    runtime.accessors.writeSlot(bootSlotIndex, 'running', options.initialLabel, options.initialMessage);
+    runtime.accessors.bumpSlotGeneration(bootSlotIndex);
+    return runtime;
+}

--- a/source/command-line-interface/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner-shared-state.test.ts
@@ -1,0 +1,243 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import {
+    createSpinnerSharedAccessors,
+    createSpinnerSharedLayout,
+    type SpinnerSharedAccessors
+} from './spinner-shared-state.ts';
+
+function createAccessors(slotCount = 4): SpinnerSharedAccessors {
+    const layout = createSpinnerSharedLayout(slotCount);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+    return createSpinnerSharedAccessors(buffer, layout);
+}
+
+test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', () => {
+    const layout = createSpinnerSharedLayout(2);
+
+    assert.strictEqual(layout.slotCount, 2);
+    assert.strictEqual(layout.headerByteLength, 16);
+    assert.strictEqual(layout.slotByteLength, 384);
+    assert.strictEqual(layout.bufferByteLength, 16 + 2 * 384);
+    assert.strictEqual(layout.maxLabelByteLength, 64);
+    assert.strictEqual(layout.maxMessageByteLength, 256);
+});
+
+test('setColumns and getColumns round-trip the value', () => {
+    const accessors = createAccessors();
+
+    accessors.setColumns(120);
+
+    assert.strictEqual(accessors.getColumns(), 120);
+});
+
+test('setIntervalMs and getIntervalMs round-trip the value', () => {
+    const accessors = createAccessors();
+
+    accessors.setIntervalMs(50);
+
+    assert.strictEqual(accessors.getIntervalMs(), 50);
+});
+
+test('isShutdownRequested returns false until requestShutdown is called', () => {
+    const accessors = createAccessors();
+
+    assert.strictEqual(accessors.isShutdownRequested(), false);
+    accessors.requestShutdown();
+    assert.strictEqual(accessors.isShutdownRequested(), true);
+});
+
+test('writeSlot stores state, label and message readable via readSlot', () => {
+    const accessors = createAccessors();
+
+    accessors.writeSlot(1, 'running', 'label-one', 'message-one');
+
+    assert.deepStrictEqual(accessors.readSlot(1), {
+        state: 'running',
+        label: 'label-one',
+        message: 'message-one'
+    });
+});
+
+test('writeSlot handles each declared slot state', () => {
+    const accessors = createAccessors();
+
+    for (const state of ['running', 'succeeded', 'failed', 'canceled', 'empty'] as const) {
+        accessors.writeSlot(0, state, 'label', 'message');
+        assert.strictEqual(accessors.readSlot(0).state, state);
+    }
+});
+
+test('writeSlot replaces previously written content with shorter content', () => {
+    const accessors = createAccessors();
+
+    accessors.writeSlot(0, 'running', 'long-label', 'long-message-that-spans-many-bytes');
+    accessors.writeSlot(0, 'succeeded', 'short', 'tiny');
+
+    assert.deepStrictEqual(accessors.readSlot(0), {
+        state: 'succeeded',
+        label: 'short',
+        message: 'tiny'
+    });
+});
+
+test('writeSlot truncates labels that exceed the maximum byte length', () => {
+    const accessors = createAccessors();
+    const layout = createSpinnerSharedLayout(1);
+    const oversizedLabel = 'a'.repeat(layout.maxLabelByteLength + 10);
+
+    accessors.writeSlot(0, 'running', oversizedLabel, 'message');
+
+    assert.strictEqual(accessors.readSlot(0).label, 'a'.repeat(layout.maxLabelByteLength));
+});
+
+test('writeSlot truncates messages that exceed the maximum byte length', () => {
+    const accessors = createAccessors();
+    const layout = createSpinnerSharedLayout(1);
+    const oversizedMessage = 'b'.repeat(layout.maxMessageByteLength + 10);
+
+    accessors.writeSlot(0, 'running', 'label', oversizedMessage);
+
+    assert.strictEqual(accessors.readSlot(0).message, 'b'.repeat(layout.maxMessageByteLength));
+});
+
+test('readSlot returns empty strings when no content was written', () => {
+    const accessors = createAccessors();
+
+    assert.deepStrictEqual(accessors.readSlot(2), { state: 'empty', label: '', message: '' });
+});
+
+test('setSlotEmpty resets the slot state and clears the stored label and message', () => {
+    const accessors = createAccessors();
+    accessors.writeSlot(0, 'running', 'label', 'message');
+
+    accessors.setSlotEmpty(0);
+
+    assert.deepStrictEqual(accessors.readSlot(0), { state: 'empty', label: '', message: '' });
+});
+
+test('readSlotGeneration starts at zero and increments for each bumpSlotGeneration call', () => {
+    const accessors = createAccessors();
+
+    assert.strictEqual(accessors.readSlotGeneration(0), 0);
+    accessors.bumpSlotGeneration(0);
+    assert.strictEqual(accessors.readSlotGeneration(0), 1);
+    accessors.bumpSlotGeneration(0);
+    assert.strictEqual(accessors.readSlotGeneration(0), 2);
+});
+
+test('bumpSlotGeneration only affects the targeted slot', () => {
+    const accessors = createAccessors();
+
+    accessors.bumpSlotGeneration(0);
+
+    assert.strictEqual(accessors.readSlotGeneration(0), 1);
+    assert.strictEqual(accessors.readSlotGeneration(1), 0);
+});
+
+test('writeSlot and readSlot operate independently per slot', () => {
+    const accessors = createAccessors();
+
+    accessors.writeSlot(0, 'running', 'first-label', 'first-message');
+    accessors.writeSlot(2, 'failed', 'third-label', 'third-message');
+
+    assert.deepStrictEqual(accessors.readSlot(0), {
+        state: 'running',
+        label: 'first-label',
+        message: 'first-message'
+    });
+    assert.deepStrictEqual(accessors.readSlot(1), { state: 'empty', label: '', message: '' });
+    assert.deepStrictEqual(accessors.readSlot(2), {
+        state: 'failed',
+        label: 'third-label',
+        message: 'third-message'
+    });
+});
+
+test('readSlot maps an unknown state byte to the empty state', () => {
+    const layout = createSpinnerSharedLayout(1);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+    const accessors = createSpinnerSharedAccessors(buffer, layout);
+    const slotStateOffset = layout.headerByteLength + 4;
+    new DataView(buffer).setUint8(slotStateOffset, 99);
+
+    assert.strictEqual(accessors.readSlot(0).state, 'empty');
+});
+
+test('setColumns and setIntervalMs default to zero before being assigned', () => {
+    const accessors = createAccessors();
+
+    assert.strictEqual(accessors.getColumns(), 0);
+    assert.strictEqual(accessors.getIntervalMs(), 0);
+});
+
+test('setColumns does not affect the stored interval', () => {
+    const accessors = createAccessors();
+    accessors.setIntervalMs(50);
+
+    accessors.setColumns(120);
+
+    assert.strictEqual(accessors.getIntervalMs(), 50);
+});
+
+test('setIntervalMs does not affect the stored columns', () => {
+    const accessors = createAccessors();
+    accessors.setColumns(120);
+
+    accessors.setIntervalMs(50);
+
+    assert.strictEqual(accessors.getColumns(), 120);
+});
+
+test('setColumns does not raise the shutdown flag', () => {
+    const accessors = createAccessors();
+
+    accessors.setColumns(120);
+
+    assert.strictEqual(accessors.isShutdownRequested(), false);
+});
+
+test('setIntervalMs does not raise the shutdown flag', () => {
+    const accessors = createAccessors();
+
+    accessors.setIntervalMs(50);
+
+    assert.strictEqual(accessors.isShutdownRequested(), false);
+});
+
+test('requestShutdown does not change the stored columns or interval', () => {
+    const accessors = createAccessors();
+    accessors.setColumns(120);
+    accessors.setIntervalMs(50);
+
+    accessors.requestShutdown();
+
+    assert.strictEqual(accessors.getColumns(), 120);
+    assert.strictEqual(accessors.getIntervalMs(), 50);
+});
+
+test('writeSlot then readSlot round-trips strings that contain multi-byte UTF-8 characters', () => {
+    const accessors = createAccessors();
+    const decoder = new TextDecoder();
+    const multibyteLabel = decoder.decode(new Uint8Array([209, 130, 208, 181, 209, 129, 209, 130]));
+    const multibyteMessage = decoder.decode(new Uint8Array([195, 169, 36, 195, 188]));
+
+    accessors.writeSlot(0, 'running', multibyteLabel, multibyteMessage);
+
+    assert.deepStrictEqual(accessors.readSlot(0), {
+        state: 'running',
+        label: multibyteLabel,
+        message: multibyteMessage
+    });
+});
+
+test('bumpSlotGeneration on one slot does not modify any other slot generation', () => {
+    const accessors = createAccessors(4);
+
+    accessors.bumpSlotGeneration(2);
+
+    assert.strictEqual(accessors.readSlotGeneration(0), 0);
+    assert.strictEqual(accessors.readSlotGeneration(1), 0);
+    assert.strictEqual(accessors.readSlotGeneration(2), 1);
+    assert.strictEqual(accessors.readSlotGeneration(3), 0);
+});

--- a/source/command-line-interface/spinner-shared-state.ts
+++ b/source/command-line-interface/spinner-shared-state.ts
@@ -1,0 +1,211 @@
+const headerByteLength = 16;
+const slotByteLength = 384;
+const labelByteLength = 64;
+const messageByteLength = 256;
+
+const slotStateOffset = 4;
+const slotLabelLengthOffset = 8;
+const slotMessageLengthOffset = 10;
+const slotLabelOffset = 16;
+const slotMessageOffset = slotLabelOffset + labelByteLength;
+
+const headerControlIndex = 0;
+const headerColumnsIndex = 1;
+const headerIntervalIndex = 2;
+const slotGenerationIndex = 0;
+
+const controlShutdownValue = 1;
+const controlIdleValue = 0;
+
+const slotStateEmpty = 0;
+const slotStateRunning = 1;
+const slotStateSucceeded = 2;
+const slotStateFailed = 3;
+const slotStateCanceled = 4;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export type SlotState = 'canceled' | 'empty' | 'failed' | 'running' | 'succeeded';
+
+const stateToByteMap: Readonly<Record<SlotState, number>> = {
+    empty: slotStateEmpty,
+    running: slotStateRunning,
+    succeeded: slotStateSucceeded,
+    failed: slotStateFailed,
+    canceled: slotStateCanceled
+};
+
+const byteToStateMap: Readonly<Record<number, SlotState>> = {
+    [slotStateEmpty]: 'empty',
+    [slotStateRunning]: 'running',
+    [slotStateSucceeded]: 'succeeded',
+    [slotStateFailed]: 'failed',
+    [slotStateCanceled]: 'canceled'
+};
+
+export type SpinnerSharedLayout = {
+    readonly bufferByteLength: number;
+    readonly slotCount: number;
+    readonly slotByteLength: number;
+    readonly headerByteLength: number;
+    readonly maxLabelByteLength: number;
+    readonly maxMessageByteLength: number;
+};
+
+export function createSpinnerSharedLayout(slotCount: number): SpinnerSharedLayout {
+    return {
+        bufferByteLength: headerByteLength + slotCount * slotByteLength,
+        slotCount,
+        slotByteLength,
+        headerByteLength,
+        maxLabelByteLength: labelByteLength,
+        maxMessageByteLength: messageByteLength
+    };
+}
+
+export type SpinnerSharedAccessors = {
+    readonly layout: SpinnerSharedLayout;
+    readonly buffer: SharedArrayBuffer;
+    readonly setColumns: (columns: number) => void;
+    readonly getColumns: () => number;
+    readonly setIntervalMs: (intervalMs: number) => void;
+    readonly getIntervalMs: () => number;
+    readonly requestShutdown: () => void;
+    readonly isShutdownRequested: () => boolean;
+    readonly readSlotGeneration: (slotIndex: number) => number;
+    readonly bumpSlotGeneration: (slotIndex: number) => void;
+    readonly setSlotEmpty: (slotIndex: number) => void;
+    readonly writeSlot: (slotIndex: number, state: SlotState, label: string, message: string) => void;
+    readonly readSlot: (slotIndex: number) => {
+        readonly state: SlotState;
+        readonly label: string;
+        readonly message: string;
+    };
+};
+
+function stateToByte(state: SlotState): number {
+    return stateToByteMap[state];
+}
+
+function byteToState(byte: number): SlotState {
+    return byteToStateMap[byte] ?? 'empty';
+}
+
+type SlotStringSlice = {
+    readonly contentOffset: number;
+    readonly contentCapacity: number;
+    readonly lengthOffset: number;
+};
+
+const labelSlice: SlotStringSlice = {
+    contentOffset: slotLabelOffset,
+    contentCapacity: labelByteLength,
+    lengthOffset: slotLabelLengthOffset
+};
+
+const messageSlice: SlotStringSlice = {
+    contentOffset: slotMessageOffset,
+    contentCapacity: messageByteLength,
+    lengthOffset: slotMessageLengthOffset
+};
+
+type Views = {
+    readonly headerInt32: Int32Array;
+    readonly headerUint32: Uint32Array;
+    readonly slotInt32: (slotIndex: number) => Int32Array;
+    readonly slotBytes: (slotIndex: number) => Uint8Array;
+    readonly slotData: (slotIndex: number) => DataView;
+};
+
+function createViews(buffer: SharedArrayBuffer, layout: SpinnerSharedLayout): Views {
+    const headerInt32 = new Int32Array(buffer);
+    const headerUint32 = new Uint32Array(buffer);
+    const slotOffset = (slotIndex: number): number => {
+        return layout.headerByteLength + slotIndex * layout.slotByteLength;
+    };
+    return {
+        headerInt32,
+        headerUint32,
+        slotInt32: (slotIndex) => {
+            return new Int32Array(buffer, slotOffset(slotIndex), 1);
+        },
+        slotBytes: (slotIndex) => {
+            return new Uint8Array(buffer, slotOffset(slotIndex), layout.slotByteLength);
+        },
+        slotData: (slotIndex) => {
+            return new DataView(buffer, slotOffset(slotIndex), layout.slotByteLength);
+        }
+    };
+}
+
+function writeStringIntoSlot(views: Views, slotIndex: number, slice: SlotStringSlice, value: string): void {
+    const target = views
+        .slotBytes(slotIndex)
+        .subarray(slice.contentOffset, slice.contentOffset + slice.contentCapacity);
+    target.fill(0);
+    const { written } = textEncoder.encodeInto(value, target);
+    views.slotData(slotIndex).setUint16(slice.lengthOffset, written, true);
+}
+
+function readStringFromSlot(views: Views, slotIndex: number, slice: SlotStringSlice): string {
+    const length = views.slotData(slotIndex).getUint16(slice.lengthOffset, true);
+    return textDecoder.decode(views.slotBytes(slotIndex).subarray(slice.contentOffset, slice.contentOffset + length));
+}
+
+export function createSpinnerSharedAccessors(
+    buffer: SharedArrayBuffer,
+    layout: SpinnerSharedLayout
+): SpinnerSharedAccessors {
+    const views = createViews(buffer, layout);
+
+    function writeStateByte(slotIndex: number, stateByte: number): void {
+        views.slotData(slotIndex).setUint8(slotStateOffset, stateByte);
+    }
+
+    return {
+        layout,
+        buffer,
+        setColumns(columns) {
+            Atomics.store(views.headerUint32, headerColumnsIndex, columns);
+        },
+        getColumns() {
+            return Atomics.load(views.headerUint32, headerColumnsIndex);
+        },
+        setIntervalMs(intervalMs) {
+            Atomics.store(views.headerUint32, headerIntervalIndex, intervalMs);
+        },
+        getIntervalMs() {
+            return Atomics.load(views.headerUint32, headerIntervalIndex);
+        },
+        requestShutdown() {
+            Atomics.store(views.headerInt32, headerControlIndex, controlShutdownValue);
+        },
+        isShutdownRequested() {
+            return Atomics.load(views.headerInt32, headerControlIndex) !== controlIdleValue;
+        },
+        readSlotGeneration(slotIndex) {
+            return Atomics.load(views.slotInt32(slotIndex), slotGenerationIndex);
+        },
+        bumpSlotGeneration(slotIndex) {
+            Atomics.add(views.slotInt32(slotIndex), slotGenerationIndex, 1);
+        },
+        setSlotEmpty(slotIndex) {
+            writeStateByte(slotIndex, slotStateEmpty);
+            writeStringIntoSlot(views, slotIndex, labelSlice, '');
+            writeStringIntoSlot(views, slotIndex, messageSlice, '');
+        },
+        writeSlot(slotIndex, state, label, message) {
+            writeStateByte(slotIndex, stateToByte(state));
+            writeStringIntoSlot(views, slotIndex, labelSlice, label);
+            writeStringIntoSlot(views, slotIndex, messageSlice, message);
+        },
+        readSlot(slotIndex) {
+            return {
+                state: byteToState(views.slotData(slotIndex).getUint8(slotStateOffset)),
+                label: readStringFromSlot(views, slotIndex, labelSlice),
+                message: readStringFromSlot(views, slotIndex, messageSlice)
+            };
+        }
+    };
+}

--- a/source/command-line-interface/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner-worker-backend.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import { fake } from 'sinon';
+import {
+    createSpinnerSharedAccessors,
+    createSpinnerSharedLayout,
+    type SpinnerSharedAccessors
+} from './spinner-shared-state.ts';
+import {
+    createSpinnerRuntime,
+    createWorkerSpinnerBackend,
+    type SpinnerRuntime,
+    type WorkerSpawnRequest
+} from './spinner-worker-backend.ts';
+
+function buildRuntime(slotCount = 4): { runtime: SpinnerRuntime; accessors: SpinnerSharedAccessors } {
+    const layout = createSpinnerSharedLayout(slotCount);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+    const accessors = createSpinnerSharedAccessors(buffer, layout);
+    return { runtime: { accessors, slotCount }, accessors };
+}
+
+test('createSpinnerRuntime sets the shared buffer up with the resolved interval and column count', () => {
+    const spawnWorker = fake();
+
+    const runtime = createSpinnerRuntime({
+        slotCount: 8,
+        intervalMs: 25,
+        stdoutFileDescriptor: 7,
+        stdoutColumns: 132,
+        spawnWorker: (request) => {
+            spawnWorker(request);
+        }
+    });
+
+    assert.strictEqual(runtime.slotCount, 8);
+    assert.strictEqual(runtime.accessors.getIntervalMs(), 25);
+    assert.strictEqual(runtime.accessors.getColumns(), 132);
+});
+
+test('createSpinnerRuntime hands the spawn helper the buffer, slot count and stdout file descriptor', () => {
+    const spawnWorker = fake();
+
+    const runtime = createSpinnerRuntime({
+        slotCount: 2,
+        stdoutFileDescriptor: 5,
+        spawnWorker: (request) => {
+            spawnWorker(request);
+        }
+    });
+
+    assert.strictEqual(spawnWorker.callCount, 1);
+    const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
+    assert.strictEqual(request.buffer, runtime.accessors.buffer);
+    assert.strictEqual(request.slotCount, 2);
+    assert.strictEqual(request.stdoutFileDescriptor, 5);
+});
+
+test('createSpinnerRuntime falls back to defaults when no options are provided', () => {
+    const spawnWorker = fake();
+
+    const runtime = createSpinnerRuntime({
+        spawnWorker: (request) => {
+            spawnWorker(request);
+        }
+    });
+
+    assert.strictEqual(runtime.slotCount, 64);
+    assert.strictEqual(runtime.accessors.getIntervalMs(), 80);
+    assert.ok(runtime.accessors.getColumns() > 0);
+});
+
+test('createWorkerSpinnerBackend.add stores a running slot in the supplied runtime', () => {
+    const { runtime, accessors } = buildRuntime();
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.add(2, 'pkg', 'starting');
+
+    assert.deepStrictEqual(accessors.readSlot(2), { state: 'running', label: 'pkg', message: 'starting' });
+    assert.strictEqual(accessors.readSlotGeneration(2), 1);
+});
+
+test('createWorkerSpinnerBackend.update writes a new running slot value and bumps the generation counter', () => {
+    const { runtime, accessors } = buildRuntime();
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.add(0, 'pkg', 'one');
+    backend.update(0, 'pkg', 'two');
+
+    assert.deepStrictEqual(accessors.readSlot(0), { state: 'running', label: 'pkg', message: 'two' });
+    assert.strictEqual(accessors.readSlotGeneration(0), 2);
+});
+
+test('createWorkerSpinnerBackend.finish records the finished status', () => {
+    const { runtime, accessors } = buildRuntime();
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.finish(1, 'succeeded', 'pkg', 'done');
+
+    assert.deepStrictEqual(accessors.readSlot(1), { state: 'succeeded', label: 'pkg', message: 'done' });
+});
+
+test('createWorkerSpinnerBackend.add throws when the slot index is at or beyond the runtime capacity', () => {
+    const { runtime } = buildRuntime(2);
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    assert.throws(() => {
+        backend.add(2, 'pkg', 'msg');
+    }, /Spinner slot index 2 exceeds backend capacity 2; increase slotCount/u);
+});
+
+test('createWorkerSpinnerBackend.update throws when the slot index is beyond the runtime capacity', () => {
+    const { runtime } = buildRuntime(1);
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    assert.throws(() => {
+        backend.update(5, 'pkg', 'msg');
+    }, /exceeds backend capacity 1/u);
+});
+
+test('createWorkerSpinnerBackend.finish throws when the slot index is beyond the runtime capacity', () => {
+    const { runtime } = buildRuntime(1);
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    assert.throws(() => {
+        backend.finish(5, 'failed', 'pkg', 'msg');
+    }, /exceeds backend capacity 1/u);
+});
+
+test('createWorkerSpinnerBackend.shutdown forwards the shutdown signal to the supplied runtime', () => {
+    const { runtime, accessors } = buildRuntime();
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.shutdown();
+
+    assert.strictEqual(accessors.isShutdownRequested(), true);
+});

--- a/source/command-line-interface/spinner-worker-backend.ts
+++ b/source/command-line-interface/spinner-worker-backend.ts
@@ -1,0 +1,117 @@
+import {
+    createSpinnerSharedAccessors,
+    createSpinnerSharedLayout,
+    type SlotState,
+    type SpinnerSharedAccessors
+} from './spinner-shared-state.ts';
+import type { SpinnerBackend } from './terminal-spinner-renderer.ts';
+
+const defaultSlotCount = 64;
+const defaultIntervalMs = 80;
+const defaultColumns = 80;
+
+export type WorkerSpawnRequest = {
+    readonly buffer: SharedArrayBuffer;
+    readonly slotCount: number;
+    readonly stdoutFileDescriptor: number;
+};
+
+export type WorkerSpawner = (request: WorkerSpawnRequest) => void;
+
+export type SpinnerRuntimeOptions = {
+    readonly slotCount?: number;
+    readonly intervalMs?: number;
+    readonly stdoutFileDescriptor?: number;
+    readonly stdoutColumns?: number;
+    readonly spawnWorker: WorkerSpawner;
+};
+
+export type SpinnerRuntime = {
+    readonly accessors: SpinnerSharedAccessors;
+    readonly slotCount: number;
+};
+
+type ResolvedOptions = {
+    readonly slotCount: number;
+    readonly intervalMs: number;
+    readonly stdoutFileDescriptor: number;
+    readonly stdoutColumns: number;
+    readonly spawnWorker: WorkerSpawner;
+};
+
+function resolveOptions(options: SpinnerRuntimeOptions): ResolvedOptions {
+    return {
+        slotCount: options.slotCount ?? defaultSlotCount,
+        intervalMs: options.intervalMs ?? defaultIntervalMs,
+        stdoutFileDescriptor: options.stdoutFileDescriptor ?? process.stdout.fd,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process.stdout.columns is undefined at runtime when stdout is not a TTY, despite the type declaring it as number
+        stdoutColumns: options.stdoutColumns ?? process.stdout.columns ?? defaultColumns,
+        spawnWorker: options.spawnWorker
+    };
+}
+
+function setupSharedBuffer(resolved: ResolvedOptions): SpinnerSharedAccessors {
+    const layout = createSpinnerSharedLayout(resolved.slotCount);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+    const accessors = createSpinnerSharedAccessors(buffer, layout);
+    accessors.setIntervalMs(resolved.intervalMs);
+    accessors.setColumns(resolved.stdoutColumns);
+    return accessors;
+}
+
+export function createSpinnerRuntime(options: SpinnerRuntimeOptions): SpinnerRuntime {
+    const resolved = resolveOptions(options);
+    const accessors = setupSharedBuffer(resolved);
+    resolved.spawnWorker({
+        buffer: accessors.buffer,
+        slotCount: accessors.layout.slotCount,
+        stdoutFileDescriptor: resolved.stdoutFileDescriptor
+    });
+    return { accessors, slotCount: resolved.slotCount };
+}
+
+type SlotUpdate = {
+    readonly slotIndex: number;
+    readonly state: SlotState;
+    readonly label: string;
+    readonly message: string;
+};
+
+function writeSlot(accessors: SpinnerSharedAccessors, update: SlotUpdate): void {
+    accessors.writeSlot(update.slotIndex, update.state, update.label, update.message);
+    accessors.bumpSlotGeneration(update.slotIndex);
+}
+
+export type WorkerSpinnerBackendDependencies = {
+    readonly runtime: SpinnerRuntime;
+};
+
+export function createWorkerSpinnerBackend(dependencies: WorkerSpinnerBackendDependencies): SpinnerBackend {
+    const { runtime } = dependencies;
+
+    function ensureSlotIndexFits(slotIndex: number): void {
+        if (slotIndex >= runtime.slotCount) {
+            throw new RangeError(
+                `Spinner slot index ${slotIndex} exceeds backend capacity ${runtime.slotCount}; increase slotCount`
+            );
+        }
+    }
+
+    return {
+        add(slotIndex, label, message) {
+            ensureSlotIndexFits(slotIndex);
+            writeSlot(runtime.accessors, { slotIndex, state: 'running', label, message });
+        },
+        update(slotIndex, label, message) {
+            ensureSlotIndexFits(slotIndex);
+            writeSlot(runtime.accessors, { slotIndex, state: 'running', label, message });
+        },
+        finish(slotIndex, status, label, message) {
+            ensureSlotIndexFits(slotIndex);
+            writeSlot(runtime.accessors, { slotIndex, state: status, label, message });
+        },
+        shutdown() {
+            runtime.accessors.requestShutdown();
+        }
+    };
+}

--- a/source/command-line-interface/spinner-worker-loop.test.ts
+++ b/source/command-line-interface/spinner-worker-loop.test.ts
@@ -1,0 +1,349 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import {
+    createSpinnerSharedAccessors,
+    createSpinnerSharedLayout,
+    type SpinnerSharedAccessors
+} from './spinner-shared-state.ts';
+import {
+    isSpinnerWorkerInput,
+    startSpinnerWorker,
+    type SpinnerWorkerDependencies,
+    type SpinnerWorkerInput
+} from './spinner-worker-loop.ts';
+
+const escapeCodePoint = 27;
+const escapeChar = String.fromCodePoint(escapeCodePoint);
+const clearLineSequence = `${escapeChar}[2K\r`;
+const successSymbolPattern = /✔/u;
+const failureSymbolPattern = /✖/u;
+
+function countOccurrences(haystack: string, needle: string): number {
+    if (needle.length === 0) {
+        return 0;
+    }
+    let count = 0;
+    let position = haystack.indexOf(needle);
+    while (position !== -1) {
+        count += 1;
+        position = haystack.indexOf(needle, position + needle.length);
+    }
+    return count;
+}
+
+function extractCursorUpLineCount(chunk: string): number | undefined {
+    const prefix = `${escapeChar}[`;
+    const start = chunk.indexOf(prefix);
+    if (start === -1) {
+        return undefined;
+    }
+    const remainder = chunk.slice(start + prefix.length);
+    const end = remainder.indexOf('A');
+    if (end === -1) {
+        return undefined;
+    }
+    const digits = remainder.slice(0, end);
+    if (!/^\d+$/u.test(digits)) {
+        return undefined;
+    }
+    return Number.parseInt(digits, 10);
+}
+
+type Harness = {
+    readonly accessors: SpinnerSharedAccessors;
+    readonly tick: () => void;
+    readonly writes: () => readonly string[];
+    readonly clearIntervalCalls: () => readonly unknown[];
+};
+
+function buildInput(
+    slotCount: number,
+    stdoutFileDescriptor = 1
+): {
+    input: SpinnerWorkerInput;
+    accessors: SpinnerSharedAccessors;
+} {
+    const layout = createSpinnerSharedLayout(slotCount);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+    const accessors = createSpinnerSharedAccessors(buffer, layout);
+    return { input: { buffer, slotCount, stdoutFileDescriptor }, accessors };
+}
+
+function createHarness(slotCount: number, stdoutFileDescriptor = 1): Harness {
+    const { input, accessors } = buildInput(slotCount, stdoutFileDescriptor);
+    const captured: { callback?: () => void } = {};
+    const writes: string[] = [];
+    const clearIntervalCalls: unknown[] = [];
+
+    const dependencies: SpinnerWorkerDependencies<string> = {
+        write: (fileDescriptor, chunk) => {
+            assert.strictEqual(fileDescriptor, stdoutFileDescriptor);
+            writes.push(chunk);
+        },
+        setInterval: (callback) => {
+            captured.callback = callback;
+            return 'ticker-handle';
+        },
+        clearInterval: (handle) => {
+            clearIntervalCalls.push(handle);
+        }
+    };
+
+    startSpinnerWorker(input, dependencies);
+
+    return {
+        accessors,
+        tick: () => {
+            if (captured.callback === undefined) {
+                throw new Error('No interval callback was scheduled');
+            }
+            captured.callback();
+        },
+        writes: () => {
+            return writes;
+        },
+        clearIntervalCalls: () => {
+            return clearIntervalCalls;
+        }
+    };
+}
+
+test('startSpinnerWorker schedules the ticker with the interval stored in the shared buffer', () => {
+    const { input, accessors } = buildInput(1);
+    accessors.setIntervalMs(40);
+    const captured: { ms?: number } = {};
+
+    startSpinnerWorker(input, {
+        write: () => {
+            // noop
+        },
+        setInterval: (_callback, ms) => {
+            captured.ms = ms;
+            return 'ticker-handle';
+        },
+        clearInterval: () => {
+            // noop
+        }
+    });
+
+    assert.strictEqual(captured.ms, 40);
+});
+
+test('startSpinnerWorker writes the running slot label and message to the configured stdout file descriptor', () => {
+    const harness = createHarness(2, 7);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'starting');
+
+    harness.tick();
+
+    const written = harness.writes().join('');
+    assert.match(written, /pkg: starting/u);
+});
+
+test('startSpinnerWorker draws the success symbol for slots that have succeeded', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'succeeded', 'pkg', 'done');
+
+    harness.tick();
+
+    assert.match(harness.writes().join(''), successSymbolPattern);
+});
+
+test('startSpinnerWorker draws the failure symbol for failed slots', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'failed', 'pkg', 'oops');
+
+    harness.tick();
+
+    assert.match(harness.writes().join(''), failureSymbolPattern);
+});
+
+test('startSpinnerWorker draws the failure symbol for canceled slots', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'canceled', 'pkg', 'aborted');
+
+    harness.tick();
+
+    assert.match(harness.writes().join(''), failureSymbolPattern);
+});
+
+const expectedSpinnerFrames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+
+function extractGlyph(chunk: string): string {
+    const marker = clearLineSequence;
+    const start = chunk.lastIndexOf(marker);
+    if (start === -1) {
+        return '';
+    }
+    return chunk.charAt(start + marker.length);
+}
+
+test('startSpinnerWorker draws a glyph from the spinner animation set for running slots', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+    harness.tick();
+
+    const written = harness.writes().join('');
+    const glyph = extractGlyph(written);
+    assert.ok(expectedSpinnerFrames.includes(glyph), `Expected glyph to be a spinner frame, got "${glyph}"`);
+});
+
+test('startSpinnerWorker uses neither the success nor failure symbol while a slot is running', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+    harness.tick();
+
+    const written = harness.writes().join('');
+    assert.doesNotMatch(written, successSymbolPattern);
+    assert.doesNotMatch(written, failureSymbolPattern);
+});
+
+test('startSpinnerWorker advances to a different spinner frame on the second tick', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+    harness.tick();
+    harness.tick();
+
+    const writes = harness.writes();
+    assert.strictEqual(writes.length, 2);
+    const firstGlyph = extractGlyph(writes[0] ?? '');
+    const secondGlyph = extractGlyph(writes[1] ?? '');
+    assert.ok(
+        expectedSpinnerFrames.includes(firstGlyph),
+        `Expected first glyph to be a spinner frame, got "${firstGlyph}"`
+    );
+    assert.ok(
+        expectedSpinnerFrames.includes(secondGlyph),
+        `Expected second glyph to be a spinner frame, got "${secondGlyph}"`
+    );
+    assert.notStrictEqual(firstGlyph, secondGlyph);
+});
+
+test('startSpinnerWorker truncates lines that would exceed the configured column width', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(8);
+    harness.accessors.writeSlot(0, 'succeeded', 'long-label', 'long-message');
+
+    harness.tick();
+
+    const lines = harness
+        .writes()
+        .join('')
+        .split('\n')
+        .filter((line) => {
+            return line.length > 0;
+        });
+    for (const line of lines) {
+        const stripped = line.split(clearLineSequence).join('');
+        assert.ok(stripped.length <= 8, `Expected line to be truncated to 8 columns, got ${stripped.length}`);
+    }
+});
+
+test('startSpinnerWorker leaves a line untruncated when columns is configured as zero', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(0);
+    harness.accessors.writeSlot(0, 'succeeded', 'lbl', 'message');
+
+    harness.tick();
+
+    assert.match(harness.writes().join(''), /lbl: message/u);
+});
+
+test('startSpinnerWorker draws one line per active slot up to the highest active index', () => {
+    const harness = createHarness(4);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'a', 'one');
+    harness.accessors.writeSlot(2, 'running', 'c', 'three');
+
+    harness.tick();
+
+    const occurrences = countOccurrences(harness.writes().join(''), clearLineSequence);
+    assert.strictEqual(occurrences, 3);
+});
+
+test('startSpinnerWorker skips writing to stdout while there is nothing to render', () => {
+    const harness = createHarness(2);
+
+    harness.tick();
+
+    assert.strictEqual(harness.writes().length, 0);
+});
+
+test('startSpinnerWorker rewinds the cursor up by the previously rendered line count before redrawing', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+    harness.tick();
+    harness.tick();
+
+    const lastChunk = harness.writes().at(-1) ?? '';
+    assert.strictEqual(extractCursorUpLineCount(lastChunk), 1);
+});
+
+test('startSpinnerWorker keeps refreshing the rendered block once a slot was drawn even if it goes empty', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+    harness.tick();
+    harness.accessors.setSlotEmpty(0);
+    harness.tick();
+
+    assert.strictEqual(harness.writes().length, 2);
+});
+
+test('startSpinnerWorker writes a final tick and clears the interval after a shutdown was requested', () => {
+    const harness = createHarness(1);
+    harness.accessors.setColumns(80);
+    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+    harness.tick();
+    harness.accessors.requestShutdown();
+    harness.tick();
+
+    assert.strictEqual(harness.clearIntervalCalls().length, 1);
+    assert.strictEqual(harness.clearIntervalCalls()[0], 'ticker-handle');
+});
+
+test('isSpinnerWorkerInput accepts a well-formed payload', () => {
+    const layout = createSpinnerSharedLayout(1);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+
+    assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: 1, stdoutFileDescriptor: 1 }), true);
+});
+
+test('isSpinnerWorkerInput rejects non-objects', () => {
+    assert.strictEqual(isSpinnerWorkerInput(null), false);
+    assert.strictEqual(isSpinnerWorkerInput('not-an-object'), false);
+});
+
+test('isSpinnerWorkerInput rejects payloads with a buffer that is not a SharedArrayBuffer', () => {
+    assert.strictEqual(
+        isSpinnerWorkerInput({ buffer: new ArrayBuffer(8), slotCount: 1, stdoutFileDescriptor: 1 }),
+        false
+    );
+});
+
+test('isSpinnerWorkerInput rejects payloads with a non-numeric slotCount', () => {
+    const layout = createSpinnerSharedLayout(1);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+
+    assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: '1', stdoutFileDescriptor: 1 }), false);
+});
+
+test('isSpinnerWorkerInput rejects payloads with a non-numeric stdoutFileDescriptor', () => {
+    const layout = createSpinnerSharedLayout(1);
+    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+
+    assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: 1, stdoutFileDescriptor: '1' }), false);
+});

--- a/source/command-line-interface/spinner-worker-loop.ts
+++ b/source/command-line-interface/spinner-worker-loop.ts
@@ -1,0 +1,146 @@
+import kleur from 'kleur';
+import {
+    createSpinnerSharedAccessors,
+    createSpinnerSharedLayout,
+    type SlotState,
+    type SpinnerSharedAccessors
+} from './spinner-shared-state.ts';
+
+const spinnerFrames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+const successSymbol = kleur.bold().green('✔');
+const failureSymbol = kleur.bold().red('✖');
+
+const cursorUp = (lines: number): string => {
+    return `[${lines}A`;
+};
+const clearEntireLine = '[2K';
+const cursorToColumnZero = '\r';
+
+type SlotSnapshot = {
+    readonly generation: number;
+    readonly state: SlotState;
+    readonly label: string;
+    readonly message: string;
+};
+
+type RenderState = {
+    snapshots: readonly SlotSnapshot[];
+    renderedLineCount: number;
+    frameIndex: number;
+};
+
+export type SpinnerWorkerInput = {
+    readonly buffer: SharedArrayBuffer;
+    readonly slotCount: number;
+    readonly stdoutFileDescriptor: number;
+};
+
+export type SpinnerWorkerDependencies<Handle = unknown> = {
+    readonly write: (fileDescriptor: number, chunk: string) => void;
+    readonly setInterval: (callback: () => void, ms: number) => Handle;
+    readonly clearInterval: (handle: Handle) => void;
+};
+
+function readSlotSnapshot(accessors: SpinnerSharedAccessors, slotIndex: number): SlotSnapshot {
+    const generation = accessors.readSlotGeneration(slotIndex);
+    const slot = accessors.readSlot(slotIndex);
+    return { generation, state: slot.state, label: slot.label, message: slot.message };
+}
+
+function selectGlyph(state: SlotState, frameIndex: number): string {
+    if (state === 'succeeded') {
+        return successSymbol;
+    }
+    if (state === 'failed' || state === 'canceled') {
+        return failureSymbol;
+    }
+    return spinnerFrames.charAt(frameIndex % spinnerFrames.length);
+}
+
+function truncateToColumns(line: string, columns: number): string {
+    if (columns <= 0) {
+        return line;
+    }
+    return line.slice(0, columns);
+}
+
+function formatLine(snapshot: SlotSnapshot, frameIndex: number, columns: number): string {
+    const glyph = selectGlyph(snapshot.state, frameIndex);
+    const composed = `${glyph} ${snapshot.label}: ${snapshot.message}`;
+    return truncateToColumns(composed, columns);
+}
+
+function readAllSnapshots(accessors: SpinnerSharedAccessors): SlotSnapshot[] {
+    const snapshots: SlotSnapshot[] = [];
+    for (let slotIndex = 0; slotIndex < accessors.layout.slotCount; slotIndex += 1) {
+        snapshots.push(readSlotSnapshot(accessors, slotIndex));
+    }
+    return snapshots;
+}
+
+function findHighestActiveSlotIndex(snapshots: readonly SlotSnapshot[]): number {
+    return snapshots.findLastIndex((snapshot) => {
+        return snapshot.state !== 'empty';
+    });
+}
+
+function buildRedrawSequence(state: RenderState, columns: number, expectedLineCount: number): string {
+    let output = '';
+    if (state.renderedLineCount > 0) {
+        output += cursorUp(state.renderedLineCount);
+    }
+
+    const visibleSnapshots = state.snapshots.slice(0, expectedLineCount);
+    for (const snapshot of visibleSnapshots) {
+        const line = formatLine(snapshot, state.frameIndex, columns);
+        output += `${clearEntireLine + cursorToColumnZero + line}\n`;
+    }
+
+    return output;
+}
+
+export function startSpinnerWorker<Handle>(
+    input: SpinnerWorkerInput,
+    dependencies: SpinnerWorkerDependencies<Handle>
+): void {
+    const layout = createSpinnerSharedLayout(input.slotCount);
+    const accessors = createSpinnerSharedAccessors(input.buffer, layout);
+    const state: RenderState = {
+        snapshots: readAllSnapshots(accessors),
+        renderedLineCount: 0,
+        frameIndex: 0
+    };
+
+    function renderTick(): void {
+        const snapshots = readAllSnapshots(accessors);
+        const highestActive = findHighestActiveSlotIndex(snapshots);
+        if (highestActive < 0 && state.renderedLineCount === 0) {
+            return;
+        }
+        const expectedLineCount = Math.max(state.renderedLineCount, highestActive + 1);
+        state.snapshots = snapshots;
+        const sequence = buildRedrawSequence(state, accessors.getColumns(), expectedLineCount);
+        dependencies.write(input.stdoutFileDescriptor, sequence);
+        state.renderedLineCount = expectedLineCount;
+        state.frameIndex += 1;
+    }
+
+    const intervalMs = accessors.getIntervalMs();
+    const ticker = dependencies.setInterval(() => {
+        renderTick();
+        if (accessors.isShutdownRequested()) {
+            renderTick();
+            dependencies.clearInterval(ticker);
+        }
+    }, intervalMs);
+}
+
+export function isSpinnerWorkerInput(value: unknown): value is SpinnerWorkerInput {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        Reflect.get(value, 'buffer') instanceof SharedArrayBuffer &&
+        typeof Reflect.get(value, 'slotCount') === 'number' &&
+        typeof Reflect.get(value, 'stdoutFileDescriptor') === 'number'
+    );
+}

--- a/source/command-line-interface/spinner-worker.entry-point.ts
+++ b/source/command-line-interface/spinner-worker.entry-point.ts
@@ -1,0 +1,17 @@
+import { writeSync } from 'node:fs';
+import { setInterval as scheduleInterval, clearInterval as cancelInterval } from 'node:timers';
+import { workerData } from 'node:worker_threads';
+import { isSpinnerWorkerInput, startSpinnerWorker } from './spinner-worker-loop.ts';
+
+if (!isSpinnerWorkerInput(workerData)) {
+    throw new TypeError('Spinner worker started with invalid workerData');
+}
+
+startSpinnerWorker(workerData, {
+    write: (fileDescriptor, chunk) => {
+        // eslint-disable-next-line node/no-sync -- the worker holds the only writer to fd 1 and synchronous writes are the simplest way to render
+        writeSync(fileDescriptor, chunk);
+    },
+    setInterval: scheduleInterval,
+    clearInterval: cancelInterval
+});

--- a/source/command-line-interface/terminal-spinner-renderer.test.ts
+++ b/source/command-line-interface/terminal-spinner-renderer.test.ts
@@ -3,61 +3,65 @@ import { test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import {
     createTerminalSpinnerRenderer,
-    type TerminalSpinnerRenderer,
-    type TerminalSpinnerRendererDependencies
+    type SpinnerBackend,
+    type TerminalSpinnerRenderer
 } from './terminal-spinner-renderer.ts';
 
-type SpinnerOverrides = {
-    start?: SinonSpy;
-    failed?: SinonSpy;
-    succeed?: SinonSpy;
-    reset?: SinonSpy;
+type BackendOverrides = {
+    add?: SinonSpy;
+    update?: SinonSpy;
+    finish?: SinonSpy;
+    shutdown?: SinonSpy;
 };
 
-type FakeSpinnerInstance = { start: SinonSpy; failed: SinonSpy; succeed: SinonSpy; text?: string; started?: boolean };
-type FakeSpinnerClass = SinonSpy<unknown[], FakeSpinnerInstance> & { reset: SinonSpy };
-
-function createFakeSpinnerClass(overrides: SpinnerOverrides = {}): FakeSpinnerClass {
-    const { start = fake(), failed = fake(), succeed = fake(), reset = fake() } = overrides;
-    const spinnerClass: FakeSpinnerClass = fake<unknown[], FakeSpinnerInstance>(() => {
-        return {
-            start,
-            failed,
-            succeed
-        };
-    }) as FakeSpinnerClass;
-    spinnerClass.reset = reset;
-
-    return spinnerClass;
+function wrapVoid(spy: SinonSpy): (...args: unknown[]) => void {
+    return (...args: unknown[]): void => {
+        spy(...args);
+    };
 }
 
-type Overrides = {
-    SpinnerClass?: FakeSpinnerClass;
-};
-
-function terminalSpinnerRendererFactory(overrides: Overrides = {}): TerminalSpinnerRenderer {
-    const { SpinnerClass = createFakeSpinnerClass() } = overrides;
-    return createTerminalSpinnerRenderer({ SpinnerClass } as unknown as TerminalSpinnerRendererDependencies);
+function createFakeBackend(overrides: BackendOverrides = {}): SpinnerBackend {
+    const addSpy = overrides.add ?? fake();
+    const updateSpy = overrides.update ?? fake();
+    const finishSpy = overrides.finish ?? fake();
+    const shutdownSpy = overrides.shutdown ?? fake();
+    const backend: SpinnerBackend = {
+        add: wrapVoid(addSpy),
+        update: wrapVoid(updateSpy),
+        finish: wrapVoid(finishSpy),
+        shutdown: wrapVoid(shutdownSpy)
+    };
+    return backend;
 }
 
-test('add() creates a new spinner and starts that spinner directly', () => {
-    const start = fake();
-    const SpinnerClass = createFakeSpinnerClass({ start });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+function terminalSpinnerRendererFactory(backend: SpinnerBackend = createFakeBackend()): TerminalSpinnerRenderer {
+    return createTerminalSpinnerRenderer({ backend });
+}
+
+test('add() forwards a new spinner to the backend at slot index zero', () => {
+    const add = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ add }));
 
     renderer.add('the-id', 'the-label', 'the message');
 
-    assert.strictEqual(SpinnerClass.callCount, 1);
-    assert.strictEqual(SpinnerClass.calledWithNew(), true);
-    assert.deepStrictEqual(SpinnerClass.firstCall.args, [{ name: 'dots' }]);
-    assert.strictEqual(start.callCount, 1);
-    assert.deepStrictEqual(start.firstCall.args, ['the message', { withPrefix: 'the-label: ' }]);
+    assert.strictEqual(add.callCount, 1);
+    assert.deepStrictEqual(add.firstCall.args, [0, 'the-label', 'the message']);
+});
+
+test('add() assigns successive spinners to consecutive slot indices', () => {
+    const add = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ add }));
+
+    renderer.add('first', 'a', '1');
+    renderer.add('second', 'b', '2');
+
+    assert.strictEqual(add.callCount, 2);
+    assert.deepStrictEqual(add.firstCall.args, [0, 'a', '1']);
+    assert.deepStrictEqual(add.secondCall.args, [1, 'b', '2']);
 });
 
 test('add() throws when adding two spinners with the same id', () => {
-    const start = fake();
-    const SpinnerClass = createFakeSpinnerClass({ start });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+    const renderer = terminalSpinnerRendererFactory();
 
     renderer.add('the-id', '', '');
 
@@ -69,32 +73,33 @@ test('add() throws when adding two spinners with the same id', () => {
     }
 });
 
-test('updateMessage() replaces the text of the spinner with the given id', () => {
-    const SpinnerClass = createFakeSpinnerClass();
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('updateMessage() forwards the new message to the backend with the spinner slot index', () => {
+    const update = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
 
-    renderer.add('the-id', '', '');
+    renderer.add('the-id', 'lbl', 'initial');
     renderer.updateMessage('the-id', 'foo');
 
-    assert.strictEqual(SpinnerClass.firstCall.returnValue.text, 'foo');
+    assert.strictEqual(update.callCount, 1);
+    assert.deepStrictEqual(update.firstCall.args, [0, 'lbl', 'foo']);
 });
 
-test('updateMessage() replaces the text of the correct spinner when having multiple', () => {
-    const SpinnerClass = createFakeSpinnerClass();
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('updateMessage() updates the correct spinner when having multiple', () => {
+    const update = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
 
-    renderer.add('first', '', '');
-    renderer.add('second', '', '');
+    renderer.add('first', 'one', '');
+    renderer.add('second', 'two', '');
     renderer.updateMessage('first', 'foo');
     renderer.updateMessage('second', 'bar');
 
-    assert.strictEqual(SpinnerClass.firstCall.returnValue.text, 'foo');
-    assert.strictEqual(SpinnerClass.secondCall.returnValue.text, 'bar');
+    assert.strictEqual(update.callCount, 2);
+    assert.deepStrictEqual(update.firstCall.args, [0, 'one', 'foo']);
+    assert.deepStrictEqual(update.secondCall.args, [1, 'two', 'bar']);
 });
 
 test('updateMessage() throws when trying to change the message of a non-existing spinner', () => {
-    const SpinnerClass = createFakeSpinnerClass();
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+    const renderer = terminalSpinnerRendererFactory();
 
     try {
         renderer.updateMessage('the-id', '');
@@ -104,59 +109,56 @@ test('updateMessage() throws when trying to change the message of a non-existing
     }
 });
 
-test('stop() stops the spinner with the given id with success status and the given message', () => {
-    const succeed = fake();
-    const SpinnerClass = createFakeSpinnerClass({ succeed });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('stop() finishes the spinner with succeeded state when the status is success', () => {
+    const finish = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    renderer.add('the-id', '', '');
+    renderer.add('the-id', 'lbl', '');
     renderer.stop('the-id', 'success', 'foo');
 
-    assert.strictEqual(succeed.callCount, 1);
-    assert.deepStrictEqual(succeed.firstCall.args, ['foo']);
+    assert.strictEqual(finish.callCount, 1);
+    assert.deepStrictEqual(finish.firstCall.args, [0, 'succeeded', 'lbl', 'foo']);
 });
 
-test('stop() stops the spinner with the given id with failure status and the given message', () => {
-    const failed = fake();
-    const SpinnerClass = createFakeSpinnerClass({ failed });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('stop() finishes the spinner with failed state when the status is failure', () => {
+    const finish = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    renderer.add('the-id', '', '');
+    renderer.add('the-id', 'lbl', '');
     renderer.stop('the-id', 'failure', 'foo');
 
-    assert.strictEqual(failed.callCount, 1);
-    assert.deepStrictEqual(failed.firstCall.args, ['foo']);
+    assert.strictEqual(finish.callCount, 1);
+    assert.deepStrictEqual(finish.firstCall.args, [0, 'failed', 'lbl', 'foo']);
 });
 
-test('stop() keeps the stopped spinner instance addressable for later updates', () => {
-    const SpinnerClass = createFakeSpinnerClass();
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('stop() keeps the stopped spinner addressable for later message updates', () => {
+    const update = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
 
-    renderer.add('the-id', '', '');
+    renderer.add('the-id', 'lbl', '');
     renderer.stop('the-id', 'success', 'foo');
     renderer.updateMessage('the-id', 'updated');
 
-    assert.strictEqual(SpinnerClass.firstCall.returnValue.text, 'updated');
+    assert.strictEqual(update.callCount, 1);
+    assert.deepStrictEqual(update.firstCall.args, [0, 'lbl', 'updated']);
 });
 
-test('stop() stops only the correct corresponding spinners when having multiple', () => {
-    const failed = fake();
-    const SpinnerClass = createFakeSpinnerClass({ failed });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('stop() finishes only the targeted spinner when having multiple', () => {
+    const finish = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    renderer.add('first', '', '');
-    renderer.add('second', '', '');
+    renderer.add('first', 'a', '');
+    renderer.add('second', 'b', '');
     renderer.stop('first', 'failure', 'foo');
     renderer.stop('second', 'failure', 'bar');
 
-    assert.strictEqual(failed.callCount, 2);
-    assert.deepStrictEqual(failed.firstCall.args, ['foo']);
-    assert.deepStrictEqual(failed.secondCall.args, ['bar']);
+    assert.strictEqual(finish.callCount, 2);
+    assert.deepStrictEqual(finish.firstCall.args, [0, 'failed', 'a', 'foo']);
+    assert.deepStrictEqual(finish.secondCall.args, [1, 'failed', 'b', 'bar']);
 });
 
 test('stop() throws when trying to stop a spinner that does not exist', () => {
-    const SpinnerClass = createFakeSpinnerClass();
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+    const renderer = terminalSpinnerRendererFactory();
 
     try {
         renderer.stop('the-id', 'failure', '');
@@ -166,28 +168,39 @@ test('stop() throws when trying to stop a spinner that does not exist', () => {
     }
 });
 
-test('stopAll() resets all spinners', () => {
-    const reset = fake();
-    const SpinnerClass = createFakeSpinnerClass({ reset });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('stopAll() shuts down the backend', () => {
+    const shutdown = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ shutdown }));
 
     renderer.add('first', '', '');
     renderer.stopAll();
 
-    assert.strictEqual(reset.callCount, 1);
-    assert.deepStrictEqual(reset.firstCall.args, []);
+    assert.strictEqual(shutdown.callCount, 1);
 });
 
-test('stopAll() stops all spinners that are still running', () => {
-    const failed = fake();
-    const SpinnerClass = createFakeSpinnerClass({ failed });
-    const renderer = terminalSpinnerRendererFactory({ SpinnerClass });
+test('stopAll() cancels all spinners that are still running', () => {
+    const finish = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    renderer.add('first', '', '');
-    renderer.add('second', '', '');
+    renderer.add('first', 'one', '');
+    renderer.add('second', 'two', '');
     renderer.stop('first', 'success', 'foo');
     renderer.stopAll();
 
-    assert.strictEqual(failed.callCount, 1);
-    assert.deepStrictEqual(failed.firstCall.args, ['Canceled …']);
+    assert.strictEqual(finish.callCount, 2);
+    assert.deepStrictEqual(finish.firstCall.args, [0, 'succeeded', 'one', 'foo']);
+    assert.deepStrictEqual(finish.secondCall.args, [1, 'canceled', 'two', 'Canceled …']);
+});
+
+test('stopAll() does not re-cancel previously canceled spinners on a second invocation', () => {
+    const finish = fake();
+    const shutdown = fake();
+    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish, shutdown }));
+
+    renderer.add('only', 'lbl', '');
+    renderer.stopAll();
+    renderer.stopAll();
+
+    assert.strictEqual(finish.callCount, 1);
+    assert.strictEqual(shutdown.callCount, 2);
 });

--- a/source/command-line-interface/terminal-spinner-renderer.ts
+++ b/source/command-line-interface/terminal-spinner-renderer.ts
@@ -1,5 +1,3 @@
-import type { Spinner } from '@topcli/spinner';
-
 type Status = 'failure' | 'success';
 
 export type TerminalSpinnerRenderer = {
@@ -9,22 +7,47 @@ export type TerminalSpinnerRenderer = {
     stopAll: () => void;
 };
 
-export type TerminalSpinnerRendererDependencies = {
-    readonly SpinnerClass: typeof Spinner;
+export type SpinnerBackend = {
+    readonly add: (slotIndex: number, label: string, message: string) => void;
+    readonly update: (slotIndex: number, label: string, message: string) => void;
+    readonly finish: (
+        slotIndex: number,
+        status: 'canceled' | 'failed' | 'succeeded',
+        label: string,
+        message: string
+    ) => void;
+    readonly shutdown: () => void;
 };
 
-type StatefulSpinner = {
-    readonly isRunning: boolean;
-    readonly instance: Spinner;
+export type TerminalSpinnerRendererDependencies = {
+    readonly backend: SpinnerBackend;
 };
+
+type SpinnerSlot = {
+    readonly slotIndex: number;
+    readonly label: string;
+    message: string;
+    status: Status | 'running';
+};
+
+const cancelMessage = 'Canceled …';
 
 export function createTerminalSpinnerRenderer(
     dependencies: TerminalSpinnerRendererDependencies
 ): TerminalSpinnerRenderer {
-    const { SpinnerClass } = dependencies;
-    const spinners = new Map<string, StatefulSpinner>();
+    const { backend } = dependencies;
+    const spinners = new Map<string, SpinnerSlot>();
+    const usedSlots = new Set<number>();
 
-    function getSpinnerById(id: string): StatefulSpinner {
+    function nextFreeSlotIndex(): number {
+        let candidate = 0;
+        while (usedSlots.has(candidate)) {
+            candidate += 1;
+        }
+        return candidate;
+    }
+
+    function getSpinnerById(id: string): SpinnerSlot {
         const spinner = spinners.get(id);
         if (spinner === undefined) {
             throw new Error(`Spinner with id ${id} does not exist`);
@@ -42,35 +65,35 @@ export function createTerminalSpinnerRenderer(
         add(id, label, message) {
             ensureIdDoesNotExist(id);
 
-            const spinner = new SpinnerClass({ name: 'dots' });
-            spinners.set(id, { instance: spinner, isRunning: true });
-            spinner.start(message, { withPrefix: `${label}: ` });
+            const slotIndex = nextFreeSlotIndex();
+            usedSlots.add(slotIndex);
+            spinners.set(id, { slotIndex, label, message, status: 'running' });
+            backend.add(slotIndex, label, message);
         },
 
         updateMessage(id, message) {
             const spinner = getSpinnerById(id);
-            spinner.instance.text = message;
+            spinner.message = message;
+            backend.update(spinner.slotIndex, spinner.label, message);
         },
 
         stop(id, status, message) {
             const spinner = getSpinnerById(id);
-
-            spinners.set(id, { instance: spinner.instance, isRunning: false });
-
-            if (status === 'failure') {
-                spinner.instance.failed(message);
-            } else {
-                spinner.instance.succeed(message);
-            }
+            spinner.message = message;
+            spinner.status = status;
+            const finalState = status === 'success' ? 'succeeded' : 'failed';
+            backend.finish(spinner.slotIndex, finalState, spinner.label, message);
         },
 
         stopAll() {
             for (const spinner of spinners.values()) {
-                if (spinner.isRunning) {
-                    spinner.instance.failed('Canceled …');
+                if (spinner.status === 'running') {
+                    spinner.message = cancelMessage;
+                    backend.finish(spinner.slotIndex, 'canceled', spinner.label, cancelMessage);
                 }
             }
-            SpinnerClass.reset();
+            spinners.clear();
+            backend.shutdown();
         }
     };
 }

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { Spinner } from '@topcli/spinner';
+import { bootedSpinnerRuntime } from '../../command-line-interface/spinner-boot.entry-point.ts';
 import type * as configTypes from '../../config/config.ts';
 import { createCommandLineInterfaceRunner } from '../../command-line-interface/runner.ts';
 import { createTerminalSpinnerRenderer } from '../../command-line-interface/terminal-spinner-renderer.ts';
+import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner-worker-backend.ts';
 import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
 import { buildAndPublishAll, resolveAndLinkAll, progressBroadcastConsumer } from '../packtory/packtory.entry-point.ts';
 
@@ -14,7 +15,9 @@ async function importModule(modulePath: string): Promise<unknown> {
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     packtory: { buildAndPublishAll, resolveAndLinkAll },
     progressBroadcaster: progressBroadcastConsumer,
-    spinnerRenderer: createTerminalSpinnerRenderer({ SpinnerClass: Spinner }),
+    spinnerRenderer: createTerminalSpinnerRenderer({
+        backend: createWorkerSpinnerBackend({ runtime: bootedSpinnerRuntime })
+    }),
     configLoader: createConfigLoader({ currentWorkingDirectory: process.cwd(), importModule }),
     log: console.log
 });

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -19,7 +19,7 @@
         "!source/**/*.test.ts",
         "!source/**/*.property.ts",
         "!source/test-libraries/**/*.ts",
-        "!source/packages/**/*.entry-point.ts"
+        "!source/**/*.entry-point.ts"
     ],
     "ignorePatterns": ["node_modules", "target", ".git", "integration-tests"],
     "disableTypeChecks": true,


### PR DESCRIPTION
The multi-spinner used `@topcli/spinner` on the main thread, so any sync work in `packtory` (notably `ts-morph` project init for each package) blocked the spinner timer and made the UI appear frozen. Move the rendering into a worker thread driven by a `SharedArrayBuffer` slot table, so spinner cadence is independent of main-thread load.

A small spinner-boot module spawns the worker as the very first import side-effect of the CLI entry point and writes a "Starting …" boot spinner; the user sees feedback within ~50 ms instead of waiting several hundred ms for module loading to complete.

Also fix a benchmark measurement bug that was conflating inter-CLI spawn time with intra-run frame gaps (caused the previous metric to read ~600 ms when real intra-run gaps were ~370 ms), add a permanent event-loop probe to the CLI subprocess for diagnostic context, tighten the responsiveness thresholds to 120 ms p99 / 200 ms max (was 240 / 480), and remove the '|| true' workaround from the CI benchmark step.