### PR TITLE
Redesign registry auth config and OTP handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [22.x, 24.x]
+                node-version: [24.x, 26.x]
         name: Node.js v${{ matrix.node-version }}
         steps:
             - uses: actions/checkout@v6
@@ -37,7 +37,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  node-version: 26.x
             - name: Install dependencies
               run: npm clean-install
             - name: Run mutation tests
@@ -51,7 +51,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  node-version: 26.x
             - name: Install dependencies
               run: npm clean-install
             - name: Run benchmarks

--- a/benchmarks/benchmark-registry.ts
+++ b/benchmarks/benchmark-registry.ts
@@ -120,7 +120,10 @@ export async function startBenchmarkRegistry(): Promise<RegistryHandle> {
     return {
         settings: {
             registryUrl,
-            token
+            auth: {
+                type: 'bearer-token',
+                token
+            }
         },
         async close() {
             try {

--- a/integration-tests/packtory/publish.test.ts
+++ b/integration-tests/packtory/publish.test.ts
@@ -13,7 +13,23 @@ import {
 import { createRegistryClient } from '../../source/bundle-emitter/registry-client.ts';
 import { extractPackageTarball } from '../../source/bundle-emitter/extract-package-tarball.ts';
 
-const registryClient = createRegistryClient({ npmFetch, publish });
+const timers = process.getBuiltinModule('node:timers');
+
+const registryClient = createRegistryClient({
+    npmFetch,
+    publish,
+    fetch: globalThis.fetch,
+    clock: {
+        getCurrentTimeInMilliseconds: () => {
+            return Date.now();
+        },
+        setTimeout: timers.setTimeout,
+        clearTimeout: timers.clearTimeout
+    },
+    resolveIdToken: async () => {
+        throw new Error('OIDC id tokens are not used in this integration test');
+    }
+});
 
 type PublishedFile = Awaited<ReturnType<typeof extractPackageTarball>>[number];
 
@@ -43,7 +59,32 @@ type PublishFixturePackagesParams = {
     readonly registryDetails: RegistryDetails;
     readonly packages?: PackageConfigList;
     readonly commonPackageSettings?: Partial<CommonPackageSettings>;
+    readonly authMode?: 'basic' | 'bearer';
 };
+
+function createRegistrySettings(
+    registryDetails: RegistryDetails,
+    authMode: PublishFixturePackagesParams['authMode'] = 'bearer'
+): PublishConfig['registrySettings'] {
+    if (authMode === 'basic') {
+        return {
+            registryUrl: registryDetails.registryUrl,
+            auth: {
+                type: 'basic',
+                username: registryDetails.username,
+                password: registryDetails.password
+            }
+        };
+    }
+
+    return {
+        registryUrl: registryDetails.registryUrl,
+        auth: {
+            type: 'bearer-token',
+            token: registryDetails.token
+        }
+    };
+}
 
 const expectedFirstPackageVersion = {
     version: '0.0.1',
@@ -184,10 +225,7 @@ async function createPublishConfig(params: CreatePublishConfigParams): Promise<P
     };
 
     return {
-        registrySettings: {
-            registryUrl: registryDetails.registryUrl,
-            token: registryDetails.token
-        },
+        registrySettings: createRegistrySettings(registryDetails),
         commonPackageSettings: mergedCommonPackageSettings,
         packages
     };
@@ -201,8 +239,9 @@ async function publishFixturePackages(params: PublishFixturePackagesParams): Pro
         ...(params.commonPackageSettings === undefined ? {} : { commonPackageSettings: params.commonPackageSettings })
     };
     const config = await createPublishConfig(configParams);
+    const registrySettings = createRegistrySettings(params.registryDetails, params.authMode);
 
-    return buildAndPublishAll(config, { dryRun: false });
+    return buildAndPublishAll({ ...config, registrySettings }, { dryRun: false });
 }
 
 function assertPublishSucceeded(result: PublishAllResult): void {
@@ -210,14 +249,15 @@ function assertPublishSucceeded(result: PublishAllResult): void {
 }
 
 async function fetchPublishedPackage(packageName: string, registryDetails: RegistryDetails): Promise<PublishedPackage> {
-    const versionDetails = await registryClient.fetchLatestVersion(packageName, registryDetails);
+    const registrySettings = createRegistrySettings(registryDetails);
+    const versionDetails = await registryClient.fetchLatestVersion(packageName, registrySettings);
 
     if (versionDetails.isNothing) {
         assert.fail(`Expected package "${packageName}" to be published`);
     }
 
     const { version, tarballUrl, shasum } = versionDetails.value;
-    const tarballData = await registryClient.fetchTarball(tarballUrl, shasum);
+    const tarballData = await registryClient.fetchTarball(tarballUrl, shasum, registrySettings);
     const files = await extractPackageTarball(tarballData);
     const manifestFile = files.find((file) => {
         return file.filePath === 'package/package.json';
@@ -335,6 +375,23 @@ test(
 
         assert.strictEqual(publishedPackage.version, '3.2.1');
         assert.strictEqual(publishedPackage.manifest.version, '3.2.1');
+    })
+);
+
+test(
+    'publishes successfully with explicit basic auth against the registry',
+    checkWithRegistry(async (registryDetails) => {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/multiple-packages-with-substitution');
+        const packages = createPackageConfigList(createPackageConfig(fixturePath, 'first', 'entry1'));
+
+        assertPublishSucceeded(
+            await publishFixturePackages({ fixturePath, registryDetails, packages, authMode: 'basic' })
+        );
+
+        const publishedPackage = await fetchPublishedPackage('first', registryDetails);
+
+        assert.strictEqual(publishedPackage.version, '0.0.1');
+        assert.strictEqual(publishedPackage.manifest.version, '0.0.1');
     })
 );
 

--- a/integration-tests/registry.ts
+++ b/integration-tests/registry.ts
@@ -86,8 +86,10 @@ async function createRegistryServer(storageDirectory: string): Promise<Server> {
 }
 
 export type RegistryDetails = {
-    registryUrl: string;
-    token: string;
+    readonly registryUrl: string;
+    readonly token: string;
+    readonly username: string;
+    readonly password: string;
 };
 
 async function startRegistry(server: Server): Promise<RegistryDetails> {
@@ -113,7 +115,7 @@ async function startRegistry(server: Server): Promise<RegistryDetails> {
         throw new Error('Couldn’t create a token');
     }
 
-    return { registryUrl, token };
+    return { registryUrl, token, username: userName, password };
 }
 
 export function checkWithRegistry(callback: (registryDetails: RegistryDetails) => Promise<void>): AsyncFunc {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
                 "verdaccio": "6.5.2"
             },
             "engines": {
-                "node": "^22 || ^24"
+                "node": "^24 || ^26"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -6449,70 +6449,34 @@
             }
         },
         "node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
             "license": "ISC",
             "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=20"
             }
         },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "license": "MIT",
             "dependencies": {
-                "color-convert": "^2.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
             },
             "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/clone-response": {
@@ -6550,6 +6514,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -6562,6 +6527,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/colorette": {
@@ -12489,15 +12455,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12774,67 +12731,6 @@
             "os": [
                 "win32"
             ]
-        },
-        "node_modules/rust-just/node_modules/cliui": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^7.2.0",
-                "strip-ansi": "^7.1.0",
-                "wrap-ansi": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/rust-just/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/rust-just/node_modules/yargs": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^9.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "string-width": "^7.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^22.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=23"
-            }
-        },
-        "node_modules/rust-just/node_modules/yargs-parser": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=23"
-            }
         },
         "node_modules/rxjs": {
             "version": "7.8.2",
@@ -14928,27 +14824,27 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
             "license": "MIT",
             "dependencies": {
-                "cliui": "^8.0.1",
+                "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
+                "string-width": "^7.2.0",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
+                "yargs-parser": "^22.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -14991,6 +14887,32 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/yargs/node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
         "verdaccio": "6.5.2"
     },
     "engines": {
-        "node": "^22 || ^24"
+        "node": "^24 || ^26"
+    },
+    "overrides": {
+        "yargs": "18.0.0"
     }
 }

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -17,7 +17,7 @@ export async function buildConfig() {
     }
 
     return {
-        registrySettings: { token: npmToken },
+        registrySettings: { auth: { type: 'bearer-token', token: npmToken } },
         checks: {
             noDuplicatedFiles: {
                 enabled: true,

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,9 @@ import fs from 'node:fs';
 
 export const config = {
     // Customize your registry settings, if needed
-    registrySettings: { token: process.env.NPM_TOKEN },
+    registrySettings: {
+        auth: { type: 'bearer-token', token: process.env.NPM_TOKEN }
+    },
 
     // Common settings shared among packages
     commonPackageSettings: {
@@ -57,13 +59,12 @@ export const config = {
     packages: [
         {
             name: 'first-package',
-            entryPoints: [ { js: 'first.js' } ],
+            entryPoints: [{ js: 'first.js' }]
         },
         {
             name: 'second-package',
-            entryPoints: [ { js: 'second.js' } ],
-            entryPoints: ,
-            bundleDependencies: ['first']
+            entryPoints: [{ js: 'second.js' }],
+            bundleDependencies: ['first-package']
         }
     ]
 };
@@ -119,8 +120,21 @@ This explanation provides a comprehensive overview of the bundling and publishin
 The configuration for `packtory` is an object with the following properties:
 
 1. **`registrySettings`** (Required):
-    - An object with at least a required `token` for authentication.
-    - Optionally, you can provide a custom `registryUrl` for non-default registries.
+    - An object with a required `auth` configuration.
+    - Optionally, you can provide a custom `registryUrl`.
+    - Supported publish auth strategies:
+        - `type: 'bearer-token'` with a `token`
+        - `type: 'basic'` with `username` and `password`
+        - `type: 'npm-oidc'` for npm trusted publishing token exchange
+    - `auth` supports two forms:
+        - Shorthand: one auth strategy used for both publish and metadata access
+        - Expanded: `{ publish, metadata }`
+    - Supported metadata modes:
+        - `'inherit-publish-auth'`
+        - `'anonymous'`
+        - `'auto'`
+        - explicit bearer/basic auth
+    - `packtory` does not read `.npmrc`; provide auth explicitly in `packtory.config.js`.
 
 2. **`commonPackageSettings`** (Optional):
     - Defines settings that can be shared for all packages.
@@ -177,7 +191,9 @@ Suppose you have a project with a utility library (`image-resizer-lib`) and a co
 ```javascript
 // packtory.config.js
 export const config = {
-    registrySettings: { token: process.env.NPM_TOKEN },
+    registrySettings: {
+        auth: { type: 'bearer-token', token: process.env.NPM_TOKEN }
+    },
     commonPackageSettings: {
         sourcesFolder: path.join(process.cwd(), 'dist/'),
         mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' })
@@ -203,7 +219,9 @@ Consider a scenario where you have an ecosystem of packages like `awesome-logger
 ```javascript
 // packtory.config.js
 export const config = {
-    registrySettings: { token: process.env.NPM_TOKEN },
+    registrySettings: {
+        auth: { type: 'bearer-token', token: process.env.NPM_TOKEN }
+    },
     commonPackageSettings: {
         sourcesFolder: path.join(process.cwd(), 'src/'),
         mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' })
@@ -226,5 +244,54 @@ export const config = {
     ]
 };
 ```
+
+### Auth examples
+
+Use a bearer token:
+
+```javascript
+registrySettings: {
+    auth: { type: 'bearer-token', token: process.env.NPM_TOKEN }
+}
+```
+
+Use explicit basic auth for registries such as Azure Artifacts or Artifactory:
+
+```javascript
+registrySettings: {
+    registryUrl: 'https://registry.example.test/',
+    auth: { type: 'basic', username: process.env.NPM_USERNAME, password: process.env.NPM_PASSWORD }
+}
+```
+
+Use npm trusted publishing / OIDC on npmjs.org:
+
+```javascript
+registrySettings: {
+    auth: {
+        publish: { type: 'npm-oidc', provider: 'auto' },
+        metadata: 'auto'
+    }
+}
+```
+
+If the registry challenges a publish with a one-time password, the CLI prompts interactively when running in a TTY. Non-interactive runs should use a token or OIDC flow that does not require a live one-time-password entry.
+
+Use metadata auto mode:
+
+```javascript
+registrySettings: {
+    auth: {
+        publish: { type: 'bearer-token', token: process.env.NPM_TOKEN },
+        metadata: 'auto'
+    }
+}
+```
+
+`metadata: 'auto'` means:
+
+- Try metadata requests without authentication first.
+- If the registry responds with an authentication challenge such as `401` or `403`, retry using the publish auth.
+- Keep in mind that `404` can be ambiguous on some registries because it may mean either "not found" or "not visible without auth".
 
 These examples demonstrate how `packtory` adapts to different project structures and facilitates the efficient bundling and publishing of packages with varying dependencies.

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -5,6 +5,8 @@ import { Maybe } from 'true-myth';
 import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { createBundleEmitter, type BundleEmitterDependencies, type BundleEmitter } from './emitter.ts';
 
+const registrySettings = { auth: { type: 'bearer-token', token: 'the-token' } } as const;
+
 function namedBundle(): ReturnType<typeof versionedBundleWithManifest> {
     return versionedBundleWithManifest({ name: 'the-name' });
 }
@@ -64,12 +66,12 @@ test('determineCurrentVersion() fetches the latest version when automatic versio
 
     await emitter.determineCurrentVersion({
         name: 'the-name',
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         versioning: { automatic: true }
     });
 
     assert.strictEqual(fetchLatestVersion.callCount, 1);
-    assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', { token: 'the-token' }]);
+    assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
 });
 
 test('determineCurrentVersion() returns the fetched version when automatic versioning is enabled', async () => {
@@ -78,7 +80,7 @@ test('determineCurrentVersion() returns the fetched version when automatic versi
 
     const result = await emitter.determineCurrentVersion({
         name: 'the-name',
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         versioning: { automatic: true }
     });
 
@@ -91,7 +93,7 @@ test('determineCurrentVersion() doesn’t fetches the latest version when manual
 
     await emitter.determineCurrentVersion({
         name: 'the-name',
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         versioning: { automatic: false, version: '' }
     });
 
@@ -103,7 +105,7 @@ test('determineCurrentVersion() returns the given version when manual versioning
 
     const result = await emitter.determineCurrentVersion({
         name: 'the-name',
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         versioning: { automatic: false, version: 'manual-version' }
     });
 
@@ -115,12 +117,12 @@ test('checkBundleAlreadyPublished() fetches the latest version', async () => {
     const emitter = emitterFactory({ fetchLatestVersion });
 
     await emitter.checkBundleAlreadyPublished({
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         bundle: namedBundle()
     });
 
     assert.strictEqual(fetchLatestVersion.callCount, 1);
-    assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', { token: 'the-token' }]);
+    assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
 });
 
 test('checkBundleAlreadyPublished() returns false when there is no latest version in the registry', async () => {
@@ -129,7 +131,7 @@ test('checkBundleAlreadyPublished() returns false when there is no latest versio
     const emitter = emitterFactory({ fetchLatestVersion, collectContents });
 
     const result = await emitter.checkBundleAlreadyPublished({
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         bundle: namedBundle()
     });
 
@@ -147,13 +149,17 @@ test('checkBundleAlreadyPublished() returns false when the latest version conten
 
     const bundle = namedBundle();
     const result = await emitter.checkBundleAlreadyPublished({
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         bundle
     });
 
     assert.deepStrictEqual(result, { alreadyPublishedAsLatest: false });
     assert.deepStrictEqual(collectContents.firstCall.args, [bundle, 'package']);
-    assert.deepStrictEqual(fetchTarball.firstCall.args, ['https://registry.example.test/package.tgz', 'def']);
+    assert.deepStrictEqual(fetchTarball.firstCall.args, [
+        'https://registry.example.test/package.tgz',
+        'def',
+        registrySettings
+    ]);
 });
 
 test('checkBundleAlreadyPublished() returns true when the latest version contents match the given bundle contents', async () => {
@@ -165,13 +171,17 @@ test('checkBundleAlreadyPublished() returns true when the latest version content
     const emitter = emitterFactory({ fetchLatestVersion, fetchTarball, collectContents });
 
     const result = await emitter.checkBundleAlreadyPublished({
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         bundle: namedBundle()
     });
 
     assert.deepStrictEqual(result, { alreadyPublishedAsLatest: true });
     assert.deepStrictEqual(collectContents.firstCall.args.at(-1), 'package');
-    assert.deepStrictEqual(fetchTarball.firstCall.args, ['https://registry.example.test/package.tgz', 'abc']);
+    assert.deepStrictEqual(fetchTarball.firstCall.args, [
+        'https://registry.example.test/package.tgz',
+        'abc',
+        registrySettings
+    ]);
 });
 
 test('publish() publishes the given bundle', async () => {
@@ -180,14 +190,10 @@ test('publish() publishes the given bundle', async () => {
     const emitter = emitterFactory({ buildTarball, publishPackage });
 
     await emitter.publish({
-        registrySettings: { token: 'the-token' },
+        registrySettings,
         bundle: namedBundle()
     });
 
     assert.strictEqual(publishPackage.callCount, 1);
-    assert.deepStrictEqual(publishPackage.firstCall.args, [
-        { name: '', version: '' },
-        emptyTarball,
-        { token: 'the-token' }
-    ]);
+    assert.deepStrictEqual(publishPackage.firstCall.args, [{ name: '', version: '' }, emptyTarball, registrySettings]);
 });

--- a/source/bundle-emitter/emitter.ts
+++ b/source/bundle-emitter/emitter.ts
@@ -60,7 +60,8 @@ export function createBundleEmitter(dependencies: BundleEmitterDependencies): Bu
             const artifactContents = artifactsBuilder.collectContents(bundle, 'package');
             const tarball = await registryClient.fetchTarball(
                 latestVersion.value.tarballUrl,
-                latestVersion.value.shasum
+                latestVersion.value.shasum,
+                registrySettings
             );
             const latestVersionArtifactContents = await extractPackageTarball(tarball);
             const result = compareFileDescriptions(artifactContents, latestVersionArtifactContents);

--- a/source/bundle-emitter/registry-client.test.ts
+++ b/source/bundle-emitter/registry-client.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert';
 import { test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
+import type { PublishAuthStrategy } from '../config/registry-settings.ts';
+import { createFakeClock, type FakeClock } from '../test-libraries/fake-clock.ts';
 import { createRegistryClient, type RegistryClientDependencies, type RegistryClient } from './registry-client.ts';
 
 type NpmFetchOverrides = {
@@ -14,9 +16,7 @@ type FakeNpmFetch = SinonSpy & { json: SinonSpy };
 function createFakeNpmFetch(overrides: NpmFetchOverrides = {}): FakeNpmFetch {
     const { buffer = fake(), json = fake() } = overrides;
     const npmFetch: FakeNpmFetch = fake.resolves({ buffer }) as FakeNpmFetch;
-
     npmFetch.json = json;
-
     return npmFetch;
 }
 
@@ -24,47 +24,53 @@ type Overrides = {
     readonly publish?: SinonSpy;
     readonly npmFetchJson?: SinonSpy;
     readonly npmFetch?: FakeNpmFetch;
+    readonly fetch?: typeof globalThis.fetch;
+    readonly clock?: FakeClock;
+    readonly resolveIdToken?: (auth: Extract<PublishAuthStrategy, { type: 'npm-oidc' }>) => Promise<string>;
+    readonly promptForOneTimePassword?: () => Promise<string | undefined>;
 };
 
-function registryClientFactory(overrides: Readonly<Overrides>): RegistryClient {
+function registryClientFactory(overrides: Readonly<Overrides> = {}): RegistryClient {
     const {
         publish = fake(),
         npmFetchJson = fake(),
-        npmFetch = createFakeNpmFetch({ json: npmFetchJson })
+        npmFetch = createFakeNpmFetch({ json: npmFetchJson }),
+        fetch: fetchImplementation = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T11:00:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch,
+        clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') }),
+        resolveIdToken = fake.resolves('upstream-id-token')
     } = overrides;
-    const fakeDependencies = {
+
+    return createRegistryClient({
         publish,
-        npmFetch
-    } as unknown as RegistryClientDependencies;
-
-    return createRegistryClient(fakeDependencies);
+        npmFetch,
+        fetch: fetchImplementation,
+        clock,
+        resolveIdToken,
+        promptForOneTimePassword: overrides.promptForOneTimePassword
+    } as unknown as RegistryClientDependencies);
 }
 
-async function expectPublishPackageCall(
-    settings: { readonly token: string; readonly registryUrl?: string },
-    expectedRegistry: string | undefined
-): Promise<void> {
-    const publish = fake.resolves(undefined);
-    const registryClient = registryClientFactory({ publish });
-    const tarData = Buffer.from([1, 2, 3, 4]);
-
-    await registryClient.publishPackage({ name: 'the-name', version: 'the-version' }, tarData, settings);
-
-    assert.strictEqual(publish.callCount, 1);
-    assert.deepStrictEqual(publish.firstCall.args, [
-        { name: 'the-name', version: 'the-version' },
-        tarData,
-        { defaultTag: 'latest', forceAuth: { alwaysAuth: true, token: settings.token }, registry: expectedRegistry }
-    ]);
+function getPublishedToken(publish: SinonSpy, callIndex = 0): string {
+    return (publish.getCall(callIndex).lastArg as { readonly forceAuth: { readonly token: string } }).forceAuth.token;
 }
 
-test('publishPackage() calls npm publish function with the given manifest and tar data and the correct options', async () => {
-    await expectPublishPackageCall({ token: 'the-token' }, undefined);
-});
-
-test('publishPackage() calls npm publish function with custom registry', async () => {
-    await expectPublishPackageCall({ token: 'the-token', registryUrl: 'the-url' }, 'the-url');
-});
+async function expectFailure(action: () => Promise<unknown>, expectedError: RegExp): Promise<void> {
+    try {
+        await action();
+        assert.fail('Expected the action to throw an error');
+    } catch (error: unknown) {
+        assert.match(String(error), expectedError);
+    }
+}
 
 function buildLatestVersionFetchJson(): SinonSpy {
     return fake.resolves({
@@ -74,304 +80,1139 @@ function buildLatestVersionFetchJson(): SinonSpy {
     });
 }
 
-async function expectFetchLatestVersionEndpointCall(
-    settings: { readonly token: string; readonly registryUrl?: string },
-    expectedRegistry: string | undefined
-): Promise<void> {
+test('publishPackage() uses shorthand bearer auth and one-time-password prompt when provided', async () => {
+    const publish = fake.resolves(undefined);
+    const promptForOneTimePassword = fake.resolves('123456');
+    const registryClient = registryClientFactory({ publish, promptForOneTimePassword });
+    const tarData = Buffer.from([1, 2, 3, 4]);
+
+    await registryClient.publishPackage({ name: 'the-name', version: 'the-version' }, tarData, {
+        auth: { type: 'bearer-token', token: 'the-token' }
+    });
+
+    assert.deepStrictEqual(publish.firstCall.args, [
+        { name: 'the-name', version: 'the-version' },
+        tarData,
+        {
+            defaultTag: 'latest',
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: { token: 'the-token' },
+            otpPrompt: promptForOneTimePassword
+        }
+    ]);
+});
+
+test('publishPackage() uses explicit basic auth when configured', async () => {
+    const publish = fake.resolves(undefined);
+    const registryClient = registryClientFactory({ publish });
+
+    await registryClient.publishPackage({ name: 'the-name', version: 'the-version' }, Buffer.from([]), {
+        registryUrl: 'https://registry.example.test',
+        auth: {
+            type: 'basic',
+            username: 'user',
+            password: 'secret'
+        }
+    });
+
+    assert.deepStrictEqual(publish.firstCall.args.at(-1), {
+        defaultTag: 'latest',
+        alwaysAuth: true,
+        registry: 'https://registry.example.test',
+        forceAuth: {
+            _auth: Buffer.from('user:secret', 'utf8').toString('base64')
+        }
+    });
+});
+
+test('fetchLatestVersion() uses shorthand auth for metadata by default', async () => {
     const npmFetchJson = buildLatestVersionFetchJson();
     const registryClient = registryClientFactory({ npmFetchJson });
 
-    await registryClient.fetchLatestVersion('the-name', settings);
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: { type: 'bearer-token', token: 'the-token' }
+    });
 
-    assert.strictEqual(npmFetchJson.callCount, 1);
     assert.deepStrictEqual(npmFetchJson.firstCall.args, [
         '/the-name',
         {
-            forceAuth: { alwaysAuth: true, token: settings.token },
-            headers: { accept: 'application/vnd.npm.install-v1+json' },
-            registry: expectedRegistry
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: { token: 'the-token' },
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
         }
     ]);
-}
-
-test('fetchLatestVersion() fetches the correct package endpoint with the correct authentication settings and headers', async () => {
-    await expectFetchLatestVersionEndpointCall({ token: 'the-token' }, undefined);
 });
 
-test('fetchLatestVersion() fetches the correct package endpoint with the correct authentication settings and headers when using a custom registry', async () => {
-    await expectFetchLatestVersionEndpointCall({ token: 'the-token', registryUrl: 'the-url' }, 'the-url');
-});
-
-test('fetchLatestVersion() fetches the correct package endpoint escaping the given name of a scoped package', async () => {
+test('fetchLatestVersion() uses explicit metadata auth when configured', async () => {
     const npmFetchJson = buildLatestVersionFetchJson();
     const registryClient = registryClientFactory({ npmFetchJson });
 
-    await registryClient.fetchLatestVersion('@the/name', { token: 'the-token' });
-
-    assert.strictEqual(npmFetchJson.callCount, 1);
-    assert.strictEqual(npmFetchJson.firstCall.firstArg, '/@the%2Fname');
-});
-
-async function expectFetchLatestVersionRejectsWith(
-    npmFetchJson: SinonSpy,
-    expectation: (caughtError: unknown) => void
-): Promise<void> {
-    const registryClient = registryClientFactory({ npmFetchJson });
-    try {
-        await registryClient.fetchLatestVersion('@the/name', { token: '' });
-        assert.fail('Expected fetchLatestVersion() to throw but it did not');
-    } catch (caughtError: unknown) {
-        expectation(caughtError);
-    }
-}
-
-async function expectFetchLatestVersionInvalidResponse(npmFetchJson: SinonSpy): Promise<void> {
-    const registryClient = registryClientFactory({ npmFetchJson });
-    await assert.rejects(async () => {
-        await registryClient.fetchLatestVersion('@the/name', { token: '' });
-    }, /^Error: Got an invalid response from registry API$/u);
-}
-
-test('fetchLatestVersion() throws and propagates the error when npmFetch throws with a generic error', async () => {
-    await expectFetchLatestVersionRejectsWith(fake.rejects(new Error('the-error')), (caughtError) => {
-        assert.strictEqual((caughtError as Error).message, 'the-error');
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'bearer-token', token: 'writer-token' },
+            metadata: { type: 'basic', username: 'reader', password: 'reader-secret' }
+        }
     });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: {
+                _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+            },
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
 });
 
-test('fetchLatestVersion() throws and propagates the error when npmFetch throws with a fetch-error and the status code is not 404 nor 403', async () => {
-    const error = new Error('fetch-error');
-    // @ts-expect-error -- ok in this case
-    error.statusCode = 500;
-    await expectFetchLatestVersionRejectsWith(fake.rejects(error), (caughtError) => {
-        assert.deepStrictEqual(caughtError, error);
-    });
-});
-
-test('fetchLatestVersion() throws when npmFetch resolves with an invalid response', async () => {
-    await expectFetchLatestVersionRejectsWith(fake.resolves({ invalid: 'response-data' }), (caughtError) => {
-        assert.strictEqual((caughtError as Error).message, 'Got an invalid response from registry API');
-    });
-});
-
-test('fetchLatestVersion() throws when npmFetch resolves to a non-object value', async () => {
-    await expectFetchLatestVersionInvalidResponse(fake.resolves('invalid'));
-});
-
-test('fetchLatestVersion() throws when npmFetch resolves with a non-object dist-tags value', async () => {
-    await expectFetchLatestVersionInvalidResponse(fake.resolves({ name: '', 'dist-tags': 'latest', versions: {} }));
-});
-
-async function expectFetchLatestVersionResolvesToNothing(): Promise<void> {
-    const npmFetchJson = fake.resolves({ name: '', 'dist-tags': {}, versions: {} });
+test('fetchLatestVersion() uses explicit bearer metadata auth when configured', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
     const registryClient = registryClientFactory({ npmFetchJson });
 
-    const result = await registryClient.fetchLatestVersion('@the/name', { token: '' });
-    assert.deepStrictEqual(result, Maybe.nothing());
-}
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'basic', username: 'writer', password: 'writer-secret' },
+            metadata: { type: 'bearer-token', token: 'reader-token' }
+        }
+    });
 
-test('fetchLatestVersion() returns nothing when the registry response has no latest tag', async () => {
-    await expectFetchLatestVersionResolvesToNothing();
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: { token: 'reader-token' },
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
 });
 
-test('fetchLatestVersion() throws when npmFetch resolves without the package name field', async () => {
-    await expectFetchLatestVersionInvalidResponse(
-        fake.resolves({
-            'dist-tags': { latest: '1' },
-            versions: { 1: { dist: { shasum: 'abc', tarball: 'the-tarball' } } }
-        })
-    );
+test('fetchLatestVersion() inherits publish auth for metadata by default when expanded auth omits metadata', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'bearer-token', token: 'writer-token' }
+        }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: { token: 'writer-token' },
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
 });
 
-test('fetchLatestVersion() throws when npmFetch resolves without dist-tags.latest version details', async () => {
-    await expectFetchLatestVersionInvalidResponse(fake.resolves({ name: '', 'dist-tags': { latest: '1' } }));
+test('fetchLatestVersion() uses anonymous metadata access by default for explicit npm oidc auth', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'npm-oidc' }
+        }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
 });
 
-test('fetchLatestVersion() throws when npmFetch resolves without a dist shasum', async () => {
-    await expectFetchLatestVersionInvalidResponse(
-        fake.resolves({
+test('fetchLatestVersion() uses shorthand npm oidc auth without attaching metadata credentials', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: { type: 'npm-oidc', provider: 'env' }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
+});
+
+test('fetchLatestVersion() uses anonymous metadata access by default for shorthand npm oidc auth', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: { type: 'npm-oidc' }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
+});
+
+test('fetchLatestVersion() uses anonymous metadata access when explicitly configured', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'bearer-token', token: 'writer-token' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
+});
+
+test('fetchLatestVersion() inherits publish auth for metadata when explicit metadata mode requests it', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'basic', username: 'reader', password: 'reader-secret', email: 'reader@example.test' },
+            metadata: 'inherit-publish-auth'
+        }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: {
+                _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+            },
+            email: 'reader@example.test',
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
+});
+
+test('fetchLatestVersion() treats inherit-publish-auth as anonymous when publish auth uses npm oidc', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'inherit-publish-auth'
+        }
+    });
+
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
+});
+
+test('metadata auto retries with publish auth on a 401 challenge', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 401;
+    let callCount = 0;
+    const npmFetchJson = fake(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+            throw error;
+        }
+        return {
             name: '',
             'dist-tags': { latest: '1' },
-            versions: { 1: { dist: { tarball: 'the-tarball' } } }
-        })
-    );
-});
-
-test('fetchLatestVersion() throws when npmFetch resolves without a dist tarball url', async () => {
-    await expectFetchLatestVersionInvalidResponse(
-        fake.resolves({
-            name: '',
-            'dist-tags': { latest: '1' },
-            versions: { 1: { dist: { shasum: 'abc' } } }
-        })
-    );
-});
-
-test('fetchLatestVersion() throws when npmFetch resolves with inconsistent data', async () => {
-    const npmFetchJson = fake.resolves({
-        name: '',
-        'dist-tags': { latest: '1' },
-        versions: { 2: { dist: { shasum: '', tarball: '' } } }
+            versions: { 1: { dist: { shasum: 'abc', tarball: 'https://registry.example.test/pkg.tgz' } } }
+        };
     });
     const registryClient = registryClientFactory({ npmFetchJson });
 
-    try {
-        await registryClient.fetchLatestVersion('@the/name', { token: '' });
-        assert.fail('Expected fetchLatestVersion() to throw but it did not');
-    } catch (caughtError: unknown) {
-        assert.strictEqual((caughtError as Error).message, 'Version "1" for package "@the/name" is missing a shasum');
-    }
+    const result = await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'bearer-token', token: 'writer-token' },
+            metadata: 'auto'
+        }
+    });
+
+    assert.deepStrictEqual(
+        result,
+        Maybe.just({
+            version: '1',
+            shasum: 'abc',
+            tarballUrl: 'https://registry.example.test/pkg.tgz'
+        })
+    );
+    assert.strictEqual(npmFetchJson.callCount, 2);
+    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
+    assert.deepStrictEqual(npmFetchJson.secondCall.args, [
+        '/the-name',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: { token: 'writer-token' },
+            headers: { accept: 'application/vnd.npm.install-v1+json' }
+        }
+    ]);
 });
 
