### PR TITLE
Lock the public API surface with tstyche type tests

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -5,6 +5,7 @@
     "exclude": [
         "source/**/*.test.ts",
         "source/**/*.property.ts",
+        "source/**/*.type-test.ts",
         "source/test-libraries/**/*.ts",
         "source/**/*.entry-point.ts",
         "integration-tests/**",

--- a/dependency-cruiser.config.js
+++ b/dependency-cruiser.config.js
@@ -7,7 +7,7 @@ const configFiles = [
 
 const entryPointFiles = ['^source/.+/.+\\.entry-point\\.ts$'];
 
-const testFiles = ['\\.(test|property)\\.ts$', '^integration-tests/'];
+const testFiles = ['\\.(test|property|type-test)\\.ts$', '^integration-tests/'];
 const testLibraryFiles = ['^source/test-libraries/'];
 const excludedFiles = ['^(\\./)?integration-tests/fixtures/', '^(\\./)?target/'];
 

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ lint: eslint prettier-check lint-dependencies lint-filename lint-unused-code
 
 lint-fix: eslint-fix prettier-fix
 
-test: test-unit-with-coverage test-unit-property test-integration
+test: test-unit-with-coverage test-unit-property test-types test-integration
 
 test-unit:
     mocha --config mocha.config.unit-tests.cjs
@@ -42,6 +42,9 @@ test-unit-with-coverage:
 
 test-unit-property:
     mocha --config mocha.config.property-tests.cjs
+
+test-types:
+    tstyche
 
 test-mutation:
     stryker run

--- a/knip.json
+++ b/knip.json
@@ -6,13 +6,15 @@
         "source/**/*.entry-point.ts!",
         "source/**/*.test.ts",
         "source/**/*.property.ts",
+        "source/**/*.type-test.ts",
         "integration-tests/**/*.ts",
         "dependency-cruiser.config.js",
         "mocha.config.base.cjs",
         "mocha.config.property-tests.cjs",
         "mocha.config.unit-tests.cjs",
         "mocha.config.integration-tests.cjs",
-        "packtory.config.js"
+        "packtory.config.js",
+        "tstyche.json"
     ],
     "project": [
         "benchmarks/**/*.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
                 "rust-just": "1.50.0",
                 "sinon": "21.1.2",
                 "tinybench": "6.0.1",
+                "tstyche": "7.1.0",
                 "typescript": "6.0.3",
                 "verdaccio": "6.5.2"
             },
@@ -13086,6 +13087,30 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/tstyche": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-7.1.0.tgz",
+            "integrity": "sha512-Ar03KIab85QcPzMRIBrLGqpaKYsnNTbEhhC+wsEGrerSaaLfBDNFDcLtoxEMJHAO/ssjeApAFkjRKUjfxUx4EQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tstyche": "dist/bin.js"
+            },
+            "engines": {
+                "node": ">=22.12"
+            },
+            "funding": {
+                "url": "https://github.com/tstyche/tstyche?sponsor=1"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.4"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/tuf-js": {
             "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "rust-just": "1.50.0",
         "sinon": "21.1.2",
         "tinybench": "6.0.1",
+        "tstyche": "7.1.0",
         "typescript": "6.0.3",
         "verdaccio": "6.5.2"
     },

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -1,0 +1,215 @@
+import { describe, test, expect } from 'tstyche';
+import type { Result } from 'true-myth';
+import type {
+    buildAndPublishAll,
+    progressBroadcastConsumer,
+    resolveAndLinkAll,
+    PacktoryConfig,
+    PublishAllResult,
+    ResolveAndLinkAllResult,
+    ResolveAndLinkFailure,
+    ResolvedPackage
+} from './packtory.entry-point.ts';
+
+type ProgressEventName =
+    | 'building'
+    | 'done'
+    | 'error'
+    | 'linking'
+    | 'publishing'
+    | 'rebuilding'
+    | 'resolving'
+    | 'scheduled';
+
+type PackageConfig = PacktoryConfig['packages'][number];
+type EntryPoint = PackageConfig['entryPoints'][number];
+type OkVariant<TResult> = Extract<TResult, { isOk: true }>;
+type ErrVariant<TResult> = Extract<TResult, { isErr: true }>;
+type PublishOk = OkVariant<PublishAllResult>['value'];
+type PublishErr = ErrVariant<PublishAllResult>['error'];
+type BuildAndPublishResult = PublishOk[number];
+
+describe('public functions', () => {
+    test('buildAndPublishAll takes an unknown config and a dry-run option and returns a PublishAllResult', () => {
+        expect<typeof buildAndPublishAll>().type.toBe<
+            (config: unknown, options: { readonly dryRun: boolean }) => Promise<PublishAllResult>
+        >();
+    });
+
+    test('resolveAndLinkAll takes an unknown config and returns a ResolveAndLinkAllResult', () => {
+        expect<typeof resolveAndLinkAll>().type.toBe<(config: unknown) => Promise<ResolveAndLinkAllResult>>();
+    });
+});
+
+describe('progressBroadcastConsumer', () => {
+    test('on accepts the documented event names', () => {
+        expect<Parameters<typeof progressBroadcastConsumer.on>[0]>().type.toBe<ProgressEventName>();
+    });
+
+    test('off accepts the documented event names', () => {
+        expect<Parameters<typeof progressBroadcastConsumer.off>[0]>().type.toBe<ProgressEventName>();
+    });
+
+    test('exposes only on and off', () => {
+        expect<keyof typeof progressBroadcastConsumer>().type.toBe<'off' | 'on'>();
+    });
+});
+
+describe('PacktoryConfig — accepted shapes', () => {
+    test('accepts a minimum valid configuration (registrySettings and packages)', () => {
+        expect<PacktoryConfig>().type.toBeAssignableFrom<{
+            readonly registrySettings: { readonly token: 'any-token' };
+            readonly packages: readonly [
+                { readonly name: 'pkg'; readonly entryPoints: readonly [{ readonly js: 'index.js' }] }
+            ];
+        }>();
+    });
+
+    test('accepts a fully populated configuration with all optional fields', () => {
+        expect<PacktoryConfig>().type.toBeAssignableFrom<{
+            readonly registrySettings: {
+                readonly token: 'any-token';
+                readonly registryUrl: 'https://registry.example';
+            };
+            readonly checks: { readonly noDuplicatedFiles: { readonly enabled: true } };
+            readonly commonPackageSettings: { readonly sourcesFolder: 'src'; readonly includeSourceMapFiles: true };
+            readonly packages: readonly [
+                {
+                    readonly name: 'pkg';
+                    readonly entryPoints: readonly [
+                        { readonly js: 'index.js'; readonly declarationFile: 'index.d.ts' }
+                    ];
+                    readonly bundleDependencies: readonly ['effect'];
+                    readonly bundlePeerDependencies: readonly ['react'];
+                    readonly includeSourceMapFiles: false;
+                }
+            ];
+        }>();
+    });
+});
+
+describe('PacktoryConfig — rejected shapes', () => {
+    test('rejects a configuration without registrySettings', () => {
+        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
+            readonly packages: readonly [];
+        }>();
+    });
+
+    test('rejects a configuration without packages', () => {
+        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
+            readonly registrySettings: { readonly token: 'tok' };
+        }>();
+    });
+
+    test('rejects a registrySettings without a token', () => {
+        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
+            readonly registrySettings: { readonly registryUrl: 'https://registry.example' };
+            readonly packages: readonly [];
+        }>();
+    });
+
+    test('rejects a package without name or entryPoints', () => {
+        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
+            readonly registrySettings: { readonly token: 'tok' };
+            readonly packages: readonly [{ readonly entryPoints: readonly [{ readonly js: 'index.js' }] }];
+        }>();
+        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
+            readonly registrySettings: { readonly token: 'tok' };
+            readonly packages: readonly [{ readonly name: 'pkg' }];
+        }>();
+    });
+});
+
+describe('PacktoryConfig — exposed structure', () => {
+    test('exposes the documented top-level keys', () => {
+        expect<keyof PacktoryConfig>().type.toBe<
+            'checks' | 'commonPackageSettings' | 'packages' | 'registrySettings'
+        >();
+    });
+
+    test('packages is a readonly array', () => {
+        expect<PacktoryConfig['packages']>().type.toBe<readonly PackageConfig[]>();
+    });
+
+    test('registrySettings has a required token and an optional registryUrl', () => {
+        expect<PacktoryConfig['registrySettings']['token']>().type.toBe<string>();
+        expect<PacktoryConfig['registrySettings']['registryUrl']>().type.toBe<string | undefined>();
+    });
+
+    test('PackageConfig requires name and entryPoints', () => {
+        expect<PackageConfig['name']>().type.toBe<string>();
+        expect<PackageConfig['entryPoints']>().type.toBe<readonly EntryPoint[]>();
+    });
+
+    test('EntryPoint requires a js path and allows an optional declarationFile', () => {
+        expect<EntryPoint['js']>().type.toBe<string>();
+        expect<EntryPoint['declarationFile']>().type.toBe<string | undefined>();
+    });
+
+    test('checks.noDuplicatedFiles toggles via an `enabled` boolean and an optional allow-list', () => {
+        type Checks = NonNullable<PacktoryConfig['checks']>;
+        type NoDuplicates = NonNullable<Checks['noDuplicatedFiles']>;
+        expect<NoDuplicates['enabled']>().type.toBe<boolean>();
+        expect<NoDuplicates['allowList']>().type.toBeAssignableTo<
+            readonly (string | { readonly filePath: string; readonly packages: readonly string[] })[] | undefined
+        >();
+    });
+});
+
+describe('PublishAllResult', () => {
+    test('is a true-myth Result whose ok value is a readonly array', () => {
+        expect<PublishAllResult>().type.toBeAssignableTo<Result<readonly unknown[], unknown>>();
+    });
+
+    test('the ok value is a readonly array of build-and-publish results', () => {
+        expect<PublishOk>().type.toBe<readonly BuildAndPublishResult[]>();
+    });
+
+    test('each result element exposes status and bundle', () => {
+        expect<BuildAndPublishResult>().type.toHaveProperty('status');
+        expect<BuildAndPublishResult>().type.toHaveProperty('bundle');
+    });
+
+    test('the status field is a fixed string union', () => {
+        expect<BuildAndPublishResult['status']>().type.toBe<'already-published' | 'initial-version' | 'new-version'>();
+    });
+
+    test('the failure variant is a discriminated union keyed by `type`', () => {
+        expect<PublishErr['type']>().type.toBe<'checks' | 'config' | 'partial'>();
+    });
+
+    test('a checks failure exposes a readonly issues array of strings', () => {
+        type ChecksFailure = Extract<PublishErr, { type: 'checks' }>;
+        expect<ChecksFailure['issues']>().type.toBe<readonly string[]>();
+    });
+
+    test('a config failure exposes a readonly issues array of strings', () => {
+        type ConfigFailure = Extract<PublishErr, { type: 'config' }>;
+        expect<ConfigFailure['issues']>().type.toBe<readonly string[]>();
+    });
+
+    test('a partial failure carries succeeded results and a list of errors', () => {
+        type PartialFailure = Extract<PublishErr, { type: 'partial' }>;
+        expect<PartialFailure['succeeded']>().type.toBe<readonly BuildAndPublishResult[]>();
+        expect<PartialFailure['failures']>().type.toBe<readonly Error[]>();
+    });
+});
+
+describe('ResolveAndLinkAllResult', () => {
+    test('is a Result of readonly ResolvedPackage entries with ResolveAndLinkFailure', () => {
+        expect<ResolveAndLinkAllResult>().type.toBe<Result<readonly ResolvedPackage[], ResolveAndLinkFailure>>();
+    });
+
+    test('the failure variant is a discriminated union keyed by `type`', () => {
+        expect<ResolveAndLinkFailure['type']>().type.toBe<'checks' | 'config' | 'partial'>();
+    });
+});
+
+describe('ResolvedPackage', () => {
+    test('exposes name, linkedBundle, and resolveOptions', () => {
+        expect<ResolvedPackage>().type.toHaveProperty('name');
+        expect<ResolvedPackage>().type.toHaveProperty('linkedBundle');
+        expect<ResolvedPackage>().type.toHaveProperty('resolveOptions');
+        expect<ResolvedPackage['name']>().type.toBe<string>();
+    });
+});

