### PR TITLE
Add npm provenance and explicit access to publish settings

### DIFF
--- a/benchmarks/generate-workload.ts
+++ b/benchmarks/generate-workload.ts
@@ -236,7 +236,8 @@ function createConfigWithoutRegistry(rootDirectory: string, clusterCount: number
         commonPackageSettings: {
             mainPackageJson: sharedMainPackageJson,
             includeSourceMapFiles: true,
-            additionalFiles: [{ sourceFilePath: '../docs/common.txt', targetFilePath: 'docs/common.txt' }]
+            additionalFiles: [{ sourceFilePath: '../docs/common.txt', targetFilePath: 'docs/common.txt' }],
+            publishSettings: { access: 'public' }
         },
         packages: createPackageConfigs(rootDirectory, clusterCount)
     };
@@ -270,7 +271,8 @@ function createCliConfigWithoutRegistry(rootDirectory: string, packageCount: num
     return {
         commonPackageSettings: {
             mainPackageJson: sharedMainPackageJson,
-            includeSourceMapFiles: true
+            includeSourceMapFiles: true,
+            publishSettings: { access: 'public' }
         },
         packages: createCliPackageConfigs(rootDirectory, packageCount)
     };

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -11,6 +11,7 @@
         "subrecord",
         "cmds",
         "htpasswd",
-        "sonarjs"
+        "sonarjs",
+        "EUSAGE"
     ]
 }

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -9,7 +9,8 @@ async function createBaseConfig(fixturePath: string): Promise<PacktoryConfigWith
     return {
         commonPackageSettings: {
             sourcesFolder: path.join(fixturePath, 'src'),
-            mainPackageJson: await loadPackageJson(fixturePath)
+            mainPackageJson: await loadPackageJson(fixturePath),
+            publishSettings: { access: 'public' }
         },
         packages: [
             {

--- a/integration-tests/packtory/publish.test.ts
+++ b/integration-tests/packtory/publish.test.ts
@@ -219,6 +219,7 @@ function createStandardPackages(fixturePath: string): PackageConfigList {
 async function createPublishConfig(params: CreatePublishConfigParams): Promise<PublishConfig> {
     const { fixturePath, registryDetails, packages, commonPackageSettings } = params;
     const mergedCommonPackageSettings: PublishConfig['commonPackageSettings'] = {
+        publishSettings: { access: 'public' },
         ...commonPackageSettings,
         sourcesFolder: path.join(fixturePath, 'src'),
         mainPackageJson: await loadPackageJson(fixturePath)

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -41,7 +41,8 @@ export async function buildConfig() {
                 author: packageJson.author,
                 contributors: packageJson.contributors,
                 engines: packageJson.engines
-            }
+            },
+            publishSettings: { access: 'public' }
         },
         packages: [
             {

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,8 @@ export const config = {
     // Common settings shared among packages
     commonPackageSettings: {
         sourcesFolder: path.join(process.cwd(), 'dist/'),
-        mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' })
+        mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+        publishSettings: { access: 'public' }
     },
 
     // Define your packages
@@ -138,7 +139,7 @@ The configuration for `packtory` is an object with the following properties:
 
 2. **`commonPackageSettings`** (Optional):
     - Defines settings that can be shared for all packages.
-    - Allowed settings: `sourcesFolder`, `mainPackageJson`, `includeSourceMapFiles`, `additionalFiles`, `additionalPackageJsonAttributes`.
+    - Allowed settings: `sourcesFolder`, `mainPackageJson`, `includeSourceMapFiles`, `additionalFiles`, `additionalPackageJsonAttributes`, `publishSettings`.
 
 3. **`packages`** (Required, Array):
     - An array of per-package configurations.
@@ -178,6 +179,16 @@ The configuration for `packtory` is an object with the following properties:
     - **`bundlePeerDependencies`** (Optional, Array of Strings):
         - Similar to `bundleDependencies` but represented as `peerDependencies` in the generated `package.json`.
 
+    - **`publishSettings`** (Required somewhere):
+        - Controls how the package is published. Must be set in `commonPackageSettings` (as a default for every package), in every package entry, or both. If neither is set, validation rejects the config with `publishSettings must be set in commonPackageSettings or in every package`.
+        - A discriminated union on `access`:
+            - `{ access: 'public' }` — publishes the package as public on the registry. Only `'public'` allows provenance.
+            - `{ access: 'restricted' }` — publishes the package as restricted (paid feature on npmjs.org for scoped packages). Provenance is not allowed in this mode.
+        - When `access: 'public'`, an optional `provenance` field enables sigstore-signed [npm provenance attestations](https://docs.npmjs.com/generating-provenance-statements):
+            - `provenance: { type: 'auto' }` — let `libnpmpublish` detect the CI environment and generate the provenance statement. Currently supported CIs: GitHub Actions and GitLab CI.
+            - `provenance: { type: 'file', path: './build/pkg.sigstore' }` — pass a pre-generated sigstore bundle. Use this for any CI not natively supported by `auto` mode (e.g. CircleCI, Jenkins, BuildKite). The bundle must have been signed against the exact tarball packtory builds; mismatches are rejected with a clear error.
+        - Per-package `publishSettings` replaces the whole common-level block (no field-level merging) so the `access` ↔ `provenance` constraint stays internally consistent at every scope.
+
 **Note**: Per-package settings override or merge with common settings when both are defined.
 
 This comprehensive configuration allows fine-tuning for individual packages and provides flexibility in defining dependencies and additional files.
@@ -196,7 +207,8 @@ export const config = {
     },
     commonPackageSettings: {
         sourcesFolder: path.join(process.cwd(), 'dist/'),
-        mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' })
+        mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+        publishSettings: { access: 'public' }
     },
     packages: [
         {
@@ -224,7 +236,8 @@ export const config = {
     },
     commonPackageSettings: {
         sourcesFolder: path.join(process.cwd(), 'src/'),
-        mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' })
+        mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+        publishSettings: { access: 'public' }
     },
     packages: [
         {
@@ -293,5 +306,100 @@ registrySettings: {
 - Try metadata requests without authentication first.
 - If the registry responds with an authentication challenge such as `401` or `403`, retry using the publish auth.
 - Keep in mind that `404` can be ambiguous on some registries because it may mean either "not found" or "not visible without auth".
+
+### Publish settings examples
+
+Set a uniform default for every package in `commonPackageSettings`:
+
+```javascript
+commonPackageSettings: {
+    sourcesFolder: path.join(process.cwd(), 'dist/'),
+    mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+    publishSettings: { access: 'public' }
+}
+```
+
+Override per package — e.g. a monorepo where the public CLI lives next to a restricted internal helper:
+
+```javascript
+commonPackageSettings: {
+    sourcesFolder: path.join(process.cwd(), 'dist/'),
+    mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+    publishSettings: { access: 'public' }
+},
+packages: [
+    {
+        name: 'image-resizer-cli',
+        entryPoints: [{ js: 'cli.js' }]
+    },
+    {
+        name: '@my-org/image-resizer-internal',
+        entryPoints: [{ js: 'internal.js' }],
+        publishSettings: { access: 'restricted' }
+    }
+]
+```
+
+Enable [npm provenance](https://docs.npmjs.com/generating-provenance-statements) automatically when running on GitHub Actions or GitLab CI:
+
+```javascript
+commonPackageSettings: {
+    sourcesFolder: path.join(process.cwd(), 'dist/'),
+    mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+    publishSettings: {
+        access: 'public',
+        provenance: { type: 'auto' }
+    }
+}
+```
+
+Pre-built provenance bundle (works on any CI):
+
+```javascript
+commonPackageSettings: {
+    sourcesFolder: path.join(process.cwd(), 'dist/'),
+    mainPackageJson: fs.readFileSync('./package.json', { encoding: 'utf8' }),
+    publishSettings: {
+        access: 'public',
+        provenance: {
+            type: 'file',
+            path: './build/my-package.sigstore'
+        }
+    }
+}
+```
+
+When using `provenance: { type: 'auto' }`, your CI workflow needs to expose an OIDC ID token to the publish step. For GitHub Actions, that means granting `id-token: write` on the workflow job:
+
+```yaml
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+            - run: npm ci
+            - run: npx packtory publish --no-dry-run
+```
+
+For GitLab CI, declare an [`id_tokens`](https://docs.gitlab.com/ee/ci/secrets/id_token_authentication.html) entry with audience `sigstore` exposed as `SIGSTORE_ID_TOKEN`:
+
+```yaml
+publish:
+    image: node:24
+    id_tokens:
+        SIGSTORE_ID_TOKEN:
+            aud: sigstore
+    script:
+        - npm ci
+        - npx packtory publish --no-dry-run
+```
+
+Other CIs (CircleCI, Jenkins, BuildKite, etc.) are supported via the `provenance: { type: 'file', path }` escape hatch — generate the sigstore bundle with the attestation tooling of your choice and point packtory at it.
 
 These examples demonstrate how `packtory` adapts to different project structures and facilitates the efficient bundling and publishing of packages with varying dependencies.

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -188,12 +188,19 @@ test('publish() publishes the given bundle', async () => {
     const buildTarball = fake.resolves({ tarData: emptyTarball });
     const publishPackage = fake.resolves(undefined);
     const emitter = emitterFactory({ buildTarball, publishPackage });
+    const publishSettings = { access: 'public' } as const;
 
     await emitter.publish({
         registrySettings,
-        bundle: namedBundle()
+        bundle: namedBundle(),
+        publishSettings
     });
 
     assert.strictEqual(publishPackage.callCount, 1);
-    assert.deepStrictEqual(publishPackage.firstCall.args, [{ name: '', version: '' }, emptyTarball, registrySettings]);
+    assert.deepStrictEqual(publishPackage.firstCall.args, [
+        { name: '', version: '' },
+        emptyTarball,
+        registrySettings,
+        publishSettings
+    ]);
 });

--- a/source/bundle-emitter/emitter.ts
+++ b/source/bundle-emitter/emitter.ts
@@ -1,5 +1,6 @@
 import { Maybe } from 'true-myth';
 import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
+import type { PublishSettings } from '../config/publish-settings.ts';
 import type { RegistrySettings } from '../config/registry-settings.ts';
 import type { VersioningSettings } from '../config/versioning-settings.ts';
 import { compareFileDescriptions } from '../file-manager/compare.ts';
@@ -13,6 +14,12 @@ export type BundleEmitterDependencies = {
 };
 
 export type PublishOptions = {
+    readonly bundle: VersionedBundleWithManifest;
+    readonly registrySettings: RegistrySettings;
+    readonly publishSettings: PublishSettings;
+};
+
+export type AlreadyPublishedCheckOptions = {
     readonly bundle: VersionedBundleWithManifest;
     readonly registrySettings: RegistrySettings;
 };
@@ -30,7 +37,7 @@ type BundlePublishedCheckResult = {
 export type BundleEmitter = {
     publish: (options: PublishOptions) => Promise<void>;
     determineCurrentVersion: (options: CurrentVersionLookupOptions) => Promise<Maybe<string>>;
-    checkBundleAlreadyPublished: (options: PublishOptions) => Promise<BundlePublishedCheckResult>;
+    checkBundleAlreadyPublished: (options: AlreadyPublishedCheckOptions) => Promise<BundlePublishedCheckResult>;
 };
 
 export function createBundleEmitter(dependencies: BundleEmitterDependencies): BundleEmitter {
@@ -71,7 +78,12 @@ export function createBundleEmitter(dependencies: BundleEmitterDependencies): Bu
         async publish(options) {
             const tarball = await artifactsBuilder.buildTarball(options.bundle);
 
-            await registryClient.publishPackage(options.bundle.packageJson, tarball.tarData, options.registrySettings);
+            await registryClient.publishPackage(
+                options.bundle.packageJson,
+                tarball.tarData,
+                options.registrySettings,
+                options.publishSettings
+            );
         }
     };
 }

--- a/source/bundle-emitter/publish-settings-bridge.test.ts
+++ b/source/bundle-emitter/publish-settings-bridge.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import type { PublishSettings } from '../config/publish-settings.ts';
+import { buildPublishOptionsForPublishSettings, remapPublishError } from './publish-settings-bridge.ts';
+
+test('buildPublishOptionsForPublishSettings() emits access "restricted" only', () => {
+    const result = buildPublishOptionsForPublishSettings({ access: 'restricted' });
+
+    assert.deepStrictEqual(result, { access: 'restricted' });
+});
+
+test('buildPublishOptionsForPublishSettings() emits access "public" without provenance keys when provenance is omitted', () => {
+    const result = buildPublishOptionsForPublishSettings({ access: 'public' });
+
+    assert.deepStrictEqual(result, { access: 'public' });
+});
+
+test('buildPublishOptionsForPublishSettings() maps auto-mode provenance to provenance: true', () => {
+    const result = buildPublishOptionsForPublishSettings({
+        access: 'public',
+        provenance: { type: 'auto' }
+    });
+
+    assert.deepStrictEqual(result, { access: 'public', provenance: true });
+});
+
+test('buildPublishOptionsForPublishSettings() maps file-mode provenance to provenanceFile', () => {
+    const result = buildPublishOptionsForPublishSettings({
+        access: 'public',
+        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+    });
+
+    assert.deepStrictEqual(result, { access: 'public', provenanceFile: '/build/pkg.sigstore' });
+});
+
+function expectRemapped(
+    originalError: unknown,
+    publishSettings: Readonly<PublishSettings>,
+    expectedMessage: string
+): void {
+    const remapped = remapPublishError(originalError, publishSettings);
+
+    assert.ok(remapped instanceof Error, 'Expected remapped value to be an Error');
+    assert.strictEqual(remapped.message, expectedMessage);
+    assert.strictEqual(remapped.cause, originalError, 'Expected the original error to be preserved as cause');
+}
+
+function buildUnsupportedProviderExpectedMessage(ciName: string): string {
+    return [
+        'Provenance auto mode requires GitHub Actions or GitLab CI.',
+        `Detected CI: ${ciName}.`,
+        "Use provenance: { type: 'file' } for other environments."
+    ].join(' ');
+}
+
+const unsupportedProviderMessage = buildUnsupportedProviderExpectedMessage('jenkins');
+
+const githubActionsIdTokenExpectedMessage =
+    'GitHub Actions provenance needs "permissions: id-token: write" on the workflow job.' +
+    ' See the packtory readme for the workflow snippet.';
+
+const gitlabSigstoreIdTokenExpectedMessage =
+    'GitLab CI provenance needs an "id_tokens" entry with audience "sigstore"' +
+    ' exposed as SIGSTORE_ID_TOKEN. See the packtory readme for the workflow snippet.';
+
+const missingFileExpectedMessage =
+    'Provenance bundle file "/build/pkg.sigstore" does not exist.' +
+    " Generate it with your CI's attestation tool (e.g. actions/attest-build-provenance) before running packtory.";
+
+const invalidBundleExpectedMessage =
+    'Provenance bundle file "/build/pkg.sigstore" is not a valid sigstore bundle. Re-generate it from the current build.';
+
+const digestMismatchExpectedMessage =
+    'Provenance bundle at "/build/pkg.sigstore" was signed against a different tarball' +
+    ' than the one packtory built. Re-generate the bundle from the current source —' +
+    ' shipping a mismatched attestation would defeat the purpose of provenance.';
+
+test('remapPublishError() rewrites the "unsupported provider" libnpmpublish error with the detected CI name', () => {
+    expectRemapped(
+        Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins'), {
+            code: 'EUSAGE'
+        }),
+        { access: 'public', provenance: { type: 'auto' } },
+        unsupportedProviderMessage
+    );
+});
+
+test('remapPublishError() handles libnpmpublish messages where the provider follows the colon directly', () => {
+    expectRemapped(
+        Object.assign(new Error('Automatic provenance generation not supported for provider:circleci'), {
+            code: 'EUSAGE'
+        }),
+        { access: 'public', provenance: { type: 'auto' } },
+        buildUnsupportedProviderExpectedMessage('circleci')
+    );
+});
+
+test('remapPublishError() falls back to "unknown" CI name when the libnpmpublish message lacks a provider', () => {
+    expectRemapped(
+        Object.assign(new Error('Automatic provenance generation not supported for provider:'), {
+            code: 'EUSAGE'
+        }),
+        { access: 'public', provenance: { type: 'auto' } },
+        buildUnsupportedProviderExpectedMessage('unknown')
+    );
+});
+
+test('remapPublishError() extracts only the first whitespace-delimited token after the "provider:" marker', () => {
+    expectRemapped(
+        Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins extra trailing'), {
+            code: 'EUSAGE'
+        }),
+        { access: 'public', provenance: { type: 'auto' } },
+        buildUnsupportedProviderExpectedMessage('jenkins')
+    );
+});
+
+test('remapPublishError() rewrites the missing GitHub Actions id-token permission error', () => {
+    expectRemapped(
+        Object.assign(
+            new Error('Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'),
+            { code: 'EUSAGE' }
+        ),
+        { access: 'public', provenance: { type: 'auto' } },
+        githubActionsIdTokenExpectedMessage
+    );
+});
+
+test('remapPublishError() rewrites the missing GitLab SIGSTORE_ID_TOKEN error', () => {
+    expectRemapped(
+        Object.assign(
+            new Error('Provenance generation in GitLab CI requires "SIGSTORE_ID_TOKEN" with "sigstore" audience'),
+            { code: 'EUSAGE' }
+        ),
+        { access: 'public', provenance: { type: 'auto' } },
+        gitlabSigstoreIdTokenExpectedMessage
+    );
+});
+
+test('remapPublishError() rewrites a missing provenance bundle file (ENOENT) error', () => {
+    expectRemapped(
+        Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' }),
+        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+        missingFileExpectedMessage
+    );
+});
+
+test('remapPublishError() rewrites an invalid sigstore bundle parse error', () => {
+    expectRemapped(
+        new Error('Bundle is invalid: malformed protobuf'),
+        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+        invalidBundleExpectedMessage
+    );
+});
+
+test('remapPublishError() rewrites a sigstore subject-digest mismatch error', () => {
+    expectRemapped(
+        new Error('Provenance subject does not match published package digest'),
+        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+        digestMismatchExpectedMessage
+    );
+});
+
+test('remapPublishError() classifies a "subject does not match" error as a digest mismatch even without the word "digest"', () => {
+    expectRemapped(
+        new Error('Provenance subject does not match'),
+        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+        digestMismatchExpectedMessage
+    );
+});
+
+test('remapPublishError() classifies a "Bundle is invalid" digest error as a digest mismatch even without the word "subject"', () => {
+    expectRemapped(
+        new Error('Bundle is invalid: digest verification failed'),
+        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+        digestMismatchExpectedMessage
+    );
+});
+
+test('remapPublishError() rewrites a generic invalid-bundle parse error without a digest hint', () => {
+    expectRemapped(
+        new Error('Unsupported bundle format'),
+        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+        invalidBundleExpectedMessage
+    );
+});
+
+test('remapPublishError() returns the original error when no remap rule matches', () => {
+    const original = new Error('Network failure: ECONNRESET');
+
+    const result = remapPublishError(original, { access: 'public' });
+
+    assert.strictEqual(result, original);
+});
+
+test('remapPublishError() ignores file-mode patterns when publishSettings does not configure file provenance', () => {
+    const original = new Error('Bundle is invalid: malformed protobuf');
+
+    const result = remapPublishError(original, { access: 'public', provenance: { type: 'auto' } });
+
+    assert.strictEqual(result, original);
+});
+
+test('remapPublishError() returns the original error in file mode when the failure is neither ENOENT nor a bundle error', () => {
+    const original = new Error('Network failure: ECONNRESET');
+
+    const result = remapPublishError(original, {
+        access: 'public',
+        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+    });
+
+    assert.strictEqual(result, original);
+});
+
+test('remapPublishError() wraps a non-Error rejection value into an Error when no remap rule matches', () => {
+    const result = remapPublishError('plain-string-failure', { access: 'public' });
+
+    assert.ok(result instanceof Error);
+    assert.strictEqual(result.message, 'plain-string-failure');
+});
+
+test('remapPublishError() wraps a null rejection value without dereferencing its non-existent message', () => {
+    const result = remapPublishError(null, { access: 'public' });
+
+    assert.ok(result instanceof Error);
+    assert.strictEqual(result.message, 'null');
+});
+
+test('remapPublishError() wraps a null rejection value when publishSettings configures file provenance', () => {
+    const result = remapPublishError(null, {
+        access: 'public',
+        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+    });
+
+    assert.ok(result instanceof Error);
+    assert.strictEqual(result.message, 'null');
+});
+
+test('remapPublishError() does not enter file-mode remapping when publishSettings has restricted access', () => {
+    const original = new Error('Bundle is invalid: malformed protobuf');
+
+    const result = remapPublishError(original, { access: 'restricted' });
+
+    assert.strictEqual(result, original);
+});
+
+test('remapPublishError() guards against a runtime-only restricted+provenance combination that bypasses the type system', () => {
+    const restrictedWithProvenance = {
+        access: 'restricted',
+        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+    } as unknown as PublishSettings;
+    const original = new Error('Bundle is invalid: malformed protobuf');
+
+    const result = remapPublishError(original, restrictedWithProvenance);
+
+    assert.strictEqual(result, original);
+});
+
+test('remapPublishError() ignores a non-string message field on an object-like rejection value', () => {
+    const result = remapPublishError({ message: 12_345 }, { access: 'public' });
+
+    assert.ok(result instanceof Error);
+    assert.strictEqual(result.message, '[object Object]');
+});

--- a/source/bundle-emitter/publish-settings-bridge.ts
+++ b/source/bundle-emitter/publish-settings-bridge.ts
@@ -1,0 +1,167 @@
+import type { PublishSettings } from '../config/publish-settings.ts';
+
+type PublishProvenanceOptions = { readonly provenance: true } | { readonly provenanceFile: string };
+
+export type PublishOptionsForLibnpmpublish = Partial<PublishProvenanceOptions> & {
+    readonly access: 'public' | 'restricted';
+};
+
+export function buildPublishOptionsForPublishSettings(
+    publishSettings: Readonly<PublishSettings>
+): PublishOptionsForLibnpmpublish {
+    if (publishSettings.access === 'restricted') {
+        return { access: 'restricted' };
+    }
+    if (publishSettings.provenance === undefined) {
+        return { access: 'public' };
+    }
+    if (publishSettings.provenance.type === 'auto') {
+        return { access: 'public', provenance: true };
+    }
+    return { access: 'public', provenanceFile: publishSettings.provenance.path };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value instanceof Object;
+}
+
+type ErrorLike = { readonly message: string; readonly code?: unknown };
+
+function isErrorLike(error: unknown): error is ErrorLike {
+    return isRecord(error) && typeof error.message === 'string';
+}
+
+const unsupportedProviderMarker = 'not supported for provider:';
+
+function getCiName(message: string): string {
+    const tail = message.slice(message.indexOf(unsupportedProviderMarker) + unsupportedProviderMarker.length).trim();
+    if (tail === '') {
+        return 'unknown';
+    }
+    const whitespaceIndex = tail.search(/\s/u);
+    if (whitespaceIndex === -1) {
+        return tail;
+    }
+    return tail.slice(0, whitespaceIndex);
+}
+
+function buildUnsupportedProviderMessage(ciName: string): string {
+    return [
+        'Provenance auto mode requires GitHub Actions or GitLab CI.',
+        `Detected CI: ${ciName}.`,
+        "Use provenance: { type: 'file' } for other environments."
+    ].join(' ');
+}
+
+const githubActionsIdTokenMessage = [
+    'GitHub Actions provenance needs "permissions: id-token: write" on the workflow job.',
+    'See the packtory readme for the workflow snippet.'
+].join(' ');
+
+const gitlabSigstoreIdTokenMessage = [
+    'GitLab CI provenance needs an "id_tokens" entry with audience "sigstore"',
+    'exposed as SIGSTORE_ID_TOKEN. See the packtory readme for the workflow snippet.'
+].join(' ');
+
+function buildMissingProvenanceFileMessage(filePath: string): string {
+    return [
+        `Provenance bundle file "${filePath}" does not exist.`,
+        "Generate it with your CI's attestation tool (e.g. actions/attest-build-provenance)",
+        'before running packtory.'
+    ].join(' ');
+}
+
+function buildInvalidProvenanceFileMessage(filePath: string): string {
+    return [
+        `Provenance bundle file "${filePath}" is not a valid sigstore bundle.`,
+        'Re-generate it from the current build.'
+    ].join(' ');
+}
+
+function buildProvenanceDigestMismatchMessage(filePath: string): string {
+    return [
+        `Provenance bundle at "${filePath}" was signed against a different tarball`,
+        'than the one packtory built. Re-generate the bundle from the current source —',
+        'shipping a mismatched attestation would defeat the purpose of provenance.'
+    ].join(' ');
+}
+
+function isProvenanceBundleError(message: string): boolean {
+    return (
+        message.includes('Bundle is invalid') ||
+        message.includes('Unsupported bundle format') ||
+        message.includes('Invalid bundle') ||
+        message.includes('subject does not match')
+    );
+}
+
+function isProvenanceDigestMismatch(message: string): boolean {
+    return message.includes('subject') || message.includes('digest');
+}
+
+function matchAutoModeError(error: unknown): Error | undefined {
+    if (!isErrorLike(error)) {
+        return undefined;
+    }
+
+    const { message } = error;
+    if (message.includes(unsupportedProviderMarker)) {
+        return new Error(buildUnsupportedProviderMessage(getCiName(message)), { cause: error });
+    }
+    if (message.includes('"write" access to the "id-token" permission')) {
+        return new Error(githubActionsIdTokenMessage, { cause: error });
+    }
+    if (message.includes('SIGSTORE_ID_TOKEN')) {
+        return new Error(gitlabSigstoreIdTokenMessage, { cause: error });
+    }
+    return undefined;
+}
+
+function matchFileModeError(error: unknown, filePath: string): Error | undefined {
+    if (isRecord(error) && error.code === 'ENOENT') {
+        return new Error(buildMissingProvenanceFileMessage(filePath), { cause: error });
+    }
+    if (!isErrorLike(error)) {
+        return undefined;
+    }
+
+    const { message } = error;
+    if (!isProvenanceBundleError(message)) {
+        return undefined;
+    }
+    if (isProvenanceDigestMismatch(message)) {
+        return new Error(buildProvenanceDigestMismatchMessage(filePath), { cause: error });
+    }
+    return new Error(buildInvalidProvenanceFileMessage(filePath), { cause: error });
+}
+
+function getProvenanceFilePath(publishSettings: Readonly<PublishSettings>): string | undefined {
+    if (publishSettings.access !== 'public') {
+        return undefined;
+    }
+    if (publishSettings.provenance?.type !== 'file') {
+        return undefined;
+    }
+    return publishSettings.provenance.path;
+}
+
+function ensureError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
+export function remapPublishError(error: unknown, publishSettings: Readonly<PublishSettings>): Error {
+    const autoModeError = matchAutoModeError(error);
+    if (autoModeError !== undefined) {
+        return autoModeError;
+    }
+
+    const filePath = getProvenanceFilePath(publishSettings);
+    if (filePath !== undefined) {
+        const fileModeError = matchFileModeError(error, filePath);
+        if (fileModeError !== undefined) {
+            return fileModeError;
+        }
+    }
+
+    return ensureError(error);
+}

--- a/source/bundle-emitter/registry-client.test.ts
+++ b/source/bundle-emitter/registry-client.test.ts
@@ -86,9 +86,14 @@ test('publishPackage() uses shorthand bearer auth and one-time-password prompt w
     const registryClient = registryClientFactory({ publish, promptForOneTimePassword });
     const tarData = Buffer.from([1, 2, 3, 4]);
 
-    await registryClient.publishPackage({ name: 'the-name', version: 'the-version' }, tarData, {
-        auth: { type: 'bearer-token', token: 'the-token' }
-    });
+    await registryClient.publishPackage(
+        { name: 'the-name', version: 'the-version' },
+        tarData,
+        {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        },
+        { access: 'public' }
+    );
 
     assert.deepStrictEqual(publish.firstCall.args, [
         { name: 'the-name', version: 'the-version' },
@@ -97,6 +102,7 @@ test('publishPackage() uses shorthand bearer auth and one-time-password prompt w
             defaultTag: 'latest',
             alwaysAuth: true,
             registry: undefined,
+            access: 'public',
             forceAuth: { token: 'the-token' },
             otpPrompt: promptForOneTimePassword
         }
@@ -107,19 +113,25 @@ test('publishPackage() uses explicit basic auth when configured', async () => {
     const publish = fake.resolves(undefined);
     const registryClient = registryClientFactory({ publish });
 
-    await registryClient.publishPackage({ name: 'the-name', version: 'the-version' }, Buffer.from([]), {
-        registryUrl: 'https://registry.example.test',
-        auth: {
-            type: 'basic',
-            username: 'user',
-            password: 'secret'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: 'the-name', version: 'the-version' },
+        Buffer.from([]),
+        {
+            registryUrl: 'https://registry.example.test',
+            auth: {
+                type: 'basic',
+                username: 'user',
+                password: 'secret'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.deepStrictEqual(publish.firstCall.args.at(-1), {
         defaultTag: 'latest',
         alwaysAuth: true,
         registry: 'https://registry.example.test',
+        access: 'public',
         forceAuth: {
             _auth: Buffer.from('user:secret', 'utf8').toString('base64')
         }
@@ -639,12 +651,17 @@ test('publishPackage() resolves and exchanges npm oidc id tokens', async () => {
         resolveIdToken
     });
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'github-actions' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'github-actions' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc', provider: 'github-actions' }]);
     assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
@@ -677,18 +694,28 @@ test('publishPackage() exchanges npm oidc tokens and caches the exchange token p
         resolveIdToken: fake.resolves('upstream-id-token')
     });
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.1' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
     assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
@@ -721,9 +748,14 @@ test('publishPackage() passes shorthand npm oidc auth through to the id token re
         resolveIdToken
     });
 
-    await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-        auth: { type: 'npm-oidc' }
-    });
+    await registryClient.publishPackage(
+        { name: 'the-name', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: { type: 'npm-oidc' }
+        },
+        { access: 'public' }
+    );
 
     assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc' }]);
     assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
@@ -749,21 +781,31 @@ test('publishPackage() refreshes the exchanged npm oidc token after expiry', asy
         resolveIdToken: fake.resolves('upstream-id-token')
     });
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     clock.tick(61_000);
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.1' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
 });
@@ -788,19 +830,29 @@ test('publishPackage() refreshes the exchanged npm oidc token when exactly 60 se
         resolveIdToken: fake.resolves('upstream-id-token')
     });
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.1' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
 });
@@ -823,18 +875,28 @@ test('publishPackage() caches exchanged npm oidc tokens per package name', async
         resolveIdToken: fake.resolves('upstream-id-token')
     });
 
-    await registryClient.publishPackage({ name: '@scope/first-package', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
-    await registryClient.publishPackage({ name: '@scope/second-package', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/first-package', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
+    await registryClient.publishPackage(
+        { name: '@scope/second-package', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
     assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
@@ -871,19 +933,29 @@ test('publishPackage() reuses exchanged npm oidc tokens between implicit and exp
         resolveIdToken: fake.resolves('upstream-id-token')
     });
 
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.0' }, Buffer.from([]), {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
-    await registryClient.publishPackage({ name: '@scope/the-name', version: '1.0.1' }, Buffer.from([]), {
-        registryUrl: 'https://registry.npmjs.org/',
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'anonymous'
-        }
-    });
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.0' },
+        Buffer.from([]),
+        {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
+    await registryClient.publishPackage(
+        { name: '@scope/the-name', version: '1.0.1' },
+        Buffer.from([]),
+        {
+            registryUrl: 'https://registry.npmjs.org/',
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'anonymous'
+            }
+        },
+        { access: 'public' }
+    );
 
     assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
 });
@@ -894,13 +966,18 @@ test('publishPackage() rejects npm oidc auth for non-npm registries', async () =
     });
 
     await expectFailure(async () => {
-        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-            registryUrl: 'https://registry.example.test',
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        });
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                registryUrl: 'https://registry.example.test',
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
     }, /^Error: npm-oidc auth is only supported with the npmjs.org registry$/u);
 });
 
@@ -916,12 +993,17 @@ test('publishPackage() rejects an invalid OIDC exchange response body', async ()
     });
 
     await expectFailure(async () => {
-        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        });
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
     }, /^TypeError: OIDC token exchange returned an invalid response$/u);
 });
 
@@ -937,12 +1019,17 @@ test('publishPackage() rejects a non-object OIDC exchange response body', async 
     });
 
     await expectFailure(async () => {
-        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        });
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
     }, /^TypeError: OIDC token exchange returned an invalid response$/u);
 });
 