-async function expectFetchLatestVersionReturnsNothingForStatusCode(statusCode: number): Promise<void> {
-    const error = new Error('fetch-error');
-    // @ts-expect-error -- ok in this case
-    error.statusCode = statusCode;
+test('metadata auto retries with publish auth on a 403 challenge', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 403;
+    let callCount = 0;
+    const npmFetchJson = fake(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+            throw error;
+        }
+
+        return {
+            name: '',
+            'dist-tags': { latest: '1' },
+            versions: { 1: { dist: { shasum: 'abc', tarball: 'https://registry.example.test/pkg.tgz' } } }
+        };
+    });
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    const result = await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'bearer-token', token: 'writer-token' },
+            metadata: 'auto'
+        }
+    });
+
+    assert.deepStrictEqual(
+        result,
+        Maybe.just({
+            version: '1',
+            shasum: 'abc',
+            tarballUrl: 'https://registry.example.test/pkg.tgz'
+        })
+    );
+    assert.strictEqual(npmFetchJson.callCount, 2);
+});
+
+test('metadata auto does not retry when the registry returns 404', async () => {
+    const error = new Error('not found');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 404;
     const npmFetchJson = fake.rejects(error);
     const registryClient = registryClientFactory({ npmFetchJson });
 
-    const result = await registryClient.fetchLatestVersion('@the/name', { token: '' });
+    const result = await registryClient.fetchLatestVersion('the-name', {
+        auth: {
+            publish: { type: 'bearer-token', token: 'writer-token' },
+            metadata: 'auto'
+        }
+    });
+
     assert.deepStrictEqual(result, Maybe.nothing());
-}
-
-test('fetchLatestVersion() returns nothing when npmFetch throws a fetch error with status code 404', async () => {
-    await expectFetchLatestVersionReturnsNothingForStatusCode(404);
+    assert.strictEqual(npmFetchJson.callCount, 1);
 });
 
-async function expectFetchLatestVersionRethrowsValue(thrown: unknown): Promise<void> {
+test('metadata auto does not retry when publish auth uses npm oidc', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 401;
+    const npmFetchJson = fake.rejects(error);
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'auto'
+            }
+        });
+    }, /^Error: auth required$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
+});
+
+test('metadata auto does not retry when the registry returns a non-auth error', async () => {
+    const error = new Error('server error');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 500;
+    const npmFetchJson = fake.rejects(error);
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'auto'
+            }
+        });
+    }, /^Error: server error$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
+});
+
+test('metadata auto rethrows non-object errors without retrying', async () => {
     const npmFetchJson = fake(async () => {
-        throw thrown;
-    });
-    await expectFetchLatestVersionRejectsWith(npmFetchJson, (caughtError) => {
-        assert.deepStrictEqual(caughtError, thrown);
-    });
-}
-
-test('fetchLatestVersion() rethrows object-like errors that do not have a statusCode', async () => {
-    await expectFetchLatestVersionRethrowsValue({ message: 'fetch-error' });
-});
-
-test('fetchLatestVersion() returns nothing when npmFetch throws a fetch error with status code 403', async () => {
-    await expectFetchLatestVersionReturnsNothingForStatusCode(403);
-});
-
-test('fetchLatestVersion() rethrows non-object errors even when they look falsy', async () => {
-    const npmFetchJson = fake(async () => {
-        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional passthrough test
-        throw '';
-    });
-    await expectFetchLatestVersionRejectsWith(npmFetchJson, (caughtError) => {
-        assert.strictEqual(caughtError, '');
-    });
-});
-
-test('fetchLatestVersion() throws when dist-tags.latest is not a string', async () => {
-    await expectFetchLatestVersionInvalidResponse(
-        fake.resolves({
-            name: '',
-            'dist-tags': { latest: 1 },
-            versions: { 1: { dist: { shasum: 'abc', tarball: 'the-tarball' } } }
-        })
-    );
-});
-
-test('fetchLatestVersion() throws when version data dist is missing entirely', async () => {
-    await expectFetchLatestVersionInvalidResponse(
-        fake.resolves({ name: '', 'dist-tags': { latest: '1' }, versions: { 1: {} } })
-    );
-});
-
-test('fetchLatestVersion() rethrows thrown strings unchanged', async () => {
-    const npmFetchJson = fake(async () => {
-        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional passthrough test
-        throw 'fetch-error';
-    });
-    await expectFetchLatestVersionRejectsWith(npmFetchJson, (caughtError) => {
-        assert.strictEqual(caughtError, 'fetch-error');
-    });
-});
-
-test('fetchLatestVersion() rethrows thrown null values unchanged', async () => {
-    const npmFetchJson = fake(async () => {
-        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional passthrough test
-        throw null;
-    });
-    await expectFetchLatestVersionRejectsWith(npmFetchJson, (caughtError) => {
-        assert.strictEqual(caughtError, null);
-    });
-});
-
-test('fetchLatestVersion() rethrows thrown symbols unchanged', async () => {
-    const error = Symbol('fetch-error');
-    const npmFetchJson = fake(async () => {
-        // eslint-disable-next-line @typescript-eslint/only-throw-error -- intentional passthrough test
-        throw error;
-    });
-    await expectFetchLatestVersionRejectsWith(npmFetchJson, (caughtError) => {
-        assert.strictEqual(caughtError, error);
-    });
-});
-
-test('fetchLatestVersion() rethrows errors with non-404/403 statusCode-like values', async () => {
-    await expectFetchLatestVersionRethrowsValue({ statusCode: '404', message: 'fetch-error' });
-});
-
-test('fetchLatestVersion() returns nothing when npmFetch throws a fetch error with status code 403', async () => {
-    await expectFetchLatestVersionReturnsNothingForStatusCode(403);
-});
-
-test('fetchLatestVersion() returns the version details when npmFetch returned the expected data', async () => {
-    const npmFetchJson = fake.resolves({
-        name: '',
-        'dist-tags': { latest: '1' },
-        versions: { 1: { dist: { shasum: 'abc', tarball: 'the-tarball' } } }
+        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
+        throw 'server-error';
     });
     const registryClient = registryClientFactory({ npmFetchJson });
 
-    const result = await registryClient.fetchLatestVersion('@the/name', { token: '' });
-    assert.deepStrictEqual(result, Maybe.just({ version: '1', shasum: 'abc', tarballUrl: 'the-tarball' }));
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'auto'
+            }
+        });
+    }, /^server-error$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
 });
 
