### PR TITLE
Route test schema parsing through schema-hub safeParse

### DIFF
--- a/source/config/additional-files.test.ts
+++ b/source/config/additional-files.test.ts
@@ -1,17 +1,18 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { additionalFileDescriptionSchema } from './additional-files.ts';
 
 test('schema accepts a valid additional file description', () => {
     assert.strictEqual(
-        additionalFileDescriptionSchema.safeParse({ sourceFilePath: 'foo', targetFilePath: 'bar' }).success,
+        safeParse(additionalFileDescriptionSchema, { sourceFilePath: 'foo', targetFilePath: 'bar' }).success,
         true
     );
 });
 
 test('schema rejects an additional file description without targetFilePath', () => {
-    assert.strictEqual(additionalFileDescriptionSchema.safeParse({ sourceFilePath: 'foo' }).success, false);
+    assert.strictEqual(safeParse(additionalFileDescriptionSchema, { sourceFilePath: 'foo' }).success, false);
 });
 
 test(

--- a/source/config/additional-package-json-attributes-schema.test.ts
+++ b/source/config/additional-package-json-attributes-schema.test.ts
@@ -5,11 +5,11 @@ import { checkValidationFailure, checkValidationSuccess } from '../test-librarie
 import { additionalPackageJsonAttributesSchema } from './additional-package-json-attributes-schema.ts';
 
 test('additional attributes schema accepts allowed keys', () => {
-    assert.strictEqual(additionalPackageJsonAttributesSchema.safeParse({ license: 'MIT' }).success, true);
+    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { license: 'MIT' }).success, true);
 });
 
 test('additional attributes schema rejects forbidden object keys', () => {
-    assert.strictEqual(additionalPackageJsonAttributesSchema.safeParse({ dependencies: {} }).success, false);
+    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { dependencies: {} }).success, false);
 });
 
 test(

--- a/source/config/automatic-versioning-settings.test.ts
+++ b/source/config/automatic-versioning-settings.test.ts
@@ -1,18 +1,19 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { automaticVersioningSettingsSchema } from './automatic-versioning-settings.ts';
 
 test('automatic versioning schema accepts automatic true', () => {
     assert.strictEqual(
-        automaticVersioningSettingsSchema.safeParse({ automatic: true, minimumVersion: '1.0.0' }).success,
+        safeParse(automaticVersioningSettingsSchema, { automatic: true, minimumVersion: '1.0.0' }).success,
         true
     );
 });
 
 test('automatic versioning schema rejects automatic false', () => {
     assert.strictEqual(
-        automaticVersioningSettingsSchema.safeParse({ automatic: false, minimumVersion: '1.0.0' }).success,
+        safeParse(automaticVersioningSettingsSchema, { automatic: false, minimumVersion: '1.0.0' }).success,
         false
     );
 });

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import {
     checkValidationFailure,
@@ -10,21 +11,21 @@ import { checksSchema } from './checks-schema.ts';
 
 test('schema accepts valid noDuplicatedFiles settings', () => {
     assert.strictEqual(
-        checksSchema.safeParse({ noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }).success,
+        safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }).success,
         true
     );
 });
 
 test('schema rejects noDuplicatedFiles settings without enabled', () => {
-    assert.strictEqual(checksSchema.safeParse({ noDuplicatedFiles: { allowList: ['src/index.ts'] } }).success, false);
+    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { allowList: ['src/index.ts'] } }).success, false);
 });
 
 test('schema accepts empty checks settings', () => {
-    assert.strictEqual(checksSchema.safeParse({}).success, true);
+    assert.strictEqual(safeParse(checksSchema, {}).success, true);
 });
 
 test('schema rejects non-object noDuplicatedFiles settings', () => {
-    assert.strictEqual(checksSchema.safeParse({ noDuplicatedFiles: true }).success, false);
+    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: true }).success, false);
 });
 
 const validNoDuplicatedFilesSettings = { enabled: true, allowList: ['src/index.ts'] };