@@ -958,12 +1045,17 @@ test('publishPackage() rejects a null OIDC exchange response body', async () => 
     });
 
     await expectFailure(async () => {
-        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        });
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
     }, /^TypeError: OIDC token exchange returned an invalid response$/u);
 });
 
@@ -979,12 +1071,17 @@ test('publishPackage() rejects a failing OIDC exchange request', async () => {
     });
 
     await expectFailure(async () => {
-        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        });
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
     }, /^Error: OIDC token exchange failed with status 502$/u);
 });
 
@@ -1005,12 +1102,17 @@ test('publishPackage() rejects an invalid OIDC exchange expiry timestamp', async
     });
 
     await expectFailure(async () => {
-        await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        });
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
     }, /^TypeError: OIDC token exchange returned an invalid expiry timestamp$/u);
 });
 
@@ -1049,12 +1151,17 @@ for (const [testName, response] of [
         });
 
         await expectFailure(async () => {
-            await registryClient.publishPackage({ name: 'the-name', version: '1.0.0' }, Buffer.from([]), {
-                auth: {
-                    publish: { type: 'npm-oidc', provider: 'env' },
-                    metadata: 'anonymous'
-                }
-            });
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                {
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                },
+                { access: 'public' }
+            );
         }, /^TypeError: OIDC token exchange returned an invalid response$/u);
     });
 }