-test('fetchLatestVersion() returns nothing when the package has no latest dist-tag', async () => {
-    await expectFetchLatestVersionResolvesToNothing();
+test('metadata auto rethrows object errors without statusCode without retrying', async () => {
+    const npmFetchJson = fake.rejects(new Error('server-error'));
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'auto'
+            }
+        });
+    }, /^Error: server-error$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
 });
 
-test('fetchTarball() fetches the tarball at the given url', async () => {
-    const npmFetch = createFakeNpmFetch();
+test('metadata using inherited publish auth does not retry on a 401 challenge', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 401;
+    const npmFetchJson = fake.rejects(error);
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'writer-token' }
+        });
+    }, /^Error: auth required$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
+});
+
+test('anonymous metadata access does not retry on a 401 challenge', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 401;
+    const npmFetchJson = fake.rejects(error);
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^Error: auth required$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
+});
+
+test('basic metadata auth does not retry on a 401 challenge', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 401;
+    const npmFetchJson = fake.rejects(error);
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: { type: 'basic', username: 'reader', password: 'reader-secret' }
+            }
+        });
+    }, /^Error: auth required$/u);
+
+    assert.strictEqual(npmFetchJson.callCount, 1);
+});
+
+test('fetchTarball() also retries metadata auto with publish auth on a 401 challenge', async () => {
+    const error = new Error('auth required');
+    // @ts-expect-error intentional test shape
+    error.statusCode = 401;
+    let callCount = 0;
+    const npmFetch = fake(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+            throw error;
+        }
+
+        return {
+            buffer: fake.resolves(Buffer.from([1, 2, 3]))
+        };
+    }) as unknown as FakeNpmFetch;
+    npmFetch.json = fake();
     const registryClient = registryClientFactory({ npmFetch });
 
-    await registryClient.fetchTarball('the-tarball-url', 'the-shasum');
-
-    assert.strictEqual(npmFetch.callCount, 1);
-    assert.deepStrictEqual(npmFetch.firstCall.args, ['the-tarball-url']);
-});
-
-test('fetchTarball() returns the buffer of the fetched tarball', async () => {
-    const npmFetch = createFakeNpmFetch({ buffer: fake.resolves(Buffer.from([1, 2, 3])) });
-    const registryClient = registryClientFactory({ npmFetch });
-
-    const result = await registryClient.fetchTarball('', '');
+    const result = await registryClient.fetchTarball('https://registry.example.test/pkg.tgz', 'abc', {
+        auth: {
+            publish: { type: 'basic', username: 'reader', password: 'reader-secret' },
+            metadata: 'auto'
+        }
+    });
 
     assert.deepStrictEqual(result, Buffer.from([1, 2, 3]));
+    assert.strictEqual(npmFetch.callCount, 2);
+    assert.deepStrictEqual(npmFetch.secondCall.args, [
+        'https://registry.example.test/pkg.tgz',
+        {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: {
+                _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+            }
+        }
+    ]);
 });
 
-async function expectFetchTarballRejectsWith(error: Error, expectedMessage: string): Promise<void> {
-    const npmFetch = fake.rejects(error) as FakeNpmFetch;
-    const registryClient = registryClientFactory({ npmFetch });
-    try {
-        await registryClient.fetchTarball('', '');
-        assert.fail('Expected fetchTarball() should fail but it did not');
-    } catch (caughtError: unknown) {
-        assert.strictEqual((caughtError as Error).message, expectedMessage);
-    }
+test('fetchLatestVersion() escapes scoped package names', async () => {
+    const npmFetchJson = buildLatestVersionFetchJson();
+    const registryClient = registryClientFactory({ npmFetchJson });
+
+    await registryClient.fetchLatestVersion('@the/name', {
+        auth: { type: 'bearer-token', token: 'the-token' }
+    });
+
+    assert.strictEqual(npmFetchJson.firstCall.firstArg, '/@the%2Fname');
+});
+
+test('publishPackage() resolves and exchanges npm oidc id tokens', async () => {
+    const publish = fake.resolves(undefined);
+    const resolveIdToken = fake.resolves('upstream-id-token');
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T11:00:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        resolveIdToken
+    });
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'github-actions' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc', provider: 'github-actions' }]);
+    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
+        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fthe-name',
+        {
+            method: 'POST',
+            headers: { Authorization: 'Bearer upstream-id-token' }
+        }
+    ]);
+    assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
+});
+
+test('publishPackage() exchanges npm oidc tokens and caches the exchange token per package', async () => {
+    const publish = fake.resolves(undefined);
+    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T11:00:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        clock,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
+    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
+        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fthe-name',
+        {
+            method: 'POST',
+            headers: { Authorization: 'Bearer upstream-id-token' }
+        }
+    ]);
+    assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
+    assert.strictEqual(getPublishedToken(publish, 1), 'oidc-exchange-token');
+});
+
+test('publishPackage() passes shorthand npm oidc auth through to the id token resolver', async () => {
+    const publish = fake.resolves(undefined);
+    const resolveIdToken = fake.resolves('upstream-id-token');
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T11:00:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        resolveIdToken
+    });
+
+    await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+        auth: { type: 'npm-oidc' }
+    });
+
+    assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc' }]);
+    assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
+});
+
+test('publishPackage() refreshes the exchanged npm oidc token after expiry', async () => {
+    const publish = fake.resolves(undefined);
+    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T10:01:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        clock,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    clock.tick(61_000);
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
+});
+
+test('publishPackage() refreshes the exchanged npm oidc token when exactly 60 seconds remain', async () => {
+    const publish = fake.resolves(undefined);
+    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T10:01:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        clock,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
+});
+
+test('publishPackage() caches exchanged npm oidc tokens per package name', async () => {
+    const publish = fake.resolves(undefined);
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T11:00:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await registryClient.publishPackage({ name: '@scope/first-package', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+    await registryClient.publishPackage({ name: '@scope/second-package', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
+    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
+        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Ffirst-package',
+        {
+            method: 'POST',
+            headers: { Authorization: 'Bearer upstream-id-token' }
+        }
+    ]);
+    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).secondCall.args, [
+        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fsecond-package',
+        {
+            method: 'POST',
+            headers: { Authorization: 'Bearer upstream-id-token' }
+        }
+    ]);
+});
+
+test('publishPackage() reuses exchanged npm oidc tokens between implicit and explicit npm registry URLs', async () => {
+    const publish = fake.resolves(undefined);
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T11:00:00.000Z'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        publish,
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
+        registryUrl: 'https://registry.npmjs.org/',
+        auth: {
+            publish: { type: 'npm-oidc', provider: 'env' },
+            metadata: 'anonymous'
+        }
+    });
+
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
+});
+
+test('publishPackage() rejects npm oidc auth for non-npm registries', async () => {
+    const registryClient = registryClientFactory({
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+            registryUrl: 'https://registry.example.test',
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^Error: npm-oidc auth is only supported with the npmjs.org registry$/u);
+});
+
+test('publishPackage() rejects an invalid OIDC exchange response body', async () => {
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({ token: 'missing-fields' })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+});
+
+test('publishPackage() rejects a non-object OIDC exchange response body', async () => {
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves('invalid-response')
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+});
+
+test('publishPackage() rejects a null OIDC exchange response body', async () => {
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves(null)
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+});
+
+test('publishPackage() rejects a failing OIDC exchange request', async () => {
+    const fetchSpy = fake.resolves({
+        ok: false,
+        status: 502,
+        json: fake.resolves({})
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^Error: OIDC token exchange failed with status 502$/u);
+});
+
+test('publishPackage() rejects an invalid OIDC exchange expiry timestamp', async () => {
+    const fetchSpy = fake.resolves({
+        ok: true,
+        status: 201,
+        json: fake.resolves({
+            token_type: 'oidc',
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: 'not-a-date'
+        })
+    }) as unknown as typeof globalThis.fetch;
+    const registryClient = registryClientFactory({
+        fetch: fetchSpy,
+        resolveIdToken: fake.resolves('upstream-id-token')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        });
+    }, /^TypeError: OIDC token exchange returned an invalid expiry timestamp$/u);
+});
+
+for (const [testName, response] of [
+    [
+        'token_type is invalid',
+        {
+            token_type: 123,
+            token: 'oidc-exchange-token',
+            created: '2026-05-06T10:00:00.000Z',
+            expires: '2026-05-06T11:00:00.000Z'
+        }
+    ],
+    [
+        'token is invalid',
+        { token_type: 'oidc', token: 123, created: '2026-05-06T10:00:00.000Z', expires: '2026-05-06T11:00:00.000Z' }
+    ],
+    [
+        'created is invalid',
+        { token_type: 'oidc', token: 'oidc-exchange-token', created: 123, expires: '2026-05-06T11:00:00.000Z' }
+    ],
+    [
+        'expires is invalid',
+        { token_type: 'oidc', token: 'oidc-exchange-token', created: '2026-05-06T10:00:00.000Z', expires: 123 }
+    ]
+] as const) {
+    test(`publishPackage() rejects an OIDC exchange response when ${testName}`, async () => {
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves(response)
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            });
+        }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+    });
 }
 
