### PR TITLE
Block scripts unless publishSettings opts in

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ The configuration for `packtory` is an object with the following properties:
         - An object to be merged directly into the generated `package.json`.
         - Useful for setting meta properties like `description` or `keywords`.
         - If defined in both per-package and common settings, they are merged.
+        - The `scripts` key is rejected by default to prevent accidental shipping of npm lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`, `prepublish`, `prepublishOnly`) — the canonical npm supply-chain attack vector. Set `publishSettings.allowScripts: true` on the resolved publish settings to opt in.
 
     - **`bundleDependencies`** (Optional, Array of Strings):
         - An array of package names to mark as dependencies, allowing the bundler to substitute import statements accordingly.
@@ -191,6 +192,7 @@ The configuration for `packtory` is an object with the following properties:
             - `provenance: { type: 'auto' }` — let `libnpmpublish` detect the CI environment and generate the provenance statement. Currently supported CIs: GitHub Actions and GitLab CI.
             - `provenance: { type: 'file', path: './build/pkg.sigstore' }` — pass a pre-generated sigstore bundle. Use this for any CI not natively supported by `auto` mode (e.g. CircleCI, Jenkins, BuildKite). The bundle must have been signed against the exact tarball packtory builds; mismatches are rejected with a clear error.
         - Per-package `publishSettings` replaces the whole common-level block (no field-level merging) so the `access` ↔ `provenance` constraint stays internally consistent at every scope.
+        - An optional `allowScripts` boolean is accepted on both branches and is `false` by default. It must be explicitly set to `true` to allow a `scripts` block in `additionalPackageJsonAttributes` to flow into the published `package.json`. This default-off behaviour exists to prevent shipping npm lifecycle scripts — the canonical supply-chain attack vector — and the opt-in lives on `publishSettings` (replace-merged per package) so it cannot be silently inherited from common settings.
 
 **Note**: Per-package settings override or merge with common settings when both are defined.
 

--- a/source/config/publish-settings.test.ts
+++ b/source/config/publish-settings.test.ts
@@ -151,3 +151,66 @@ test(
         expectedMessages: ['at sbom: unexpected additional property: "extra"']
     })
 );
+
+test(
+    'validation succeeds with public access and allowScripts true',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'public', allowScripts: true },
+        expectedData: { access: 'public', allowScripts: true }
+    })
+);
+
+test(
+    'validation succeeds with public access and allowScripts false',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'public', allowScripts: false },
+        expectedData: { access: 'public', allowScripts: false }
+    })
+);
+
+test(
+    'validation succeeds with public access and allowScripts undefined',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'public', allowScripts: undefined },
+        expectedData: { access: 'public', allowScripts: undefined }
+    })
+);
+
+test(
+    'validation succeeds with restricted access and allowScripts true',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'restricted', allowScripts: true },
+        expectedData: { access: 'restricted', allowScripts: true }
+    })
+);
+
+test(
+    'validation succeeds with restricted access and allowScripts false',
+    checkValidationSuccess({
+        schema: publishSettingsSchema,
+        data: { access: 'restricted', allowScripts: false },
+        expectedData: { access: 'restricted', allowScripts: false }
+    })
+);
+
+test(
+    'validation fails when allowScripts is not a boolean on public access',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'public', allowScripts: 'yes' },
+        expectedMessages: ['at allowScripts: expected boolean, but got string']
+    })
+);
+
+test(
+    'validation fails when allowScripts is not a boolean on restricted access',
+    checkValidationFailure({
+        schema: publishSettingsSchema,
+        data: { access: 'restricted', allowScripts: 1 },
+        expectedMessages: ['at allowScripts: expected boolean, but got number']
+    })
+);

--- a/source/config/publish-settings.ts
+++ b/source/config/publish-settings.ts
@@ -19,11 +19,13 @@ export const publishSettingsSchema = z.readonly(
         z.strictObject({
             access: z.literal('public'),
             provenance: z.optional(provenanceConfigSchema),
-            sbom: z.optional(sbomSettingsSchema)
+            sbom: z.optional(sbomSettingsSchema),
+            allowScripts: z.optional(z.boolean())
         }),
         z.strictObject({
             access: z.literal('restricted'),
-            sbom: z.optional(sbomSettingsSchema)
+            sbom: z.optional(sbomSettingsSchema),
+            allowScripts: z.optional(z.boolean())
         })
     ])
 );

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -305,12 +305,16 @@ test('validateConfigWithoutRegistry() returns duplicate and missing dependency i
     assert.deepStrictEqual(result, Result.err(duplicateCAndMissingBErrors));
 });
 
-function withCommonWithoutPublishSettings(packages: readonly ConfigInput[]): ConfigInput {
+function withCustomCommon(commonExtras: ConfigInput, packages: readonly ConfigInput[]): ConfigInput {
     return {
         registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: { type: 'module' } },
+        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: { type: 'module' }, ...commonExtras },
         packages
     };
+}
+
+function withCommonWithoutPublishSettings(packages: readonly ConfigInput[]): ConfigInput {
+    return withCustomCommon({}, packages);
 }
 
 const placementErrorMessage = 'publishSettings must be set in commonPackageSettings or in every package';
@@ -363,4 +367,97 @@ test('accepts a config when no commonPackageSettings is provided and every packa
     });
 
     assert.strictEqual(result.isOk, true);
+});
+
+const allowScriptsErrorFor = (packageName: string): string => {
+    return (
+        `Package "${packageName}": "scripts" in additionalPackageJsonAttributes` +
+        ' requires "publishSettings.allowScripts: true"'
+    );
+};
+
+const postinstallScripts = { postinstall: 'echo hi' };
+
+test('accepts a config without scripts anywhere', () => {
+    const result = validateConfig(withRegistry({ packages: [{ name: 'foo', entryPoints: [{ js: 'foo' }] }] }));
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a config with per-package scripts and per-package allowScripts true', () => {
+    const result = validateConfig(
+        withRegistry({
+            packages: [
+                {
+                    name: 'foo',
+                    entryPoints: [{ js: 'foo' }],
+                    additionalPackageJsonAttributes: { scripts: postinstallScripts },
+                    publishSettings: { access: 'public', allowScripts: true }
+                }
+            ]
+        })
+    );
+
+    assert.strictEqual(result.isOk, true);
+});
+
+const publicWithAllowScripts = { publishSettings: { access: 'public', allowScripts: true } };
+const commonScriptsAttribute = { additionalPackageJsonAttributes: { scripts: postinstallScripts } };
+const fooPackageWithScripts: ConfigInput = {
+    name: 'foo',
+    entryPoints: [{ js: 'foo' }],
+    additionalPackageJsonAttributes: { scripts: postinstallScripts }
+};
+
+test('accepts a config with per-package scripts and common allowScripts true', () => {
+    const result = validateConfig(withCustomCommon(publicWithAllowScripts, [fooPackageWithScripts]));
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a config with common scripts and common allowScripts true and per-package nothing', () => {
+    const result = validateConfig(
+        withCustomCommon({ ...commonScriptsAttribute, ...publicWithAllowScripts }, [fooPackage()])
+    );
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('accepts a config with allowScripts true but no scripts anywhere', () => {
+    const result = validateConfig(withCustomCommon(publicWithAllowScripts, [fooPackage()]));
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('rejects a config with per-package scripts and no allowScripts anywhere', () => {
+    const result = validateConfig(withRegistry({ packages: [fooPackageWithScripts] }));
+
+    assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo')]));
+});
+
+test('rejects every package when common scripts and no allowScripts anywhere', () => {
+    const result = validateConfig(
+        withCustomCommon({ ...commonScriptsAttribute, publishSettings: { access: 'public' } }, [
+            fooPackage(),
+            fooPackage('bar')
+        ])
+    );
+
+    assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo'), allowScriptsErrorFor('bar')]));
+});
+
+test('rejects with both placement and allowScripts errors when scripts are set but publishSettings is missing', () => {
+    const result = validateConfig(withCommonWithoutPublishSettings([fooPackageWithScripts]));
+
+    assert.deepStrictEqual(result, Result.err([placementErrorMessage, allowScriptsErrorFor('foo')]));
+});
+
+test('rejects when common allows scripts but per-package replaces publishSettings without allowScripts', () => {
+    const result = validateConfig(
+        withCustomCommon({ ...commonScriptsAttribute, ...publicWithAllowScripts }, [
+            { name: 'foo', entryPoints: [{ js: 'foo' }], publishSettings: { access: 'public' } }
+        ])
+    );
+
+    assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo')]));
 });

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -139,6 +139,25 @@ function validatePublishSettingsArePlaced(packtoryConfig: Readonly<PacktoryConfi
     return ['publishSettings must be set in commonPackageSettings or in every package'];
 }
 
+function validateAllowScriptsConsistency(packtoryConfig: Readonly<PacktoryConfigWithoutRegistry>): readonly string[] {
+    const commonAttributes = packtoryConfig.commonPackageSettings?.additionalPackageJsonAttributes;
+    const commonPublishSettings = packtoryConfig.commonPackageSettings?.publishSettings;
+
+    return packtoryConfig.packages.flatMap((packageConfig) => {
+        const mergedAttributes = { ...commonAttributes, ...packageConfig.additionalPackageJsonAttributes };
+        const resolvedPublishSettings = packageConfig.publishSettings ?? commonPublishSettings;
+
+        if (!('scripts' in mergedAttributes)) {
+            return [];
+        }
+        if (resolvedPublishSettings?.allowScripts === true) {
+            return [];
+        }
+        const prefix = `Package "${packageConfig.name}": "scripts" in additionalPackageJsonAttributes`;
+        return [`${prefix} requires "publishSettings.allowScripts: true"`];
+    });
+}
+
 function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWithoutRegistry>(
     schema: ZodMiniType<TConfig>,
     config: unknown
@@ -154,6 +173,7 @@ function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWith
 
     const preGraphIssues = [
         ...validatePublishSettingsArePlaced(packtoryConfig),
+        ...validateAllowScriptsConsistency(packtoryConfig),
         ...validateDependenciesExist(packageConfigs),
         ...validateNoDuplicatedFilesAllowList(packageConfigs, packtoryConfig.checks)
     ];

--- a/source/version-manager/manifest/builder.test.ts
+++ b/source/version-manager/manifest/builder.test.ts
@@ -58,6 +58,21 @@ test('buildPackageManifest() includes dependency, peer dependency, type, and typ
     });
 });
 
+test('buildPackageManifest() passes through a scripts block from additional attributes', () => {
+    const result = buildPackageManifest(
+        createBundle({
+            additionalAttributes: { scripts: { postinstall: 'echo hi' } }
+        })
+    );
+
+    assert.deepStrictEqual(result, {
+        name: 'package-a',
+        version: '1.2.3',
+        main: 'index.js',
+        scripts: { postinstall: 'echo hi' }
+    });
+});
+
 test('buildPackageManifest() lets generated manifest fields override conflicting additional attributes', () => {
     const result = buildPackageManifest(
         createBundle({


### PR DESCRIPTION
Add `publishSettings.allowScripts` (default off) so a `scripts` key in `additionalPackageJsonAttributes` is rejected unless the resolved publish settings explicitly allow it. Closes the supply-chain hole where `additionalPackageJsonAttributes` could spread arbitrary `preinstall`/`postinstall`/`prepare` hooks into the published manifest. The check runs on the merged attributes against the resolved publish settings so the asymmetric merge between `additionalPackageJsonAttributes` (merged) and `publishSettings` (replaced) cannot smuggle scripts past validation.