@@ -1215,4 +1322,42 @@ test('fetchLatestVersion() rethrows object unexpected errors without statusCode'
             auth: { type: 'bearer-token', token: 'the-token' }
         });
     }, /^Error: unexpected-failure$/u);
+});
+
+test('publishPackage() forwards the access and provenance options resolved from publishSettings to libnpmpublish', async () => {
+    const publish = fake.resolves(undefined);
+    const registryClient = registryClientFactory({ publish });
+
+    await registryClient.publishPackage(
+        { name: 'the-name', version: '1.0.0' },
+        Buffer.from([]),
+        { auth: { type: 'bearer-token', token: 'the-token' } },
+        { access: 'public', provenance: { type: 'auto' } }
+    );
+
+    const publishOptions = publish.firstCall.args.at(-1) as Record<string, unknown>;
+    assert.strictEqual(publishOptions.access, 'public');
+    assert.strictEqual(publishOptions.provenance, true);
+});
+
+test('publishPackage() rewrites a libnpmpublish error through the publish-settings bridge', async () => {
+    const original = Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins'), {
+        code: 'EUSAGE'
+    });
+    const publish = fake.rejects(original);
+    const registryClient = registryClientFactory({ publish });
+
+    try {
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            { auth: { type: 'bearer-token', token: 'the-token' } },
+            { access: 'public', provenance: { type: 'auto' } }
+        );
+        assert.fail('Expected publishPackage() to throw');
+    } catch (error: unknown) {
+        assert.ok(error instanceof Error, 'Expected the thrown value to be an Error');
+        assert.match(error.message, /^Provenance auto mode requires GitHub Actions or GitLab CI/u);
+        assert.strictEqual(error.cause, original);
+    }
 });