-test('fetchTarball() throws when npmFetch throws a fetch error with status code 404', async () => {
-    const error = new Error('fetch-error');
-    // @ts-expect-error -- ok in this case
-    error.statusCode = 404;
-    await expectFetchTarballRejectsWith(error, 'fetch-error');
+test('fetchLatestVersion() returns nothing for 404 and 403 responses', async () => {
+    for (const statusCode of [404, 403]) {
+        const error = new Error('fetch-error');
+        // @ts-expect-error -- intentional shape for npm fetch errors
+        error.statusCode = statusCode;
+        const registryClient = registryClientFactory({ npmFetchJson: fake.rejects(error) });
+
+        const result = await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+
+        assert.deepStrictEqual(result, Maybe.nothing());
+    }
 });
 
-test('fetchTarball() throws when npmFetch throws any error', async () => {
-    await expectFetchTarballRejectsWith(new Error('any-error'), 'any-error');
+test('fetchLatestVersion() throws on invalid registry payloads', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake.resolves({ invalid: 'response-data' })
+    });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+    }, /^Error: Got an invalid response from registry API$/u);
+});
+
+test('fetchLatestVersion() throws on invalid non-object registry payloads', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake.resolves('invalid-response')
+    });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+    }, /^Error: Got an invalid response from registry API$/u);
+});
+
+test('fetchLatestVersion() returns nothing when the registry response has no latest tag', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake.resolves({
+            name: 'the-name',
+            'dist-tags': {},
+            versions: { '1.0.0': { dist: { shasum: 'abc', tarball: 'https://registry.example.test/pkg.tgz' } } }
+        })
+    });
+
+    const result = await registryClient.fetchLatestVersion('the-name', {
+        auth: { type: 'bearer-token', token: 'the-token' }
+    });
+
+    assert.deepStrictEqual(result, Maybe.nothing());
+});
+
+test('fetchLatestVersion() throws when the latest tag points to a missing version entry', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake.resolves({
+            name: 'the-name',
+            'dist-tags': { latest: '1.0.0' },
+            versions: {}
+        })
+    });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+    }, /^Error: Version "1.0.0" for package "the-name" is missing a shasum$/u);
+});
+
+for (const [testName, response] of [
+    ['response is not an object', 'invalid-response'],
+    ['dist-tags is not an object', { name: 'the-name', 'dist-tags': 'invalid', versions: {} }],
+    ['dist-tags latest is not a string', { name: 'the-name', 'dist-tags': { latest: 1 }, versions: {} }],
+    ['versions is not an object', { name: 'the-name', 'dist-tags': {}, versions: 'invalid' }],
+    ['version dist is missing', { name: 'the-name', 'dist-tags': { latest: '1.0.0' }, versions: { '1.0.0': {} } }],
+    [
+        'version shasum is not a string',
+        {
+            name: 'the-name',
+            'dist-tags': { latest: '1.0.0' },
+            versions: { '1.0.0': { dist: { shasum: 123, tarball: 'https://registry.example.test/pkg.tgz' } } }
+        }
+    ],
+    [
+        'version tarball is not a string',
+        {
+            name: 'the-name',
+            'dist-tags': { latest: '1.0.0' },
+            versions: { '1.0.0': { dist: { shasum: 'abc', tarball: false } } }
+        }
+    ],
+    [
+        'version dist fields are not strings',
+        {
+            name: 'the-name',
+            'dist-tags': { latest: '1.0.0' },
+            versions: { '1.0.0': { dist: { shasum: 123, tarball: false } } }
+        }
+    ]
+] as const) {
+    test(`fetchLatestVersion() rejects invalid registry payloads when ${testName}`, async () => {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves(response)
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+        }, /^Error: Got an invalid response from registry API$/u);
+    });
+}
+
+test('fetchLatestVersion() rejects null versions payloads', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake.resolves({
+            name: 'the-name',
+            'dist-tags': { latest: '1.0.0' },
+            versions: null
+        })
+    });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+    }, /^Error: Got an invalid response from registry API$/u);
+});
+
+test('fetchLatestVersion() rethrows non-object unexpected errors', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake(async () => {
+            // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
+            throw 'unexpected-failure';
+        })
+    });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+    }, /^unexpected-failure$/u);
+});
+
+test('fetchLatestVersion() rethrows object unexpected errors without statusCode', async () => {
+    const registryClient = registryClientFactory({
+        npmFetchJson: fake.rejects(new Error('unexpected-failure'))
+    });
+
+    await expectFailure(async () => {
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+    }, /^Error: unexpected-failure$/u);
 });

--- a/source/bundle-emitter/registry-client.ts
+++ b/source/bundle-emitter/registry-client.ts
@@ -2,23 +2,78 @@
 import type _npmFetch from 'npm-registry-fetch';
 import type { publish as _publish } from 'libnpmpublish';
 import { Maybe } from 'true-myth';
-import type { RegistrySettings } from '../config/registry-settings.ts';
+import { z } from 'zod/mini';
+import type { Clock } from '../common/clock.ts';
+import type {
+    MetadataAuthMode,
+    MetadataAuthStrategy,
+    PublishAuthStrategy,
+    RegistrySettings
+} from '../config/registry-settings.ts';
 import type { BundlePackageJson } from '../version-manager/versioned-bundle.ts';
 
 type PublishFunction = typeof _publish;
 const notFoundStatusCode = 404;
+const unauthorizedStatusCode = 401;
 const forbiddenStatusCode = 403;
+const npmRegistryUrl = 'https://registry.npmjs.org/';
+const oidcExchangeRefreshThresholdInMilliseconds = 60_000;
+
+type OidcExchangeResponse = {
+    readonly token_type: string;
+    readonly token: string;
+    readonly created: string;
+    readonly expires: string;
+};
+
+type OidcExchangeToken = {
+    readonly token: string;
+    readonly expiresAt: number;
+};
 
 export type RegistryClientDependencies = {
     readonly npmFetch: typeof _npmFetch;
     readonly publish: PublishFunction;
+    readonly fetch: typeof globalThis.fetch;
+    readonly clock: Clock;
+    readonly resolveIdToken: (auth: Extract<PublishAuthStrategy, { type: 'npm-oidc' }>) => Promise<string>;
+    readonly promptForOneTimePassword?: (() => Promise<string | undefined>) | undefined;
 };
 
 export type RegistryClient = {
     fetchLatestVersion: (packageName: string, config: RegistrySettings) => Promise<Maybe<PackageVersionDetails>>;
     publishPackage: (manifest: Readonly<BundlePackageJson>, tarData: Buffer, config: RegistrySettings) => Promise<void>;
-    fetchTarball: (tarballUrl: string, shasum: string) => Promise<Buffer>;
+    fetchTarball: (tarballUrl: string, shasum: string, config: RegistrySettings) => Promise<Buffer>;
 };
