### PR TITLE
Replace hand-rolled patterns with remeda helpers

### DIFF
--- a/source/command-line-interface/spinner-worker-loop.ts
+++ b/source/command-line-interface/spinner-worker-loop.ts
@@ -1,3 +1,4 @@
+import { times } from 'remeda';
 import { bold, green, red } from 'yoctocolors';
 import {
     createSpinnerSharedAccessors,
@@ -71,11 +72,9 @@ function formatLine(snapshot: SlotSnapshot, frameIndex: number, columns: number)
 }
 
 function readAllSnapshots(accessors: SpinnerSharedAccessors): SlotSnapshot[] {
-    const snapshots: SlotSnapshot[] = [];
-    for (let slotIndex = 0; slotIndex < accessors.layout.slotCount; slotIndex += 1) {
-        snapshots.push(readSlotSnapshot(accessors, slotIndex));
-    }
-    return snapshots;
+    return times(accessors.layout.slotCount, (slotIndex) => {
+        return readSlotSnapshot(accessors, slotIndex);
+    });
 }
 
 function findHighestActiveSlotIndex(snapshots: readonly SlotSnapshot[]): number {

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -195,7 +195,7 @@ test('configToResolveAndLinkOptions() keeps package-specific overrides over inhe
 
             const result = configToResolveAndLinkOptions(
                 packageConfig.name,
-                new Map(
+                Object.fromEntries(
                     typedConfig.packages.map((entry) => {
                         return [entry.name, entry];
                     })

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -33,6 +33,8 @@ export type PackageConfig = {
     readonly additionalPackageJsonAttributes?: AdditionalPackageJsonAttributes | undefined;
 };
 
+export type PackageConfigsByName = Readonly<Record<string, PackageConfig>>;
+
 const bundledDependencyPropertyNames = ['bundleDependencies', 'bundlePeerDependencies'] as const;
 
 export function getBundledDependencies(packageConfig: PackageConfig): readonly string[] {

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -1,5 +1,6 @@
 import { Result } from 'true-myth';
 import { safeParse } from '@schema-hub/zod-error-formatter';
+import { indexBy } from 'remeda';
 import type { ZodMiniType } from 'zod/mini';
 import { type DirectedGraph, createDirectedGraph } from '../directed-graph/graph.ts';
 import {
@@ -7,19 +8,20 @@ import {
     type ChecksSettings,
     type PacktoryConfig,
     type PackageConfig,
+    type PackageConfigsByName,
     type PacktoryConfigWithoutRegistry
 } from './config.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
 import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-registry-schema.ts';
 
-function buildPackageGraph(packages: ReadonlyMap<string, PackageConfig>): DirectedGraph<string, undefined> {
+function buildPackageGraph(packages: PackageConfigsByName): DirectedGraph<string, undefined> {
     const graph = createDirectedGraph<string, undefined>();
 
-    for (const packageConfig of packages.values()) {
+    for (const packageConfig of Object.values(packages)) {
         graph.addNode(packageConfig.name, undefined);
     }
 
-    for (const packageConfig of packages.values()) {
+    for (const packageConfig of Object.values(packages)) {
         for (const dependency of getBundledDependencies(packageConfig)) {
             graph.connect({ from: packageConfig.name, to: dependency });
         }
@@ -45,9 +47,9 @@ function validateDependenciesExistForSinglePackage(
         });
 }
 
-function validateDependenciesExist(packageConfigs: Map<string, PackageConfig>): readonly string[] {
-    const knownPackageNames = Array.from(packageConfigs.keys());
-    return Array.from(packageConfigs.values()).flatMap((packageConfig) => {
+function validateDependenciesExist(packageConfigs: PackageConfigsByName): readonly string[] {
+    const knownPackageNames = Object.keys(packageConfigs);
+    return Object.values(packageConfigs).flatMap((packageConfig) => {
         return [
             ...validateDependenciesExistForSinglePackage(
                 packageConfig.name,
@@ -65,15 +67,14 @@ function validateDependenciesExist(packageConfigs: Map<string, PackageConfig>): 
     });
 }
 
-function packageListToMap(packages: readonly PackageConfig[]): Map<string, PackageConfig> {
-    return packages.reduce((map, packageConfig) => {
-        map.set(packageConfig.name, packageConfig);
-        return map;
-    }, new Map<string, PackageConfig>());
+function packageListToRecord(packages: readonly PackageConfig[]): PackageConfigsByName {
+    return indexBy(packages, (packageConfig) => {
+        return packageConfig.name;
+    });
 }
 
 function validateNoDuplicatedFilesAllowList(
-    packageConfigs: ReadonlyMap<string, PackageConfig>,
+    packageConfigs: PackageConfigsByName,
     checks: ChecksSettings | undefined
 ): readonly string[] {
     const allowList = checks?.noDuplicatedFiles?.allowList;
@@ -86,7 +87,7 @@ function validateNoDuplicatedFilesAllowList(
         }
         return entry.packages
             .filter((name) => {
-                return !packageConfigs.has(name);
+                return !Object.hasOwn(packageConfigs, name);
             })
             .map((name) => {
                 return `Allow list entry for "${entry.filePath}" references unknown package "${name}"`;
@@ -117,7 +118,7 @@ function validateCyclicDependencies(packageGraph: DirectedGraph<string, undefine
 
 type GraphGenerationPossibleResult<TConfig extends { packages: readonly PackageConfig[] }> = {
     readonly packtoryConfig: TConfig;
-    readonly packageConfigs: Map<string, PackageConfig>;
+    readonly packageConfigs: PackageConfigsByName;
 };
 
 type ConfigWithGraphInternal<TConfig extends { packages: readonly PackageConfig[] }> =
@@ -136,7 +137,7 @@ function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWith
     }
 
     const packtoryConfig: TConfig = schemaValidationResult.data;
-    const packageConfigs = packageListToMap(packtoryConfig.packages);
+    const packageConfigs = packageListToRecord(packtoryConfig.packages);
 
     const preGraphIssues = [
         ...validateDependenciesExist(packageConfigs),

--- a/source/dependency-scanner/dependency-graph.ts
+++ b/source/dependency-scanner/dependency-graph.ts
@@ -1,6 +1,6 @@
 import type { Maybe } from 'true-myth';
 import type { Project } from 'ts-morph';
-import { unique } from 'remeda';
+import { indexBy, unique, values } from 'remeda';
 import { createDirectedGraph } from '../directed-graph/graph.ts';
 import {
     mergeExternalDependencies,
@@ -35,14 +35,12 @@ export function mergeDependencyFiles(
     first: Readonly<DependencyFiles>,
     second: Readonly<DependencyFiles>
 ): Readonly<DependencyFiles> {
-    const mergedLocalFiles = new Map<string, LocalFile>();
-
-    for (const localFile of [...first.localFiles, ...second.localFiles]) {
-        mergedLocalFiles.set(localFile.filePath, localFile);
-    }
-
     return {
-        localFiles: Array.from(mergedLocalFiles.values()),
+        localFiles: values(
+            indexBy([...first.localFiles, ...second.localFiles], (localFile) => {
+                return localFile.filePath;
+            })
+        ),
         externalDependencies: mergeExternalDependencies(first.externalDependencies, second.externalDependencies)
     };
 }

--- a/source/dependency-scanner/source-file-references.ts
+++ b/source/dependency-scanner/source-file-references.ts
@@ -1,4 +1,5 @@
 import { isBuiltin } from 'node:module';
+import { isDefined } from 'remeda';
 import { ts, type SourceFile, type StringLiteral } from 'ts-morph';
 
 export function resolveSourceFileForLiteral(
@@ -19,10 +20,6 @@ export function resolveSourceFileForLiteral(
     }
 
     return undefined;
-}
-
-function isDefined<T>(value: T): value is Exclude<T, undefined> {
-    return value !== undefined;
 }
 
 export function getReferencedSourceFiles(sourceFile: Readonly<SourceFile>): readonly Readonly<SourceFile>[] {

--- a/source/linker/resource-graph.ts
+++ b/source/linker/resource-graph.ts
@@ -1,4 +1,5 @@
 import type { Project } from 'ts-morph';
+import { filter, map, pipe } from 'remeda';
 import type { ExternalDependencies } from '../dependency-scanner/external-dependencies.ts';
 import { type DirectedGraph, createDirectedGraph } from '../directed-graph/graph.ts';
 import type { TransferableFileDescription } from '../file-manager/file-description.ts';
@@ -17,13 +18,15 @@ function collectResourceSpecificExternalDependencies(
     resource: BundleResource,
     externalDependencies: ExternalDependencies
 ): readonly string[] {
-    return Array.from(externalDependencies.values())
-        .filter((dependency) => {
+    return pipe(
+        Array.from(externalDependencies.values()),
+        filter((dependency) => {
             return dependency.referencedFrom.includes(resource.fileDescription.sourceFilePath);
-        })
-        .map((dependency) => {
+        }),
+        map((dependency) => {
             return dependency.name;
-        });
+        })
+    );
 }
 
 export function createGraphFromResolvedBundle(bundle: ResolvedBundle): ResourceGraph {

--- a/source/linker/substitute-bundles.ts
+++ b/source/linker/substitute-bundles.ts
@@ -35,19 +35,25 @@ function findAllPathReplacements(
     files: readonly string[],
     bundleDependencies: readonly BundleSubstitutionSource[]
 ): Replacements {
-    const allReplacements = new Map<string, string>();
-    const usedBundleDependencies: string[] = [];
-
-    for (const file of files) {
+    const matched = files.flatMap((file) => {
         const result = findReplacement(file, bundleDependencies);
-        if (result.isJust) {
-            const { targetPath, packageName } = result.value;
-            allReplacements.set(file, targetPath);
-            usedBundleDependencies.push(packageName);
+        if (!result.isJust) {
+            return [];
         }
-    }
+        const { targetPath, packageName } = result.value;
+        return [{ file, targetPath, packageName }];
+    });
 
-    return { importPathReplacements: allReplacements, bundleDependencies: usedBundleDependencies };
+    return {
+        importPathReplacements: new Map(
+            matched.map((entry) => {
+                return [entry.file, entry.targetPath];
+            })
+        ),
+        bundleDependencies: matched.map((entry) => {
+            return entry.packageName;
+        })
+    };
 }
 
 export function substituteDependencies(

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -6,7 +6,7 @@ import type { VersionedBundleWithManifest } from '../version-manager/versioned-b
 import { configToBuildAndPublishOptions } from './map-config.ts';
 
 type ConfigArgs = Parameters<typeof configToBuildAndPublishOptions>;
-type PackageConfigInput = ConfigArgs[1] extends Map<string, infer V> ? V : never;
+type PackageConfigInput = ConfigArgs[1] extends Readonly<Record<string, infer V>> ? V : never;
 type PacktoryConfigInput = ConfigArgs[2];
 
 const placeholderPackage = fooPackageConfigFactory.build({ name: '', sourcesFolder: '' });
@@ -41,7 +41,7 @@ function runMapConfig(
     } as unknown as PacktoryConfigInput;
     return configToBuildAndPublishOptions(
         packageName,
-        new Map([[packageName, packageConfig]]),
+        { [packageName]: packageConfig },
         baseConfig,
         options.bundleDependencies ?? []
     );
@@ -64,7 +64,7 @@ test('throws when the given packageName doesn’t exist in the configs', () => {
     try {
         configToBuildAndPublishOptions(
             'foo',
-            new Map(),
+            {},
             {
                 registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 packages: [{ name: '', sourcesFolder: '', entryPoints: [{ js: '' }], mainPackageJson: {} }]

--- a/source/packtory/map-config.ts
+++ b/source/packtory/map-config.ts
@@ -1,4 +1,10 @@
-import type { PackageConfig, PacktoryConfig, PacktoryConfigWithoutRegistry } from '../config/config.ts';
+import { indexBy, values } from 'remeda';
+import type {
+    PackageConfig,
+    PackageConfigsByName,
+    PacktoryConfig,
+    PacktoryConfigWithoutRegistry
+} from '../config/config.ts';
 import type { MainPackageJson } from '../config/package-json.ts';
 import type { AdditionalFileDescription } from '../config/additional-files.ts';
 import type { RegistrySettings } from '../config/registry-settings.ts';
@@ -32,14 +38,12 @@ function dependencyNamesToBundles<TBundle extends { name: string }>(
     dependencyNames: readonly string[],
     bundles: readonly TBundle[]
 ): readonly TBundle[] {
-    const bundlesByName = new Map(
-        bundles.map((bundle) => {
-            return [bundle.name, bundle] as const;
-        })
-    );
+    const bundlesByName = indexBy(bundles, (bundle) => {
+        return bundle.name;
+    });
 
     return dependencyNames.map((dependencyName) => {
-        const matchingBundle = bundlesByName.get(dependencyName);
+        const matchingBundle = bundlesByName[dependencyName];
         if (matchingBundle === undefined) {
             throw new Error(`Dependent bundle "${dependencyName}" not found`);
         }
@@ -51,14 +55,11 @@ function mergeAdditionalFiles(
     firstFiles: readonly AdditionalFileDescription[] = [],
     secondFiles: readonly AdditionalFileDescription[] = []
 ): readonly AdditionalFileDescription[] {
-    const filesWithUniqueTargetPath = new Map<string, AdditionalFileDescription>();
-    for (const file of firstFiles) {
-        filesWithUniqueTargetPath.set(file.targetFilePath, file);
-    }
-    for (const file of secondFiles) {
-        filesWithUniqueTargetPath.set(file.targetFilePath, file);
-    }
-    return Array.from(filesWithUniqueTargetPath.values());
+    return values(
+        indexBy([...firstFiles, ...secondFiles], (file) => {
+            return file.targetFilePath;
+        })
+    );
 }
 
 type PreparedPackageOptions<TBundle extends { name: string }> = {
@@ -66,8 +67,8 @@ type PreparedPackageOptions<TBundle extends { name: string }> = {
     readonly versioning: VersioningSettings;
 };
 
-function getPackageConfig(packageName: string, packageConfigs: Map<string, PackageConfig>): PackageConfig {
-    const packageConfig = packageConfigs.get(packageName);
+function getPackageConfig(packageName: string, packageConfigs: PackageConfigsByName): PackageConfig {
+    const packageConfig = packageConfigs[packageName];
 
     if (packageConfig === undefined) {
         throw new Error(`Config for package "${packageName}" is missing`);
@@ -177,7 +178,7 @@ function buildSharedOptions<TBundle extends { name: string }>(
 
 function preparePackageOptions<TBundle extends { name: string }>(
     packageName: string,
-    packageConfigs: Map<string, PackageConfig>,
+    packageConfigs: PackageConfigsByName,
     packtoryConfig: PacktoryConfigWithoutRegistry,
     existingBundles: readonly TBundle[]
 ): PreparedPackageOptions<TBundle> {
@@ -190,7 +191,7 @@ function preparePackageOptions<TBundle extends { name: string }>(
 
 export function configToBuildAndPublishOptions(
     packageName: string,
-    packageConfigs: Map<string, PackageConfig>,
+    packageConfigs: PackageConfigsByName,
     packtoryConfig: PacktoryConfig,
     existingBundles: readonly VersionedBundleWithManifest[]
 ): BuildAndPublishOptions {
@@ -210,7 +211,7 @@ export function configToBuildAndPublishOptions(
 
 export function configToResolveAndLinkOptions(
     packageName: string,
-    packageConfigs: Map<string, PackageConfig>,
+    packageConfigs: PackageConfigsByName,
     packtoryConfig: PacktoryConfigWithoutRegistry,
     existingBundles: readonly BundleSubstitutionSource[]
 ): ResolveAndLinkOptions {

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -1,4 +1,5 @@
 import { Result } from 'true-myth';
+import { mapToObj } from 'remeda';
 import type { PacktoryConfig, PacktoryConfigWithoutRegistry } from '../config/config.ts';
 import {
     validateConfig,
@@ -134,10 +135,11 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         resolvedPackages: readonly ResolvedPackage[],
         options: Options
     ): Promise<Result<readonly BuildAndPublishResult[], PartialError<BuildAndPublishResult>>> {
-        const linkedBundlesByName = new Map<string, LinkedBundle>(
-            resolvedPackages.map((resolvedPackage) => {
+        const linkedBundlesByName: Readonly<Record<string, LinkedBundle>> = mapToObj(
+            resolvedPackages,
+            (resolvedPackage) => {
                 return [resolvedPackage.name, resolvedPackage.linkedBundle];
-            })
+            }
         );
 
         return scheduler.runForEachScheduledPackage<
@@ -157,7 +159,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
                 );
             },
             execute: async (buildOptions) => {
-                const linkedBundle = linkedBundlesByName.get(buildOptions.name);
+                const linkedBundle = linkedBundlesByName[buildOptions.name];
                 if (linkedBundle === undefined) {
                     throw new Error(`Linked bundle for package "${buildOptions.name}" is missing`);
                 }

--- a/source/test-libraries/verify-schema-validation.ts
+++ b/source/test-libraries/verify-schema-validation.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test, type Func } from 'mocha';
+import { isPlainObject, omit } from 'remeda';
 import type { $ZodType } from 'zod/v4/core';
 
 const invalidNumberValue = 2;
@@ -59,10 +60,6 @@ function pathDotNotationToBracketNotation(path: string): string {
     return path.replaceAll(/\.(?<index>\d+)(?=\.|$)/g, '[$<index>]');
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
 function parsePathSegment(pathSegment: string): PathSegment {
     return /^\d+$/.test(pathSegment) ? Number(pathSegment) : pathSegment;
 }
@@ -84,11 +81,7 @@ function setArrayValue(array: readonly unknown[], index: number, value: unknown)
 }
 
 function removeRecordKey(record: Readonly<Record<string, unknown>>, key: string): Record<string, unknown> {
-    return Object.fromEntries(
-        Object.entries(record).filter(([entryKey]) => {
-            return entryKey !== key;
-        })
-    );
+    return omit(record, [key]);
 }
 
 function setRecordValue(
@@ -134,7 +127,7 @@ function updateLeafValue(
         return updateLeafArrayValue(current, pathSegment, modification, value);
     }
 
-    if (isRecord(current) && typeof pathSegment === 'string') {
+    if (isPlainObject(current) && typeof pathSegment === 'string') {
         return updateLeafRecordValue(current, pathSegment, modification, value);
     }
 
@@ -165,7 +158,7 @@ function updateNestedValue(
         );
     }
 
-    if (isRecord(current) && typeof pathSegment === 'string') {
+    if (isPlainObject(current) && typeof pathSegment === 'string') {
         return setRecordValue(
             current,
             pathSegment,

--- a/source/version-manager/manifest/builder.ts
+++ b/source/version-manager/manifest/builder.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from 'remeda';
 import type { VersionedBundle, BundlePackageJson } from '../versioned-bundle.ts';
 
 export function buildPackageManifest(bundle: VersionedBundle): BundlePackageJson {
@@ -5,8 +6,8 @@ export function buildPackageManifest(bundle: VersionedBundle): BundlePackageJson
         name: bundle.name,
         version: bundle.version,
         main: bundle.mainFile.targetFilePath,
-        ...(Object.keys(bundle.dependencies).length > 0 ? { dependencies: bundle.dependencies } : {}),
-        ...(Object.keys(bundle.peerDependencies).length > 0 ? { peerDependencies: bundle.peerDependencies } : {}),
+        ...(isEmpty(bundle.dependencies) ? {} : { dependencies: bundle.dependencies }),
+        ...(isEmpty(bundle.peerDependencies) ? {} : { peerDependencies: bundle.peerDependencies }),
         ...(bundle.packageType === undefined ? {} : { type: bundle.packageType }),
         ...(bundle.typesMainFile === undefined ? {} : { types: bundle.typesMainFile.targetFilePath })
     };

--- a/source/version-manager/manifest/serialize.ts
+++ b/source/version-manager/manifest/serialize.ts
@@ -1,24 +1,11 @@
 import type { PackageJson } from 'type-fest';
-import { compareValues, type ComparisonResult } from './sort-values.ts';
+import { entries, fromEntries, isPlainObject, mapValues, pipe, sortBy } from 'remeda';
+import { compareValues } from './sort-values.ts';
 
 const indentationSize = 4;
 
-type UnknownRecord = Record<string, unknown>;
-type UnknownRecordEntry = readonly [key: string, value: unknown];
-
 function isArray(value: unknown): value is unknown[] {
     return Array.isArray(value);
-}
-
-function compareEntryKeys(entryA: UnknownRecordEntry, entryB: UnknownRecordEntry): ComparisonResult {
-    const [keyA] = entryA;
-    const [keyB] = entryB;
-
-    return compareValues(keyA, keyB);
-}
-
-function isRecord(value: unknown): value is UnknownRecord {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function assertNoCircularStructures(value: unknown): void {
@@ -42,14 +29,15 @@ function deepSortValue(value: unknown): unknown {
         return value.map(deepSortValue).toSorted(compareValues);
     }
 
-    if (isRecord(value)) {
-        const entries = Object.entries(value);
-        entries.sort(compareEntryKeys);
-
-        return Object.fromEntries(
-            entries.map(([propertyName, propertyValue]) => {
-                return [propertyName, deepSortValue(propertyValue)];
-            })
+    if (isPlainObject(value)) {
+        return pipe(
+            value,
+            mapValues(deepSortValue),
+            entries(),
+            sortBy((entry) => {
+                return entry[0];
+            }),
+            fromEntries()
         );
     }
 

--- a/source/version-manager/versioned-bundle.ts
+++ b/source/version-manager/versioned-bundle.ts
@@ -1,5 +1,6 @@
 import type { PackageJson, SetRequired } from 'type-fest';
 import { oneLine } from 'common-tags';
+import { mergeAll } from 'remeda';
 import type { LinkedBundle } from '../linker/linked-bundle.ts';
 import type { AdditionalPackageJsonAttributes, MainPackageJson } from '../config/package-json.ts';
 import type { FileDescription, TransferableFileDescription } from '../file-manager/file-description.ts';
@@ -51,15 +52,18 @@ type GroupedDependencies = {
 };
 
 function mergeDependencyGroups(...groups: Readonly<GroupedDependencies>[]): Readonly<GroupedDependencies> {
-    const dependencies: Record<string, string> = {};
-    const peerDependencies: Record<string, string> = {};
-
-    for (const group of groups) {
-        Object.assign(dependencies, group.dependencies);
-        Object.assign(peerDependencies, group.peerDependencies);
-    }
-
-    return { dependencies, peerDependencies };
+    return {
+        dependencies: mergeAll(
+            groups.map((group) => {
+                return group.dependencies;
+            })
+        ),
+        peerDependencies: mergeAll(
+            groups.map((group) => {
+                return group.peerDependencies;
+            })
+        )
+    };
 }
 
 function groupBundleDependencies(


### PR DESCRIPTION
Use indexBy, mapToObj, mergeAll, omit, uniqueBy, mapValues, isPlainObject, isDefined, isEmpty, times, and pipe to replace manual reduce, Map dedup, Object.assign, Object.fromEntries+filter, and similar imperative patterns. Switch the validated package-config lookup from Map<string, PackageConfig> to Record<string, PackageConfig> so it composes with indexBy.