--- a/source/config/common-package-settings-schemas.test.ts
+++ b/source/config/common-package-settings-schemas.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import {
     checkValidationFailure,
@@ -14,34 +15,34 @@ import {
 } from './common-package-settings-schemas.ts';
 
 test('optional common settings schema accepts an empty object', () => {
-    assert.strictEqual(optionalCommonPackageSettingsSchema.safeParse({}).success, true);
+    assert.strictEqual(safeParse(optionalCommonPackageSettingsSchema, {}).success, true);
 });
 
 test('required common settings schema accepts both required properties', () => {
     assert.strictEqual(
-        requiredCommonPackageSettingsSchema.safeParse({ sourcesFolder: 'src', mainPackageJson: {} }).success,
+        safeParse(requiredCommonPackageSettingsSchema, { sourcesFolder: 'src', mainPackageJson: {} }).success,
         true
     );
 });
 
 test('required common settings schema rejects missing sourcesFolder', () => {
-    assert.strictEqual(requiredCommonPackageSettingsSchema.safeParse({ mainPackageJson: {} }).success, false);
+    assert.strictEqual(safeParse(requiredCommonPackageSettingsSchema, { mainPackageJson: {} }).success, false);
 });
 
 test('required common settings schema rejects missing mainPackageJson', () => {
-    assert.strictEqual(requiredCommonPackageSettingsSchema.safeParse({ sourcesFolder: 'src' }).success, false);
+    assert.strictEqual(safeParse(requiredCommonPackageSettingsSchema, { sourcesFolder: 'src' }).success, false);
 });
 
 test('sourcesFolder-required common settings schema accepts sourcesFolder only', () => {
     assert.strictEqual(
-        commonPackageSettingsSourcesFolderRequiredSchema.safeParse({ sourcesFolder: 'src' }).success,
+        safeParse(commonPackageSettingsSourcesFolderRequiredSchema, { sourcesFolder: 'src' }).success,
         true
     );
 });
 
 test('mainPackageJson-required common settings schema accepts mainPackageJson only', () => {
     assert.strictEqual(
-        commonPackageSettingsMainPackageJsonRequiredSchema.safeParse({ mainPackageJson: {} }).success,
+        safeParse(commonPackageSettingsMainPackageJsonRequiredSchema, { mainPackageJson: {} }).success,
         true
     );
 });

--- a/source/config/config.test.ts
+++ b/source/config/config.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { getBundledDependencies } from './config.ts';
@@ -29,7 +30,7 @@ test('getBundledDependencies returns an empty list when no bundled dependencies 
 
 test('config schema accepts a valid config', () => {
     assert.strictEqual(
-        packtoryConfigSchema.safeParse({
+        safeParse(packtoryConfigSchema, {
             registrySettings: { token: 'foo' },
             packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
         }).success,
@@ -39,7 +40,7 @@ test('config schema accepts a valid config', () => {
 
 test('config schema rejects configs without registrySettings', () => {
     assert.strictEqual(
-        packtoryConfigSchema.safeParse({
+        safeParse(packtoryConfigSchema, {
             packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
         }).success,
         false
@@ -47,7 +48,7 @@ test('config schema rejects configs without registrySettings', () => {
 });
 
 test('config without registry schema rejects an empty packages tuple', () => {
-    assert.strictEqual(packtoryConfigWithoutRegistrySchema.safeParse({ packages: [] }).success, false);
+    assert.strictEqual(safeParse(packtoryConfigWithoutRegistrySchema, { packages: [] }).success, false);
 });
 
 test(

--- a/source/config/entry-point.test.ts
+++ b/source/config/entry-point.test.ts
@@ -1,14 +1,15 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { entryPointSchema } from './entry-point.ts';
 
 test('schema accepts an entry point with js only', () => {
-    assert.strictEqual(entryPointSchema.safeParse({ js: 'foo' }).success, true);
+    assert.strictEqual(safeParse(entryPointSchema, { js: 'foo' }).success, true);
 });
 
 test('schema rejects an entry point without js', () => {
-    assert.strictEqual(entryPointSchema.safeParse({ declarationFile: 'bar' }).success, false);
+    assert.strictEqual(safeParse(entryPointSchema, { declarationFile: 'bar' }).success, false);
 });
 
 test(

--- a/source/config/main-package-json-schema.test.ts
+++ b/source/config/main-package-json-schema.test.ts
@@ -1,14 +1,15 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { mainPackageJsonSchema } from './main-package-json-schema.ts';
 
 test('schema accepts type module', () => {
-    assert.strictEqual(mainPackageJsonSchema.safeParse({ type: 'module' }).success, true);
+    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'module' }).success, true);
 });
 
 test('schema rejects type commonjs', () => {
-    assert.strictEqual(mainPackageJsonSchema.safeParse({ type: 'commonjs' }).success, false);
+    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'commonjs' }).success, false);
 });
 
 test(

--- a/source/config/manual-versioning-settings.test.ts
+++ b/source/config/manual-versioning-settings.test.ts
@@ -1,14 +1,15 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { manualVersioningSettingsSchema } from './manual-versioning-settings.ts';
 
 test('manual versioning schema accepts automatic false', () => {
-    assert.strictEqual(manualVersioningSettingsSchema.safeParse({ automatic: false, version: '1.0.0' }).success, true);
+    assert.strictEqual(safeParse(manualVersioningSettingsSchema, { automatic: false, version: '1.0.0' }).success, true);
 });
 
 test('manual versioning schema rejects automatic true', () => {
-    assert.strictEqual(manualVersioningSettingsSchema.safeParse({ automatic: true, version: '1.0.0' }).success, false);
+    assert.strictEqual(safeParse(manualVersioningSettingsSchema, { automatic: true, version: '1.0.0' }).success, false);
 });
 
 test(

--- a/source/config/optional-package-settings-schema.test.ts
+++ b/source/config/optional-package-settings-schema.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import {
     checkValidationFailure,
@@ -14,11 +15,11 @@ const validOptionalPackageSettings = {
 };
 
 test('optional package settings schema accepts an empty object', () => {
-    assert.strictEqual(optionalPackageSettingsSchema.safeParse({}).success, true);
+    assert.strictEqual(safeParse(optionalPackageSettingsSchema, {}).success, true);
 });
 
 test('optional package settings schema rejects an invalid includeSourceMapFiles value', () => {
-    assert.strictEqual(optionalPackageSettingsSchema.safeParse({ includeSourceMapFiles: 'yes' }).success, false);
+    assert.strictEqual(safeParse(optionalPackageSettingsSchema, { includeSourceMapFiles: 'yes' }).success, false);
 });
 
 createTestCasesForOptionalField({

--- a/source/config/package-json.test.ts
+++ b/source/config/package-json.test.ts
@@ -18,19 +18,19 @@ test('forbidden additional package.json attribute helper identifies allowed and 
 });
 
 test('main package.json schema accepts type module', () => {
-    assert.strictEqual(mainPackageJsonSchema.safeParse({ type: 'module' }).success, true);
+    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'module' }).success, true);
 });
 
 test('main package.json schema rejects type commonjs', () => {
-    assert.strictEqual(mainPackageJsonSchema.safeParse({ type: 'commonjs' }).success, false);
+    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'commonjs' }).success, false);
 });
 
 test('additional package.json attributes schema rejects dependencies', () => {
-    assert.strictEqual(additionalPackageJsonAttributesSchema.safeParse({ dependencies: {} }).success, false);
+    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { dependencies: {} }).success, false);
 });
 
 test('additional package.json attributes schema accepts license', () => {
-    assert.strictEqual(additionalPackageJsonAttributesSchema.safeParse({ license: 'MIT' }).success, true);
+    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { license: 'MIT' }).success, true);
 });
 
 test(

--- a/source/config/package-schemas.test.ts
+++ b/source/config/package-schemas.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import {
@@ -10,7 +11,7 @@ import {
 
 test('package schema with all common settings accepts a valid package', () => {
     assert.strictEqual(
-        packageSchemaWithAllCommonSettings.safeParse({
+        safeParse(packageSchemaWithAllCommonSettings, {
             sourcesFolder: 'src',
             mainPackageJson: {},
             name: 'pkg',
@@ -22,7 +23,7 @@ test('package schema with all common settings accepts a valid package', () => {
 
 test('package schema with all common settings rejects empty entryPoints', () => {
     assert.strictEqual(
-        packageSchemaWithAllCommonSettings.safeParse({
+        safeParse(packageSchemaWithAllCommonSettings, {
             sourcesFolder: 'src',
             mainPackageJson: {},
             name: 'pkg',
@@ -34,7 +35,7 @@ test('package schema with all common settings rejects empty entryPoints', () => 
 
 test('package schema with partial common settings accepts package-specific settings only', () => {
     assert.strictEqual(
-        packageSchemaWithPartialCommonSettings.safeParse({
+        safeParse(packageSchemaWithPartialCommonSettings, {
             name: 'pkg',
             entryPoints: [{ js: 'index.js' }]
         }).success,
@@ -44,7 +45,7 @@ test('package schema with partial common settings accepts package-specific setti
 
 test('package schema with mandatory sourcesFolder rejects packages without it', () => {
     assert.strictEqual(
-        packageSchemaWithMandatorySourcesFolder.safeParse({
+        safeParse(packageSchemaWithMandatorySourcesFolder, {
             mainPackageJson: {},
             name: 'pkg',
             entryPoints: [{ js: 'index.js' }]
@@ -55,7 +56,7 @@ test('package schema with mandatory sourcesFolder rejects packages without it', 
 
 test('package schema with mandatory mainPackageJson rejects packages without it', () => {
     assert.strictEqual(
-        packageSchemaWithMandatoryMainPackageJson.safeParse({
+        safeParse(packageSchemaWithMandatoryMainPackageJson, {
             sourcesFolder: 'src',
             name: 'pkg',
             entryPoints: [{ js: 'index.js' }]

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
@@ -9,12 +10,12 @@ const validConfig = {
 };
 
 test('packtory config schema accepts a valid config', () => {
-    assert.strictEqual(packtoryConfigSchema.safeParse(validConfig).success, true);
+    assert.strictEqual(safeParse(packtoryConfigSchema, validConfig).success, true);
 });
 
 test('packtory config schema rejects configs without registrySettings', () => {
     assert.strictEqual(
-        packtoryConfigSchema.safeParse({
+        safeParse(packtoryConfigSchema, {
             packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
         }).success,
         false

--- a/source/config/packtory-config-without-registry-schema.test.ts
+++ b/source/config/packtory-config-without-registry-schema.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-registry-schema.ts';
 
 test('config without registry schema accepts package configs with optional common settings', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             packages: [{ sourcesFolder: 'src', mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
         true
@@ -14,7 +15,7 @@ test('config without registry schema accepts package configs with optional commo
 
 test('config without registry schema accepts required common package settings', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             commonPackageSettings: { sourcesFolder: 'src', mainPackageJson: {} },
             packages: [{ name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
@@ -24,7 +25,7 @@ test('config without registry schema accepts required common package settings', 
 
 test('config without registry schema accepts required mainPackageJson', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             commonPackageSettings: { mainPackageJson: {} },
             packages: [{ sourcesFolder: 'src', name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
@@ -34,7 +35,7 @@ test('config without registry schema accepts required mainPackageJson', () => {
 
 test('config without registry schema accepts required sourcesFolder', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             commonPackageSettings: { sourcesFolder: 'src' },
             packages: [{ mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
@@ -43,12 +44,12 @@ test('config without registry schema accepts required sourcesFolder', () => {
 });
 
 test('config without registry schema rejects an empty packages tuple', () => {
-    assert.strictEqual(packtoryConfigWithoutRegistrySchema.safeParse({ packages: [] }).success, false);
+    assert.strictEqual(safeParse(packtoryConfigWithoutRegistrySchema, { packages: [] }).success, false);
 });
 
 test('required common settings branch rejects an empty packages tuple', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             commonPackageSettings: { sourcesFolder: 'src', mainPackageJson: {} },
             packages: []
         }).success,
@@ -58,7 +59,7 @@ test('required common settings branch rejects an empty packages tuple', () => {
 
 test('required mainPackageJson branch rejects an empty packages tuple', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             commonPackageSettings: { mainPackageJson: {} },
             packages: []
         }).success,
@@ -68,7 +69,7 @@ test('required mainPackageJson branch rejects an empty packages tuple', () => {
 
 test('required sourcesFolder branch rejects an empty packages tuple', () => {
     assert.strictEqual(
-        packtoryConfigWithoutRegistrySchema.safeParse({
+        safeParse(packtoryConfigWithoutRegistrySchema, {
             commonPackageSettings: { sourcesFolder: 'src' },
             packages: []
         }).success,

--- a/source/config/per-package-settings-schema.test.ts
+++ b/source/config/per-package-settings-schema.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import {
     checkValidationFailure,
@@ -17,12 +18,12 @@ const validPerPackageSettings = {
 };
 
 test('per-package settings schema accepts a valid package definition', () => {
-    assert.strictEqual(perPackageSettingsSchema.safeParse(validPerPackageSettings).success, true);
+    assert.strictEqual(safeParse(perPackageSettingsSchema, validPerPackageSettings).success, true);
 });
 
 test('per-package settings schema rejects empty entryPoints', () => {
     assert.strictEqual(
-        perPackageSettingsSchema.safeParse({ ...validPerPackageSettings, entryPoints: [] }).success,
+        safeParse(perPackageSettingsSchema, { ...validPerPackageSettings, entryPoints: [] }).success,
         false
     );
 });

--- a/source/config/registry-settings.test.ts
+++ b/source/config/registry-settings.test.ts
@@ -1,14 +1,15 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { registrySettingsSchema } from './registry-settings.ts';
 
 test('schema accepts registry settings with token only', () => {
-    assert.strictEqual(registrySettingsSchema.safeParse({ token: 'foo' }).success, true);
+    assert.strictEqual(safeParse(registrySettingsSchema, { token: 'foo' }).success, true);
 });
 
 test('schema rejects registry settings without token', () => {
-    assert.strictEqual(registrySettingsSchema.safeParse({ registryUrl: 'bar' }).success, false);
+    assert.strictEqual(safeParse(registrySettingsSchema, { registryUrl: 'bar' }).success, false);
 });
 
 test(

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -33,6 +33,7 @@ test('leaf config schemas keep their expected object keys and strict object beha
 
 test('versioning schema keeps the discriminant and both branches', async () => {
     const result = await runNodeProbe(`
+        import { safeParse } from '@schema-hub/zod-error-formatter';
         import { versioningSettingsSchema } from './source/config/versioning-settings.ts';
 
         const unionDef = versioningSettingsSchema._zod.def.innerType.def;
@@ -42,16 +43,16 @@ test('versioning schema keeps the discriminant and both branches', async () => {
             optionCount: unionDef.options.length,
             branchKeys: unionDef.options.map((option) => Object.keys(option.def.innerType.def.shape)),
             branchLiterals: unionDef.options.map((option) => option.def.innerType.def.shape.automatic.def.values[0]),
-            automaticSuccess: versioningSettingsSchema.safeParse({
+            automaticSuccess: safeParse(versioningSettingsSchema, {
                 automatic: true,
                 minimumVersion: '1.0.0'
             }).success,
-            manualSuccess: versioningSettingsSchema.safeParse({ automatic: false, version: '1.0.0' }).success,
-            invalidAutomaticBranchSuccess: versioningSettingsSchema.safeParse({
+            manualSuccess: safeParse(versioningSettingsSchema, { automatic: false, version: '1.0.0' }).success,
+            invalidAutomaticBranchSuccess: safeParse(versioningSettingsSchema, {
                 automatic: true,
                 version: '1.0.0'
             }).success,
-            invalidManualBranchSuccess: versioningSettingsSchema.safeParse({
+            invalidManualBranchSuccess: safeParse(versioningSettingsSchema, {
                 automatic: false,
                 minimumVersion: '1.0.0'
             }).success
@@ -75,6 +76,7 @@ test('versioning schema keeps the discriminant and both branches', async () => {
 
 test('package json schemas keep their runtime structure and forbidden key behavior', async () => {
     const result = await runNodeProbe(`
+        import { safeParse } from '@schema-hub/zod-error-formatter';
         import {
             additionalPackageJsonAttributesSchema
         } from './source/config/additional-package-json-attributes-schema.ts';
@@ -90,7 +92,7 @@ test('package json schemas keep their runtime structure and forbidden key behavi
             'types',
             'type',
             'version'
-        ].map((key) => additionalPackageJsonAttributesSchema.safeParse({ [key]: '1.0.0' }).success);
+        ].map((key) => safeParse(additionalPackageJsonAttributesSchema, { [key]: '1.0.0' }).success);
 
         console.log(JSON.stringify({
             mainShape: Object.keys(mainShape),
@@ -98,7 +100,7 @@ test('package json schemas keep their runtime structure and forbidden key behavi
             dependencyRecordType: mainShape.dependencies.def.innerType.def.innerType.def.type,
             devDependencyRecordType: mainShape.devDependencies.def.innerType.def.innerType.def.type,
             peerDependencyRecordType: mainShape.peerDependencies.def.innerType.def.innerType.def.type,
-            validMainSuccess: mainPackageJsonSchema.safeParse({
+            validMainSuccess: safeParse(mainPackageJsonSchema, {
                 type: 'module',
                 dependencies: { dep: '1.0.0' }
             }).success,
@@ -119,6 +121,7 @@ test('package json schemas keep their runtime structure and forbidden key behavi
 
 test('packtory config schemas keep their union and package tuple structure', async () => {
     const result = await runNodeProbe(`
+        import { safeParse } from '@schema-hub/zod-error-formatter';
         import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
         import {
             packtoryConfigWithoutRegistrySchema
@@ -146,7 +149,7 @@ test('packtory config schemas keep their union and package tuple structure', asy
             configIntersectionLeftKeys: Object.keys(
                 packtoryConfigSchema._zod.def.left.def.shape
             ),
-            validWithoutRegistrySuccess: packtoryConfigWithoutRegistrySchema.safeParse({
+            validWithoutRegistrySuccess: safeParse(packtoryConfigWithoutRegistrySchema, {
                 packages: [
                     {
                         name: 'pkg',
@@ -196,38 +199,39 @@ test('packtory config schemas keep their union and package tuple structure', asy
 
 test('schema source modules still validate representative valid and invalid inputs', async () => {
     const result = await runNodeProbe(`
+        import { safeParse } from '@schema-hub/zod-error-formatter';
         import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
         import { entryPointSchema } from './source/config/entry-point.ts';
         import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
         import { registrySettingsSchema } from './source/config/registry-settings.ts';
 
         console.log(JSON.stringify({
-            validAdditionalFileSuccess: additionalFileDescriptionSchema.safeParse({
+            validAdditionalFileSuccess: safeParse(additionalFileDescriptionSchema, {
                 sourceFilePath: 'README.md',
                 targetFilePath: 'README.md'
             }).success,
-            missingAdditionalFileSourceSuccess: additionalFileDescriptionSchema.safeParse({
+            missingAdditionalFileSourceSuccess: safeParse(additionalFileDescriptionSchema, {
                 targetFilePath: 'README.md'
             }).success,
-            validEntryPointSuccess: entryPointSchema.safeParse({
+            validEntryPointSuccess: safeParse(entryPointSchema, {
                 js: 'index.js',
                 declarationFile: 'index.d.ts'
             }).success,
-            missingEntryPointJsSuccess: entryPointSchema.safeParse({
+            missingEntryPointJsSuccess: safeParse(entryPointSchema, {
                 declarationFile: 'index.d.ts'
             }).success,
-            extraEntryPointPropertySuccess: entryPointSchema.safeParse({
+            extraEntryPointPropertySuccess: safeParse(entryPointSchema, {
                 js: 'index.js',
                 extra: 'nope'
             }).success,
-            validRegistrySuccess: registrySettingsSchema.safeParse({
+            validRegistrySuccess: safeParse(registrySettingsSchema, {
                 token: 'secret',
                 registryUrl: 'https://example.test'
             }).success,
-            missingRegistryTokenSuccess: registrySettingsSchema.safeParse({
+            missingRegistryTokenSuccess: safeParse(registrySettingsSchema, {
                 registryUrl: 'https://example.test'
             }).success,
-            validConfigSuccess: packtoryConfigSchema.safeParse({
+            validConfigSuccess: safeParse(packtoryConfigSchema, {
                 registrySettings: { token: 'secret' },
                 packages: [{
                     sourcesFolder: 'src',
@@ -236,7 +240,7 @@ test('schema source modules still validate representative valid and invalid inpu
                     entryPoints: [{ js: 'index.js' }]
                 }]
             }).success,
-            missingConfigRegistrySuccess: packtoryConfigSchema.safeParse({
+            missingConfigRegistrySuccess: safeParse(packtoryConfigSchema, {
                 packages: [{
                     sourcesFolder: 'src',
                     mainPackageJson: {},
@@ -244,7 +248,7 @@ test('schema source modules still validate representative valid and invalid inpu
                     entryPoints: [{ js: 'index.js' }]
                 }]
             }).success,
-            emptyConfigPackagesSuccess: packtoryConfigSchema.safeParse({
+            emptyConfigPackagesSuccess: safeParse(packtoryConfigSchema, {
                 registrySettings: { token: 'secret' },
                 packages: []
             }).success

--- a/source/config/versioning-settings.test.ts
+++ b/source/config/versioning-settings.test.ts
@@ -1,18 +1,19 @@
 import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { versioningSettingsSchema } from './versioning-settings.ts';
 
 test('schema accepts the automatic versioning branch', () => {
-    assert.strictEqual(versioningSettingsSchema.safeParse({ automatic: true, minimumVersion: 'foo' }).success, true);
+    assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, minimumVersion: 'foo' }).success, true);
 });
 
 test('schema accepts the manual versioning branch', () => {
-    assert.strictEqual(versioningSettingsSchema.safeParse({ automatic: false, version: '1' }).success, true);
+    assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: false, version: '1' }).success, true);
 });
 
 test('schema rejects mixing automatic with manual-only fields', () => {
-    assert.strictEqual(versioningSettingsSchema.safeParse({ automatic: true, version: '1' }).success, false);
+    assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, version: '1' }).success, false);
 });
 
 test(


### PR DESCRIPTION
Replace direct schema.safeParse(value) calls in source/config/*.test.ts with safeParse(schema, value) from @schema-hub/zod-error-formatter to keep validation paths consistent with the rest of the codebase.