--- a/source/tsconfig.json
+++ b/source/tsconfig.json
@@ -1,4 +1,8 @@
 {
     "files": [],
-    "references": [{ "path": "tsconfig.sources.json" }, { "path": "tsconfig.unit-tests.json" }]
+    "references": [
+        { "path": "tsconfig.sources.json" },
+        { "path": "tsconfig.unit-tests.json" },
+        { "path": "tsconfig.type-tests.json" }
+    ]
 }

--- a/source/tsconfig.sources.json
+++ b/source/tsconfig.sources.json
@@ -6,5 +6,5 @@
         "types": ["node"]
     },
     "include": ["./**/*.ts"],
-    "exclude": ["./**/*.test.ts", "./**/*.property.ts", "./test-libraries/**/*.ts"]
+    "exclude": ["./**/*.test.ts", "./**/*.property.ts", "./**/*.type-test.ts", "./test-libraries/**/*.ts"]
 }

--- a/source/tsconfig.type-tests.json
+++ b/source/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "tsBuildInfoFile": "../target/buildcache/type-tests.tsbuildinfo",
+        "rootDir": "..",
+        "noEmit": true,
+        "types": ["node"]
+    },
+    "references": [{ "path": "./tsconfig.sources.json" }],
+    "include": ["./**/*.type-test.ts"]
+}

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -18,6 +18,7 @@
         "source/**/*.ts",
         "!source/**/*.test.ts",
         "!source/**/*.property.ts",
+        "!source/**/*.type-test.ts",
         "!source/test-libraries/**/*.ts",
         "!source/**/*.entry-point.ts"
     ],

--- a/tstyche.json
+++ b/tstyche.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://tstyche.org/schemas/config.json",
+    "testFileMatch": ["source/**/*.type-test.ts"],
+    "target": "6.0"
+}


### PR DESCRIPTION
Adds a tstyche test that pins every symbol exported from `source/packages/packtory/packtory.entry-point.ts` so that any unintended drift in the published TypeScript API fails CI. The test covers `buildAndPublishAll`, `resolveAndLinkAll`,
`progressBroadcastConsumer`, `PacktoryConfig` (accepted/rejected shapes and drilled fields), `PublishAllResult` (ok and failure variants), `ResolveAndLinkAllResult`, `ResolvedPackage`, and `ResolveAndLinkFailure`.

Wired up via a dedicated `source/tsconfig.type-tests.json` and a new `just test-types` recipe chained into `just test`, with knip and dependency-cruiser updated to recognise `*.type-test.ts`.