+
+type NpmFetchOptions = Parameters<typeof _npmFetch>[1];
+type AuthResolution = {
+    readonly allowsAutomaticRetry: boolean;
+    readonly registry: string | undefined;
+    readonly options: NpmFetchOptions;
+};
+
+const packageVersionDetailsSchema = z.object({
+    dist: z.object({
+        shasum: z.string(),
+        tarball: z.string()
+    })
+});
+
+const abbreviatedPackageResponseSchema = z.object({
+    name: z.string(),
+    'dist-tags': z.object({
+        latest: z.optional(z.string())
+    }),
+    versions: z.record(z.string(), packageVersionDetailsSchema)
+});
+
+const oidcExchangeResponseSchema = z.object({
+    token_type: z.string(),
+    token: z.string(),
+    created: z.string(),
+    expires: z.string()
+});
 
 function encodePackageName(name: string): string {
     return name.replace('/', '%2F');
@@ -39,44 +94,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function parseAbbreviatedPackageResponse(response: unknown): AbbreviatedPackageResponse | undefined {
-    const responseRecord = isRecord(response) ? response : undefined;
-
-    if (typeof responseRecord?.name !== 'string') {
-        return undefined;
-    }
-
-    const distTags = responseRecord['dist-tags'];
-    if (!isRecord(distTags)) {
-        return undefined;
-    }
-
-    if (distTags.latest !== undefined && typeof distTags.latest !== 'string') {
-        return undefined;
-    }
-
-    if (!isRecord(responseRecord.versions)) {
-        return undefined;
-    }
-
-    const versions: Record<string, { dist: { shasum: string; tarball: string } }> = {};
-
-    for (const [version, value] of Object.entries(responseRecord.versions)) {
-        if (!isRecord(value) || !isRecord(value.dist)) {
-            return undefined;
-        }
-
-        if (typeof value.dist.shasum !== 'string' || typeof value.dist.tarball !== 'string') {
-            return undefined;
-        }
-
-        versions[version] = { dist: { shasum: value.dist.shasum, tarball: value.dist.tarball } };
-    }
-
-    return {
-        name: responseRecord.name,
-        'dist-tags': { latest: distTags.latest },
-        versions
-    };
+    const result = abbreviatedPackageResponseSchema.safeParse(response);
+    return result.success ? result.data : undefined;
 }
 
 export type PackageVersionDetails = {
@@ -92,22 +111,229 @@ function toPublishManifest(manifest: Readonly<BundlePackageJson>): PublishManife
     return manifest as unknown as PublishManifest;
 }
 
+function resolveRegistryUrl(registrySettings: Readonly<RegistrySettings>): string | undefined {
+    return registrySettings.registryUrl;
+}
+
+function isNpmRegistry(registry: string | undefined): boolean {
+    return new URL(registry ?? npmRegistryUrl).href === npmRegistryUrl;
+}
+
+function normalizeAuthConfig(registrySettings: Readonly<RegistrySettings>): {
+    readonly publish: PublishAuthStrategy;
+    readonly metadata: MetadataAuthMode | undefined;
+} {
+    if ('type' in registrySettings.auth) {
+        return {
+            publish: registrySettings.auth,
+            metadata: undefined
+        };
+    }
+
+    return {
+        publish: registrySettings.auth.publish,
+        metadata: registrySettings.auth.metadata
+    };
+}
+
+function resolvePublishAuth(registrySettings: Readonly<RegistrySettings>): PublishAuthStrategy {
+    return normalizeAuthConfig(registrySettings).publish;
+}
+
+function createBaseOptions(registrySettings: Readonly<RegistrySettings>): NpmFetchOptions {
+    return {
+        alwaysAuth: true,
+        registry: resolveRegistryUrl(registrySettings)
+    };
+}
+
+function buildAuthOptions(auth: MetadataAuthStrategy, registrySettings: Readonly<RegistrySettings>): AuthResolution {
+    const registry = resolveRegistryUrl(registrySettings);
+    const options = createBaseOptions(registrySettings);
+
+    if (auth.type === 'bearer-token') {
+        return {
+            allowsAutomaticRetry: false,
+            registry,
+            options: {
+                ...options,
+                forceAuth: {
+                    token: auth.token
+                }
+            }
+        };
+    }
+
+    return {
+        allowsAutomaticRetry: false,
+        registry,
+        options: {
+            ...options,
+            forceAuth: {
+                _auth: Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
+            },
+            ...(auth.email === undefined ? {} : { email: auth.email })
+        }
+    };
+}
+
+function createAnonymousAuthResolution(registrySettings: Readonly<RegistrySettings>): AuthResolution {
+    return {
+        allowsAutomaticRetry: false,
+        registry: resolveRegistryUrl(registrySettings),
+        options: createBaseOptions(registrySettings)
+    };
+}
+
+function parseOidcExchangeResponse(response: unknown): OidcExchangeResponse | undefined {
+    const result = oidcExchangeResponseSchema.safeParse(response);
+    return result.success ? result.data : undefined;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+    return response.json() as Promise<unknown>;
+}
+
 export function createRegistryClient(dependencies: Readonly<RegistryClientDependencies>): RegistryClient {
-    const { npmFetch, publish } = dependencies;
+    const {
+        npmFetch,
+        publish,
+        fetch: fetchImplementation,
+        clock,
+        promptForOneTimePassword,
+        resolveIdToken
+    } = dependencies;
+    const oidcExchangeTokenCache = new Map<string, OidcExchangeToken>();
+
+    async function exchangeOidcToken(
+        packageName: string,
+        registrySettings: Readonly<RegistrySettings>,
+        auth: Extract<PublishAuthStrategy, { type: 'npm-oidc' }>
+    ): Promise<string> {
+        const cacheKey = `${resolveRegistryUrl(registrySettings) ?? npmRegistryUrl}::${packageName}`;
+        const cachedToken = oidcExchangeTokenCache.get(cacheKey);
+        const currentTime = clock.getCurrentTimeInMilliseconds();
+        if (
+            cachedToken !== undefined &&
+            cachedToken.expiresAt - currentTime > oidcExchangeRefreshThresholdInMilliseconds
+        ) {
+            return cachedToken.token;
+        }
+
+        if (!isNpmRegistry(resolveRegistryUrl(registrySettings))) {
+            throw new Error('npm-oidc auth is only supported with the npmjs.org registry');
+        }
+
+        const idToken = await resolveIdToken(auth);
+        const exchangeResponse = await fetchImplementation(
+            `${npmRegistryUrl}-/npm/v1/oidc/token/exchange/package/${encodePackageName(packageName)}`,
+            {
+                method: 'POST',
+                headers: { Authorization: `Bearer ${idToken}` }
+            } satisfies RequestInit
+        );
+
+        if (!exchangeResponse.ok) {
+            throw new Error(`OIDC token exchange failed with status ${exchangeResponse.status}`);
+        }
+
+        const body = parseOidcExchangeResponse(await parseJsonResponse(exchangeResponse));
+        if (body === undefined) {
+            throw new TypeError('OIDC token exchange returned an invalid response');
+        }
+
+        const expiresAt = Date.parse(body.expires);
+        if (!Number.isFinite(expiresAt)) {
+            throw new TypeError('OIDC token exchange returned an invalid expiry timestamp');
+        }
+
+        oidcExchangeTokenCache.set(cacheKey, {
+            token: body.token,
+            expiresAt
+        });
+
+        return body.token;
+    }
+
+    async function resolveWriteAuthOptions(
+        packageName: string,
+        registrySettings: Readonly<RegistrySettings>
+    ): Promise<NpmFetchOptions> {
+        const auth = resolvePublishAuth(registrySettings);
+        if (auth.type !== 'npm-oidc') {
+            return buildAuthOptions(auth, registrySettings).options;
+        }
+
+        const token = await exchangeOidcToken(packageName, registrySettings, auth);
+        return {
+            ...createBaseOptions(registrySettings),
+            forceAuth: {
+                token
+            }
+        };
+    }
+
+    function resolveMetadataAuthOptions(registrySettings: Readonly<RegistrySettings>): AuthResolution {
+        const { metadata: metadataMode, publish: publishAuth } = normalizeAuthConfig(registrySettings);
+        if (metadataMode === undefined || metadataMode === 'inherit-publish-auth') {
+            if (publishAuth.type === 'npm-oidc') {
+                return createAnonymousAuthResolution(registrySettings);
+            }
+
+            return buildAuthOptions(publishAuth, registrySettings);
+        }
+
+        if (metadataMode === 'auto') {
+            return {
+                ...createAnonymousAuthResolution(registrySettings),
+                allowsAutomaticRetry: true
+            };
+        }
+
+        if (typeof metadataMode !== 'object') {
+            return createAnonymousAuthResolution(registrySettings);
+        }
+
+        return buildAuthOptions(metadataMode, registrySettings);
+    }
+
+    async function retryAutoMetadataAuth<T>(
+        registrySettings: Readonly<RegistrySettings>,
+        auth: AuthResolution,
+        run: (options: NpmFetchOptions) => Promise<T>
+    ): Promise<T> {
+        try {
+            return await run(auth.options);
+        } catch (error: unknown) {
+            const statusCode = isRecord(error) ? error.statusCode : undefined;
+            if (
+                !auth.allowsAutomaticRetry ||
+                (statusCode !== forbiddenStatusCode && statusCode !== unauthorizedStatusCode)
+            ) {
+                throw error;
+            }
+
+            const publishAuth = resolvePublishAuth(registrySettings);
+            if (publishAuth.type === 'npm-oidc') {
+                throw error;
+            }
+
+            return run(buildAuthOptions(publishAuth, registrySettings).options);
+        }
+    }
 
     async function fetchRegistryEndpoint(
         endpoint: string,
         registrySettings: Readonly<RegistrySettings>
     ): Promise<unknown> {
         const acceptHeaderForFetchingAbbreviatedResponse = 'application/vnd.npm.install-v1+json';
+        const auth = resolveMetadataAuthOptions(registrySettings);
 
-        return npmFetch.json(endpoint, {
-            forceAuth: {
-                alwaysAuth: true,
-                token: registrySettings.token
-            },
-            registry: registrySettings.registryUrl,
-            headers: { accept: acceptHeaderForFetchingAbbreviatedResponse }
+        return retryAutoMetadataAuth(registrySettings, auth, async (options) => {
+            return npmFetch.json(endpoint, {
+                ...options,
+                headers: { accept: acceptHeaderForFetchingAbbreviatedResponse }
+            });
         });
     }
 
@@ -136,19 +362,20 @@ export function createRegistryClient(dependencies: Readonly<RegistryClientDepend
     }
 
     return {
-        async fetchTarball(tarballUrl) {
-            const response = await npmFetch(tarballUrl);
+        async fetchTarball(tarballUrl, _shasum, registrySettings) {
+            const auth = resolveMetadataAuthOptions(registrySettings);
+            const response = await retryAutoMetadataAuth(registrySettings, auth, async (options) => {
+                return npmFetch(tarballUrl, options);
+            });
             return response.buffer();
         },
 
         async publishPackage(manifest, tarData, registrySettings) {
+            const authOptions = await resolveWriteAuthOptions(manifest.name, registrySettings);
             await publish(toPublishManifest(manifest), tarData, {
                 defaultTag: 'latest',
-                forceAuth: {
-                    alwaysAuth: true,
-                    token: registrySettings.token
-                },
-                registry: registrySettings.registryUrl
+                ...authOptions,
+                ...(promptForOneTimePassword === undefined ? {} : { otpPrompt: promptForOneTimePassword })
             });
         },
 

--- a/source/command-line-interface/config-loader.property.ts
+++ b/source/command-line-interface/config-loader.property.ts
@@ -3,6 +3,15 @@ import fc from 'fast-check';
 import { test } from 'mocha';
 import { createConfigLoader } from './config-loader.ts';
 
+async function expectFailure(action: () => Promise<unknown>): Promise<void> {
+    try {
+        await action();
+        assert.fail('Expected the action to throw an error');
+    } catch (error: unknown) {
+        assert.ok(error instanceof Error);
+    }
+}
+
 function createLoader(moduleValue: unknown) {
     return createConfigLoader({
         currentWorkingDirectory: '/workspace',
@@ -24,9 +33,9 @@ test('load() rejects malformed module export shapes', async () => {
                 fc.array(fc.anything())
             ),
             async (moduleValue) => {
-                await assert.rejects(async () => {
+                await expectFailure(async () => {
                     await createLoader(moduleValue).load();
-                }, Error);
+                });
             }
         )
     );
@@ -39,9 +48,9 @@ test('load() rejects objects without config and buildConfig exports', async () =
                 return;
             }
 
-            await assert.rejects(async () => {
+            await expectFailure(async () => {
                 await createLoader(moduleValue).load();
-            }, Error);
+            });
         })
     );
 });
@@ -53,9 +62,9 @@ test('load() rejects non-function buildConfig exports when config is absent', as
                 return typeof value !== 'function';
             }),
             async (buildConfig) => {
-                await assert.rejects(async () => {
+                await expectFailure(async () => {
                     await createLoader({ buildConfig }).load();
-                }, Error);
+                });
             }
         )
     );

--- a/source/command-line-interface/one-time-password-prompt.test.ts
+++ b/source/command-line-interface/one-time-password-prompt.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import { createFakeClock, type FakeClock } from '../test-libraries/fake-clock.ts';
+import { createOneTimePasswordPrompt } from './one-time-password-prompt.ts';
+
+async function expectFailure(action: () => Promise<unknown>, expectedError: RegExp): Promise<void> {
+    try {
+        await action();
+        assert.fail('Expected the action to throw an error');
+    } catch (error: unknown) {
+        assert.match(String(error), expectedError);
+    }
+}
+
+type Overrides = {
+    readonly clock?: FakeClock;
+    readonly isInteractiveTerminal?: () => boolean;
+    readonly stopSpinner?: SinonSpy;
+    readonly question?: Partial<SinonSpy> & (() => Promise<string>);
+    readonly close?: SinonSpy;
+};
+
+function createPrompt(overrides: Overrides = {}) {
+    const stopSpinner = overrides.stopSpinner ?? fake();
+    const question = overrides.question ?? fake.resolves('123456');
+    const close = overrides.close ?? fake();
+
+    return {
+        prompt: createOneTimePasswordPrompt({
+            clock: overrides.clock ?? createFakeClock(),
+            isInteractiveTerminal: overrides.isInteractiveTerminal ?? (() => true),
+            stopSpinner: () => {
+                stopSpinner();
+            },
+            createInterface: () => {
+                return {
+                    question,
+                    close: () => {
+                        close();
+                    }
+                };
+            }
+        }),
+        stopSpinner,
+        question,
+        close
+    };
+}
+
+test('throws when one-time-password prompting is attempted without an interactive terminal', async () => {
+    const { prompt, stopSpinner, question, close } = createPrompt({
+        isInteractiveTerminal: () => false
+    });
+
+    await expectFailure(async () => {
+        await prompt();
+    }, /^Error: The registry requested a one-time password, but prompting requires an interactive terminal$/u);
+
+    assert.strictEqual(stopSpinner.callCount, 0);
+    assert.strictEqual(question.callCount, 0);
+    assert.strictEqual(close.callCount, 0);
+});
+
+test('stops the spinner before prompting and trims the entered one-time password', async () => {
+    const stopSpinner = fake();
+    const question = fake.resolves(' 123456 ');
+    const { prompt } = createPrompt({ stopSpinner, question });
+
+    const result = await prompt();
+
+    assert.strictEqual(result, '123456');
+    assert.strictEqual(stopSpinner.callCount, 1);
+    assert.deepStrictEqual(question.firstCall.args, ['Registry one-time password: ']);
+    assert.ok(stopSpinner.calledBefore(question));
+});
+
+test('closes the prompt interface after a successful prompt', async () => {
+    const close = fake();
+    const { prompt } = createPrompt({ close });
+
+    await prompt();
+
+    assert.strictEqual(close.callCount, 1);
+});
+
+test('closes the prompt interface when the prompt times out', async () => {
+    const close = fake();
+    const clock = createFakeClock();
+    const { prompt } = createPrompt({
+        clock,
+        close,
+        question: async () => {
+            return new Promise<string>(() => {
+                // Intentionally unresolved to exercise the timeout path.
+            });
+        }
+    });
+
+    const promptPromise = prompt();
+    clock.tick(90_000);
+    await expectFailure(async () => {
+        await promptPromise;
+    }, /^Error: One-time password input timed out or was empty$/u);
+
+    assert.strictEqual(close.callCount, 1);
+});
+
+test('throws when the entered one-time password is empty after trimming', async () => {
+    const { prompt } = createPrompt({
+        question: fake.resolves('   ')
+    });
+
+    await expectFailure(async () => {
+        await prompt();
+    }, /^Error: One-time password input timed out or was empty$/u);
+});

--- a/source/command-line-interface/one-time-password-prompt.ts
+++ b/source/command-line-interface/one-time-password-prompt.ts
@@ -1,0 +1,53 @@
+import type { Clock } from '../common/clock.ts';
+
+type OneTimePasswordReadline = {
+    question: (prompt: string) => Promise<string>;
+    close: () => void;
+};
+
+export type OneTimePasswordPromptDependencies = {
+    readonly clock: Clock;
+    readonly isInteractiveTerminal: () => boolean;
+    readonly stopSpinner: () => void;
+    readonly createInterface: () => OneTimePasswordReadline;
+};
+
+export type OneTimePasswordPrompt = () => Promise<string | undefined>;
+
+const oneTimePasswordPromptTimeoutMs = 90_000;
+
+export function createOneTimePasswordPrompt(
+    dependencies: Readonly<OneTimePasswordPromptDependencies>
+): OneTimePasswordPrompt {
+    const { clock, isInteractiveTerminal, stopSpinner, createInterface } = dependencies;
+
+    return async () => {
+        if (!isInteractiveTerminal()) {
+            throw new Error(
+                'The registry requested a one-time password, but prompting requires an interactive terminal'
+            );
+        }
+
+        stopSpinner();
+        const interfaceInstance = createInterface();
+
+        try {
+            const answer = await Promise.race([
+                interfaceInstance.question('Registry one-time password: '),
+                new Promise<undefined>((resolve) => {
+                    clock.setTimeout(() => {
+                        resolve(undefined);
+                    }, oneTimePasswordPromptTimeoutMs);
+                })
+            ]);
+
+            if (typeof answer !== 'string' || answer.trim().length === 0) {
+                throw new Error('One-time password input timed out or was empty');
+            }
+
+            return answer.trim();
+        } finally {
+            interfaceInstance.close();
+        }
+    };
+}

--- a/source/common/clock.test.ts
+++ b/source/common/clock.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { clearTimeout as clearTimer, setTimeout as setTimer } from 'node:timers';
+import { test } from 'mocha';
+import { createClock } from './clock.ts';
+
+test('createClock() returns the current wall-clock time in milliseconds', () => {
+    const clock = createClock();
+    const before = Date.now();
+    const currentTime = clock.getCurrentTimeInMilliseconds();
+    const after = Date.now();
+
+    assert.ok(currentTime >= before);
+    assert.ok(currentTime <= after);
+});
+
+test('createClock() exposes the global timeout functions', () => {
+    const clock = createClock();
+
+    assert.strictEqual(clock.setTimeout, setTimer);
+    assert.strictEqual(clock.clearTimeout, clearTimer);
+});

--- a/source/common/clock.ts
+++ b/source/common/clock.ts
@@ -1,0 +1,23 @@
+import { clearTimeout as clearTimer, setTimeout as setTimer } from 'node:timers';
+
+export type Clock = {
+    readonly getCurrentTimeInMilliseconds: () => number;
+    readonly setTimeout: <Arguments extends readonly unknown[]>(
+        handler: (...args: Arguments) => void,
+        delayInMilliseconds: number,
+        ...args: Arguments
+    ) => ReturnType<typeof globalThis.setTimeout>;
+    readonly clearTimeout: (id: ReturnType<typeof globalThis.setTimeout>) => void;
+};
+
+export function createClock(): Clock {
+    return {
+        getCurrentTimeInMilliseconds() {
+            return Date.now();
+        },
+
+        setTimeout: setTimer,
+
+        clearTimeout: clearTimer
+    };
+}