--- a/source/bundle-emitter/registry-client.ts
+++ b/source/bundle-emitter/registry-client.ts
@@ -4,6 +4,7 @@ import type { publish as _publish } from 'libnpmpublish';
 import { Maybe } from 'true-myth';
 import { z } from 'zod/mini';
 import type { Clock } from '../common/clock.ts';
+import type { PublishSettings } from '../config/publish-settings.ts';
 import type {
     MetadataAuthMode,
     MetadataAuthStrategy,
@@ -11,6 +12,7 @@ import type {
     RegistrySettings
 } from '../config/registry-settings.ts';
 import type { BundlePackageJson } from '../version-manager/versioned-bundle.ts';
+import { buildPublishOptionsForPublishSettings, remapPublishError } from './publish-settings-bridge.ts';
 
 type PublishFunction = typeof _publish;
 const notFoundStatusCode = 404;
@@ -42,7 +44,12 @@ export type RegistryClientDependencies = {
 
 export type RegistryClient = {
     fetchLatestVersion: (packageName: string, config: RegistrySettings) => Promise<Maybe<PackageVersionDetails>>;
-    publishPackage: (manifest: Readonly<BundlePackageJson>, tarData: Buffer, config: RegistrySettings) => Promise<void>;
+    publishPackage: (
+        manifest: Readonly<BundlePackageJson>,
+        tarData: Buffer,
+        config: RegistrySettings,
+        publishSettings: PublishSettings
+    ) => Promise<void>;
     fetchTarball: (tarballUrl: string, shasum: string, config: RegistrySettings) => Promise<Buffer>;
 };
 
@@ -370,13 +377,19 @@ export function createRegistryClient(dependencies: Readonly<RegistryClientDepend
             return response.buffer();
         },
 
-        async publishPackage(manifest, tarData, registrySettings) {
+        async publishPackage(manifest, tarData, registrySettings, publishSettings) {
             const authOptions = await resolveWriteAuthOptions(manifest.name, registrySettings);
-            await publish(toPublishManifest(manifest), tarData, {
-                defaultTag: 'latest',
-                ...authOptions,
-                ...(promptForOneTimePassword === undefined ? {} : { otpPrompt: promptForOneTimePassword })
-            });
+            const publishOptionsFromSettings = buildPublishOptionsForPublishSettings(publishSettings);
+            try {
+                await publish(toPublishManifest(manifest), tarData, {
+                    defaultTag: 'latest',
+                    ...authOptions,
+                    ...publishOptionsFromSettings,
+                    ...(promptForOneTimePassword === undefined ? {} : { otpPrompt: promptForOneTimePassword })
+                });
+            } catch (error: unknown) {
+                throw remapPublishError(error, publishSettings);
+            }
         },
 
         async fetchLatestVersion(packageName, registrySettings) {

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -1,6 +1,7 @@
 import type { AdditionalFileDescription } from './additional-files.ts';
 import type { EntryPoint } from './entry-point.ts';
 import type { AdditionalPackageJsonAttributes, MainPackageJson } from './package-json.ts';
+import type { PublishSettings } from './publish-settings.ts';
 import type { RegistrySettings } from './registry-settings.ts';
 import type { VersioningSettings } from './versioning-settings.ts';
 
@@ -31,6 +32,7 @@ export type PackageConfig = {
     readonly additionalFiles?: readonly AdditionalFileDescription[] | undefined;
     readonly includeSourceMapFiles?: boolean | undefined;
     readonly additionalPackageJsonAttributes?: AdditionalPackageJsonAttributes | undefined;
+    readonly publishSettings?: PublishSettings | undefined;
 };
 
 export type PackageConfigsByName = Readonly<Record<string, PackageConfig>>;
@@ -49,6 +51,7 @@ export type CommonPackageSettings = {
     readonly additionalFiles?: readonly AdditionalFileDescription[] | undefined;
     readonly includeSourceMapFiles?: boolean | undefined;
     readonly additionalPackageJsonAttributes?: AdditionalPackageJsonAttributes | undefined;
+    readonly publishSettings?: PublishSettings | undefined;
 };
 
 export type PacktoryConfigWithoutRegistry = {

--- a/source/config/optional-package-settings-schema.ts
+++ b/source/config/optional-package-settings-schema.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod/mini';
 import { additionalFileDescriptionSchema } from './additional-files.ts';
 import { additionalPackageJsonAttributesSchema } from './additional-package-json-attributes-schema.ts';
+import { publishSettingsSchema } from './publish-settings.ts';
 
 export const optionalPackageSettingsSchema = z.strictObject({
     additionalFiles: z.optional(z.readonly(z.array(additionalFileDescriptionSchema))),
     includeSourceMapFiles: z.optional(z.boolean()),
-    additionalPackageJsonAttributes: z.optional(additionalPackageJsonAttributesSchema)
+    additionalPackageJsonAttributes: z.optional(additionalPackageJsonAttributesSchema),
+    publishSettings: z.optional(publishSettingsSchema)
 });

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -6,7 +6,15 @@ import { packtoryConfigSchema } from './packtory-config-schema.ts';
 
 const validConfig = {
     registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-    packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
+    packages: [
+        {
+            sourcesFolder: 'source',
+            mainPackageJson: {},
+            name: 'foo',
+            entryPoints: [{ js: 'foo' }],
+            publishSettings: { access: 'public' }
+        }
+    ]
 };
 
 test('packtory config schema accepts a valid config', () => {
@@ -16,7 +24,15 @@ test('packtory config schema accepts a valid config', () => {
 test('packtory config schema rejects configs without registrySettings', () => {
     assert.strictEqual(
         safeParse(packtoryConfigSchema, {
-            packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
+            packages: [
+                {
+                    sourcesFolder: 'source',
+                    mainPackageJson: {},
+                    name: 'foo',
+                    entryPoints: [{ js: 'foo' }],
+                    publishSettings: { access: 'public' }
+                }
+            ]
         }).success,
         false
     );
@@ -36,8 +52,58 @@ test(
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
-            packages: [{ sourcesFolder: 'source', mainPackageJson: {}, name: 'foo', entryPoints: [{ js: 'foo' }] }]
+            packages: [
+                {
+                    sourcesFolder: 'source',
+                    mainPackageJson: {},
+                    name: 'foo',
+                    entryPoints: [{ js: 'foo' }],
+                    publishSettings: { access: 'public' }
+                }
+            ]
         },
         expectedMessages: ['at registrySettings: missing property']
+    })
+);
+
+test(
+    'packtory config schema: accepts a config with publishSettings declared in commonPackageSettings only',
+    checkValidationSuccess({
+        schema: packtoryConfigSchema,
+        data: {
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            commonPackageSettings: {
+                sourcesFolder: 'source',
+                mainPackageJson: {},
+                publishSettings: { access: 'public', provenance: { type: 'auto' } }
+            },
+            packages: [{ name: 'foo', entryPoints: [{ js: 'foo' }] }]
+        }
+    })
+);
+
+test(
+    'packtory config schema: accepts a config with mixed common default and per-package override',
+    checkValidationSuccess({
+        schema: packtoryConfigSchema,
+        data: {
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            commonPackageSettings: {
+                sourcesFolder: 'source',
+                mainPackageJson: {},
+                publishSettings: { access: 'public' }
+            },
+            packages: [
+                {
+                    name: 'foo',
+                    entryPoints: [{ js: 'foo' }]
+                },
+                {
+                    name: 'bar',
+                    entryPoints: [{ js: 'bar' }],
+                    publishSettings: { access: 'restricted' }
+                }
+            ]
+        }
     })
 );

--- a/source/config/packtory-config-without-registry-schema.test.ts
+++ b/source/config/packtory-config-without-registry-schema.test.ts
@@ -4,10 +4,20 @@ import { test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-registry-schema.ts';
 
+const publicPublishSettings = { access: 'public' } as const;
+
 test('config without registry schema accepts package configs with optional common settings', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            packages: [{ sourcesFolder: 'src', mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
+            packages: [
+                {
+                    sourcesFolder: 'src',
+                    mainPackageJson: {},
+                    name: 'pkg',
+                    entryPoints: [{ js: 'index.js' }],
+                    publishSettings: publicPublishSettings
+                }
+            ]
         }).success,
         true
     );
@@ -16,7 +26,11 @@ test('config without registry schema accepts package configs with optional commo
 test('config without registry schema accepts required common package settings', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { sourcesFolder: 'src', mainPackageJson: {} },
+            commonPackageSettings: {
+                sourcesFolder: 'src',
+                mainPackageJson: {},
+                publishSettings: publicPublishSettings
+            },
             packages: [{ name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
         true
@@ -26,7 +40,7 @@ test('config without registry schema accepts required common package settings', 
 test('config without registry schema accepts required mainPackageJson', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { mainPackageJson: {} },
+            commonPackageSettings: { mainPackageJson: {}, publishSettings: publicPublishSettings },
             packages: [{ sourcesFolder: 'src', name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
         true
@@ -36,7 +50,7 @@ test('config without registry schema accepts required mainPackageJson', () => {
 test('config without registry schema accepts required sourcesFolder', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { sourcesFolder: 'src' },
+            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
             packages: [{ mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }).success,
         true
@@ -50,7 +64,11 @@ test('config without registry schema rejects an empty packages tuple', () => {
 test('required common settings branch rejects an empty packages tuple', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { sourcesFolder: 'src', mainPackageJson: {} },
+            commonPackageSettings: {
+                sourcesFolder: 'src',
+                mainPackageJson: {},
+                publishSettings: publicPublishSettings
+            },
             packages: []
         }).success,
         false
@@ -60,7 +78,7 @@ test('required common settings branch rejects an empty packages tuple', () => {
 test('required mainPackageJson branch rejects an empty packages tuple', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { mainPackageJson: {} },
+            commonPackageSettings: { mainPackageJson: {}, publishSettings: publicPublishSettings },
             packages: []
         }).success,
         false
@@ -70,7 +88,7 @@ test('required mainPackageJson branch rejects an empty packages tuple', () => {
 test('required sourcesFolder branch rejects an empty packages tuple', () => {
     assert.strictEqual(
         safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { sourcesFolder: 'src' },
+            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
             packages: []
         }).success,
         false
@@ -82,10 +100,26 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigWithoutRegistrySchema,
         data: {
-            packages: [{ sourcesFolder: 'src', mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
+            packages: [
+                {
+                    sourcesFolder: 'src',
+                    mainPackageJson: {},
+                    name: 'pkg',
+                    entryPoints: [{ js: 'index.js' }],
+                    publishSettings: publicPublishSettings
+                }
+            ]
         },
         expectedData: {
-            packages: [{ sourcesFolder: 'src', mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
+            packages: [
+                {
+                    sourcesFolder: 'src',
+                    mainPackageJson: {},
+                    name: 'pkg',
+                    entryPoints: [{ js: 'index.js' }],
+                    publishSettings: publicPublishSettings
+                }
+            ]
         }
     })
 );
@@ -95,11 +129,19 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigWithoutRegistrySchema,
         data: {
-            commonPackageSettings: { sourcesFolder: 'src', mainPackageJson: {} },
+            commonPackageSettings: {
+                sourcesFolder: 'src',
+                mainPackageJson: {},
+                publishSettings: publicPublishSettings
+            },
             packages: [{ name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         },
         expectedData: {
-            commonPackageSettings: { sourcesFolder: 'src', mainPackageJson: {} },
+            commonPackageSettings: {
+                sourcesFolder: 'src',
+                mainPackageJson: {},
+                publishSettings: publicPublishSettings
+            },
             packages: [{ name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }
     })
@@ -110,11 +152,11 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigWithoutRegistrySchema,
         data: {
-            commonPackageSettings: { mainPackageJson: {} },
+            commonPackageSettings: { mainPackageJson: {}, publishSettings: publicPublishSettings },
             packages: [{ sourcesFolder: 'src', name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         },
         expectedData: {
-            commonPackageSettings: { mainPackageJson: {} },
+            commonPackageSettings: { mainPackageJson: {}, publishSettings: publicPublishSettings },
             packages: [{ sourcesFolder: 'src', name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }
     })
@@ -125,11 +167,11 @@ test(
     checkValidationSuccess({
         schema: packtoryConfigWithoutRegistrySchema,
         data: {
-            commonPackageSettings: { sourcesFolder: 'src' },
+            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
             packages: [{ mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         },
         expectedData: {
-            commonPackageSettings: { sourcesFolder: 'src' },
+            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
             packages: [{ mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
         }
     })
@@ -141,5 +183,53 @@ test(
         schema: packtoryConfigWithoutRegistrySchema,
         data: { packages: [] },
         expectedMessages: ['invalid value doesn’t match expected union']
+    })
+);
+
+test(
+    'config without registry: validation succeeds when per-package publishSettings overrides the common default',
+    checkValidationSuccess({
+        schema: packtoryConfigWithoutRegistrySchema,
+        data: {
+            commonPackageSettings: {
+                sourcesFolder: 'src',
+                mainPackageJson: {},
+                publishSettings: publicPublishSettings
+            },
+            packages: [
+                {
+                    name: 'pkg',
+                    entryPoints: [{ js: 'index.js' }],
+                    publishSettings: { access: 'restricted' }
+                }
+            ]
+        },
+        expectedData: {
+            commonPackageSettings: {
+                sourcesFolder: 'src',
+                mainPackageJson: {},
+                publishSettings: publicPublishSettings
+            },
+            packages: [
+                {
+                    name: 'pkg',
+                    entryPoints: [{ js: 'index.js' }],
+                    publishSettings: { access: 'restricted' }
+                }
+            ]
+        }
+    })
+);
+
+test(
+    'config without registry: schema accepts a config without publishSettings (placement is enforced in validateConfig)',
+    checkValidationSuccess({
+        schema: packtoryConfigWithoutRegistrySchema,
+        data: {
+            packages: [{ sourcesFolder: 'src', mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
+        },
+        expectedData: {
+            packages: [{ sourcesFolder: 'src', mainPackageJson: {}, name: 'pkg', entryPoints: [{ js: 'index.js' }] }]
+        }
     })
 );

--- a/source/config/publish-settings.test.ts
+++ b/source/config/publish-settings.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import { test } from 'mocha';
+import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
+import { publishSettingsSchema } from './publish-settings.ts';
+
+test('schema accepts the minimal public publish settings', () => {
+    assert.strictEqual(safeParse(publishSettingsSchema, { access: 'public' }).success, true);
+});
+
+test(
+    'validation succeeds with public access and no provenance',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'public' },
+        expectedData: { access: 'public' }
+    })
+);
+
+test(
+    'validation succeeds with public access and provenance auto mode',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'public', provenance: { type: 'auto' } },
+        expectedData: { access: 'public', provenance: { type: 'auto' } }
+    })
+);
+
+test(
+    'validation succeeds with public access and provenance file mode',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'public', provenance: { type: 'file', path: './build/pkg.sigstore' } },
+        expectedData: { access: 'public', provenance: { type: 'file', path: './build/pkg.sigstore' } }
+    })
+);
+
+test(
+    'validation succeeds with restricted access',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'restricted' },
+        expectedData: { access: 'restricted' }
+    })
+);
+
+test(
+    'validation fails when restricted access carries provenance',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'restricted', provenance: { type: 'auto' } },
+        expectedMessages: ['unexpected additional property: "provenance"']
+    })
+);
+
+test(
+    'validation fails when access is missing',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { provenance: { type: 'auto' } },
+        expectedMessages: ['at access: missing property']
+    })
+);
+
+test(
+    'validation fails when access is an unknown literal',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'private' },
+        expectedMessages: ['at access: invalid value doesn’t match expected union']
+    })
+);
+
+test(
+    'validation fails when provenance type is missing',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'public', provenance: {} },
+        expectedMessages: ['at provenance.type: missing property']
+    })
+);
+
+test(
+    'validation fails when provenance type is unknown',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'public', provenance: { type: 'unknown' } },
+        expectedMessages: ['at provenance.type: invalid value doesn’t match expected union']
+    })
+);
+
+test(
+    'validation fails when provenance file path is missing',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'public', provenance: { type: 'file' } },
+        expectedMessages: ['at provenance.path: missing property']
+    })
+);
+
+test(
+    'validation fails when provenance file path is empty',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'public', provenance: { type: 'file', path: '' } },
+        expectedMessages: ['at provenance.path: string must contain at least 1 character']
+    })
+);
+
+test(
+    'validation fails when an additional property is given on a public publish settings block',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'public', extra: 'bar' },
+        expectedMessages: ['unexpected additional property: "extra"']
+    })
+);

--- a/source/config/publish-settings.ts
+++ b/source/config/publish-settings.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod/mini';
+import { nonEmptyStringSchema } from './base-validations.ts';
+
+const provenanceConfigSchema = z.readonly(
+    z.discriminatedUnion('type', [
+        z.strictObject({
+            type: z.literal('auto')
+        }),
+        z.strictObject({
+            type: z.literal('file'),
+            path: nonEmptyStringSchema
+        })
+    ])
+);
+
+export const publishSettingsSchema = z.readonly(
+    z.discriminatedUnion('access', [
+        z.strictObject({
+            access: z.literal('public'),
+            provenance: z.optional(provenanceConfigSchema)
+        }),
+        z.strictObject({
+            access: z.literal('restricted')
+        })
+    ])
+);
+
+export type ProvenanceConfig = z.infer<typeof provenanceConfigSchema>;
+export type PublishSettings = z.infer<typeof publishSettingsSchema>;

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -178,6 +178,7 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'additionalFiles',
             'includeSourceMapFiles',
             'additionalPackageJsonAttributes',
+            'publishSettings',
             'name',
             'entryPoints',
             'versioning',
@@ -190,7 +191,8 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'mainPackageJson',
             'additionalFiles',
             'includeSourceMapFiles',
-            'additionalPackageJsonAttributes'
+            'additionalPackageJsonAttributes',
+            'publishSettings'
         ],
         configIntersectionLeftKeys: ['registrySettings'],
         validWithoutRegistrySuccess: true

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -9,7 +9,7 @@ type ConfigInput = Record<string, unknown>;
 function withRegistry(extra: ConfigInput): ConfigInput {
     return {
         registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {}, publishSettings: { access: 'public' } },
         ...extra
     };
 }