--- a/source/common/fake-clock.test.ts
+++ b/source/common/fake-clock.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import { createFakeClock } from '../test-libraries/fake-clock.ts';
+
+test('createFakeClock() exposes the initial timestamp and advances with tick()', () => {
+    const clock = createFakeClock({ initialTimestamp: 10 });
+
+    assert.strictEqual(clock.getCurrentTimeInMilliseconds(), 10);
+    clock.tick(15);
+    assert.strictEqual(clock.getCurrentTimeInMilliseconds(), 25);
+});
+
+test('createFakeClock() runs due handlers in order when time advances', () => {
+    const clock = createFakeClock();
+    const calls: string[] = [];
+
+    clock.setTimeout(() => {
+        calls.push('late');
+    }, 10);
+    clock.setTimeout(() => {
+        calls.push('early');
+    }, 5);
+
+    clock.tick(5);
+    assert.deepStrictEqual(calls, ['early']);
+
+    clock.tick(5);
+    assert.deepStrictEqual(calls, ['early', 'late']);
+});
+
+test('createFakeClock() runs zero-delay handlers immediately', () => {
+    const clock = createFakeClock();
+    const calls: string[] = [];
+
+    clock.setTimeout(
+        (value: string) => {
+            calls.push(value);
+        },
+        0,
+        'now'
+    );
+
+    assert.deepStrictEqual(calls, ['now']);
+});
+
+test('createFakeClock() can clear scheduled handlers', () => {
+    const clock = createFakeClock();
+    const calls: string[] = [];
+    const timeoutId = clock.setTimeout(() => {
+        calls.push('should-not-run');
+    }, 10);
+
+    clock.clearTimeout(timeoutId);
+    clock.tick(10);
+
+    assert.deepStrictEqual(calls, []);
+});
+
+test('createFakeClock() returns sequential timeout identifiers', () => {
+    const clock = createFakeClock();
+
+    const firstTimeoutId = clock.setTimeout(() => {
+        return undefined;
+    }, 10);
+    const secondTimeoutId = clock.setTimeout(() => {
+        return undefined;
+    }, 10);
+
+    assert.strictEqual(firstTimeoutId, 0);
+    assert.strictEqual(secondTimeoutId, 1);
+});
+
+test('createFakeClock() keeps returning increasing timeout identifiers after clearing timers', () => {
+    const clock = createFakeClock();
+    const firstTimeoutId = clock.setTimeout(() => {
+        return undefined;
+    }, 10);
+
+    clock.clearTimeout(firstTimeoutId);
+
+    const secondTimeoutId = clock.setTimeout(() => {
+        return undefined;
+    }, 10);
+
+    assert.strictEqual(firstTimeoutId, 0);
+    assert.strictEqual(secondTimeoutId, 1);
+});
+
+test('createFakeClock() rejects negative delays', () => {
+    const clock = createFakeClock();
+
+    assert.throws(() => {
+        clock.setTimeout(() => {
+            return undefined;
+        }, -1);
+    }, /^Error: Invalid delay -1, must be greater than or equal to 0$/u);
+});
+
+test('createFakeClock() rejects non-finite delays', () => {
+    const clock = createFakeClock();
+
+    assert.throws(() => {
+        clock.setTimeout(() => {
+            return undefined;
+        }, Number.POSITIVE_INFINITY);
+    }, /^TypeError: Invalid delay, must be a finite number$/u);
+});

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -83,7 +83,7 @@ const validConfigArbitrary = fc
         };
 
         return {
-            registrySettings: { token: 'token' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings,
             packages: [
                 {

--- a/source/config/config.test.ts
+++ b/source/config/config.test.ts
@@ -31,7 +31,7 @@ test('getBundledDependencies returns an empty list when no bundled dependencies 
 test('config schema accepts a valid config', () => {
     assert.strictEqual(
         safeParse(packtoryConfigSchema, {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
         }).success,
         true
@@ -56,7 +56,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {},
             packages: [
                 {
@@ -68,7 +68,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {},
             packages: [
                 {
@@ -105,7 +105,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: []
         },
         expectedMessages: ['invalid value doesn’t match expected union']
@@ -117,7 +117,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'source',
@@ -136,7 +136,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     allowList: ['foo/bar.ts']
@@ -160,7 +160,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     enabled: true,
@@ -185,7 +185,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     enabled: true,
@@ -202,7 +202,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     enabled: true,
@@ -226,7 +226,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     enabled: true,
@@ -243,7 +243,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     enabled: true,
@@ -267,7 +267,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 includeSourceMapFiles: true,
                 additionalFiles: [],
@@ -283,7 +283,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 includeSourceMapFiles: true,
                 additionalFiles: [],
@@ -305,7 +305,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'source',
@@ -316,7 +316,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'source',
@@ -334,7 +334,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -347,7 +347,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -367,7 +367,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -382,7 +382,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -404,7 +404,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source'
             },
@@ -417,7 +417,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source'
             },
@@ -437,7 +437,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source'
             },
@@ -451,7 +451,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source'
             },
@@ -472,7 +472,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 mainPackageJson: {}
             },
@@ -485,7 +485,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 mainPackageJson: {}
             },
@@ -505,7 +505,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 mainPackageJson: {}
             },
@@ -519,7 +519,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 mainPackageJson: {}
             },
@@ -540,7 +540,7 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {},
@@ -564,7 +564,7 @@ test(
             ]
         },
         expectedData: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {},
@@ -613,7 +613,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'source',
@@ -631,7 +631,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: []
         },
         expectedMessages: ['invalid value doesn’t match expected union']
@@ -643,7 +643,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'source',
@@ -662,7 +662,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     allowList: ['foo/bar.ts']
@@ -686,7 +686,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
                     enabled: true,
@@ -711,7 +711,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {},
             packages: [
                 {
@@ -729,7 +729,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 mainPackageJson: {}
             },
@@ -749,7 +749,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: undefined,
             packages: [
                 {
@@ -768,7 +768,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'foo'
             },
@@ -788,7 +788,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'foo',
@@ -806,7 +806,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'foo',
@@ -825,7 +825,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'foo',
@@ -843,7 +843,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'foo',
@@ -862,7 +862,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'foo',
@@ -881,7 +881,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
                     sourcesFolder: 'foo',
@@ -900,7 +900,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {},
@@ -922,7 +922,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {},
@@ -944,7 +944,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {},
@@ -966,7 +966,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -988,7 +988,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -1010,7 +1010,7 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 'foo' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             commonPackageSettings: {
                 sourcesFolder: 'source',
                 mainPackageJson: {}
@@ -1177,7 +1177,9 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            registrySettings: { token: 42 },
+            registrySettings: {
+                auth: { type: 'bearer-token', token: 42 }
+            },
             packages: [
                 {
                     sourcesFolder: 'source',
@@ -1187,6 +1189,6 @@ test(
                 }
             ]
         },
-        expectedMessages: ['at registrySettings.token: expected string, but got number']
+        expectedMessages: ['at registrySettings.auth: invalid value doesn’t match expected union']
     })
 );

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -5,7 +5,7 @@ import { checkValidationFailure, checkValidationSuccess } from '../test-librarie
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
 
 const validConfig = {
-    registrySettings: { token: 'foo' },
+    registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
     packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
 };
 

--- a/source/config/registry-settings.test.ts
+++ b/source/config/registry-settings.test.ts
@@ -4,38 +4,122 @@ import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { registrySettingsSchema } from './registry-settings.ts';
 
-test('schema accepts registry settings with token only', () => {
-    assert.strictEqual(safeParse(registrySettingsSchema, { token: 'foo' }).success, true);
+const bearerTokenAuth = { type: 'bearer-token', token: 'foo' } as const;
+
+test('schema accepts registry settings with shorthand auth', () => {
+    assert.strictEqual(safeParse(registrySettingsSchema, { auth: bearerTokenAuth }).success, true);
 });
 
-test('schema rejects registry settings without token', () => {
+test('schema rejects registry settings without auth', () => {
     assert.strictEqual(safeParse(registrySettingsSchema, { registryUrl: 'bar' }).success, false);
 });
 
 test(
-    'validation succeeds when no url is given',
+    'validation succeeds when shorthand auth is given',
     checkValidationSuccess({
         schema: registrySettingsSchema,
         data: {
-            token: 'foo'
+            auth: bearerTokenAuth
         },
         expectedData: {
-            token: 'foo'
+            auth: bearerTokenAuth
         }
     })
 );
 
 test(
-    'validation succeeds when url is given',
+    'validation succeeds when explicit publish and metadata auth are given',
     checkValidationSuccess({
         schema: registrySettingsSchema,
         data: {
-            token: 'foo',
-            registryUrl: 'bar'
+            registryUrl: 'https://registry.example',
+            auth: {
+                publish: { type: 'basic', username: 'foo', password: 'bar', email: 'foo@example.test' },
+                metadata: 'auto'
+            }
         },
         expectedData: {
-            token: 'foo',
-            registryUrl: 'bar'
+            registryUrl: 'https://registry.example',
+            auth: {
+                publish: { type: 'basic', username: 'foo', password: 'bar', email: 'foo@example.test' },
+                metadata: 'auto'
+            }
+        }
+    })
+);
+
+test(
+    'validation succeeds when explicit metadata auth inherits separate basic credentials',
+    checkValidationSuccess({
+        schema: registrySettingsSchema,
+        data: {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: { type: 'basic', username: 'reader', password: 'secret' }
+            }
+        },
+        expectedData: {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: { type: 'basic', username: 'reader', password: 'secret' }
+            }
+        }
+    })
+);
+
+test(
+    'validation accepts npm oidc publish auth',
+    checkValidationSuccess({
+        schema: registrySettingsSchema,
+        data: {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' },
+                metadata: 'anonymous'
+            }
+        },
+        expectedData: {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' },
+                metadata: 'anonymous'
+            }
+        }
+    })
+);
+
+test(
+    'validation accepts npm oidc publish auth for the auto provider',
+    checkValidationSuccess({
+        schema: registrySettingsSchema,
+        data: {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'auto' },
+                metadata: 'anonymous'
+            }
+        },
+        expectedData: {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'auto' },
+                metadata: 'anonymous'
+            }
+        }
+    })
+);
+
+test(
+    'validation accepts npm oidc publish auth for the GitHub Actions provider',
+    checkValidationSuccess({
+        schema: registrySettingsSchema,
+        data: {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'github-actions' },
+                metadata: 'anonymous'
+            }
+        },
+        expectedData: {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'github-actions' },
+                metadata: 'anonymous'
+            }
         }
     })
 );
@@ -54,52 +138,32 @@ test(
     checkValidationFailure({
         schema: registrySettingsSchema,
         data: {},
-        expectedMessages: ['at token: missing property']
+        expectedMessages: ['at auth: missing property']
     })
 );
 
 test(
-    'validation fails when token is not a string',
+    'validation fails when shorthand auth uses an empty token',
     checkValidationFailure({
         schema: registrySettingsSchema,
-        data: { token: 42 },
-        expectedMessages: ['at token: expected string, but got number']
+        data: { auth: { type: 'bearer-token', token: '' } },
+        expectedMessages: ['at auth.token: string must contain at least 1 character']
     })
 );
 
 test(
-    'validation fails when token is undefined',
+    'validation fails when metadata auth uses npm oidc',
     checkValidationFailure({
         schema: registrySettingsSchema,
-        data: { token: undefined },
-        expectedMessages: ['at token: expected string, but got undefined']
-    })
-);
-
-test(
-    'validation fails when token is null',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: { token: null },
-        expectedMessages: ['at token: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when token is an empty string',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: { token: '' },
-        expectedMessages: ['at token: string must contain at least 1 character']
-    })
-);
-
-test(
-    'validation succeeds when registryUrl is undefined',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: { token: 'foo', registryUrl: undefined },
-        expectedData: { token: 'foo', registryUrl: undefined }
+        data: {
+            auth: {
+                publish: bearerTokenAuth,
+                metadata: { type: 'npm-oidc' }
+            }
+        },
+        expectedMessages: [
+            'at auth: invalid value: expected one of "auto", "anonymous" or "inherit-publish-auth", but got object'
+        ]
     })
 );
 