@@ -274,7 +274,7 @@ test('validateConfigWithoutRegistry() returns schema issues when the config is i
 
 test('validateConfigWithoutRegistry() returns an issue for unknown packages in a scoped allow-list entry', () => {
     const result = validateConfigWithoutRegistry({
-        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {}, publishSettings: { access: 'public' } },
         ...configWithGhostAllowList(['a', 'ghost'])
     });
 
@@ -286,9 +286,70 @@ test('validateConfigWithoutRegistry() returns an issue for unknown packages in a
 
 test('validateConfigWithoutRegistry() returns duplicate and missing dependency issues', () => {
     const result = validateConfigWithoutRegistry({
-        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {}, publishSettings: { access: 'public' } },
         packages: duplicateCAndMissingBPackages
     });
 
     assert.deepStrictEqual(result, Result.err(duplicateCAndMissingBErrors));
+});
+
+function withCommonWithoutPublishSettings(packages: readonly ConfigInput[]): ConfigInput {
+    return {
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: {} },
+        packages
+    };
+}
+
+const placementErrorMessage = 'publishSettings must be set in commonPackageSettings or in every package';
+
+test('returns an issue when publishSettings is missing from both commonPackageSettings and every package', () => {
+    const result = validateConfig(withCommonWithoutPublishSettings([{ name: 'foo', entryPoints: [{ js: 'foo' }] }]));
+
+    assert.deepStrictEqual(result, Result.err([placementErrorMessage]));
+});
+
+test('returns an issue when publishSettings is missing for at least one package and not provided in common', () => {
+    const result = validateConfig(
+        withCommonWithoutPublishSettings([
+            { name: 'foo', entryPoints: [{ js: 'foo' }], publishSettings: { access: 'public' } },
+            { name: 'bar', entryPoints: [{ js: 'bar' }] }
+        ])
+    );
+
+    assert.deepStrictEqual(result, Result.err([placementErrorMessage]));
+});
+
+test('accepts a config when publishSettings is set only in commonPackageSettings', () => {
+    const result = validateConfig(withRegistry({ packages: [{ name: 'foo', entryPoints: [{ js: 'foo' }] }] }));
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a config when publishSettings is set only on every package', () => {
+    const result = validateConfig(
+        withCommonWithoutPublishSettings([
+            { name: 'foo', entryPoints: [{ js: 'foo' }], publishSettings: { access: 'public' } },
+            { name: 'bar', entryPoints: [{ js: 'bar' }], publishSettings: { access: 'restricted' } }
+        ])
+    );
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a config when no commonPackageSettings is provided and every package supplies its own publishSettings', () => {
+    const result = validateConfig({
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        packages: [
+            {
+                sourcesFolder: 'foo',
+                mainPackageJson: {},
+                name: 'foo',
+                entryPoints: [{ js: 'foo' }],
+                publishSettings: { access: 'public' }
+            }
+        ]
+    });
+
+    assert.strictEqual(result.isOk, true);
 });

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -126,6 +126,19 @@ type ConfigWithGraphInternal<TConfig extends { packages: readonly PackageConfig[
         readonly packageGraph: DirectedGraph<string, undefined>;
     };
 
+function validatePublishSettingsArePlaced(packtoryConfig: Readonly<PacktoryConfigWithoutRegistry>): readonly string[] {
+    if (packtoryConfig.commonPackageSettings?.publishSettings !== undefined) {
+        return [];
+    }
+    const everyPackageHasIt = packtoryConfig.packages.every((packageConfig) => {
+        return packageConfig.publishSettings !== undefined;
+    });
+    if (everyPackageHasIt) {
+        return [];
+    }
+    return ['publishSettings must be set in commonPackageSettings or in every package'];
+}
+
 function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWithoutRegistry>(
     schema: ZodMiniType<TConfig>,
     config: unknown
@@ -140,6 +153,7 @@ function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWith
     const packageConfigs = packageListToRecord(packtoryConfig.packages);
 
     const preGraphIssues = [
+        ...validatePublishSettingsArePlaced(packtoryConfig),
         ...validateDependenciesExist(packageConfigs),
         ...validateNoDuplicatedFilesAllowList(packageConfigs, packtoryConfig.checks)
     ];

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -33,3 +33,18 @@ Create a `packtory.config.js` file in your project to define the configuration. 
 - If the registry challenges a publish with a one-time password, the CLI prompts for it when running in an interactive TTY.
 - The prompt times out after 90 seconds.
 - Non-interactive runs cannot answer a one-time-password challenge. For CI, prefer an auth method that does not require live one-time-password entry, such as npm trusted publishing / OIDC or a suitable registry token setup.
+
+**Publish settings:**
+
+Every package needs a `publishSettings` value, either set in `commonPackageSettings` as a default or on each package entry directly. If neither is set, the CLI exits with `publishSettings must be set in commonPackageSettings or in every package`. See the [main configuration docs](https://github.com/enormora/packtory/blob/main/readme.md) for the full shape and the access ↔ provenance constraint.
+
+**Common publish-time errors:**
+
+When publishing with `publishSettings.provenance` configured, the CLI surfaces packtory-flavored errors instead of raw `libnpmpublish` messages so you know where to look:
+
+- `Provenance auto mode requires GitHub Actions or GitLab CI. Detected CI: <name>. Use provenance: { type: 'file' } for other environments.` — your CI is not natively supported by `auto` mode; either run from GHA / GitLab CI or switch to `provenance: { type: 'file', path }` and pre-generate the bundle.
+- `GitHub Actions provenance needs "permissions: id-token: write" on the workflow job.` — add the `id-token: write` permission to the workflow job that runs `packtory publish`.
+- `GitLab CI provenance needs an "id_tokens" entry with audience "sigstore" exposed as SIGSTORE_ID_TOKEN.` — declare the OIDC ID token for the job with audience `sigstore`.
+- `Provenance bundle file "<path>" does not exist.` — the file you configured under `provenance.path` was not found. Generate it with your CI's attestation tool before running packtory.
+- `Provenance bundle file "<path>" is not a valid sigstore bundle.` — the file is corrupted or was not produced by a supported sigstore client.
+- `Provenance bundle at "<path>" was signed against a different tarball than the one packtory built.` — the bundle's signed digest does not match the tarball packtory built. Re-generate the bundle from the current source so it matches.

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -31,17 +31,25 @@ function runMapConfig(
 ): ReturnType<typeof configToBuildAndPublishOptions> {
     const packageName = options.packageName ?? 'foo';
     const additionalPackages = options.extraPackages ?? [placeholderPackage];
+    const commonProvidesPublishSettings = options.commonPackageSettings?.publishSettings !== undefined;
+    const packageProvidesPublishSettings = packageConfig.publishSettings !== undefined;
+    const needsPublishSettingsFallback = !commonProvidesPublishSettings && !packageProvidesPublishSettings;
+    const fallbackPackage: PackageConfigInput = {
+        publishSettings: { access: 'public' },
+        ...packageConfig
+    };
+    const packageWithFallback = needsPublishSettingsFallback ? fallbackPackage : packageConfig;
     const baseConfig = {
         registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         ...options.extraConfig,
         ...(options.commonPackageSettings === undefined
             ? {}
             : { commonPackageSettings: options.commonPackageSettings }),
-        packages: [packageConfig, ...additionalPackages]
+        packages: [packageWithFallback, ...additionalPackages]
     } as unknown as PacktoryConfigInput;
     return configToBuildAndPublishOptions(
         packageName,
-        { [packageName]: packageConfig },
+        { [packageName]: packageWithFallback },
         baseConfig,
         options.bundleDependencies ?? []
     );
@@ -334,4 +342,40 @@ test('overwrites additionalPackageJsonAttributes from common settings when there
     );
 
     assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'qux' });
+});
+
+test('uses the common publishSettings when the package config does not override it', () => {
+    const result = runMapConfig(fooPackageConfigFactory.build(), {
+        commonPackageSettings: { publishSettings: { access: 'public', provenance: { type: 'auto' } } },
+        extraPackages: []
+    });
+
+    assert.deepStrictEqual(result.publishSettings, { access: 'public', provenance: { type: 'auto' } });
+});
+
+test('prefers the per-package publishSettings over the common default', () => {
+    const result = runMapConfig(
+        { ...fooPackageConfigFactory.build(), publishSettings: { access: 'restricted' } },
+        {
+            commonPackageSettings: { publishSettings: { access: 'public' } },
+            extraPackages: []
+        }
+    );
+
+    assert.deepStrictEqual(result.publishSettings, { access: 'restricted' });
+});
+
+test('throws a "missing publish settings" error when neither commonPackageSettings nor the package supplies one', () => {
+    const packageWithoutPublishSettings = fooPackageConfigFactory.build();
+    const config = {
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        packages: [packageWithoutPublishSettings]
+    } as unknown as PacktoryConfigInput;
+
+    assert.throws(
+        () => {
+            configToBuildAndPublishOptions('foo', { foo: packageWithoutPublishSettings }, config, []);
+        },
+        { message: 'Config for package "foo" is missing publish settings' }
+    );
 });

--- a/source/packtory/map-config.ts
+++ b/source/packtory/map-config.ts
@@ -14,6 +14,7 @@ import type { BuildVersionedBundleOptions, VersionedBundleWithManifest } from '.
 import type { BundleSubstitutionSource } from '../linker/linked-bundle.ts';
 import { normalizeAdditionalFile, normalizeEntryPoint } from './normalize-paths.ts';
 
+type PublishSettings = NonNullable<PackageConfig['publishSettings']>;
 type ManifestOptionsSubset = Pick<BuildVersionedBundleOptions, 'additionalPackageJsonAttributes' | 'mainPackageJson'>;
 type SharedModuleResolution = ResourceResolveOptions['moduleResolution'];
 
@@ -29,6 +30,7 @@ export type BuildOptions = SharedPackageOptions<VersionedBundleWithManifest> & {
 
 export type BuildAndPublishOptions = SharedPackageOptions<VersionedBundleWithManifest> & {
     readonly registrySettings: RegistrySettings;
+    readonly publishSettings: PublishSettings;
     readonly versioning: VersioningSettings;
 };
 
@@ -99,6 +101,16 @@ function resolveMainPackageJson(
     return getRequiredValue(
         packageConfig.mainPackageJson ?? packtoryConfig.commonPackageSettings?.mainPackageJson,
         `Config for package "${packageConfig.name}" is missing the main package.json settings`
+    );
+}
+
+function resolvePublishSettings(
+    packageConfig: PackageConfig,
+    packtoryConfig: PacktoryConfigWithoutRegistry
+): PublishSettings {
+    return getRequiredValue(
+        packageConfig.publishSettings ?? packtoryConfig.commonPackageSettings?.publishSettings,
+        `Config for package "${packageConfig.name}" is missing publish settings`
     );
 }
 
@@ -201,11 +213,13 @@ export function configToBuildAndPublishOptions(
         packtoryConfig,
         existingBundles
     );
+    const packageConfig = getPackageConfig(packageName, packageConfigs);
 
     return {
         ...sharedOptions,
         versioning,
-        registrySettings: packtoryConfig.registrySettings
+        registrySettings: packtoryConfig.registrySettings,
+        publishSettings: resolvePublishSettings(packageConfig, packtoryConfig)
     };
 }
 

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -143,6 +143,7 @@ function createBuildAndPublishOptions(): BuildAndPublishOptions {
         ...createResolveOptions(),
         versioning: { automatic: true } as const,
         registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        publishSettings: { access: 'public' } as const,
         bundleDependencies: [createVersionedBundle('bundle-dependency', '1.0.0')],
         bundlePeerDependencies: [createVersionedBundle('peer-dependency', '2.0.0')]
     };
@@ -430,7 +431,11 @@ test('buildAndPublish() publishes the rebuilt bundle and emits publishing progre
 
     assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'new-version' });
     assert.deepStrictEqual(publish.firstCall.args, [
-        { bundle: rebuiltBundle, registrySettings: { auth: { type: 'bearer-token', token: 'token' } } }
+        {
+            bundle: rebuiltBundle,
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            publishSettings: { access: 'public' }
+        }
     ]);
     assert.deepStrictEqual(getCallArgs(emit), [
         ['building', { packageName: 'package-a', version: '1.2.3' }],

--- a/source/packtory/package-processor.ts
+++ b/source/packtory/package-processor.ts
@@ -162,7 +162,8 @@ export function createPackageProcessor(dependencies: PackageProcessorDependencie
             });
             await bundleEmitter.publish({
                 bundle: result.bundle,
-                registrySettings: options.buildOptions.registrySettings
+                registrySettings: options.buildOptions.registrySettings,
+                publishSettings: options.buildOptions.publishSettings
             });
 
             return result;

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -35,7 +35,8 @@ function createConfigWithoutRegistry(overrides: Record<string, unknown> = {}): P
     return {
         commonPackageSettings: {
             sourcesFolder: '/src',
-            mainPackageJson: { type: 'module' }
+            mainPackageJson: { type: 'module' },
+            publishSettings: { access: 'public' }
         },
         packages: [{ name: 'package-a', entryPoints: [{ js: 'package-a/index.js' }] }],
         ...overrides

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -11,7 +11,11 @@ type PackageNameResult = { readonly packageName: string };
 
 function createValidatedConfig(packages: readonly Record<string, unknown>[]): ValidConfigWithoutRegistryResult {
     const result = validateConfigWithoutRegistry({
-        commonPackageSettings: { sourcesFolder: '/src', mainPackageJson: {} },
+        commonPackageSettings: {
+            sourcesFolder: '/src',
+            mainPackageJson: {},
+            publishSettings: { access: 'public' }
+        },
         packages
     });
 


### PR DESCRIPTION
Introduce a `publishSettings` config field so every bundled package declares its registry visibility and, optionally, a sigstore-signed provenance attestation. Without this packtory could not publish with provenance because libnpmpublish hard-rejects provenance on packages without an explicit access: 'public' setting, and packtory previously exposed neither knob.