@@ -107,17 +171,8 @@ test(
     'validation fails when registryUrl is null',
     checkValidationFailure({
         schema: registrySettingsSchema,
-        data: { token: 'foo', registryUrl: null },
+        data: { auth: bearerTokenAuth, registryUrl: null },
         expectedMessages: ['at registryUrl: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when registryUrl is an empty string',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: { token: 'foo', registryUrl: '' },
-        expectedMessages: ['at registryUrl: string must contain at least 1 character']
     })
 );
 
@@ -125,7 +180,7 @@ test(
     'validation fails when an additional property is given',
     checkValidationFailure({
         schema: registrySettingsSchema,
-        data: { token: 'foo', extra: 'bar' },
+        data: { auth: bearerTokenAuth, extra: 'bar' },
         expectedMessages: ['unexpected additional property: "extra"']
     })
 );

--- a/source/config/registry-settings.ts
+++ b/source/config/registry-settings.ts
@@ -1,11 +1,64 @@
 import { z } from 'zod/mini';
 import { nonEmptyStringSchema } from './base-validations.ts';
 
-export const registrySettingsSchema = z.readonly(
+const bearerTokenAuthSchema = z.readonly(
     z.strictObject({
-        registryUrl: z.optional(nonEmptyStringSchema),
+        type: z.literal('bearer-token'),
         token: nonEmptyStringSchema
     })
 );
 
+const basicAuthSchema = z.readonly(
+    z.strictObject({
+        type: z.literal('basic'),
+        username: nonEmptyStringSchema,
+        password: nonEmptyStringSchema,
+        email: z.optional(nonEmptyStringSchema)
+    })
+);
+
+const npmOidcAuthSchema = z.readonly(
+    z.strictObject({
+        type: z.literal('npm-oidc'),
+        provider: z.optional(z.enum(['auto', 'github-actions', 'env'])),
+        idTokenEnvVar: z.optional(nonEmptyStringSchema)
+    })
+);
+
+const publishAuthStrategySchema = z.discriminatedUnion('type', [
+    bearerTokenAuthSchema,
+    basicAuthSchema,
+    npmOidcAuthSchema
+]);
+
+const metadataAuthStrategySchema = z.discriminatedUnion('type', [bearerTokenAuthSchema, basicAuthSchema]);
+
+const metadataAuthModeSchema = z.union([
+    z.literal('auto'),
+    z.literal('anonymous'),
+    z.literal('inherit-publish-auth'),
+    metadataAuthStrategySchema
+]);
+
+const authConfigSchema = z.union([
+    z.readonly(publishAuthStrategySchema),
+    z.readonly(
+        z.strictObject({
+            publish: publishAuthStrategySchema,
+            metadata: z.optional(metadataAuthModeSchema)
+        })
+    )
+]);
+
+export const registrySettingsSchema = z.readonly(
+    z.strictObject({
+        registryUrl: z.optional(nonEmptyStringSchema),
+        auth: authConfigSchema
+    })
+);
+
+export type PublishAuthStrategy = z.infer<typeof publishAuthStrategySchema>;
+export type MetadataAuthStrategy = z.infer<typeof metadataAuthStrategySchema>;
+export type MetadataAuthMode = z.infer<typeof metadataAuthModeSchema>;
+export type RegistryAuthConfig = z.infer<typeof authConfigSchema>;
 export type RegistrySettings = z.infer<typeof registrySettingsSchema>;

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -23,7 +23,7 @@ test('leaf config schemas keep their expected object keys and strict object beha
     assert.deepStrictEqual(result, {
         additionalFileShape: ['sourceFilePath', 'targetFilePath'],
         entryPointShape: ['js', 'declarationFile'],
-        registrySettingsShape: ['registryUrl', 'token'],
+        registrySettingsShape: ['registryUrl', 'auth'],
         mainPackageJsonShape: ['type', 'dependencies', 'devDependencies', 'peerDependencies'],
         additionalFileCatchallType: 'never',
         entryPointCatchallType: 'never',
@@ -225,14 +225,14 @@ test('schema source modules still validate representative valid and invalid inpu
                 extra: 'nope'
             }).success,
             validRegistrySuccess: safeParse(registrySettingsSchema, {
-                token: 'secret',
+                auth: { type: 'bearer-token', token: 'secret' },
                 registryUrl: 'https://example.test'
             }).success,
             missingRegistryTokenSuccess: safeParse(registrySettingsSchema, {
                 registryUrl: 'https://example.test'
             }).success,
             validConfigSuccess: safeParse(packtoryConfigSchema, {
-                registrySettings: { token: 'secret' },
+                registrySettings: { auth: { type: 'bearer-token', token: 'secret' } },
                 packages: [{
                     sourcesFolder: 'src',
                     mainPackageJson: {},
@@ -249,7 +249,7 @@ test('schema source modules still validate representative valid and invalid inpu
                 }]
             }).success,
             emptyConfigPackagesSuccess: safeParse(packtoryConfigSchema, {
-                registrySettings: { token: 'secret' },
+                registrySettings: { auth: { type: 'bearer-token', token: 'secret' } },
                 packages: []
             }).success
         }));

--- a/source/config/validation.property.ts
+++ b/source/config/validation.property.ts
@@ -32,7 +32,7 @@ test('validateConfig() rejects configs with missing bundle dependencies', () => 
             fc.pre(packageName !== missingDependencyName);
 
             const result = validateConfig({
-                registrySettings: { token: 'token' },
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 packages: [
                     {
                         ...createValidPackage(packageName),
@@ -52,13 +52,13 @@ test('validateConfig() rejects duplicate package definitions and cyclic dependen
             fc.pre(firstName !== secondName);
 
             const duplicateResult = validateConfig({
-                registrySettings: { token: 'token' },
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 packages: [createValidPackage(firstName), createValidPackage(firstName)]
             });
             assert.strictEqual(duplicateResult.isErr, true);
 
             const cyclicResult = validateConfig({
-                registrySettings: { token: 'token' },
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 packages: [
                     {
                         ...createValidPackage(firstName),

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -8,7 +8,7 @@ type ConfigInput = Record<string, unknown>;
 
 function withRegistry(extra: ConfigInput): ConfigInput {
     return {
-        registrySettings: { token: 'foo' },
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
         ...extra
     };

--- a/source/npm-oidc-id-token-resolver.test.ts
+++ b/source/npm-oidc-id-token-resolver.test.ts
@@ -1,0 +1,227 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import { createNpmOidcIdTokenResolver } from './npm-oidc-id-token-resolver.ts';
+
+type Overrides = {
+    readonly fetch?: typeof globalThis.fetch;
+    readonly environmentVariables?: Readonly<Record<string, string | undefined>>;
+};
+
+const gitHubActionsEnvironmentVariables = {
+    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://actions.example.test/id-token',
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'actions-request-token'
+} as const;
+
+function createEnvironmentVariableReader(
+    environmentVariables: Readonly<Record<string, string | undefined>> = {}
+): (variableName: string) => string | undefined {
+    return (variableName) => {
+        const value = environmentVariables[variableName];
+        return value === undefined || value.length === 0 ? undefined : value;
+    };
+}
+
+function resolverFactory(overrides: Readonly<Overrides> = {}) {
+    const {
+        fetch: fetchImplementation = fake.resolves({
+            ok: true,
+            status: 200,
+            json: fake.resolves({ value: 'github-id-token' })
+        }) as unknown as typeof globalThis.fetch,
+        environmentVariables = {}
+    } = overrides;
+
+    return createNpmOidcIdTokenResolver({
+        fetch: fetchImplementation,
+        getEnvironmentVariable: createEnvironmentVariableReader(environmentVariables)
+    });
+}
+
+function createGitHubActionsFetch(fetchCalls?: unknown[][]): typeof globalThis.fetch {
+    return (async (...args: unknown[]) => {
+        fetchCalls?.push(args);
+        return {
+            ok: true,
+            status: 200,
+            json: fake.resolves({ value: 'github-id-token' })
+        };
+    }) as unknown as typeof globalThis.fetch;
+}
+
+function createGitHubActionsResolver(overrides: Readonly<Overrides> = {}) {
+    return resolverFactory({
+        ...overrides,
+        environmentVariables: {
+            ...gitHubActionsEnvironmentVariables,
+            ...overrides.environmentVariables
+        }
+    });
+}
+
+async function expectFailure(action: () => Promise<unknown>, expectedError: RegExp): Promise<void> {
+    try {
+        await action();
+        assert.fail('Expected the action to throw an error');
+    } catch (error: unknown) {
+        assert.match(String(error), expectedError);
+    }
+}
+
+test('resolver uses the default environment variable when npm oidc provider is omitted', async () => {
+    const resolveIdToken = resolverFactory({
+        environmentVariables: {
+            GITHUB_ACTIONS: 'false',
+            NPM_ID_TOKEN: 'upstream-id-token'
+        }
+    });
+
+    const idToken = await resolveIdToken({ type: 'npm-oidc' });
+
+    assert.strictEqual(idToken, 'upstream-id-token');
+});
+
+test('resolver fetches a GitHub Actions id token when requested', async () => {
+    const fetchCalls: unknown[][] = [];
+    const resolveIdToken = createGitHubActionsResolver({
+        fetch: createGitHubActionsFetch(fetchCalls)
+    });
+
+    const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+
+    assert.strictEqual(idToken, 'github-id-token');
+    assert.deepStrictEqual(fetchCalls, [
+        [
+            new URL('https://actions.example.test/id-token?audience=npm%3Aregistry.npmjs.org'),
+            {
+                headers: { Authorization: 'Bearer actions-request-token' }
+            }
+        ]
+    ]);
+});
+
+test('resolver auto-detects GitHub Actions when npm oidc provider is omitted', async () => {
+    const fetchCalls: unknown[][] = [];
+    const resolveIdToken = createGitHubActionsResolver({
+        fetch: createGitHubActionsFetch(fetchCalls),
+        environmentVariables: {
+            GITHUB_ACTIONS: 'true'
+        }
+    });
+
+    const idToken = await resolveIdToken({ type: 'npm-oidc' });
+
+    assert.strictEqual(idToken, 'github-id-token');
+    assert.strictEqual(fetchCalls.length, 1);
+});
+
+test('resolver uses the env provider even when GitHub Actions markers are present', async () => {
+    const fetchSpy = fake() as unknown as typeof globalThis.fetch;
+    const resolveIdToken = resolverFactory({
+        fetch: fetchSpy,
+        environmentVariables: {
+            GITHUB_ACTIONS: 'true',
+            NPM_ID_TOKEN: 'upstream-id-token'
+        }
+    });
+
+    const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'env' });
+
+    assert.strictEqual(idToken, 'upstream-id-token');
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 0);
+});
+
+test('resolver falls back to environment id tokens when auto-detection does not match GitHub Actions', async () => {
+    const fetchSpy = fake() as unknown as typeof globalThis.fetch;
+    const resolveIdToken = resolverFactory({
+        fetch: fetchSpy,
+        environmentVariables: {
+            GITHUB_ACTIONS: 'false',
+            NPM_ID_TOKEN: 'upstream-id-token'
+        }
+    });
+
+    const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'auto' });
+
+    assert.strictEqual(idToken, 'upstream-id-token');
+    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 0);
+});
+
+test('resolver rejects GitHub Actions OIDC when required environment variables are missing', async () => {
+    const resolveIdToken = resolverFactory();
+
+    await expectFailure(async () => {
+        await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+    }, /^Error: GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN$/u);
+});
+
+for (const [missingVariable, requestUrl, requestToken] of [
+    ['ACTIONS_ID_TOKEN_REQUEST_URL', undefined, 'actions-request-token'],
+    ['ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'https://actions.example.test/id-token', undefined]
+] as const) {
+    test(`resolver rejects GitHub Actions OIDC when ${missingVariable} is missing`, async () => {
+        const resolveIdToken = createGitHubActionsResolver({
+            environmentVariables: {
+                ACTIONS_ID_TOKEN_REQUEST_URL: requestUrl,
+                ACTIONS_ID_TOKEN_REQUEST_TOKEN: requestToken
+            }
+        });
+
+        await expectFailure(async () => {
+            await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+        }, /^Error: GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN$/u);
+    });
+}
+
+for (const [testName, response] of [
+    ['an unusable', {}],
+    ['a non-object', 'invalid-response'],
+    ['an array', Object.assign([], { value: 'github-id-token' })],
+    ['an empty', { value: '' }]
+] as const) {
+    test(`resolver rejects ${testName} GitHub Actions id token response`, async () => {
+        const resolveIdToken = createGitHubActionsResolver({
+            fetch: fake.resolves({
+                ok: true,
+                status: 200,
+                json: fake.resolves(response)
+            }) as unknown as typeof globalThis.fetch
+        });
+
+        await expectFailure(async () => {
+            await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+        }, /^Error: GitHub Actions OIDC token response did not contain a usable id_token$/u);
+    });
+}
+
+test('resolver rejects a failing GitHub Actions id token request', async () => {
+    const resolveIdToken = createGitHubActionsResolver({
+        fetch: fake.resolves({
+            ok: false,
+            status: 500,
+            json: fake.resolves({})
+        }) as unknown as typeof globalThis.fetch
+    });
+
+    await expectFailure(async () => {
+        await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+    }, /^Error: GitHub Actions OIDC token request failed with status 500$/u);
+});
+
+test('resolver rejects a missing environment id token for env provider', async () => {
+    const resolveIdToken = resolverFactory();
+
+    await expectFailure(async () => {
+        await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
+    }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
+});
+
+test('resolver rejects an empty environment id token for env provider', async () => {
+    const resolveIdToken = resolverFactory({
+        environmentVariables: { CUSTOM_ID_TOKEN: '' }
+    });
+
+    await expectFailure(async () => {
+        await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
+    }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
+});

--- a/source/npm-oidc-id-token-resolver.ts
+++ b/source/npm-oidc-id-token-resolver.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod/mini';
+import type { PublishAuthStrategy } from './config/registry-settings.ts';
+
+const githubActionsAudience = 'npm:registry.npmjs.org';
+const defaultOidcIdTokenEnvVariableName = 'NPM_ID_TOKEN';
+
+type NpmOidcAuth = Extract<PublishAuthStrategy, { type: 'npm-oidc' }>;
+
+export type NpmOidcIdTokenResolver = (auth: NpmOidcAuth) => Promise<string>;
+
+export type NpmOidcIdTokenResolverDependencies = {
+    readonly fetch: typeof globalThis.fetch;
+    readonly getEnvironmentVariable: (variableName: string) => string | undefined;
+};
+
+const gitHubActionsIdTokenResponseSchema = z.object({
+    value: z.string().check(z.minLength(1))
+});
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+    return response.json() as Promise<unknown>;
+}
+
+function getGitHubActionsRequestConfig(getEnvironmentVariable: (variableName: string) => string | undefined): {
+    readonly requestUrl: string;
+    readonly requestToken: string;
+} {
+    const requestUrl = getEnvironmentVariable('ACTIONS_ID_TOKEN_REQUEST_URL');
+    const requestToken = getEnvironmentVariable('ACTIONS_ID_TOKEN_REQUEST_TOKEN');
+
+    if (requestUrl === undefined || requestToken === undefined) {
+        throw new Error('GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN');
+    }
+
+    return { requestUrl, requestToken };
+}
+
+function parseGitHubActionsIdTokenResponse(body: unknown): string {
+    const result = gitHubActionsIdTokenResponseSchema.safeParse(body);
+    if (!result.success) {
+        throw new Error('GitHub Actions OIDC token response did not contain a usable id_token');
+    }
+
+    return result.data.value;
+}
+
+function usesGitHubActionsProvider(
+    auth: NpmOidcAuth,
+    getEnvironmentVariable: (variableName: string) => string | undefined
+): boolean {
+    const provider = auth.provider ?? 'auto';
+    const runsInGitHubActions = getEnvironmentVariable('GITHUB_ACTIONS') === 'true';
+    return provider === 'github-actions' || (provider === 'auto' && runsInGitHubActions);
+}
+
+export function createNpmOidcIdTokenResolver(
+    dependencies: Readonly<NpmOidcIdTokenResolverDependencies>
+): NpmOidcIdTokenResolver {
+    const { fetch: fetchImplementation, getEnvironmentVariable } = dependencies;
+
+    async function fetchGitHubActionsIdToken(): Promise<string> {
+        const { requestUrl, requestToken } = getGitHubActionsRequestConfig(getEnvironmentVariable);
+        const url = new URL(requestUrl);
+        url.searchParams.set('audience', githubActionsAudience);
+        const response = await fetchImplementation(url, {
+            headers: { Authorization: `Bearer ${requestToken}` }
+        });
+
+        if (!response.ok) {
+            throw new Error(`GitHub Actions OIDC token request failed with status ${response.status}`);
+        }
+
+        return parseGitHubActionsIdTokenResponse(await parseJsonResponse(response));
+    }
+
+    return async (auth) => {
+        if (usesGitHubActionsProvider(auth, getEnvironmentVariable)) {
+            return fetchGitHubActionsIdToken();
+        }
+
+        const variableName = auth.idTokenEnvVar ?? defaultOidcIdTokenEnvVariableName;
+        const value = getEnvironmentVariable(variableName);
+        if (value === undefined) {
+            throw new Error(`OIDC id_token environment variable "${variableName}" is missing`);
+        }
+
+        return value;
+    };
+}

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -1,23 +1,58 @@
 #!/usr/bin/env node
 
+import readline from 'node:readline/promises';
+import { createClock } from '../../common/clock.ts';
 import { bootedSpinnerRuntime } from '../../command-line-interface/spinner-boot.entry-point.ts';
+import { createOneTimePasswordPrompt } from '../../command-line-interface/one-time-password-prompt.ts';
 import type * as configTypes from '../../config/config.ts';
 import { createCommandLineInterfaceRunner } from '../../command-line-interface/runner.ts';
 import { createTerminalSpinnerRenderer } from '../../command-line-interface/terminal-spinner-renderer.ts';
 import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner-worker-backend.ts';
 import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
-import { buildAndPublishAll, resolveAndLinkAll, progressBroadcastConsumer } from '../packtory/packtory.entry-point.ts';
+import { createPacktory } from '../../packtory/packtory.ts';
+import { createScheduler } from '../../packtory/scheduler.ts';
+import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
 
 async function importModule(modulePath: string): Promise<unknown> {
     return import(modulePath);
 }
 
+const spinnerRenderer = createTerminalSpinnerRenderer({
+    backend: createWorkerSpinnerBackend({ runtime: bootedSpinnerRuntime })
+});
+const clock = createClock();
+
+const promptForOneTimePassword = createOneTimePasswordPrompt({
+    clock,
+    isInteractiveTerminal: () => {
+        return process.stdin.isTTY && process.stdout.isTTY;
+    },
+    stopSpinner: () => {
+        spinnerRenderer.stopAll();
+    },
+    createInterface: () => {
+        return readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+    }
+});
+
+const { packageProcessor, progressBroadcaster } = buildPackageProcessorComposition({
+    promptForOneTimePassword
+});
+const scheduler = createScheduler({
+    progressBroadcastProvider: progressBroadcaster.provider
+});
+const packtory = createPacktory({
+    scheduler,
+    packageProcessor
+});
+
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
-    packtory: { buildAndPublishAll, resolveAndLinkAll },
-    progressBroadcaster: progressBroadcastConsumer,
-    spinnerRenderer: createTerminalSpinnerRenderer({
-        backend: createWorkerSpinnerBackend({ runtime: bootedSpinnerRuntime })
-    }),
+    packtory,
+    progressBroadcaster: progressBroadcaster.consumer,
+    spinnerRenderer,
     configLoader: createConfigLoader({ currentWorkingDirectory: process.cwd(), importModule }),
     log: console.log
 });

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -27,3 +27,9 @@ packtory <command> [options]
 **Configuration:**
 
 Create a `packtory.config.js` file in your project to define the configuration. Refer to the [full documentation](https://github.com/enormora/packtory/blob/main/readme.md) for detailed configuration options.
+
+**One-time-password support:**
+
+- If the registry challenges a publish with a one-time password, the CLI prompts for it when running in an interactive TTY.
+- The prompt times out after 90 seconds.
+- Non-interactive runs cannot answer a one-time-password challenge. For CI, prefer an auth method that does not require live one-time-password entry, such as npm trusted publishing / OIDC or a suitable registry token setup.

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -18,11 +18,24 @@ import { createProgressBroadcaster, type ProgressBroadcaster } from '../progress
 import { createResourceResolver } from '../resource-resolver/resource-resolver.ts';
 import { createTarballBuilder } from '../tar/tarball-builder.ts';
 import { createVersionManager } from '../version-manager/manager.ts';
+import { createClock, type Clock } from '../common/clock.ts';
+import { createNpmOidcIdTokenResolver, type NpmOidcIdTokenResolver } from '../npm-oidc-id-token-resolver.ts';
 
 export type PackageProcessorComposition = {
     readonly packageProcessor: PackageProcessor;
     readonly progressBroadcaster: ProgressBroadcaster;
 };
+
+export type PackageProcessorCompositionOptions = {
+    readonly promptForOneTimePassword?: (() => Promise<string | undefined>) | undefined;
+    readonly clock?: Clock | undefined;
+    readonly resolveIdToken?: NpmOidcIdTokenResolver | undefined;
+};
+
+function getEnvironmentVariable(variableName: string): string | undefined {
+    const environment = process.env[variableName];
+    return environment === undefined || environment.length === 0 ? undefined : environment;
+}
 
 function createDependencyScannerWith(fileManager: FileManager): DependencyScanner {
     const sourceMapFileLocator = createSourceMapFileLocator({ fileManager });
@@ -35,10 +48,25 @@ function createDependencyScannerWith(fileManager: FileManager): DependencyScanne
     return createDependencyScanner({ sourceMapFileLocator, typescriptProjectAnalyzer });
 }
 
-export function buildPackageProcessorComposition(): PackageProcessorComposition {
+export function buildPackageProcessorComposition(
+    options: PackageProcessorCompositionOptions = {}
+): PackageProcessorComposition {
+    const clock = options.clock ?? createClock();
     const fileManager = createFileManager({ hostFileSystem: fs.promises });
     const dependencyScanner = createDependencyScannerWith(fileManager);
-    const registryClient = createRegistryClient({ npmFetch, publish });
+    const registryClient = createRegistryClient({
+        npmFetch,
+        publish,
+        fetch: globalThis.fetch,
+        clock,
+        resolveIdToken:
+            options.resolveIdToken ??
+            createNpmOidcIdTokenResolver({
+                fetch: globalThis.fetch,
+                getEnvironmentVariable
+            }),
+        promptForOneTimePassword: options.promptForOneTimePassword
+    });
     const artifactsBuilder = createArtifactsBuilder({ fileManager, tarballBuilder: createTarballBuilder() });
     const progressBroadcaster = createProgressBroadcaster();
     const bundleEmitter = createBundleEmitter({ registryClient, artifactsBuilder });

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'tstyche';
 import type { Result } from 'true-myth';
+import type { MetadataAuthMode, PublishAuthStrategy, RegistryAuthConfig } from '../../config/registry-settings.ts';
 import type {
     buildAndPublishAll,
     progressBroadcastConsumer,
@@ -58,7 +59,9 @@ describe('progressBroadcastConsumer', () => {
 describe('PacktoryConfig — accepted shapes', () => {
     test('accepts a minimum valid configuration (registrySettings and packages)', () => {
         expect<PacktoryConfig>().type.toBeAssignableFrom<{
-            readonly registrySettings: { readonly token: 'any-token' };
+            readonly registrySettings: {
+                readonly auth: { readonly type: 'bearer-token'; readonly token: 'any-token' };
+            };
             readonly packages: readonly [
                 { readonly name: 'pkg'; readonly entryPoints: readonly [{ readonly js: 'index.js' }] }
             ];
@@ -68,8 +71,15 @@ describe('PacktoryConfig — accepted shapes', () => {
     test('accepts a fully populated configuration with all optional fields', () => {
         expect<PacktoryConfig>().type.toBeAssignableFrom<{
             readonly registrySettings: {
-                readonly token: 'any-token';
                 readonly registryUrl: 'https://registry.example';
+                readonly auth: {
+                    readonly publish: {
+                        readonly type: 'basic';
+                        readonly username: 'user';
+                        readonly password: 'secret';
+                    };
+                    readonly metadata: 'auto';
+                };
             };
             readonly checks: { readonly noDuplicatedFiles: { readonly enabled: true } };
             readonly commonPackageSettings: { readonly sourcesFolder: 'src'; readonly includeSourceMapFiles: true };
@@ -97,11 +107,13 @@ describe('PacktoryConfig — rejected shapes', () => {
 
     test('rejects a configuration without packages', () => {
         expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
-            readonly registrySettings: { readonly token: 'tok' };
+            readonly registrySettings: {
+                readonly auth: { readonly type: 'bearer-token'; readonly token: 'tok' };
+            };
         }>();
     });
 
-    test('rejects a registrySettings without a token', () => {
+    test('rejects a registrySettings without auth', () => {
         expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
             readonly registrySettings: { readonly registryUrl: 'https://registry.example' };
             readonly packages: readonly [];
@@ -110,11 +122,15 @@ describe('PacktoryConfig — rejected shapes', () => {
 
     test('rejects a package without name or entryPoints', () => {
         expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
-            readonly registrySettings: { readonly token: 'tok' };
+            readonly registrySettings: {
+                readonly auth: { readonly type: 'bearer-token'; readonly token: 'tok' };
+            };
             readonly packages: readonly [{ readonly entryPoints: readonly [{ readonly js: 'index.js' }] }];
         }>();
         expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
-            readonly registrySettings: { readonly token: 'tok' };
+            readonly registrySettings: {
+                readonly auth: { readonly type: 'bearer-token'; readonly token: 'tok' };
+            };
             readonly packages: readonly [{ readonly name: 'pkg' }];
         }>();
     });
@@ -131,9 +147,12 @@ describe('PacktoryConfig — exposed structure', () => {
         expect<PacktoryConfig['packages']>().type.toBe<readonly PackageConfig[]>();
     });
 
-    test('registrySettings has a required token and an optional registryUrl', () => {
-        expect<PacktoryConfig['registrySettings']['token']>().type.toBe<string>();
+    test('registrySettings exposes the documented auth fields', () => {
         expect<PacktoryConfig['registrySettings']['registryUrl']>().type.toBe<string | undefined>();
+        expect<PacktoryConfig['registrySettings']['auth']>().type.toBe<RegistryAuthConfig>();
+        type ExpandedAuth = Extract<RegistryAuthConfig, { publish: unknown }>;
+        expect<ExpandedAuth['publish']>().type.toBe<PublishAuthStrategy>();
+        expect<ExpandedAuth['metadata']>().type.toBe<MetadataAuthMode | undefined>();
     });
 
     test('PackageConfig requires name and entryPoints', () => {

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -32,7 +32,7 @@ function runMapConfig(
     const packageName = options.packageName ?? 'foo';
     const additionalPackages = options.extraPackages ?? [placeholderPackage];
     const baseConfig = {
-        registrySettings: { token: '' },
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         ...options.extraConfig,
         ...(options.commonPackageSettings === undefined
             ? {}
@@ -66,7 +66,7 @@ test('throws when the given packageName doesn’t exist in the configs', () => {
             'foo',
             new Map(),
             {
-                registrySettings: { token: '' },
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 packages: [{ name: '', sourcesFolder: '', entryPoints: [{ js: '' }], mainPackageJson: {} }]
             },
             []

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -142,7 +142,7 @@ function createBuildAndPublishOptions(): BuildAndPublishOptions {
     return {
         ...createResolveOptions(),
         versioning: { automatic: true } as const,
-        registrySettings: { token: 'token' },
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         bundleDependencies: [createVersionedBundle('bundle-dependency', '1.0.0')],
         bundlePeerDependencies: [createVersionedBundle('peer-dependency', '2.0.0')]
     };
@@ -238,7 +238,7 @@ test('tryBuildAndPublish() returns already-published when the emitted bundle alr
     assert.deepStrictEqual(checkBundleAlreadyPublished.firstCall.args, [
         {
             bundle: versionedBundle,
-            registrySettings: { token: 'token' }
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } }
         }
     ]);
     assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '0.0.0' }]]);
@@ -260,7 +260,7 @@ test('tryBuildAndPublish() rebuilds with an increased version for the first publ
     assert.deepStrictEqual(determineCurrentVersion.firstCall.args, [
         {
             name: 'package-a',
-            registrySettings: { token: 'token' },
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             versioning: { automatic: true }
         }
     ]);
@@ -429,7 +429,9 @@ test('buildAndPublish() publishes the rebuilt bundle and emits publishing progre
     const result = await processor.buildAndPublish(options);
 
     assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'new-version' });
-    assert.deepStrictEqual(publish.firstCall.args, [{ bundle: rebuiltBundle, registrySettings: { token: 'token' } }]);
+    assert.deepStrictEqual(publish.firstCall.args, [
+        { bundle: rebuiltBundle, registrySettings: { auth: { type: 'bearer-token', token: 'token' } } }
+    ]);
     assert.deepStrictEqual(getCallArgs(emit), [
         ['building', { packageName: 'package-a', version: '1.2.3' }],
         ['rebuilding', { packageName: 'package-a', version: '1.2.3' }],

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -44,7 +44,7 @@ function createConfigWithoutRegistry(overrides: Record<string, unknown> = {}): P
 
 function createConfig(overrides: Record<string, unknown> = {}): PacktoryConfig {
     return {
-        registrySettings: { token: 'token' },
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         ...createConfigWithoutRegistry(overrides)
     };
 }

--- a/source/tar/extract-tar.property.ts
+++ b/source/tar/extract-tar.property.ts
@@ -7,12 +7,21 @@ const nonGzipBufferArbitrary = fc.uint8Array({ maxLength: 256 }).filter((data) =
     return data.length < 2 || data[0] !== 0x1f || data[1] !== 0x8b;
 });
 
+async function expectFailure(action: () => Promise<unknown>): Promise<void> {
+    try {
+        await action();
+        assert.fail('Expected the action to throw an error');
+    } catch (error: unknown) {
+        assert.ok(error instanceof Error);
+    }
+}
+
 test('extractTarEntries() rejects malformed non-gzip buffers explicitly', async () => {
     await fc.assert(
         fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
-            await assert.rejects(async () => {
+            await expectFailure(async () => {
                 await extractTarEntries(Buffer.from(data));
-            }, Error);
+            });
         }),
         { numRuns: 50 }
     );

--- a/source/tar/extract-tar.test.ts
+++ b/source/tar/extract-tar.test.ts
@@ -5,6 +5,20 @@ import sinon from 'sinon';
 import { extractTarEntries } from './extract-tar.ts';
 import { createTarballBuilder } from './tarball-builder.ts';
 
+async function expectFailure(action: () => Promise<unknown>, expectedError: RegExp | 'error'): Promise<void> {
+    try {
+        await action();
+        assert.fail('Expected the action to throw an error');
+    } catch (error: unknown) {
+        if (expectedError === 'error') {
+            assert.ok(error instanceof Error);
+            return;
+        }
+
+        assert.match(String(error), expectedError);
+    }
+}
+
 test('returns an empty array when the given tar buffer has no files', async () => {
     const builder = createTarballBuilder();
     const tar = await builder.build([]);
@@ -73,9 +87,9 @@ test('returns every extracted entry in tar order when the tarball contains multi
 });
 
 test('rejects when the given buffer is not a valid gzip tarball', async () => {
-    await assert.rejects(async () => {
+    await expectFailure(async () => {
         await extractTarEntries(Buffer.from('not-a-tarball'));
-    }, Error);
+    }, 'error');
 });
 
 async function runWithThrowingStream(thrown: () => never, expectedError: RegExp): Promise<void> {
@@ -98,7 +112,7 @@ async function runWithThrowingStream(thrown: () => never, expectedError: RegExp)
     const stub = sinon.stub(Readable, 'from').returns(source as unknown as Readable);
 
     try {
-        await assert.rejects(async () => {
+        await expectFailure(async () => {
             await extractTarEntries(Buffer.from('unused'));
         }, expectedError);
     } finally {

--- a/source/test-libraries/fake-clock.ts
+++ b/source/test-libraries/fake-clock.ts
@@ -1,0 +1,76 @@
+import type { Clock } from '../common/clock.ts';
+
+type FakeClockOptions = {
+    readonly initialTimestamp?: number;
+};
+
+type HandlerInfo = {
+    readonly executionTimestamp: number;
+    readonly handler: () => void;
+};
+
+export type FakeClock = Clock & {
+    readonly tick: (delayInMilliseconds: number) => void;
+};
+
+type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
+
+export function createFakeClock(options: FakeClockOptions = {}): FakeClock {
+    const { initialTimestamp = 0 } = options;
+
+    let currentTimestamp = initialTimestamp;
+    let currentHandlerIndex = -1;
+    const handlers = new Map<number, HandlerInfo>();
+
+    function runScheduledHandlers(): void {
+        Array.from(handlers.entries()).forEach(([id, handlerInfo]) => {
+            if (currentTimestamp >= handlerInfo.executionTimestamp) {
+                handlers.delete(id);
+                handlerInfo.handler();
+            }
+        });
+    }
+
+    return {
+        getCurrentTimeInMilliseconds() {
+            return currentTimestamp;
+        },
+
+        setTimeout<Arguments extends readonly unknown[]>(
+            handler: (...args: Arguments) => void,
+            delayInMilliseconds: number,
+            ...args: Arguments
+        ) {
+            if (delayInMilliseconds < 0) {
+                throw new Error(`Invalid delay ${delayInMilliseconds}, must be greater than or equal to 0`);
+            }
+
+            if (!Number.isFinite(delayInMilliseconds)) {
+                throw new TypeError('Invalid delay, must be a finite number');
+            }
+
+            currentHandlerIndex += 1;
+            const executionTimestamp = currentTimestamp + delayInMilliseconds;
+            handlers.set(currentHandlerIndex, {
+                executionTimestamp,
+                handler: () => {
+                    handler(...args);
+                }
+            });
+
+            runScheduledHandlers();
+
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- node/browser timeout handle types differ
+            return currentHandlerIndex as unknown as TimerHandle;
+        },
+
+        clearTimeout(id) {
+            handlers.delete(Number(id));
+        },
+
+        tick(delayInMilliseconds) {
+            currentTimestamp += delayInMilliseconds;
+            runScheduledHandlers();
+        }
+    };
+}


### PR DESCRIPTION
Replace the public registry auth surface with an auth-focused config model.

The new schema supports a shorthand auth form for the common case and an expanded form with separate publish and metadata behavior. Metadata access now supports an explicit auto mode that attempts anonymous access first and retries with publish auth on 401/403 challenges. This keeps the config intent-driven while preserving the existing correctness around private registries and npmjs-specific OIDC publishing.

Update the registry client to normalize the new auth config, resolve bearer/basic/OIDC publish auth, and apply metadata policy consistently to version lookups and tarball downloads. npm OIDC token exchange remains package-scoped and cached until expiry. Bearer and basic auth are now forced explicitly for registries instead of relying on ambient npm config.

Keep OTP support CLI-only and interactive. The CLI now wires an OTP prompt into the publish path, stops the spinner before prompting, trims the entered code, and fails after a 90 second timeout. Non-interactive flows still cannot satisfy live OTP challenges and are documented accordingly.