### PR TITLE
Expand the checks framework with five new rules

### DIFF
--- a/integration-tests/fixtures/independent-packages/package.json
+++ b/integration-tests/fixtures/independent-packages/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "independent-packages-fixture",
+    "version": "0.0.0-dev",
+    "type": "module"
+}

--- a/integration-tests/fixtures/independent-packages/src/pkg-a/index.js
+++ b/integration-tests/fixtures/independent-packages/src/pkg-a/index.js
@@ -1,0 +1,1 @@
+export const packageAValue = 'A';

--- a/integration-tests/fixtures/independent-packages/src/pkg-b/index.js
+++ b/integration-tests/fixtures/independent-packages/src/pkg-b/index.js
@@ -1,0 +1,1 @@
+export const packageBValue = 'B';

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -94,6 +94,42 @@ test('resolveAndLinkAll succeeds when every owner consents to the duplicated fil
     assert.strictEqual(result.value.length, 2);
 });
 
+test('resolveAndLinkAll reports an external dependency that is only declared in devDependencies', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/with-peer-dependencies');
+    const config: PacktoryConfigWithoutRegistry = {
+        commonPackageSettings: {
+            sourcesFolder: path.join(fixturePath, 'src'),
+            mainPackageJson: {
+                type: 'module',
+                devDependencies: { 'example-module': '1.2.3' }
+            },
+            publishSettings: { access: 'public' }
+        },
+        checks: { noDevDependencyImports: { enabled: true } },
+        packages: [
+            {
+                name: 'leaky',
+                entryPoints: [{ js: path.join(fixturePath, 'src/entry.js') }]
+            }
+        ]
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected resolveAndLinkAll to fail because example-module is dev-only');
+        return;
+    }
+
+    if (result.error.type === 'checks') {
+        assert.deepStrictEqual(result.error.issues, [
+            'Package "leaky" imports "example-module" which is only declared in devDependencies of the main package.json'
+        ]);
+    } else {
+        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+    }
+});
+
 test('resolveAndLinkAll reports a declared bundleDependency that is never imported', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -70,6 +70,24 @@ test('resolveAndLinkAll succeeds when checks are disabled', async () => {
     assert.strictEqual(result.value.length, 2);
 });
 
+test('resolveAndLinkAll succeeds when the global allowList covers the duplicated file', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const sharedFile = `${fixturePath}/src/shared/util.js`;
+    const config = {
+        ...baseConfig,
+        checks: { noDuplicatedFiles: { enabled: true, allowList: [sharedFile] } }
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isOk) {
+        assert.fail('Globally allow-listed shared file should not fail checks');
+    }
+
+    assert.strictEqual(result.value.length, 2);
+});
+
 test('resolveAndLinkAll succeeds when every owner consents to the duplicated file', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);
@@ -165,12 +183,12 @@ test('resolveAndLinkAll reports an external dependency that is only declared in 
 });
 
 test('resolveAndLinkAll reports a declared bundleDependency that is never imported', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/independent-packages');
     const baseConfig = await createBaseConfig(fixturePath);
     const config = {
         ...baseConfig,
         checks: { noUnusedBundleDependencies: { enabled: true } },
-        packages: [{ ...baseConfig.packages[0]!, bundleDependencies: ['pkg-b'] }, baseConfig.packages[1]!]
+        packages: [baseConfig.packages[1]!, { ...baseConfig.packages[0]!, bundleDependencies: ['pkg-b'] }]
     };
 
     const result = await resolveAndLinkAll(config);

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -70,126 +70,58 @@ test('resolveAndLinkAll succeeds when checks are disabled', async () => {
     assert.strictEqual(result.value.length, 2);
 });
 
-test('resolveAndLinkAll succeeds when duplicated files are allow-listed', async () => {
+test('resolveAndLinkAll succeeds when every owner consents to the duplicated file', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);
+    const sharedFile = `${fixturePath}/src/shared/util.js`;
     const config = {
         ...baseConfig,
-        checks: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [`${fixturePath}/src/shared/util.js`]
-            }
-        }
+        checks: { noDuplicatedFiles: { enabled: true } },
+        packages: baseConfig.packages.map((packageConfig) => {
+            return {
+                ...packageConfig,
+                checks: { noDuplicatedFiles: { allowList: [sharedFile] } }
+            };
+        })
     };
 
     const result = await resolveAndLinkAll(config);
 
     if (!result.isOk) {
-        assert.fail('Duplicated files that are allow-listed should not fail checks');
+        assert.fail('Owners that all consent to the shared file should not fail checks');
     }
 
     assert.strictEqual(result.value.length, 2);
 });
 
-test('resolveAndLinkAll succeeds when a scoped allow-list entry covers all owners of the duplicated file', async () => {
+test('resolveAndLinkAll reports the duplicate when one owner does not consent', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);
+    const sharedFile = `${fixturePath}/src/shared/util.js`;
     const config = {
         ...baseConfig,
-        checks: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [
-                    {
-                        filePath: `${fixturePath}/src/shared/util.js`,
-                        packages: ['pkg-a', 'pkg-b']
-                    }
-                ]
-            }
-        }
-    };
-
-    const result = await resolveAndLinkAll(config);
-
-    if (!result.isOk) {
-        assert.fail('Scoped allow-list entry covering all owners should not fail checks');
-    }
-
-    assert.strictEqual(result.value.length, 2);
-});
-
-test('resolveAndLinkAll reports the duplicate when an owner is outside the scoped allow-list entry', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const config = {
-        ...baseConfig,
+        checks: { noDuplicatedFiles: { enabled: true } },
         packages: [
-            ...baseConfig.packages,
             {
-                name: 'pkg-c',
-                entryPoints: [{ js: path.join(fixturePath, 'src/pkg-c/index.js') }]
-            }
-        ],
-        checks: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [
-                    {
-                        filePath: `${fixturePath}/src/shared/util.js`,
-                        packages: ['pkg-a', 'pkg-b']
-                    }
-                ]
-            }
-        }
+                ...baseConfig.packages[0]!,
+                checks: { noDuplicatedFiles: { allowList: [sharedFile] } }
+            },
+            baseConfig.packages[1]!
+        ]
     };
 
     const result = await resolveAndLinkAll(config);
 
     if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because pkg-c is outside the scoped allow-list entry');
+        assert.fail('Expected resolveAndLinkAll to fail because pkg-b did not consent');
         return;
     }
 
     if (result.error.type === 'checks') {
         assert.deepStrictEqual(result.error.issues, [
-            `File "${fixturePath}/src/shared/util.js" is included in multiple packages: pkg-a, pkg-b, pkg-c`
+            `File "${sharedFile}" is included in multiple packages: pkg-a, pkg-b`
         ]);
     } else {
         assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
-});
-
-test('resolveAndLinkAll fails validation when a scoped allow-list entry references an unknown package', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const config = {
-        ...baseConfig,
-        checks: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [
-                    {
-                        filePath: `${fixturePath}/src/shared/util.js`,
-                        packages: ['pkg-a', 'ghost']
-                    }
-                ]
-            }
-        }
-    };
-
-    const result = await resolveAndLinkAll(config);
-
-    if (!result.isErr) {
-        assert.fail('Expected validation to fail because of the unknown package reference');
-        return;
-    }
-
-    if (result.error.type === 'config') {
-        assert.deepStrictEqual(result.error.issues, [
-            `Allow list entry for "${fixturePath}/src/shared/util.js" references unknown package "ghost"`
-        ]);
-    } else {
-        assert.fail(`Expected a config failure, but received "${result.error.type}"`);
     }
 });

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -94,6 +94,31 @@ test('resolveAndLinkAll succeeds when every owner consents to the duplicated fil
     assert.strictEqual(result.value.length, 2);
 });
 
+test('resolveAndLinkAll reports a missing required file for every bundle that lacks it', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const config = {
+        ...baseConfig,
+        checks: { requiredFiles: { enabled: true, files: ['LICENSE'] } }
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected resolveAndLinkAll to fail because of missing required files');
+        return;
+    }
+
+    if (result.error.type === 'checks') {
+        assert.deepStrictEqual(result.error.issues, [
+            'Package "pkg-a" is missing required file "LICENSE"',
+            'Package "pkg-b" is missing required file "LICENSE"'
+        ]);
+    } else {
+        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+    }
+});
+
 test('resolveAndLinkAll reports the duplicate when one owner does not consent', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -94,6 +94,39 @@ test('resolveAndLinkAll succeeds when every owner consents to the duplicated fil
     assert.strictEqual(result.value.length, 2);
 });
 
+test('resolveAndLinkAll reports a per-package bundle size override that is exceeded', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const config = {
+        ...baseConfig,
+        checks: { maxBundleSize: { enabled: true, bytes: 10_000 } },
+        packages: [
+            {
+                ...baseConfig.packages[0]!,
+                checks: { maxBundleSize: { bytes: 1 } }
+            },
+            baseConfig.packages[1]!
+        ]
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected resolveAndLinkAll to fail because pkg-a exceeds its size override');
+        return;
+    }
+
+    if (result.error.type === 'checks') {
+        assert.strictEqual(result.error.issues.length, 1);
+        assert.match(
+            result.error.issues[0]!,
+            /^Package "pkg-a" exceeds the maximum bundle size: \d+ bytes \(limit: 1 bytes\)$/u
+        );
+    } else {
+        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+    }
+});
+
 test('resolveAndLinkAll reports a missing required file for every bundle that lacks it', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -94,6 +94,29 @@ test('resolveAndLinkAll succeeds when every owner consents to the duplicated fil
     assert.strictEqual(result.value.length, 2);
 });
 
+test('resolveAndLinkAll reports a declared bundleDependency that is never imported', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const config = {
+        ...baseConfig,
+        checks: { noUnusedBundleDependencies: { enabled: true } },
+        packages: [{ ...baseConfig.packages[0]!, bundleDependencies: ['pkg-b'] }, baseConfig.packages[1]!]
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected resolveAndLinkAll to fail because pkg-a does not import from pkg-b');
+        return;
+    }
+
+    if (result.error.type === 'checks') {
+        assert.deepStrictEqual(result.error.issues, ['Unused bundle dependency "pkg-b" declared by package "pkg-a"']);
+    } else {
+        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+    }
+});
+
 test('resolveAndLinkAll reports a per-package bundle size override that is exceeded', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
     const baseConfig = await createBaseConfig(fixturePath);

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -94,6 +94,40 @@ test('resolveAndLinkAll succeeds when every owner consents to the duplicated fil
     assert.strictEqual(result.value.length, 2);
 });
 
+test('resolveAndLinkAll reports a colliding targetFilePath inside a bundle', async () => {
+    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+    const baseConfig = await createBaseConfig(fixturePath);
+    const collidingSource = path.join(fixturePath, 'package.json');
+    const config = {
+        ...baseConfig,
+        checks: { uniqueTargetPaths: { enabled: true } },
+        packages: [
+            {
+                ...baseConfig.packages[0]!,
+                additionalFiles: [{ sourceFilePath: collidingSource, targetFilePath: 'pkg-a/index.js' }]
+            },
+            baseConfig.packages[1]!
+        ]
+    };
+
+    const result = await resolveAndLinkAll(config);
+
+    if (!result.isErr) {
+        assert.fail('Expected resolveAndLinkAll to fail because of a colliding target path');
+        return;
+    }
+
+    if (result.error.type === 'checks') {
+        assert.strictEqual(result.error.issues.length, 1);
+        assert.match(result.error.issues[0]!, /^Package "pkg-a" maps multiple sources to "pkg-a\/index.js":/u);
+    } else if (result.error.type === 'partial') {
+        const failureMessages = result.error.error.failures.map((failure) => failure.message).join('; ');
+        assert.fail(`Resolve/link failed unexpectedly: ${failureMessages}`);
+    } else {
+        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+    }
+});
+
 test('resolveAndLinkAll reports an external dependency that is only declared in devDependencies', async () => {
     const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/with-peer-dependencies');
     const config: PacktoryConfigWithoutRegistry = {

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -16,13 +16,13 @@ export async function buildConfig() {
         throw new Error('Missing NPM_TOKEN environment variable');
     }
 
+    const sharedLicensePath = path.join(projectFolder, 'LICENSE');
+    const licenseConsent = { noDuplicatedFiles: { allowList: [sharedLicensePath] } };
+
     return {
         registrySettings: { token: npmToken },
         checks: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [path.join(projectFolder, 'LICENSE')]
-            }
+            noDuplicatedFiles: { enabled: true }
         },
         commonPackageSettings: {
             sourcesFolder,
@@ -30,7 +30,7 @@ export async function buildConfig() {
             includeSourceMapFiles: true,
             additionalFiles: [
                 {
-                    sourceFilePath: path.join(projectFolder, 'LICENSE'),
+                    sourceFilePath: sharedLicensePath,
                     targetFilePath: 'LICENSE'
                 }
             ],
@@ -60,7 +60,8 @@ export async function buildConfig() {
                         sourceFilePath: path.join(projectFolder, 'source/packages/packtory/readme.md'),
                         targetFilePath: 'readme.md'
                     }
-                ]
+                ],
+                checks: licenseConsent
             },
             {
                 name: '@packtory/cli',
@@ -83,7 +84,8 @@ export async function buildConfig() {
                         targetFilePath: 'readme.md'
                     }
                 ],
-                bundleDependencies: ['packtory']
+                bundleDependencies: ['packtory'],
+                checks: licenseConsent
             }
         ]
     };

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -17,12 +17,11 @@ export async function buildConfig() {
     }
 
     const sharedLicensePath = path.join(projectFolder, 'LICENSE');
-    const licenseConsent = { noDuplicatedFiles: { allowList: [sharedLicensePath] } };
 
     return {
         registrySettings: { token: npmToken },
         checks: {
-            noDuplicatedFiles: { enabled: true }
+            noDuplicatedFiles: { enabled: true, allowList: [sharedLicensePath] }
         },
         commonPackageSettings: {
             sourcesFolder,
@@ -60,8 +59,7 @@ export async function buildConfig() {
                         sourceFilePath: path.join(projectFolder, 'source/packages/packtory/readme.md'),
                         targetFilePath: 'readme.md'
                     }
-                ],
-                checks: licenseConsent
+                ]
             },
             {
                 name: '@packtory/cli',
@@ -84,8 +82,7 @@ export async function buildConfig() {
                         targetFilePath: 'readme.md'
                     }
                 ],
-                bundleDependencies: ['packtory'],
-                checks: licenseConsent
+                bundleDependencies: ['packtory']
             }
         ]
     };

--- a/readme.md
+++ b/readme.md
@@ -228,21 +228,29 @@ checks: {
 
 Reports any source file that ends up in more than one bundle.
 
-- **Top-level:** `enabled: boolean`.
-- **Per-package:** `allowList?: string[]` — files this package consents to share with other packages. A duplicate is allowed iff _every_ owning bundle's allowList contains the file path. A package that does not list a file effectively vetoes any duplicate involving it.
+- **Top-level:** `enabled: boolean`, `allowList?: string[]` — files that may appear in any number of bundles unconditionally. Use this for files you intentionally distribute across every package (e.g. a shared `LICENSE` injected via `commonPackageSettings.additionalFiles`).
+- **Per-package:** `allowList?: string[]` — files this package consents to share with other packages.
+
+A duplicate is suppressed iff the file is in the top-level `allowList`, **or** every owning bundle's per-package `allowList` contains it. A package that does not list a file (and that file is not globally allow-listed) effectively vetoes any duplicate involving it.
 
 ```javascript
+// Blanket allow — every bundle may ship the shared LICENSE
+checks: { noDuplicatedFiles: { enabled: true, allowList: [path.join(projectFolder, 'LICENSE')] } }
+```
+
+```javascript
+// Per-package consent — pkg-a and pkg-b agree to share util.ts; nobody else may
 checks: { noDuplicatedFiles: { enabled: true } },
 packages: [
     {
         name: 'pkg-a',
         entryPoints: [{ js: 'a.js' }],
-        checks: { noDuplicatedFiles: { allowList: [path.join(projectFolder, 'LICENSE')] } }
+        checks: { noDuplicatedFiles: { allowList: ['util.ts'] } }
     },
     {
         name: 'pkg-b',
         entryPoints: [{ js: 'b.js' }],
-        checks: { noDuplicatedFiles: { allowList: [path.join(projectFolder, 'LICENSE')] } }
+        checks: { noDuplicatedFiles: { allowList: ['util.ts'] } }
     }
 ]
 ```

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,10 @@ The configuration for `packtory` is an object with the following properties:
     - Defines settings that can be shared for all packages.
     - Allowed settings: `sourcesFolder`, `mainPackageJson`, `includeSourceMapFiles`, `additionalFiles`, `additionalPackageJsonAttributes`, `publishSettings`.
 
-3. **`packages`** (Required, Array):
+3. **`checks`** (Optional, Object):
+    - Toggles and configures the cross-package checks that run after every bundle has been linked. Lives at the top level (not inside `commonPackageSettings`) because every check operates over the full set of bundles. See [Checks](#checks).
+
+4. **`packages`** (Required, Array):
     - An array of per-package configurations.
     - Each per-package configuration has the following settings:
 
@@ -183,6 +186,9 @@ The configuration for `packtory` is an object with the following properties:
     - **`bundlePeerDependencies`** (Optional, Array of Strings):
         - Similar to `bundleDependencies` but represented as `peerDependencies` in the generated `package.json`.
 
+    - **`checks`** (Optional, Object):
+        - Per-package contribution to the configured checks. See [Checks](#checks). Each enabled check decides whether per-package overrides apply to it; rules without per-package configuration accept only an empty object for that key.
+
     - **`publishSettings`** (Required somewhere):
         - Controls how the package is published. Must be set in `commonPackageSettings` (as a default for every package), in every package entry, or both. If neither is set, validation rejects the config with `publishSettings must be set in commonPackageSettings or in every package`.
         - A discriminated union on `access`:
@@ -197,6 +203,101 @@ The configuration for `packtory` is an object with the following properties:
 **Note**: Per-package settings override or merge with common settings when both are defined.
 
 This comprehensive configuration allows fine-tuning for individual packages and provides flexibility in defining dependencies and additional files.
+
+## Checks
+
+Checks are post-bundling validations that run after every bundle has been linked. They operate over the full set of bundles, so a single rule can flag issues that span multiple packages (e.g. duplicated files). Configuration is split across two scopes:
+
+- **Top-level `checks`** — a sibling of `commonPackageSettings` and `packages`. Toggles each rule via `enabled` and holds any cross-package or default settings the rule needs. A rule cannot be disabled per package.
+- **Per-package `checks`** — lives on each `PackageConfig`. Carries that package's contribution to (or override of) a rule's settings. Only rules that document per-package fields accept anything beyond `{}` here.
+
+If `checks` is omitted, every rule is off.
+
+```javascript
+checks: {
+    noDuplicatedFiles: { enabled: true },
+    requiredFiles: { enabled: true, files: ['LICENSE'] },
+    maxBundleSize: { enabled: true, bytes: 500_000 },
+    noUnusedBundleDependencies: { enabled: true },
+    noDevDependencyImports: { enabled: true },
+    uniqueTargetPaths: { enabled: true }
+}
+```
+
+### `noDuplicatedFiles`
+
+Reports any source file that ends up in more than one bundle.
+
+- **Top-level:** `enabled: boolean`.
+- **Per-package:** `allowList?: string[]` — files this package consents to share with other packages. A duplicate is allowed iff _every_ owning bundle's allowList contains the file path. A package that does not list a file effectively vetoes any duplicate involving it.
+
+```javascript
+checks: { noDuplicatedFiles: { enabled: true } },
+packages: [
+    {
+        name: 'pkg-a',
+        entryPoints: [{ js: 'a.js' }],
+        checks: { noDuplicatedFiles: { allowList: [path.join(projectFolder, 'LICENSE')] } }
+    },
+    {
+        name: 'pkg-b',
+        entryPoints: [{ js: 'b.js' }],
+        checks: { noDuplicatedFiles: { allowList: [path.join(projectFolder, 'LICENSE')] } }
+    }
+]
+```
+
+### `requiredFiles`
+
+Each bundle must contain every file in the effective list, matched on the bundle's `targetFilePath`.
+
+- **Top-level:** `enabled: boolean`, `files?: string[]` — defaults applied to every package.
+- **Per-package:** `files?: string[]` — extends the global list. The effective list is the deduplicated union of both.
+
+```javascript
+checks: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } }
+```
+
+### `maxBundleSize`
+
+Reports any bundle whose resources sum to more than the configured byte limit, measured as UTF-8 byte length.
+
+- **Top-level:** `enabled: boolean`, `bytes?: number` — default threshold for every package.
+- **Per-package:** `bytes?: number` — overrides the global default for that package.
+- A bundle without any applicable threshold (no global default and no per-package value) is skipped.
+
+```javascript
+checks: { maxBundleSize: { enabled: true, bytes: 500_000 } },
+packages: [
+    {
+        name: 'image-resizer-cli',
+        entryPoints: [{ js: 'cli.js' }],
+        checks: { maxBundleSize: { bytes: 2_000_000 } }
+    }
+]
+```
+
+### `noUnusedBundleDependencies`
+
+Reports declared `bundleDependencies` and `bundlePeerDependencies` whose imports were never substituted by the linker — i.e. no file in the bundle imports anything from the named package, so the declaration is dead config.
+
+- **Top-level:** `enabled: boolean`.
+- **Per-package:** `{}` only.
+
+### `noDevDependencyImports`
+
+Reports any external dependency reachable from a package's source that is declared only in `mainPackageJson.devDependencies` and not in `dependencies` or `peerDependencies`. Catches dev-only deps that have leaked into runtime imports — a likely break for downstream consumers.
+
+- **Top-level:** `enabled: boolean`.
+- **Per-package:** `{}` only.
+- The effective `mainPackageJson` is resolved per package (per-package overrides `commonPackageSettings`) before the rule runs.
+
+### `uniqueTargetPaths`
+
+Reports any bundle where two resources resolve to the same `targetFilePath`. Typically arises when an `additionalFiles` entry's `targetFilePath` collides with the relative path of an already-resolved local file; without this rule the artifact writer silently overwrites one with the other.
+
+- **Top-level:** `enabled: boolean`.
+- **Per-package:** `{}` only.
 
 ## Example Use-Cases
 

--- a/source/checks/check-runner.test.ts
+++ b/source/checks/check-runner.test.ts
@@ -7,6 +7,7 @@ test('does not invoke any rule when settings are empty', () => {
     const issues = runChecks({
         settings: {},
         perPackageSettings: new Map(),
+        packageConfigs: {},
         bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
     });
 
@@ -17,6 +18,7 @@ test('dispatches an enabled rule with the provided bundles and aggregates its is
     const issues = runChecks({
         settings: { noDuplicatedFiles: { enabled: true } },
         perPackageSettings: new Map(),
+        packageConfigs: {},
         bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
     });
 
@@ -31,6 +33,7 @@ test('threads per-package settings through to the rule for cross-package consent
             ['a', consent],
             ['b', consent]
         ]),
+        packageConfigs: {},
         bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
     });
 

--- a/source/checks/check-runner.test.ts
+++ b/source/checks/check-runner.test.ts
@@ -1,102 +1,38 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import type { LinkedBundle } from '../linker/linked-bundle.ts';
+import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
 import { runChecks } from './check-runner.ts';
 
-function createBundle(name: string, filePaths: readonly string[]): LinkedBundle {
-    return {
-        name,
-        contents: filePaths.map((filePath) => {
-            return {
-                fileDescription: {
-                    sourceFilePath: filePath,
-                    targetFilePath: filePath,
-                    content: '',
-                    isExecutable: false
-                },
-                directDependencies: new Set<string>(),
-                isSubstituted: false,
-                isExplicitlyIncluded: false
-            };
-        }),
-        entryPoints: [
-            {
-                js: {
-                    sourceFilePath: `${name}/index.js`,
-                    targetFilePath: 'index.js',
-                    content: '',
-                    isExecutable: false
-                }
-            }
-        ],
-        linkedBundleDependencies: new Map(),
-        externalDependencies: new Map()
-    };
-}
-
-test('does not report issues when checks are disabled', () => {
+test('does not invoke any rule when settings are empty', () => {
     const issues = runChecks({
         settings: {},
-        bundles: [createBundle('a', ['file-a.ts']), createBundle('b', ['file-b.ts'])]
+        perPackageSettings: new Map(),
+        bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
     });
 
     assert.deepStrictEqual(issues, []);
 });
 
-test('reports duplicate files when the rule is enabled', () => {
+test('dispatches an enabled rule with the provided bundles and aggregates its issues', () => {
     const issues = runChecks({
         settings: { noDuplicatedFiles: { enabled: true } },
-        bundles: [createBundle('a', ['shared.ts']), createBundle('b', ['shared.ts'])]
+        perPackageSettings: new Map(),
+        bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
     });
 
     assert.deepStrictEqual(issues, ['File "shared.ts" is included in multiple packages: a, b']);
 });
 
-test('runChecks() executes the configured rule set instead of returning a static empty array', () => {
+test('threads per-package settings through to the rule for cross-package consent decisions', () => {
+    const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
     const issues = runChecks({
         settings: { noDuplicatedFiles: { enabled: true } },
-        bundles: [createBundle('b', ['shared.ts']), createBundle('a', ['shared.ts'])]
-    });
-
-    assert.strictEqual(issues.length, 1);
-    assert.strictEqual(issues[0], 'File "shared.ts" is included in multiple packages: a, b');
-});
-
-test('returns the duplicate-file issues only from the configured rule set', () => {
-    const issues = runChecks({
-        settings: { noDuplicatedFiles: { enabled: true, allowList: ['ignored.ts'] } },
-        bundles: [createBundle('a', ['ignored.ts', 'shared.ts']), createBundle('b', ['ignored.ts', 'shared.ts'])]
-    });
-
-    assert.deepStrictEqual(issues, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('ignores duplicate files when the rule is disabled', () => {
-    const issues = runChecks({
-        settings: {},
-        bundles: [createBundle('a', ['shared.ts']), createBundle('b', ['shared.ts'])]
+        perPackageSettings: new Map([
+            ['a', consent],
+            ['b', consent]
+        ]),
+        bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
     });
 
     assert.deepStrictEqual(issues, []);
-});
-
-test('ignores duplicate files that are present in the allow list', () => {
-    const issues = runChecks({
-        settings: { noDuplicatedFiles: { enabled: true, allowList: ['shared.ts'] } },
-        bundles: [createBundle('a', ['shared.ts']), createBundle('b', ['shared.ts']), createBundle('c', ['other.ts'])]
-    });
-
-    assert.deepStrictEqual(issues, []);
-});
-
-test('reports duplicate files that are not present in the allow list', () => {
-    const issues = runChecks({
-        settings: { noDuplicatedFiles: { enabled: true, allowList: ['shared.ts'] } },
-        bundles: [
-            createBundle('a', ['shared.ts', 'not-allowed.ts']),
-            createBundle('b', ['shared.ts', 'not-allowed.ts'])
-        ]
-    });
-
-    assert.deepStrictEqual(issues, ['File "not-allowed.ts" is included in multiple packages: a, b']);
 });

--- a/source/checks/check-runner.ts
+++ b/source/checks/check-runner.ts
@@ -1,17 +1,15 @@
-import type { ChecksSettings } from '../config/config.ts';
-import type { CheckContext } from './rule.ts';
-import { isNoDuplicatedFilesRuleEnabled, runNoDuplicatedFilesRule } from './rules/no-duplicated-files.ts';
+import type { ChecksSettings, PackageChecksSettings } from '../config/config.ts';
+import type { LinkedBundle } from '../linker/linked-bundle.ts';
+import { allRules } from './rules/registry.ts';
 
-export type CheckRunnerParams = CheckContext & {
+export type CheckRunnerParams = {
+    readonly bundles: readonly LinkedBundle[];
     readonly settings: ChecksSettings | undefined;
+    readonly perPackageSettings: ReadonlyMap<string, PackageChecksSettings | undefined>;
 };
 
 export function runChecks(params: CheckRunnerParams): readonly string[] {
-    const { settings, bundles: packages } = params;
-
-    if (!isNoDuplicatedFilesRuleEnabled(settings)) {
-        return [];
-    }
-
-    return runNoDuplicatedFilesRule({ bundles: packages }, settings);
+    return allRules.flatMap((rule) => {
+        return rule.run(params);
+    });
 }

--- a/source/checks/check-runner.ts
+++ b/source/checks/check-runner.ts
@@ -1,4 +1,4 @@
-import type { ChecksSettings, PackageChecksSettings } from '../config/config.ts';
+import type { ChecksSettings, PackageChecksSettings, PackageConfigsByName } from '../config/config.ts';
 import type { LinkedBundle } from '../linker/linked-bundle.ts';
 import { allRules } from './rules/registry.ts';
 
@@ -6,6 +6,7 @@ export type CheckRunnerParams = {
     readonly bundles: readonly LinkedBundle[];
     readonly settings: ChecksSettings | undefined;
     readonly perPackageSettings: ReadonlyMap<string, PackageChecksSettings | undefined>;
+    readonly packageConfigs: PackageConfigsByName;
 };
 
 export function runChecks(params: CheckRunnerParams): readonly string[] {

--- a/source/checks/rule.ts
+++ b/source/checks/rule.ts
@@ -5,6 +5,11 @@ type RuleGlobalConfig = {
     readonly enabled: boolean;
 };
 
+export type RulePackageConfig = {
+    readonly bundleDependencies?: readonly string[] | undefined;
+    readonly bundlePeerDependencies?: readonly string[] | undefined;
+};
+
 export type RuleRunParams<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {
     readonly bundles: readonly LinkedBundle[];
     readonly settings: Readonly<Partial<Record<TName, TGlobal | undefined>>> | undefined;
@@ -12,6 +17,7 @@ export type RuleRunParams<TName extends string, TGlobal extends RuleGlobalConfig
         string,
         Readonly<Partial<Record<TName, TPerPackage | undefined>>> | undefined
     >;
+    readonly packageConfigs?: Readonly<Record<string, RulePackageConfig>>;
 };
 
 export type CheckRuleDefinition<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {

--- a/source/checks/rule.ts
+++ b/source/checks/rule.ts
@@ -1,13 +1,23 @@
-import type { ZodMiniType } from 'zod/mini';
+import { z, type ZodMiniType } from 'zod/mini';
 import type { LinkedBundle } from '../linker/linked-bundle.ts';
+
+export const enabledOnlyGlobalSchema = z.strictObject({ enabled: z.boolean() });
+export const emptyPerPackageSchema = z.strictObject({});
 
 type RuleGlobalConfig = {
     readonly enabled: boolean;
 };
 
+type MainPackageJsonShape = {
+    readonly dependencies?: Readonly<Record<string, string>> | undefined;
+    readonly devDependencies?: Readonly<Record<string, string>> | undefined;
+    readonly peerDependencies?: Readonly<Record<string, string>> | undefined;
+};
+
 export type RulePackageConfig = {
     readonly bundleDependencies?: readonly string[] | undefined;
     readonly bundlePeerDependencies?: readonly string[] | undefined;
+    readonly mainPackageJson?: MainPackageJsonShape | undefined;
 };
 
 export type RuleRunParams<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {

--- a/source/checks/rule.ts
+++ b/source/checks/rule.ts
@@ -1,5 +1,22 @@
+import type { ZodMiniType } from 'zod/mini';
 import type { LinkedBundle } from '../linker/linked-bundle.ts';
 
-export type CheckContext = {
+type RuleGlobalConfig = {
+    readonly enabled: boolean;
+};
+
+export type RuleRunParams<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {
     readonly bundles: readonly LinkedBundle[];
+    readonly settings: Readonly<Partial<Record<TName, TGlobal | undefined>>> | undefined;
+    readonly perPackageSettings: ReadonlyMap<
+        string,
+        Readonly<Partial<Record<TName, TPerPackage | undefined>>> | undefined
+    >;
+};
+
+export type CheckRuleDefinition<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {
+    readonly name: TName;
+    readonly globalSchema: ZodMiniType<TGlobal>;
+    readonly perPackageSchema: ZodMiniType<TPerPackage>;
+    readonly run: (params: RuleRunParams<TName, TGlobal, TPerPackage>) => readonly string[];
 };

--- a/source/checks/rules/max-bundle-size.test.ts
+++ b/source/checks/rules/max-bundle-size.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import { bundleResource, linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
+import { maxBundleSizeRule } from './max-bundle-size.ts';
+
+function bundleWithBytes(name: string, bytes: number): LinkedBundle {
+    return linkedBundle({
+        name,
+        contents: [{ ...bundleResource(`/${name}/index.js`, { content: 'a'.repeat(bytes) }), isSubstituted: false }]
+    });
+}
+
+test('rule definition exposes name, schemas and a run function', () => {
+    assert.strictEqual(maxBundleSizeRule.name, 'maxBundleSize');
+    assert.strictEqual(typeof maxBundleSizeRule.run, 'function');
+});
+
+test('returns no issues when settings are missing', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: undefined,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the rule is disabled', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: false, bytes: 10 } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when neither global nor per-package threshold is set', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: true } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports a bundle exceeding the global threshold', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: true, bytes: 50 } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
+});
+
+test('passes a bundle exactly at the threshold', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: true, bytes: 100 } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('per-package bytes overrides the global default upward', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: true, bytes: 50 } },
+        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 1000 } }]])
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('per-package bytes overrides the global default downward', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: true, bytes: 1000 } },
+        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
+});
+
+test('per-package bytes acts as the threshold when no global default is set', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100), bundleWithBytes('b', 100)],
+        settings: { maxBundleSize: { enabled: true } },
+        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
+});
+
+test('measures bundle size as the UTF-8 byte length of every resource’s content', () => {
+    const bundle = linkedBundle({
+        name: 'multi',
+        contents: [
+            { ...bundleResource('/multi/a.js', { content: 'ä' }), isSubstituted: false },
+            { ...bundleResource('/multi/b.js', { content: 'ab' }), isSubstituted: false }
+        ]
+    });
+
+    const result = maxBundleSizeRule.run({
+        bundles: [bundle],
+        settings: { maxBundleSize: { enabled: true, bytes: 3 } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, ['Package "multi" exceeds the maximum bundle size: 4 bytes (limit: 3 bytes)']);
+});

--- a/source/checks/rules/max-bundle-size.test.ts
+++ b/source/checks/rules/max-bundle-size.test.ts
@@ -66,24 +66,22 @@ test('passes a bundle exactly at the threshold', () => {
     assert.deepStrictEqual(result, []);
 });
 
-test('per-package bytes overrides the global default upward', () => {
-    const result = maxBundleSizeRule.run({
+function runWithGlobalAndOverride(globalBytes: number, override: number): readonly string[] {
+    return maxBundleSizeRule.run({
         bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true, bytes: 50 } },
-        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 1000 } }]])
+        settings: { maxBundleSize: { enabled: true, bytes: globalBytes } },
+        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: override } }]])
     });
+}
 
-    assert.deepStrictEqual(result, []);
+test('per-package bytes overrides the global default upward', () => {
+    assert.deepStrictEqual(runWithGlobalAndOverride(50, 1000), []);
 });
 
 test('per-package bytes overrides the global default downward', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true, bytes: 1000 } },
-        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
-    });
-
-    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
+    assert.deepStrictEqual(runWithGlobalAndOverride(1000, 50), [
+        'Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)'
+    ]);
 });
 
 test('per-package bytes acts as the threshold when no global default is set', () => {
@@ -91,6 +89,16 @@ test('per-package bytes acts as the threshold when no global default is set', ()
         bundles: [bundleWithBytes('a', 100), bundleWithBytes('b', 100)],
         settings: { maxBundleSize: { enabled: true } },
         perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
+});
+
+test('falls back to the global default when the per-package entry has no maxBundleSize key', () => {
+    const result = maxBundleSizeRule.run({
+        bundles: [bundleWithBytes('a', 100)],
+        settings: { maxBundleSize: { enabled: true, bytes: 50 } },
+        perPackageSettings: new Map([['a', {}]])
     });
 
     assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);

--- a/source/checks/rules/max-bundle-size.ts
+++ b/source/checks/rules/max-bundle-size.ts
@@ -22,7 +22,7 @@ type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
 function bundleSizeBytes(bundle: LinkedBundle): number {
     let total = 0;
     for (const resource of bundle.contents) {
-        total += Buffer.byteLength(resource.fileDescription.content, 'utf8');
+        total += Buffer.byteLength(resource.fileDescription.content);
     }
     return total;
 }

--- a/source/checks/rules/max-bundle-size.ts
+++ b/source/checks/rules/max-bundle-size.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod/mini';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+
+const ruleName = 'maxBundleSize';
+
+const byteLimitSchema = z.number().check(z.int(), z.nonnegative());
+
+const globalSchema = z.strictObject({
+    enabled: z.boolean(),
+    bytes: z.optional(byteLimitSchema)
+});
+
+const perPackageSchema = z.strictObject({
+    bytes: z.optional(byteLimitSchema)
+});
+
+type GlobalConfig = z.infer<typeof globalSchema>;
+type PerPackageConfig = z.infer<typeof perPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+
+function bundleSizeBytes(bundle: LinkedBundle): number {
+    let total = 0;
+    for (const resource of bundle.contents) {
+        total += Buffer.byteLength(resource.fileDescription.content, 'utf8');
+    }
+    return total;
+}
+
+function checkBundle(bundle: LinkedBundle, threshold: number | undefined): readonly string[] {
+    if (threshold === undefined) {
+        return [];
+    }
+    const size = bundleSizeBytes(bundle);
+    if (size <= threshold) {
+        return [];
+    }
+    return [`Package "${bundle.name}" exceeds the maximum bundle size: ${size} bytes (limit: ${threshold} bytes)`];
+}
+
+function run(params: RunParams): readonly string[] {
+    const globalConfig = params.settings?.maxBundleSize;
+    if (globalConfig?.enabled !== true) {
+        return [];
+    }
+
+    return params.bundles.flatMap((bundle) => {
+        const override = params.perPackageSettings.get(bundle.name)?.maxBundleSize?.bytes;
+        return checkBundle(bundle, override ?? globalConfig.bytes);
+    });
+}
+
+export const maxBundleSizeRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema,
+    perPackageSchema,
+    run
+};

--- a/source/checks/rules/no-dev-dependency-imports.test.ts
+++ b/source/checks/rules/no-dev-dependency-imports.test.ts
@@ -45,6 +45,27 @@ test('returns no issues when the rule is disabled', () => {
     assert.deepStrictEqual(result, []);
 });
 
+test('returns no issues when packageConfigs is omitted entirely', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leaked'])],
+        settings: enabled,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when packageConfigs has no entry for the bundle', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leaked'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {}
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
 test('returns no issues when the package has no main package.json', () => {
     const result = noDevDependencyImportsRule.run({
         bundles: [bundleWithExternals('a', ['leaked'])],

--- a/source/checks/rules/no-dev-dependency-imports.test.ts
+++ b/source/checks/rules/no-dev-dependency-imports.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
+import { linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
+import { noDevDependencyImportsRule } from './no-dev-dependency-imports.ts';
+
+function bundleWithExternals(name: string, externals: readonly string[]): LinkedBundle {
+    return linkedBundle({
+        name,
+        externalDependencies: new Map<string, ExternalDependency>(
+            externals.map((dep) => {
+                return [dep, { name: dep, referencedFrom: [`/${name}/index.js`] }];
+            })
+        )
+    });
+}
+
+const enabled = { noDevDependencyImports: { enabled: true } };
+
+test('rule definition exposes name, schemas and a run function', () => {
+    assert.strictEqual(noDevDependencyImportsRule.name, 'noDevDependencyImports');
+    assert.strictEqual(typeof noDevDependencyImportsRule.run, 'function');
+});
+
+test('returns no issues when settings are missing', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leaked'])],
+        settings: undefined,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the rule is disabled', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leaked'])],
+        settings: { noDevDependencyImports: { enabled: false } },
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the package has no main package.json', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leaked'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: {} }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports an external dependency that is only declared in devDependencies', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leaked'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+    });
+
+    assert.deepStrictEqual(result, [
+        'Package "a" imports "leaked" which is only declared in devDependencies of the main package.json'
+    ]);
+});
+
+test('does not report when the dependency is also declared in dependencies', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['shared'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {
+            a: {
+                mainPackageJson: {
+                    dependencies: { shared: '1.0.0' },
+                    devDependencies: { shared: '1.0.0' }
+                }
+            }
+        }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('does not report when the dependency is declared in peerDependencies', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['peer'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {
+            a: {
+                mainPackageJson: {
+                    peerDependencies: { peer: '1.0.0' },
+                    devDependencies: { peer: '1.0.0' }
+                }
+            }
+        }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('does not report when the dependency is not in any list', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['unknown'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { mainPackageJson: {} } }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports independently per bundle', () => {
+    const result = noDevDependencyImportsRule.run({
+        bundles: [bundleWithExternals('a', ['leak-a']), bundleWithExternals('b', ['fine'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {
+            a: { mainPackageJson: { devDependencies: { 'leak-a': '1.0.0' } } },
+            b: { mainPackageJson: { dependencies: { fine: '1.0.0' } } }
+        }
+    });
+
+    assert.deepStrictEqual(result, [
+        'Package "a" imports "leak-a" which is only declared in devDependencies of the main package.json'
+    ]);
+});

--- a/source/checks/rules/no-dev-dependency-imports.ts
+++ b/source/checks/rules/no-dev-dependency-imports.ts
@@ -1,0 +1,57 @@
+import type { z } from 'zod/mini';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import {
+    emptyPerPackageSchema,
+    enabledOnlyGlobalSchema,
+    type CheckRuleDefinition,
+    type RulePackageConfig,
+    type RuleRunParams
+} from '../rule.ts';
+
+const ruleName = 'noDevDependencyImports';
+
+type GlobalConfig = z.infer<typeof enabledOnlyGlobalSchema>;
+type PerPackageConfig = z.infer<typeof emptyPerPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+
+function findLeakedDevDependencies(
+    bundle: LinkedBundle,
+    packageConfig: RulePackageConfig | undefined
+): readonly string[] {
+    const mainPackageJson = packageConfig?.mainPackageJson;
+    if (mainPackageJson === undefined) {
+        return [];
+    }
+    const runtimeDependencyNames = new Set([
+        ...Object.keys(mainPackageJson.dependencies ?? {}),
+        ...Object.keys(mainPackageJson.peerDependencies ?? {})
+    ]);
+    const devDependencyNames = new Set(Object.keys(mainPackageJson.devDependencies ?? {}));
+
+    return Array.from(bundle.externalDependencies.keys())
+        .filter((name) => {
+            return devDependencyNames.has(name) && !runtimeDependencyNames.has(name);
+        })
+        .map((name) => {
+            const reason = 'is only declared in devDependencies of the main package.json';
+            return `Package "${bundle.name}" imports "${name}" which ${reason}`;
+        });
+}
+
+function run(params: RunParams): readonly string[] {
+    const globalConfig = params.settings?.noDevDependencyImports;
+    if (globalConfig?.enabled !== true) {
+        return [];
+    }
+
+    return params.bundles.flatMap((bundle) => {
+        return findLeakedDevDependencies(bundle, params.packageConfigs?.[bundle.name]);
+    });
+}
+
+export const noDevDependencyImportsRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema: enabledOnlyGlobalSchema,
+    perPackageSchema: emptyPerPackageSchema,
+    run
+};

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -110,3 +110,26 @@ test('returns no issues when there are no duplicates', () => {
 
     assert.deepStrictEqual(result, []);
 });
+
+function runWithMixedConsent(secondOwnerSettings: PackageChecksSettings): readonly string[] {
+    return noDuplicatedFilesRule.run({
+        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        settings: { noDuplicatedFiles: { enabled: true } },
+        perPackageSettings: new Map([
+            ['a', { noDuplicatedFiles: { allowList: ['shared.ts'] } }],
+            ['b', secondOwnerSettings]
+        ])
+    });
+}
+
+test('reports a duplicate when an owner has per-package settings without a noDuplicatedFiles key', () => {
+    const result = runWithMixedConsent({});
+
+    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
+});
+
+test('reports a duplicate when an owner has noDuplicatedFiles without an allowList', () => {
+    const result = runWithMixedConsent({ noDuplicatedFiles: {} });
+
+    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
+});

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -133,3 +133,23 @@ test('reports a duplicate when an owner has noDuplicatedFiles without an allowLi
 
     assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
 });
+
+test('ignores duplicates when the global allowList contains the file path even without per-package consent', () => {
+    const result = noDuplicatedFilesRule.run({
+        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        settings: { noDuplicatedFiles: { enabled: true, allowList: ['shared.ts'] } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports a duplicate that is not present in the global allowList', () => {
+    const result = noDuplicatedFilesRule.run({
+        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        settings: { noDuplicatedFiles: { enabled: true, allowList: ['other.ts'] } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
+});

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -1,168 +1,112 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
 import type { LinkedBundle } from '../../linker/linked-bundle.ts';
-import { isNoDuplicatedFilesRuleEnabled, runNoDuplicatedFilesRule } from './no-duplicated-files.ts';
+import type { PackageChecksSettings } from '../../config/config.ts';
+import { checkBundle } from '../../test-libraries/check-bundle-fixture.ts';
+import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
 
-function createBundle(name: string, sourceFilePath: string): LinkedBundle {
-    return {
-        name,
-        contents: [
-            {
-                fileDescription: {
-                    sourceFilePath,
-                    targetFilePath: sourceFilePath,
-                    content: '',
-                    isExecutable: false
-                },
-                directDependencies: new Set<string>(),
-                isSubstituted: false,
-                isExplicitlyIncluded: false
-            }
-        ],
-        entryPoints: [
-            {
-                js: {
-                    sourceFilePath,
-                    targetFilePath: sourceFilePath,
-                    content: '',
-                    isExecutable: false
-                }
-            }
-        ] as const,
-        linkedBundleDependencies: new Map(),
-        externalDependencies: new Map()
-    };
+function bundle(name: string, sourceFilePath: string): LinkedBundle {
+    return checkBundle(name, [sourceFilePath]);
 }
 
-test('exports the enabled-check and runner functions', () => {
-    assert.strictEqual(typeof isNoDuplicatedFilesRuleEnabled, 'function');
-    assert.strictEqual(typeof runNoDuplicatedFilesRule, 'function');
+function consentMap(
+    consenters: readonly (readonly [string, readonly string[]])[]
+): ReadonlyMap<string, PackageChecksSettings> {
+    return new Map(
+        consenters.map(([name, allowList]) => {
+            return [name, { noDuplicatedFiles: { allowList } }];
+        })
+    );
+}
+
+function runWithConsent(
+    bundles: readonly LinkedBundle[],
+    consenters: readonly (readonly [string, readonly string[]])[]
+): readonly string[] {
+    return noDuplicatedFilesRule.run({
+        bundles,
+        settings: { noDuplicatedFiles: { enabled: true } },
+        perPackageSettings: consentMap(consenters)
+    });
+}
+
+test('rule definition exposes name, schemas and a run function', () => {
+    assert.strictEqual(noDuplicatedFilesRule.name, 'noDuplicatedFiles');
+    assert.strictEqual(typeof noDuplicatedFilesRule.run, 'function');
+    assert.notStrictEqual(noDuplicatedFilesRule.globalSchema, undefined);
+    assert.notStrictEqual(noDuplicatedFilesRule.perPackageSchema, undefined);
 });
 
-test('run() returns all duplicate-file issues when no allow list is configured', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('b', 'shared.ts'), createBundle('a', 'shared.ts')] },
-        { noDuplicatedFiles: { enabled: true } }
-    );
+test('returns no issues when settings are missing entirely', () => {
+    const result = noDuplicatedFilesRule.run({
+        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        settings: undefined,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the rule is disabled at the top level', () => {
+    const result = noDuplicatedFilesRule.run({
+        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        settings: { noDuplicatedFiles: { enabled: false } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports every duplicate when no per-package consent is configured', () => {
+    const result = runWithConsent([bundle('b', 'shared.ts'), bundle('a', 'shared.ts')], []);
 
     assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
 });
 
-test('isEnabled() returns false when the rule config is missing', () => {
-    const result = isNoDuplicatedFilesRuleEnabled(undefined);
-
-    assert.strictEqual(result, false);
-});
-
-test('isEnabled() returns true when the rule is explicitly enabled', () => {
-    const result = isNoDuplicatedFilesRuleEnabled({ noDuplicatedFiles: { enabled: true } });
-
-    assert.strictEqual(result, true);
-});
-
-test('isEnabled() returns false when the rule is explicitly disabled', () => {
-    const result = isNoDuplicatedFilesRuleEnabled({ noDuplicatedFiles: { enabled: false } });
-
-    assert.strictEqual(result, false);
-});
-
-test('run() still reports duplicates when the allow list is empty because the rule is disabled', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
-        { noDuplicatedFiles: { enabled: false } }
-    );
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('run() ignores duplicate-file issues that are allow-listed only when the rule is enabled', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
-        { noDuplicatedFiles: { enabled: true, allowList: ['shared.ts'] } }
+test('ignores duplicates when every owning package consents via its allowList', () => {
+    const result = runWithConsent(
+        [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        [
+            ['a', ['shared.ts']],
+            ['b', ['shared.ts']]
+        ]
     );
 
     assert.deepStrictEqual(result, []);
 });
 
-test('run() still reports duplicates when settings are missing entirely', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
-        undefined
-    );
+test('reports a duplicate when only one owner consents', () => {
+    const result = runWithConsent([bundle('a', 'shared.ts'), bundle('b', 'shared.ts')], [['a', ['shared.ts']]]);
 
     assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
 });
 
-test('run() ignores the allow list when the rule is disabled', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
-        { noDuplicatedFiles: { enabled: false, allowList: ['shared.ts'] } }
-    );
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('run() suppresses a duplicate when a scoped allow-list entry covers all owners', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
-        {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'shared.ts', packages: ['a', 'b'] }]
-            }
-        }
-    );
-
-    assert.deepStrictEqual(result, []);
-});
-
-test('run() reports a duplicate when a scoped allow-list entry omits one of the actual owners', () => {
-    const result = runNoDuplicatedFilesRule(
-        {
-            bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts'), createBundle('c', 'shared.ts')]
-        },
-        {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'shared.ts', packages: ['a', 'b'] }]
-            }
-        }
+test('reports a duplicate when a third owner did not consent', () => {
+    const result = runWithConsent(
+        [bundle('a', 'shared.ts'), bundle('b', 'shared.ts'), bundle('c', 'shared.ts')],
+        [
+            ['a', ['shared.ts']],
+            ['b', ['shared.ts']]
+        ]
     );
 
     assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b, c']);
 });
 
-test('run() does not match a scoped entry when the file path differs', () => {
-    const result = runNoDuplicatedFilesRule(
-        { bundles: [createBundle('a', 'shared.ts'), createBundle('b', 'shared.ts')] },
-        {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'other.ts', packages: ['a', 'b'] }]
-            }
-        }
+test('does not match consent for a different file path', () => {
+    const result = runWithConsent(
+        [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+        [
+            ['a', ['other.ts']],
+            ['b', ['other.ts']]
+        ]
     );
 
     assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
 });
 
-test('run() supports a mix of plain string and scoped allow-list entries', () => {
-    const result = runNoDuplicatedFilesRule(
-        {
-            bundles: [
-                createBundle('a', 'shared.ts'),
-                createBundle('b', 'shared.ts'),
-                createBundle('c', 'license'),
-                createBundle('d', 'license')
-            ]
-        },
-        {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: ['license', { filePath: 'shared.ts', packages: ['a', 'b'] }]
-            }
-        }
-    );
+test('returns no issues when there are no duplicates', () => {
+    const result = runWithConsent([bundle('a', 'a.ts'), bundle('b', 'b.ts')], []);
 
     assert.deepStrictEqual(result, []);
 });

--- a/source/checks/rules/no-duplicated-files.ts
+++ b/source/checks/rules/no-duplicated-files.ts
@@ -6,7 +6,8 @@ import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
 const ruleName = 'noDuplicatedFiles';
 
 const globalSchema = z.strictObject({
-    enabled: z.boolean()
+    enabled: z.boolean(),
+    allowList: z.optional(z.readonly(z.array(nonEmptyStringSchema)))
 });
 
 const perPackageSchema = z.strictObject({
@@ -53,12 +54,14 @@ function formatOwners(owners: ReadonlySet<string>): string {
 
 function findDuplicateIssues(
     bundles: readonly LinkedBundle[],
-    perPackageSettings: RunParams['perPackageSettings']
+    perPackageSettings: RunParams['perPackageSettings'],
+    globalConfig: GlobalConfig
 ): readonly string[] {
+    const globallyAllowed = new Set(globalConfig.allowList);
     return Array.from(collectFileOwnership(bundles).entries()).flatMap(([filePath, owners]) => {
         const isDuplicate = owners.size > 1;
-        const consented = everyOwnerConsents(filePath, owners, perPackageSettings);
-        if (isDuplicate && !consented) {
+        const isAllowed = globallyAllowed.has(filePath) || everyOwnerConsents(filePath, owners, perPackageSettings);
+        if (isDuplicate && !isAllowed) {
             return [`File "${filePath}" is included in multiple packages: ${formatOwners(owners)}`];
         }
         return [];
@@ -70,7 +73,7 @@ function run(params: RunParams): readonly string[] {
     if (globalConfig?.enabled !== true) {
         return [];
     }
-    return findDuplicateIssues(params.bundles, params.perPackageSettings);
+    return findDuplicateIssues(params.bundles, params.perPackageSettings, globalConfig);
 }
 
 export const noDuplicatedFilesRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {

--- a/source/checks/rules/no-duplicated-files.ts
+++ b/source/checks/rules/no-duplicated-files.ts
@@ -1,6 +1,21 @@
+import { z } from 'zod/mini';
 import type { LinkedBundle } from '../../linker/linked-bundle.ts';
-import type { AllowListEntry, ChecksSettings } from '../../config/config.ts';
-import type { CheckContext } from '../rule.ts';
+import { nonEmptyStringSchema } from '../../config/base-validations.ts';
+import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+
+const ruleName = 'noDuplicatedFiles';
+
+const globalSchema = z.strictObject({
+    enabled: z.boolean()
+});
+
+const perPackageSchema = z.strictObject({
+    allowList: z.optional(z.readonly(z.array(nonEmptyStringSchema)))
+});
+
+type GlobalConfig = z.infer<typeof globalSchema>;
+type PerPackageConfig = z.infer<typeof perPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 function collectFileOwnership(bundles: readonly LinkedBundle[]): Map<string, Set<string>> {
     const fileOwnership = new Map<string, Set<string>>();
@@ -17,69 +32,61 @@ function collectFileOwnership(bundles: readonly LinkedBundle[]): Map<string, Set
     return fileOwnership;
 }
 
-function getAllowList(settings: ChecksSettings | undefined): readonly AllowListEntry[] | undefined {
-    const option = settings?.noDuplicatedFiles;
-
-    if (option?.enabled !== true) {
-        return undefined;
-    }
-
-    return option.allowList;
-}
-
-function isAllowed(
+function everyOwnerConsents(
     filePath: string,
     owners: ReadonlySet<string>,
-    allowList: readonly AllowListEntry[] | undefined
+    perPackageConfigByBundle: ReadonlyMap<string, PerPackageConfig>
 ): boolean {
-    if (allowList === undefined) {
-        return false;
-    }
-
-    return allowList.some((entry) => {
-        if (typeof entry === 'string') {
-            return entry === filePath;
-        }
-
-        if (entry.filePath !== filePath) {
-            return false;
-        }
-
-        const allowedOwners = new Set(entry.packages);
-        return Array.from(owners).every((owner) => {
-            return allowedOwners.has(owner);
-        });
+    return Array.from(owners).every((owner) => {
+        const allowList = perPackageConfigByBundle.get(owner)?.allowList ?? [];
+        return allowList.includes(filePath);
     });
 }
 
-export function isNoDuplicatedFilesRuleEnabled(settings: ChecksSettings | undefined): boolean {
-    const option = settings?.noDuplicatedFiles;
-
-    if (option === undefined) {
-        return false;
-    }
-
-    return option.enabled;
+function formatOwners(owners: ReadonlySet<string>): string {
+    return Array.from(owners)
+        .toSorted((left, right) => {
+            return left.localeCompare(right);
+        })
+        .join(', ');
 }
 
-export function runNoDuplicatedFilesRule(
-    context: CheckContext,
-    settings: ChecksSettings | undefined
+function buildPerPackageConfigByBundle(
+    perPackageSettings: RunParams['perPackageSettings']
+): ReadonlyMap<string, PerPackageConfig> {
+    return new Map(
+        Array.from(perPackageSettings.entries()).flatMap(([bundleName, packageChecks]) => {
+            const ruleConfig = packageChecks?.noDuplicatedFiles;
+            return ruleConfig === undefined ? [] : [[bundleName, ruleConfig] as const];
+        })
+    );
+}
+
+function findDuplicateIssues(
+    bundles: readonly LinkedBundle[],
+    perPackageConfigByBundle: ReadonlyMap<string, PerPackageConfig>
 ): readonly string[] {
-    const fileOwnership = collectFileOwnership(context.bundles);
-    const issues: string[] = [];
-    const allowList = getAllowList(settings);
-
-    for (const [filePath, owners] of fileOwnership.entries()) {
-        if (owners.size > 1 && !isAllowed(filePath, owners, allowList)) {
-            const ownerList = Array.from(owners)
-                .toSorted((left, right) => {
-                    return left.localeCompare(right);
-                })
-                .join(', ');
-            issues.push(`File "${filePath}" is included in multiple packages: ${ownerList}`);
+    return Array.from(collectFileOwnership(bundles).entries()).flatMap(([filePath, owners]) => {
+        const isDuplicate = owners.size > 1;
+        const consented = everyOwnerConsents(filePath, owners, perPackageConfigByBundle);
+        if (isDuplicate && !consented) {
+            return [`File "${filePath}" is included in multiple packages: ${formatOwners(owners)}`];
         }
-    }
-
-    return issues;
+        return [];
+    });
 }
+
+function run(params: RunParams): readonly string[] {
+    const globalConfig = params.settings?.noDuplicatedFiles;
+    if (globalConfig?.enabled !== true) {
+        return [];
+    }
+    return findDuplicateIssues(params.bundles, buildPerPackageConfigByBundle(params.perPackageSettings));
+}
+
+export const noDuplicatedFilesRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema,
+    perPackageSchema,
+    run
+};

--- a/source/checks/rules/no-duplicated-files.ts
+++ b/source/checks/rules/no-duplicated-files.ts
@@ -35,11 +35,11 @@ function collectFileOwnership(bundles: readonly LinkedBundle[]): Map<string, Set
 function everyOwnerConsents(
     filePath: string,
     owners: ReadonlySet<string>,
-    perPackageConfigByBundle: ReadonlyMap<string, PerPackageConfig>
+    perPackageSettings: RunParams['perPackageSettings']
 ): boolean {
     return Array.from(owners).every((owner) => {
-        const allowList = perPackageConfigByBundle.get(owner)?.allowList ?? [];
-        return allowList.includes(filePath);
+        const allowList = perPackageSettings.get(owner)?.noDuplicatedFiles?.allowList;
+        return allowList?.includes(filePath) ?? false;
     });
 }
 
@@ -51,24 +51,13 @@ function formatOwners(owners: ReadonlySet<string>): string {
         .join(', ');
 }
 
-function buildPerPackageConfigByBundle(
-    perPackageSettings: RunParams['perPackageSettings']
-): ReadonlyMap<string, PerPackageConfig> {
-    return new Map(
-        Array.from(perPackageSettings.entries()).flatMap(([bundleName, packageChecks]) => {
-            const ruleConfig = packageChecks?.noDuplicatedFiles;
-            return ruleConfig === undefined ? [] : [[bundleName, ruleConfig] as const];
-        })
-    );
-}
-
 function findDuplicateIssues(
     bundles: readonly LinkedBundle[],
-    perPackageConfigByBundle: ReadonlyMap<string, PerPackageConfig>
+    perPackageSettings: RunParams['perPackageSettings']
 ): readonly string[] {
     return Array.from(collectFileOwnership(bundles).entries()).flatMap(([filePath, owners]) => {
         const isDuplicate = owners.size > 1;
-        const consented = everyOwnerConsents(filePath, owners, perPackageConfigByBundle);
+        const consented = everyOwnerConsents(filePath, owners, perPackageSettings);
         if (isDuplicate && !consented) {
             return [`File "${filePath}" is included in multiple packages: ${formatOwners(owners)}`];
         }
@@ -81,7 +70,7 @@ function run(params: RunParams): readonly string[] {
     if (globalConfig?.enabled !== true) {
         return [];
     }
-    return findDuplicateIssues(params.bundles, buildPerPackageConfigByBundle(params.perPackageSettings));
+    return findDuplicateIssues(params.bundles, params.perPackageSettings);
 }
 
 export const noDuplicatedFilesRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {

--- a/source/checks/rules/no-unused-bundle-dependencies.test.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.test.ts
@@ -45,6 +45,27 @@ test('returns no issues when the rule is disabled', () => {
     assert.deepStrictEqual(result, []);
 });
 
+test('returns no issues when packageConfigs is omitted entirely', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: enabled,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when no entry exists in packageConfigs for the bundle', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {}
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
 test('returns no issues when the package declares no bundle dependencies', () => {
     const result = noUnusedBundleDependenciesRule.run({
         bundles: [bundleWithLinkedDeps('a', [])],

--- a/source/checks/rules/no-unused-bundle-dependencies.test.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
+import { linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
+import { noUnusedBundleDependenciesRule } from './no-unused-bundle-dependencies.ts';
+
+function bundleWithLinkedDeps(name: string, linked: readonly string[]): LinkedBundle {
+    return linkedBundle({
+        name,
+        linkedBundleDependencies: new Map<string, ExternalDependency>(
+            linked.map((dependencyName) => {
+                return [dependencyName, { name: dependencyName, referencedFrom: [`/${name}/index.js`] }];
+            })
+        )
+    });
+}
+
+const enabled = { noUnusedBundleDependencies: { enabled: true } };
+
+test('rule definition exposes name, schemas and a run function', () => {
+    assert.strictEqual(noUnusedBundleDependenciesRule.name, 'noUnusedBundleDependencies');
+    assert.strictEqual(typeof noUnusedBundleDependenciesRule.run, 'function');
+});
+
+test('returns no issues when settings are missing', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: undefined,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { bundleDependencies: ['unused'] } }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the rule is disabled', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: { noUnusedBundleDependencies: { enabled: false } },
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { bundleDependencies: ['unused'] } }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the package declares no bundle dependencies', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: {} }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports a declared bundleDependency that is never substituted', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { bundleDependencies: ['unused'] } }
+    });
+
+    assert.deepStrictEqual(result, ['Unused bundle dependency "unused" declared by package "a"']);
+});
+
+test('reports a declared bundlePeerDependency that is never substituted', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', [])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { bundlePeerDependencies: ['unused-peer'] } }
+    });
+
+    assert.deepStrictEqual(result, ['Unused bundle peer dependency "unused-peer" declared by package "a"']);
+});
+
+test('does not report a declared bundleDependency that was substituted', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', ['used'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: { a: { bundleDependencies: ['used'] } }
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports a mix of unused regular and peer dependencies for the same package', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', ['used'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {
+            a: { bundleDependencies: ['used', 'orphan'], bundlePeerDependencies: ['orphan-peer'] }
+        }
+    });
+
+    assert.deepStrictEqual(result, [
+        'Unused bundle dependency "orphan" declared by package "a"',
+        'Unused bundle peer dependency "orphan-peer" declared by package "a"'
+    ]);
+});
+
+test('iterates every bundle independently', () => {
+    const result = noUnusedBundleDependenciesRule.run({
+        bundles: [bundleWithLinkedDeps('a', []), bundleWithLinkedDeps('b', ['used'])],
+        settings: enabled,
+        perPackageSettings: new Map(),
+        packageConfigs: {
+            a: { bundleDependencies: ['unused-a'] },
+            b: { bundleDependencies: ['used'] }
+        }
+    });
+
+    assert.deepStrictEqual(result, ['Unused bundle dependency "unused-a" declared by package "a"']);
+});

--- a/source/checks/rules/no-unused-bundle-dependencies.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.ts
@@ -27,12 +27,9 @@ function findUnused(bundle: LinkedBundle, declared: readonly string[], kind: Dep
 }
 
 function checkBundle(bundle: LinkedBundle, packageConfig: RulePackageConfig | undefined): readonly string[] {
-    if (packageConfig === undefined) {
-        return [];
-    }
     return [
-        ...findUnused(bundle, packageConfig.bundleDependencies ?? [], 'bundle'),
-        ...findUnused(bundle, packageConfig.bundlePeerDependencies ?? [], 'bundle peer')
+        ...findUnused(bundle, packageConfig?.bundleDependencies ?? [], 'bundle'),
+        ...findUnused(bundle, packageConfig?.bundlePeerDependencies ?? [], 'bundle peer')
     ];
 }
 

--- a/source/checks/rules/no-unused-bundle-dependencies.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod/mini';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import type { CheckRuleDefinition, RulePackageConfig, RuleRunParams } from '../rule.ts';
+
+const ruleName = 'noUnusedBundleDependencies';
+
+const globalSchema = z.strictObject({
+    enabled: z.boolean()
+});
+
+const perPackageSchema = z.strictObject({});
+
+type GlobalConfig = z.infer<typeof globalSchema>;
+type PerPackageConfig = z.infer<typeof perPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+
+type DependencyKind = 'bundle' | 'bundle peer';
+
+function findUnused(bundle: LinkedBundle, declared: readonly string[], kind: DependencyKind): readonly string[] {
+    return declared
+        .filter((dependencyName) => {
+            return !bundle.linkedBundleDependencies.has(dependencyName);
+        })
+        .map((dependencyName) => {
+            return `Unused ${kind} dependency "${dependencyName}" declared by package "${bundle.name}"`;
+        });
+}
+
+function checkBundle(bundle: LinkedBundle, packageConfig: RulePackageConfig | undefined): readonly string[] {
+    if (packageConfig === undefined) {
+        return [];
+    }
+    return [
+        ...findUnused(bundle, packageConfig.bundleDependencies ?? [], 'bundle'),
+        ...findUnused(bundle, packageConfig.bundlePeerDependencies ?? [], 'bundle peer')
+    ];
+}
+
+function run(params: RunParams): readonly string[] {
+    const globalConfig = params.settings?.noUnusedBundleDependencies;
+    if (globalConfig?.enabled !== true) {
+        return [];
+    }
+
+    return params.bundles.flatMap((bundle) => {
+        return checkBundle(bundle, params.packageConfigs?.[bundle.name]);
+    });
+}
+
+export const noUnusedBundleDependenciesRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema,
+    perPackageSchema,
+    run
+};

--- a/source/checks/rules/no-unused-bundle-dependencies.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.ts
@@ -1,17 +1,17 @@
-import { z } from 'zod/mini';
+import type { z } from 'zod/mini';
 import type { LinkedBundle } from '../../linker/linked-bundle.ts';
-import type { CheckRuleDefinition, RulePackageConfig, RuleRunParams } from '../rule.ts';
+import {
+    emptyPerPackageSchema,
+    enabledOnlyGlobalSchema,
+    type CheckRuleDefinition,
+    type RulePackageConfig,
+    type RuleRunParams
+} from '../rule.ts';
 
 const ruleName = 'noUnusedBundleDependencies';
 
-const globalSchema = z.strictObject({
-    enabled: z.boolean()
-});
-
-const perPackageSchema = z.strictObject({});
-
-type GlobalConfig = z.infer<typeof globalSchema>;
-type PerPackageConfig = z.infer<typeof perPackageSchema>;
+type GlobalConfig = z.infer<typeof enabledOnlyGlobalSchema>;
+type PerPackageConfig = z.infer<typeof emptyPerPackageSchema>;
 type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 type DependencyKind = 'bundle' | 'bundle peer';
@@ -49,7 +49,7 @@ function run(params: RunParams): readonly string[] {
 
 export const noUnusedBundleDependenciesRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
     name: ruleName,
-    globalSchema,
-    perPackageSchema,
+    globalSchema: enabledOnlyGlobalSchema,
+    perPackageSchema: emptyPerPackageSchema,
     run
 };

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -3,11 +3,13 @@ import { noDevDependencyImportsRule } from './no-dev-dependency-imports.ts';
 import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
 import { noUnusedBundleDependenciesRule } from './no-unused-bundle-dependencies.ts';
 import { requiredFilesRule } from './required-files.ts';
+import { uniqueTargetPathsRule } from './unique-target-paths.ts';
 
 export const allRules = [
     noDuplicatedFilesRule,
     requiredFilesRule,
     maxBundleSizeRule,
     noUnusedBundleDependenciesRule,
-    noDevDependencyImportsRule
+    noDevDependencyImportsRule,
+    uniqueTargetPathsRule
 ] as const;

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -1,4 +1,5 @@
 import { maxBundleSizeRule } from './max-bundle-size.ts';
+import { noDevDependencyImportsRule } from './no-dev-dependency-imports.ts';
 import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
 import { noUnusedBundleDependenciesRule } from './no-unused-bundle-dependencies.ts';
 import { requiredFilesRule } from './required-files.ts';
@@ -7,5 +8,6 @@ export const allRules = [
     noDuplicatedFilesRule,
     requiredFilesRule,
     maxBundleSizeRule,
-    noUnusedBundleDependenciesRule
+    noUnusedBundleDependenciesRule,
+    noDevDependencyImportsRule
 ] as const;

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -1,0 +1,3 @@
+import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
+
+export const allRules = [noDuplicatedFilesRule] as const;

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -1,3 +1,4 @@
 import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
+import { requiredFilesRule } from './required-files.ts';
 
-export const allRules = [noDuplicatedFilesRule] as const;
+export const allRules = [noDuplicatedFilesRule, requiredFilesRule] as const;

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -1,4 +1,5 @@
+import { maxBundleSizeRule } from './max-bundle-size.ts';
 import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
 import { requiredFilesRule } from './required-files.ts';
 
-export const allRules = [noDuplicatedFilesRule, requiredFilesRule] as const;
+export const allRules = [noDuplicatedFilesRule, requiredFilesRule, maxBundleSizeRule] as const;

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -1,5 +1,11 @@
 import { maxBundleSizeRule } from './max-bundle-size.ts';
 import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
+import { noUnusedBundleDependenciesRule } from './no-unused-bundle-dependencies.ts';
 import { requiredFilesRule } from './required-files.ts';
 
-export const allRules = [noDuplicatedFilesRule, requiredFilesRule, maxBundleSizeRule] as const;
+export const allRules = [
+    noDuplicatedFilesRule,
+    requiredFilesRule,
+    maxBundleSizeRule,
+    noUnusedBundleDependenciesRule
+] as const;

--- a/source/checks/rules/required-files.test.ts
+++ b/source/checks/rules/required-files.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import type { PackageChecksSettings } from '../../config/config.ts';
+import { checkBundle as bundle } from '../../test-libraries/check-bundle-fixture.ts';
+import { requiredFilesRule } from './required-files.ts';
+
+function packageRequiring(files: readonly string[]): PackageChecksSettings {
+    return { requiredFiles: { files } };
+}
+
+test('rule definition exposes name, schemas and a run function', () => {
+    assert.strictEqual(requiredFilesRule.name, 'requiredFiles');
+    assert.strictEqual(typeof requiredFilesRule.run, 'function');
+});
+
+test('returns no issues when settings are missing', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', [])],
+        settings: undefined,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the rule is disabled', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', [])],
+        settings: { requiredFiles: { enabled: false, files: ['LICENSE'] } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports a missing global required file for every bundle that lacks it', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', ['LICENSE']), bundle('b', [])],
+        settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, ['Package "b" is missing required file "LICENSE"']);
+});
+
+test('returns no issues when all bundles contain every globally required file', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', ['LICENSE', 'readme.md']), bundle('b', ['LICENSE', 'readme.md'])],
+        settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('extends global required files with per-package required files', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', ['LICENSE'])],
+        settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
+        perPackageSettings: new Map([['a', packageRequiring(['CHANGELOG.md'])]])
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" is missing required file "CHANGELOG.md"']);
+});
+
+test('deduplicates required files when per-package config repeats a global entry', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', [])],
+        settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
+        perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
+});
+
+test('uses per-package required files even when the global list is empty', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', [])],
+        settings: { requiredFiles: { enabled: true } },
+        perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
+});
+
+test('reports multiple missing files for a single bundle', () => {
+    const result = requiredFilesRule.run({
+        bundles: [bundle('a', [])],
+        settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, [
+        'Package "a" is missing required file "LICENSE"',
+        'Package "a" is missing required file "readme.md"'
+    ]);
+});

--- a/source/checks/rules/required-files.ts
+++ b/source/checks/rules/required-files.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod/mini';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import { nonEmptyStringSchema } from '../../config/base-validations.ts';
+import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+
+const ruleName = 'requiredFiles';
+
+const fileListSchema = z.readonly(z.array(nonEmptyStringSchema));
+
+const globalSchema = z.strictObject({
+    enabled: z.boolean(),
+    files: z.optional(fileListSchema)
+});
+
+const perPackageSchema = z.strictObject({
+    files: z.optional(fileListSchema)
+});
+
+type GlobalConfig = z.infer<typeof globalSchema>;
+type PerPackageConfig = z.infer<typeof perPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+
+function effectiveRequiredFiles(
+    globalConfig: GlobalConfig,
+    perPackageConfig: PerPackageConfig | undefined
+): readonly string[] {
+    return Array.from(new Set([...(globalConfig.files ?? []), ...(perPackageConfig?.files ?? [])]));
+}
+
+function findMissingFiles(bundle: LinkedBundle, requiredFiles: readonly string[]): readonly string[] {
+    const presentTargets = new Set(
+        bundle.contents.map((resource) => {
+            return resource.fileDescription.targetFilePath;
+        })
+    );
+    return requiredFiles.filter((file) => {
+        return !presentTargets.has(file);
+    });
+}
+
+function run(params: RunParams): readonly string[] {
+    const globalConfig = params.settings?.requiredFiles;
+    if (globalConfig?.enabled !== true) {
+        return [];
+    }
+
+    return params.bundles.flatMap((bundle) => {
+        const requiredFiles = effectiveRequiredFiles(
+            globalConfig,
+            params.perPackageSettings.get(bundle.name)?.requiredFiles
+        );
+        return findMissingFiles(bundle, requiredFiles).map((file) => {
+            return `Package "${bundle.name}" is missing required file "${file}"`;
+        });
+    });
+}
+
+export const requiredFilesRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema,
+    perPackageSchema,
+    run
+};

--- a/source/checks/rules/unique-target-paths.test.ts
+++ b/source/checks/rules/unique-target-paths.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert';
+import { test } from 'mocha';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import { bundleResource, linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
+import { uniqueTargetPathsRule } from './unique-target-paths.ts';
+
+function bundleWithMappings(name: string, mappings: readonly (readonly [string, string])[]): LinkedBundle {
+    return linkedBundle({
+        name,
+        contents: mappings.map(([sourceFilePath, targetFilePath]) => {
+            return { ...bundleResource(sourceFilePath, { targetFilePath }), isSubstituted: false };
+        })
+    });
+}
+
+const enabled = { uniqueTargetPaths: { enabled: true } };
+
+test('rule definition exposes name, schemas and a run function', () => {
+    assert.strictEqual(uniqueTargetPathsRule.name, 'uniqueTargetPaths');
+    assert.strictEqual(typeof uniqueTargetPathsRule.run, 'function');
+});
+
+test('returns no issues when settings are missing', () => {
+    const result = uniqueTargetPathsRule.run({
+        bundles: [
+            bundleWithMappings('a', [
+                ['/src/a.js', 'collide.js'],
+                ['/src/b.js', 'collide.js']
+            ])
+        ],
+        settings: undefined,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when the rule is disabled', () => {
+    const result = uniqueTargetPathsRule.run({
+        bundles: [
+            bundleWithMappings('a', [
+                ['/src/a.js', 'collide.js'],
+                ['/src/b.js', 'collide.js']
+            ])
+        ],
+        settings: { uniqueTargetPaths: { enabled: false } },
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('returns no issues when every targetFilePath is unique', () => {
+    const result = uniqueTargetPathsRule.run({
+        bundles: [
+            bundleWithMappings('a', [
+                ['/src/a.js', 'a.js'],
+                ['/src/b.js', 'b.js']
+            ])
+        ],
+        settings: enabled,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, []);
+});
+
+test('reports a collision and lists the colliding source paths sorted', () => {
+    const result = uniqueTargetPathsRule.run({
+        bundles: [
+            bundleWithMappings('a', [
+                ['/src/b.js', 'collide.js'],
+                ['/src/a.js', 'collide.js']
+            ])
+        ],
+        settings: enabled,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "collide.js": /src/a.js, /src/b.js']);
+});
+
+test('reports collisions independently per bundle', () => {
+    const result = uniqueTargetPathsRule.run({
+        bundles: [
+            bundleWithMappings('a', [
+                ['/a-src/x.js', 'shared.js'],
+                ['/a-src/y.js', 'shared.js']
+            ]),
+            bundleWithMappings('b', [
+                ['/b-src/p.js', 'p.js'],
+                ['/b-src/q.js', 'q.js']
+            ])
+        ],
+        settings: enabled,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "shared.js": /a-src/x.js, /a-src/y.js']);
+});
+
+test('reports each colliding target path of a bundle', () => {
+    const result = uniqueTargetPathsRule.run({
+        bundles: [
+            bundleWithMappings('a', [
+                ['/src/x1.js', 'one.js'],
+                ['/src/x2.js', 'one.js'],
+                ['/src/y1.js', 'two.js'],
+                ['/src/y2.js', 'two.js']
+            ])
+        ],
+        settings: enabled,
+        perPackageSettings: new Map()
+    });
+
+    assert.deepStrictEqual(result, [
+        'Package "a" maps multiple sources to "one.js": /src/x1.js, /src/x2.js',
+        'Package "a" maps multiple sources to "two.js": /src/y1.js, /src/y2.js'
+    ]);
+});

--- a/source/checks/rules/unique-target-paths.ts
+++ b/source/checks/rules/unique-target-paths.ts
@@ -1,0 +1,50 @@
+import type { z } from 'zod/mini';
+import type { LinkedBundle } from '../../linker/linked-bundle.ts';
+import {
+    emptyPerPackageSchema,
+    enabledOnlyGlobalSchema,
+    type CheckRuleDefinition,
+    type RuleRunParams
+} from '../rule.ts';
+
+const ruleName = 'uniqueTargetPaths';
+
+type GlobalConfig = z.infer<typeof enabledOnlyGlobalSchema>;
+type PerPackageConfig = z.infer<typeof emptyPerPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+
+function findCollidingTargetPaths(bundle: LinkedBundle): readonly string[] {
+    const sourcesByTarget = new Map<string, string[]>();
+    for (const resource of bundle.contents) {
+        const { targetFilePath, sourceFilePath } = resource.fileDescription;
+        const sources = sourcesByTarget.get(targetFilePath) ?? [];
+        sources.push(sourceFilePath);
+        sourcesByTarget.set(targetFilePath, sources);
+    }
+
+    return Array.from(sourcesByTarget.entries()).flatMap(([targetFilePath, sources]) => {
+        if (sources.length <= 1) {
+            return [];
+        }
+        const sortedSources = sources.toSorted((left, right) => {
+            return left.localeCompare(right);
+        });
+        return [`Package "${bundle.name}" maps multiple sources to "${targetFilePath}": ${sortedSources.join(', ')}`];
+    });
+}
+
+function run(params: RunParams): readonly string[] {
+    const globalConfig = params.settings?.uniqueTargetPaths;
+    if (globalConfig?.enabled !== true) {
+        return [];
+    }
+
+    return params.bundles.flatMap(findCollidingTargetPaths);
+}
+
+export const uniqueTargetPathsRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema: enabledOnlyGlobalSchema,
+    perPackageSchema: emptyPerPackageSchema,
+    run
+};

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -13,9 +13,16 @@ test('schema accepts valid noDuplicatedFiles settings at the top level', () => {
     assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { enabled: true } }).success, true);
 });
 
-test('top-level schema rejects an allowList field on noDuplicatedFiles', () => {
+test('top-level schema accepts a global allowList on noDuplicatedFiles', () => {
     assert.strictEqual(
         safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }).success,
+        true
+    );
+});
+
+test('top-level schema rejects an empty path inside the noDuplicatedFiles allowList', () => {
+    assert.strictEqual(
+        safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: [''] } }).success,
         false
     );
 });

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -7,17 +7,21 @@ import {
     createTestCasesForOptionalField,
     createTestCasesForRequiredField
 } from '../test-libraries/verify-schema-validation.ts';
-import { checksSchema } from './checks-schema.ts';
+import { checksPerPackageSchema, checksSchema } from './checks-schema.ts';
 
-test('schema accepts valid noDuplicatedFiles settings', () => {
+test('schema accepts valid noDuplicatedFiles settings at the top level', () => {
+    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { enabled: true } }).success, true);
+});
+
+test('top-level schema rejects an allowList field on noDuplicatedFiles', () => {
     assert.strictEqual(
         safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }).success,
-        true
+        false
     );
 });
 
 test('schema rejects noDuplicatedFiles settings without enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { allowList: ['src/index.ts'] } }).success, false);
+    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: {} }).success, false);
 });
 
 test('schema accepts empty checks settings', () => {
@@ -28,35 +32,28 @@ test('schema rejects non-object noDuplicatedFiles settings', () => {
     assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: true }).success, false);
 });
 
-const validNoDuplicatedFilesSettings = { enabled: true, allowList: ['src/index.ts'] };
+const validNoDuplicatedFilesGlobal = { enabled: true };
 
 createTestCasesForOptionalField({
     schema: checksSchema,
-    data: { noDuplicatedFiles: validNoDuplicatedFilesSettings },
+    data: { noDuplicatedFiles: validNoDuplicatedFilesGlobal },
     path: 'noDuplicatedFiles',
     expectedFieldType: 'object'
 });
 
 createTestCasesForRequiredField({
     schema: checksSchema,
-    data: { noDuplicatedFiles: validNoDuplicatedFilesSettings },
+    data: { noDuplicatedFiles: validNoDuplicatedFilesGlobal },
     path: 'noDuplicatedFiles.enabled',
     expectedFieldType: 'boolean'
 });
 
-createTestCasesForOptionalField({
-    schema: checksSchema,
-    data: { noDuplicatedFiles: validNoDuplicatedFilesSettings },
-    path: 'noDuplicatedFiles.allowList',
-    expectedFieldType: 'array'
-});
-
 test(
-    'no duplicated files settings: validation succeeds with enabled and allow list',
+    'no duplicated files settings: validation succeeds with enabled at the top level',
     checkValidationSuccess({
         schema: checksSchema,
-        data: { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } },
-        expectedData: { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }
+        data: { noDuplicatedFiles: { enabled: true } },
+        expectedData: { noDuplicatedFiles: { enabled: true } }
     })
 );
 
@@ -64,7 +61,7 @@ test(
     'no duplicated files settings: validation fails when enabled is missing',
     checkValidationFailure({
         schema: checksSchema,
-        data: { noDuplicatedFiles: { allowList: ['src/index.ts'] } },
+        data: { noDuplicatedFiles: {} },
         expectedMessages: ['at noDuplicatedFiles.enabled: missing property']
     })
 );
@@ -91,87 +88,44 @@ test(
     'no duplicated files settings: validation fails when an additional property is given',
     checkValidationFailure({
         schema: checksSchema,
-        data: { noDuplicatedFiles: { ...validNoDuplicatedFilesSettings, extra: true } },
+        data: { noDuplicatedFiles: { ...validNoDuplicatedFilesGlobal, extra: true } },
         expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
     })
 );
 
-test(
-    'allow list: validation succeeds with a scoped entry naming two packages',
-    checkValidationSuccess({
-        schema: checksSchema,
-        data: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
-            }
-        },
-        expectedData: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
-            }
-        }
-    })
-);
+test('per-package schema accepts an empty noDuplicatedFiles object', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: {} }).success, true);
+});
+
+test('per-package schema accepts an allowList of file paths', () => {
+    assert.strictEqual(
+        safeParse(checksPerPackageSchema, { noDuplicatedFiles: { allowList: ['src/shared/util.ts'] } }).success,
+        true
+    );
+});
+
+test('per-package schema rejects an enabled flag', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: { enabled: true } }).success, false);
+});
+
+test('per-package schema rejects an empty string in the allowList', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: { allowList: [''] } }).success, false);
+});
 
 test(
-    'allow list: validation succeeds with a mix of plain string and scoped entries',
-    checkValidationSuccess({
-        schema: checksSchema,
-        data: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: ['LICENSE', { filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
-            }
-        },
-        expectedData: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: ['LICENSE', { filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
-            }
-        }
-    })
-);
-
-test(
-    'allow list: validation fails when a scoped entry has fewer than two packages',
+    'per-package: validation fails when allowList contains an empty path',
     checkValidationFailure({
-        schema: checksSchema,
-        data: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a'] }]
-            }
-        },
-        expectedMessages: ['at noDuplicatedFiles.allowList[0].packages: array must contain at least 2 elements']
+        schema: checksPerPackageSchema,
+        data: { noDuplicatedFiles: { allowList: [''] } },
+        expectedMessages: ['at noDuplicatedFiles.allowList[0]: string must contain at least 1 character']
     })
 );
 
 test(
-    'allow list: validation fails when a scoped entry omits filePath',
+    'per-package: validation fails when an unknown extra property is given',
     checkValidationFailure({
-        schema: checksSchema,
-        data: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ packages: ['a', 'b'] }]
-            }
-        },
-        expectedMessages: ['at noDuplicatedFiles.allowList[0]: invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'allow list: validation fails when a scoped entry has an unknown extra property',
-    checkValidationFailure({
-        schema: checksSchema,
-        data: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'], extra: true }]
-            }
-        },
-        expectedMessages: ['at noDuplicatedFiles.allowList[0]: invalid value doesn’t match expected union']
+        schema: checksPerPackageSchema,
+        data: { noDuplicatedFiles: { allowList: ['LICENSE'], extra: true } },
+        expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
     })
 );

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -208,3 +208,19 @@ test('per-package schema accepts an empty noDevDependencyImports object', () => 
 test('per-package schema rejects any field on noDevDependencyImports', () => {
     assert.strictEqual(safeParse(checksPerPackageSchema, { noDevDependencyImports: { enabled: true } }).success, false);
 });
+
+test('top-level schema accepts uniqueTargetPaths with enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { uniqueTargetPaths: { enabled: true } }).success, true);
+});
+
+test('top-level schema rejects uniqueTargetPaths without enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { uniqueTargetPaths: {} }).success, false);
+});
+
+test('per-package schema accepts an empty uniqueTargetPaths object', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { uniqueTargetPaths: {} }).success, true);
+});
+
+test('per-package schema rejects any field on uniqueTargetPaths', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { uniqueTargetPaths: { enabled: true } }).success, false);
+});

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -173,3 +173,22 @@ test('per-package schema accepts a maxBundleSize override', () => {
 test('per-package schema rejects an enabled flag on maxBundleSize', () => {
     assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { enabled: true } }).success, false);
 });
+
+test('top-level schema accepts noUnusedBundleDependencies with enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { noUnusedBundleDependencies: { enabled: true } }).success, true);
+});
+
+test('top-level schema rejects noUnusedBundleDependencies without enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { noUnusedBundleDependencies: {} }).success, false);
+});
+
+test('per-package schema accepts an empty noUnusedBundleDependencies object', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { noUnusedBundleDependencies: {} }).success, true);
+});
+
+test('per-package schema rejects any field on noUnusedBundleDependencies', () => {
+    assert.strictEqual(
+        safeParse(checksPerPackageSchema, { noUnusedBundleDependencies: { enabled: true } }).success,
+        false
+    );
+});

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -192,3 +192,19 @@ test('per-package schema rejects any field on noUnusedBundleDependencies', () =>
         false
     );
 });
+
+test('top-level schema accepts noDevDependencyImports with enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { noDevDependencyImports: { enabled: true } }).success, true);
+});
+
+test('top-level schema rejects noDevDependencyImports without enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { noDevDependencyImports: {} }).success, false);
+});
+
+test('per-package schema accepts an empty noDevDependencyImports object', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { noDevDependencyImports: {} }).success, true);
+});
+
+test('per-package schema rejects any field on noDevDependencyImports', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { noDevDependencyImports: { enabled: true } }).success, false);
+});

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -129,3 +129,23 @@ test(
         expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
     })
 );
+
+test('top-level schema accepts requiredFiles with enabled and a files list', () => {
+    assert.strictEqual(safeParse(checksSchema, { requiredFiles: { enabled: true, files: ['LICENSE'] } }).success, true);
+});
+
+test('top-level schema rejects requiredFiles without enabled', () => {
+    assert.strictEqual(safeParse(checksSchema, { requiredFiles: { files: ['LICENSE'] } }).success, false);
+});
+
+test('top-level schema rejects an empty path in requiredFiles.files', () => {
+    assert.strictEqual(safeParse(checksSchema, { requiredFiles: { enabled: true, files: [''] } }).success, false);
+});
+
+test('per-package schema accepts requiredFiles with a files list', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { files: ['LICENSE'] } }).success, true);
+});
+
+test('per-package schema rejects an enabled flag on requiredFiles', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { enabled: true } }).success, false);
+});

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -149,3 +149,27 @@ test('per-package schema accepts requiredFiles with a files list', () => {
 test('per-package schema rejects an enabled flag on requiredFiles', () => {
     assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { enabled: true } }).success, false);
 });
+
+test('top-level schema accepts maxBundleSize with enabled and a bytes threshold', () => {
+    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: 1024 } }).success, true);
+});
+
+test('top-level schema accepts maxBundleSize without bytes', () => {
+    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true } }).success, true);
+});
+
+test('top-level schema rejects a negative byte threshold', () => {
+    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: -1 } }).success, false);
+});
+
+test('top-level schema rejects a non-integer byte threshold', () => {
+    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: 1.5 } }).success, false);
+});
+
+test('per-package schema accepts a maxBundleSize override', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { bytes: 2048 } }).success, true);
+});
+
+test('per-package schema rejects an enabled flag on maxBundleSize', () => {
+    assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { enabled: true } }).success, false);
+});

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -4,13 +4,15 @@ import { noDevDependencyImportsRule } from '../checks/rules/no-dev-dependency-im
 import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
 import { noUnusedBundleDependenciesRule } from '../checks/rules/no-unused-bundle-dependencies.ts';
 import { requiredFilesRule } from '../checks/rules/required-files.ts';
+import { uniqueTargetPathsRule } from '../checks/rules/unique-target-paths.ts';
 
 export const checksSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema),
     requiredFiles: z.optional(requiredFilesRule.globalSchema),
     maxBundleSize: z.optional(maxBundleSizeRule.globalSchema),
     noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.globalSchema),
-    noDevDependencyImports: z.optional(noDevDependencyImportsRule.globalSchema)
+    noDevDependencyImports: z.optional(noDevDependencyImportsRule.globalSchema),
+    uniqueTargetPaths: z.optional(uniqueTargetPathsRule.globalSchema)
 });
 
 export const checksPerPackageSchema = z.strictObject({
@@ -18,5 +20,6 @@ export const checksPerPackageSchema = z.strictObject({
     requiredFiles: z.optional(requiredFilesRule.perPackageSchema),
     maxBundleSize: z.optional(maxBundleSizeRule.perPackageSchema),
     noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.perPackageSchema),
-    noDevDependencyImports: z.optional(noDevDependencyImportsRule.perPackageSchema)
+    noDevDependencyImports: z.optional(noDevDependencyImportsRule.perPackageSchema),
+    uniqueTargetPaths: z.optional(uniqueTargetPathsRule.perPackageSchema)
 });

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,16 +1,19 @@
 import { z } from 'zod/mini';
 import { maxBundleSizeRule } from '../checks/rules/max-bundle-size.ts';
 import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
+import { noUnusedBundleDependenciesRule } from '../checks/rules/no-unused-bundle-dependencies.ts';
 import { requiredFilesRule } from '../checks/rules/required-files.ts';
 
 export const checksSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema),
     requiredFiles: z.optional(requiredFilesRule.globalSchema),
-    maxBundleSize: z.optional(maxBundleSizeRule.globalSchema)
+    maxBundleSize: z.optional(maxBundleSizeRule.globalSchema),
+    noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.globalSchema)
 });
 
 export const checksPerPackageSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema),
     requiredFiles: z.optional(requiredFilesRule.perPackageSchema),
-    maxBundleSize: z.optional(maxBundleSizeRule.perPackageSchema)
+    maxBundleSize: z.optional(maxBundleSizeRule.perPackageSchema),
+    noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.perPackageSchema)
 });

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/mini';
 import { maxBundleSizeRule } from '../checks/rules/max-bundle-size.ts';
+import { noDevDependencyImportsRule } from '../checks/rules/no-dev-dependency-imports.ts';
 import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
 import { noUnusedBundleDependenciesRule } from '../checks/rules/no-unused-bundle-dependencies.ts';
 import { requiredFilesRule } from '../checks/rules/required-files.ts';
@@ -8,12 +9,14 @@ export const checksSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema),
     requiredFiles: z.optional(requiredFilesRule.globalSchema),
     maxBundleSize: z.optional(maxBundleSizeRule.globalSchema),
-    noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.globalSchema)
+    noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.globalSchema),
+    noDevDependencyImports: z.optional(noDevDependencyImportsRule.globalSchema)
 });
 
 export const checksPerPackageSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema),
     requiredFiles: z.optional(requiredFilesRule.perPackageSchema),
     maxBundleSize: z.optional(maxBundleSizeRule.perPackageSchema),
-    noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.perPackageSchema)
+    noUnusedBundleDependencies: z.optional(noUnusedBundleDependenciesRule.perPackageSchema),
+    noDevDependencyImports: z.optional(noDevDependencyImportsRule.perPackageSchema)
 });

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,20 +1,10 @@
 import { z } from 'zod/mini';
-import { nonEmptyStringSchema } from './base-validations.ts';
-
-const minScopedEntryPackages = 2;
-
-const scopedAllowListEntrySchema = z.strictObject({
-    filePath: nonEmptyStringSchema,
-    packages: z.readonly(z.array(nonEmptyStringSchema).check(z.minLength(minScopedEntryPackages)))
-});
-
-const allowListEntrySchema = z.union([nonEmptyStringSchema, scopedAllowListEntrySchema]);
-
-const noDuplicatedFilesSettingsSchema = z.strictObject({
-    enabled: z.boolean(),
-    allowList: z.optional(z.readonly(z.array(allowListEntrySchema)))
-});
+import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
 
 export const checksSchema = z.strictObject({
-    noDuplicatedFiles: z.optional(noDuplicatedFilesSettingsSchema)
+    noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema)
+});
+
+export const checksPerPackageSchema = z.strictObject({
+    noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema)
 });

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod/mini';
 import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
+import { requiredFilesRule } from '../checks/rules/required-files.ts';
 
 export const checksSchema = z.strictObject({
-    noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema)
+    noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema),
+    requiredFiles: z.optional(requiredFilesRule.globalSchema)
 });
 
 export const checksPerPackageSchema = z.strictObject({
-    noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema)
+    noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema),
+    requiredFiles: z.optional(requiredFilesRule.perPackageSchema)
 });

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,13 +1,16 @@
 import { z } from 'zod/mini';
+import { maxBundleSizeRule } from '../checks/rules/max-bundle-size.ts';
 import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
 import { requiredFilesRule } from '../checks/rules/required-files.ts';
 
 export const checksSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema),
-    requiredFiles: z.optional(requiredFilesRule.globalSchema)
+    requiredFiles: z.optional(requiredFilesRule.globalSchema),
+    maxBundleSize: z.optional(maxBundleSizeRule.globalSchema)
 });
 
 export const checksPerPackageSchema = z.strictObject({
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema),
-    requiredFiles: z.optional(requiredFilesRule.perPackageSchema)
+    requiredFiles: z.optional(requiredFilesRule.perPackageSchema),
+    maxBundleSize: z.optional(maxBundleSizeRule.perPackageSchema)
 });

--- a/source/config/config.test.ts
+++ b/source/config/config.test.ts
@@ -152,9 +152,7 @@ test(
         data: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    allowList: ['foo/bar.ts']
-                }
+                noDuplicatedFiles: {}
             },
             packages: [
                 {
@@ -170,15 +168,14 @@ test(
 );
 
 test(
-    'validation fails when checks.noDuplicatedFiles.allowList contains an empty path',
+    'validation fails when a per-package noDuplicatedFiles.allowList contains an empty path',
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
                 noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['']
+                    enabled: true
                 }
             },
             packages: [
@@ -186,49 +183,48 @@ test(
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
                     name: 'foo',
-                    entryPoints: [{ js: 'foo' }]
+                    entryPoints: [{ js: 'foo' }],
+                    checks: { noDuplicatedFiles: { allowList: [''] } }
                 }
             ]
         },
-        expectedMessages: ['at checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character']
+        expectedMessages: [
+            'at packages[0].checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character'
+        ]
     })
 );
 
 test(
-    'validation succeeds when checks.noDuplicatedFiles specifies an allow list',
+    'validation succeeds when a package declares a per-package noDuplicatedFiles allowList',
     checkValidationSuccess({
         schema: packtoryConfigSchema,
         data: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['foo/bar.ts']
-                }
+                noDuplicatedFiles: { enabled: true }
             },
             packages: [
                 {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
                     name: 'foo',
-                    entryPoints: [{ js: 'foo' }]
+                    entryPoints: [{ js: 'foo' }],
+                    checks: { noDuplicatedFiles: { allowList: ['foo/bar.ts'] } }
                 }
             ]
         },
         expectedData: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['foo/bar.ts']
-                }
+                noDuplicatedFiles: { enabled: true }
             },
             packages: [
                 {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
                     name: 'foo',
-                    entryPoints: [{ js: 'foo' }]
+                    entryPoints: [{ js: 'foo' }],
+                    checks: { noDuplicatedFiles: { allowList: ['foo/bar.ts'] } }
                 }
             ]
         }
@@ -242,10 +238,7 @@ test(
         data: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['foo/bar.ts']
-                }
+                noDuplicatedFiles: { enabled: true }
             },
             packages: [
                 {
@@ -259,10 +252,7 @@ test(
         expectedData: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['foo/bar.ts']
-                }
+                noDuplicatedFiles: { enabled: true }
             },
             packages: [
                 {
@@ -678,9 +668,7 @@ test(
         data: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    allowList: ['foo/bar.ts']
-                }
+                noDuplicatedFiles: {}
             },
             packages: [
                 {
@@ -696,27 +684,27 @@ test(
 );
 
 test(
-    'validation fails when checks.noDuplicatedFiles.allowList contains an empty path',
+    'validation fails when a per-package noDuplicatedFiles.allowList contains an empty path (registry config)',
     checkValidationFailure({
         schema: packtoryConfigSchema,
         data: {
             registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['']
-                }
+                noDuplicatedFiles: { enabled: true }
             },
             packages: [
                 {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
                     name: 'foo',
-                    entryPoints: [{ js: 'foo' }]
+                    entryPoints: [{ js: 'foo' }],
+                    checks: { noDuplicatedFiles: { allowList: [''] } }
                 }
             ]
         },
-        expectedMessages: ['at checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character']
+        expectedMessages: [
+            'at packages[0].checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character'
+        ]
     })
 );
 

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod/mini';
+import type { checksPerPackageSchema, checksSchema } from './checks-schema.ts';
 import type { AdditionalFileDescription } from './additional-files.ts';
 import type { DependencyPolicy } from './dependency-policy.ts';
 import type { EntryPoint } from './entry-point.ts';
@@ -6,21 +8,8 @@ import type { PublishSettings } from './publish-settings.ts';
 import type { RegistrySettings } from './registry-settings.ts';
 import type { VersioningSettings } from './versioning-settings.ts';
 
-type ScopedAllowListEntry = {
-    readonly filePath: string;
-    readonly packages: readonly string[];
-};
-
-export type AllowListEntry = ScopedAllowListEntry | string;
-
-type NoDuplicatedFilesSettings = {
-    readonly enabled: boolean;
-    readonly allowList?: readonly AllowListEntry[] | undefined;
-};
-
-export type ChecksSettings = {
-    readonly noDuplicatedFiles?: NoDuplicatedFilesSettings | undefined;
-};
+export type ChecksSettings = z.infer<typeof checksSchema>;
+export type PackageChecksSettings = z.infer<typeof checksPerPackageSchema>;
 
 export type PackageConfig = {
     readonly name: string;
@@ -35,6 +24,7 @@ export type PackageConfig = {
     readonly additionalPackageJsonAttributes?: AdditionalPackageJsonAttributes | undefined;
     readonly publishSettings?: PublishSettings | undefined;
     readonly dependencyPolicy?: DependencyPolicy | undefined;
+    readonly checks?: PackageChecksSettings | undefined;
 };
 
 export type PackageConfigsByName = Readonly<Record<string, PackageConfig>>;

--- a/source/config/per-package-settings-schema.test.ts
+++ b/source/config/per-package-settings-schema.test.ts
@@ -63,6 +63,13 @@ createTestCasesForOptionalField({
     expectedFieldType: 'array'
 });
 
+createTestCasesForOptionalField({
+    schema: perPackageSettingsSchema,
+    data: validPerPackageSettings,
+    path: 'checks',
+    expectedFieldType: 'object'
+});
+
 test(
     'per package settings schema: validation succeeds with required fields',
     checkValidationSuccess({

--- a/source/config/per-package-settings-schema.ts
+++ b/source/config/per-package-settings-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/mini';
+import { checksPerPackageSchema } from './checks-schema.ts';
 import { entryPointSchema } from './entry-point.ts';
 import { nonEmptyStringSchema } from './base-validations.ts';
 import { versioningSettingsSchema } from './versioning-settings.ts';
@@ -8,5 +9,6 @@ export const perPackageSettingsSchema = z.strictObject({
     entryPoints: z.readonly(z.tuple([entryPointSchema], entryPointSchema)),
     versioning: z.optional(versioningSettingsSchema),
     bundleDependencies: z.optional(z.readonly(z.array(nonEmptyStringSchema))),
-    bundlePeerDependencies: z.optional(z.readonly(z.array(nonEmptyStringSchema)))
+    bundlePeerDependencies: z.optional(z.readonly(z.array(nonEmptyStringSchema))),
+    checks: z.optional(checksPerPackageSchema)
 });

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -187,7 +187,7 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'bundlePeerDependencies',
             'checks'
         ],
-        checksShapeKeys: ['noDuplicatedFiles'],
+        checksShapeKeys: ['noDuplicatedFiles', 'requiredFiles'],
         commonShapeKeys: [
             'sourcesFolder',
             'mainPackageJson',

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -187,7 +187,7 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'bundlePeerDependencies',
             'checks'
         ],
-        checksShapeKeys: ['noDuplicatedFiles', 'requiredFiles', 'maxBundleSize'],
+        checksShapeKeys: ['noDuplicatedFiles', 'requiredFiles', 'maxBundleSize', 'noUnusedBundleDependencies'],
         commonShapeKeys: [
             'sourcesFolder',
             'mainPackageJson',

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -192,7 +192,8 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'requiredFiles',
             'maxBundleSize',
             'noUnusedBundleDependencies',
-            'noDevDependencyImports'
+            'noDevDependencyImports',
+            'uniqueTargetPaths'
         ],
         commonShapeKeys: [
             'sourcesFolder',

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -187,7 +187,13 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'bundlePeerDependencies',
             'checks'
         ],
-        checksShapeKeys: ['noDuplicatedFiles', 'requiredFiles', 'maxBundleSize', 'noUnusedBundleDependencies'],
+        checksShapeKeys: [
+            'noDuplicatedFiles',
+            'requiredFiles',
+            'maxBundleSize',
+            'noUnusedBundleDependencies',
+            'noDevDependencyImports'
+        ],
         commonShapeKeys: [
             'sourcesFolder',
             'mainPackageJson',

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -187,7 +187,7 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'bundlePeerDependencies',
             'checks'
         ],
-        checksShapeKeys: ['noDuplicatedFiles', 'requiredFiles'],
+        checksShapeKeys: ['noDuplicatedFiles', 'requiredFiles', 'maxBundleSize'],
         commonShapeKeys: [
             'sourcesFolder',
             'mainPackageJson',

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -184,7 +184,8 @@ test('packtory config schemas keep their union and package tuple structure', asy
             'entryPoints',
             'versioning',
             'bundleDependencies',
-            'bundlePeerDependencies'
+            'bundlePeerDependencies',
+            'checks'
         ],
         checksShapeKeys: ['noDuplicatedFiles'],
         commonShapeKeys: [

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -33,18 +33,6 @@ function fooPackage(name = 'foo'): ConfigInput {
     return minimalPackageConfigFactory.build({ name });
 }
 
-function configWithGhostAllowList(allowListPackages: readonly string[]): ConfigInput {
-    return {
-        checks: {
-            noDuplicatedFiles: {
-                enabled: true,
-                allowList: [{ filePath: 'src/shared/util.ts', packages: allowListPackages }]
-            }
-        },
-        packages: [fooPackage('a'), fooPackage('b')]
-    };
-}
-
 test('returns the issues when the given config doesn’t match the schema', () => {
     const result = validateConfig({ not: 'valid' });
     assert.deepStrictEqual(
@@ -192,27 +180,6 @@ test('doesn’t report cyclic dependency issues when there is also a missing dep
     assert.deepStrictEqual(result, Result.err(['Bundle peer dependency "b" referenced in "a" does not exist']));
 });
 
-test('returns an issue when a scoped allow-list entry references an unknown package', () => {
-    const result = validateConfig(withRegistry(configWithGhostAllowList(['a', 'ghost'])));
-
-    assert.deepStrictEqual(
-        result,
-        Result.err(['Allow list entry for "src/shared/util.ts" references unknown package "ghost"'])
-    );
-});
-
-test('returns one issue per unknown package in a scoped allow-list entry', () => {
-    const result = validateConfig(withRegistry(configWithGhostAllowList(['ghost', 'phantom'])));
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Allow list entry for "src/shared/util.ts" references unknown package "ghost"',
-            'Allow list entry for "src/shared/util.ts" references unknown package "phantom"'
-        ])
-    );
-});
-
 test('accepts a config where checks is defined but noDuplicatedFiles is omitted', () => {
     const result = validateConfig(
         withRegistry({
@@ -235,34 +202,16 @@ test('accepts a config where checks.noDuplicatedFiles is defined without an allo
     assert.strictEqual(result.isOk, true);
 });
 
-test('does not report unknown-package issues for plain string allow-list entries', () => {
+test('accepts a config where packages declare per-package noDuplicatedFiles allowList', () => {
     const result = validateConfig(
         withRegistry({
-            checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: ['LICENSE']
-                }
-            },
-            packages: [{ name: 'a', entryPoints: [{ js: 'foo' }] }]
-        })
-    );
-
-    assert.strictEqual(result.isOk, true);
-});
-
-test('accepts a scoped allow-list entry when all referenced packages exist', () => {
-    const result = validateConfig(
-        withRegistry({
-            checks: {
-                noDuplicatedFiles: {
-                    enabled: true,
-                    allowList: [{ filePath: 'src/shared/util.ts', packages: ['a', 'b'] }]
-                }
-            },
+            checks: { noDuplicatedFiles: { enabled: true } },
             packages: [
-                { name: 'a', entryPoints: [{ js: 'foo' }] },
-                { name: 'b', entryPoints: [{ js: 'foo' }] }
+                {
+                    name: 'a',
+                    entryPoints: [{ js: 'foo' }],
+                    checks: { noDuplicatedFiles: { allowList: ['LICENSE'] } }
+                }
             ]
         })
     );
@@ -274,22 +223,6 @@ test('validateConfigWithoutRegistry() returns schema issues when the config is i
     const result = validateConfigWithoutRegistry({ not: 'valid' });
 
     assert.deepStrictEqual(result, Result.err(['invalid value doesn’t match expected union']));
-});
-
-test('validateConfigWithoutRegistry() returns an issue for unknown packages in a scoped allow-list entry', () => {
-    const result = validateConfigWithoutRegistry({
-        commonPackageSettings: {
-            sourcesFolder: 'foo',
-            mainPackageJson: { type: 'module' },
-            publishSettings: { access: 'public' }
-        },
-        ...configWithGhostAllowList(['a', 'ghost'])
-    });
-
-    assert.deepStrictEqual(
-        result,
-        Result.err(['Allow list entry for "src/shared/util.ts" references unknown package "ghost"'])
-    );
 });
 
 test('validateConfigWithoutRegistry() returns duplicate and missing dependency issues', () => {

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -5,7 +5,6 @@ import type { ZodMiniType } from 'zod/mini';
 import { type DirectedGraph, createDirectedGraph } from '../directed-graph/graph.ts';
 import {
     getBundledDependencies,
-    type ChecksSettings,
     type PacktoryConfig,
     type PackageConfig,
     type PackageConfigsByName,
@@ -70,28 +69,6 @@ function validateDependenciesExist(packageConfigs: PackageConfigsByName): readon
 function packageListToRecord(packages: readonly PackageConfig[]): PackageConfigsByName {
     return indexBy(packages, (packageConfig) => {
         return packageConfig.name;
-    });
-}
-
-function validateNoDuplicatedFilesAllowList(
-    packageConfigs: PackageConfigsByName,
-    checks: ChecksSettings | undefined
-): readonly string[] {
-    const allowList = checks?.noDuplicatedFiles?.allowList;
-    if (allowList === undefined) {
-        return [];
-    }
-    return allowList.flatMap((entry) => {
-        if (typeof entry === 'string') {
-            return [];
-        }
-        return entry.packages
-            .filter((name) => {
-                return !Object.hasOwn(packageConfigs, name);
-            })
-            .map((name) => {
-                return `Allow list entry for "${entry.filePath}" references unknown package "${name}"`;
-            });
     });
 }
 
@@ -174,8 +151,7 @@ function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWith
     const preGraphIssues = [
         ...validatePublishSettingsArePlaced(packtoryConfig),
         ...validateAllowScriptsConsistency(packtoryConfig),
-        ...validateDependenciesExist(packageConfigs),
-        ...validateNoDuplicatedFilesAllowList(packageConfigs, packtoryConfig.checks)
+        ...validateDependenciesExist(packageConfigs)
     ];
     if (preGraphIssues.length > 0) {
         return Result.err([...validateDuplicatePackages(packtoryConfig.packages), ...preGraphIssues]);

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -164,13 +164,16 @@ describe('PacktoryConfig — exposed structure', () => {
         expect<EntryPoint['declarationFile']>().type.toBe<string | undefined>();
     });
 
-    test('checks.noDuplicatedFiles toggles via an `enabled` boolean and an optional allow-list', () => {
+    test('checks.noDuplicatedFiles is toggled at the top level via `enabled`', () => {
         type Checks = NonNullable<PacktoryConfig['checks']>;
         type NoDuplicates = NonNullable<Checks['noDuplicatedFiles']>;
         expect<NoDuplicates['enabled']>().type.toBe<boolean>();
-        expect<NoDuplicates['allowList']>().type.toBeAssignableTo<
-            readonly (string | { readonly filePath: string; readonly packages: readonly string[] })[] | undefined
-        >();
+    });
+
+    test('PackageConfig.checks.noDuplicatedFiles carries the per-package allowList', () => {
+        type PackageChecks = NonNullable<PackageConfig['checks']>;
+        type NoDuplicates = NonNullable<PackageChecks['noDuplicatedFiles']>;
+        expect<NoDuplicates['allowList']>().type.toBe<readonly string[] | undefined>();
     });
 });
 

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -267,12 +267,16 @@ test('resolveAndLinkAll() returns partial scheduler failures', async () => {
     );
 });
 
-test('resolveAndLinkAll() returns check failures after the linked bundles were built', async () => {
-    const { packtory } = createPacktoryUnderTest({
+function createPacktoryThatSharesSourceFile(): ReturnType<typeof createPacktoryUnderTest> {
+    return createPacktoryUnderTest({
         resolveAndLink: fake(async (options: { name: string }) => {
             return createLinkedBundle(options.name, '/shared.js');
         })
     });
+}
+
+test('resolveAndLinkAll() returns check failures after the linked bundles were built', async () => {
+    const { packtory } = createPacktoryThatSharesSourceFile();
 
     const result = await packtory.resolveAndLinkAll(
         createConfigWithoutRegistry({
@@ -280,6 +284,131 @@ test('resolveAndLinkAll() returns check failures after the linked bundles were b
             packages: twoPackageEntries
         })
     );
+
+    assert.deepStrictEqual(
+        result,
+        Result.err({
+            type: 'checks',
+            issues: ['File "/shared.js" is included in multiple packages: package-a, package-b']
+        })
+    );
+});
+
+test('resolveAndLinkAll() threads per-package noDuplicatedFiles consent through the runner', async () => {
+    const { packtory } = createPacktoryThatSharesSourceFile();
+
+    const result = await packtory.resolveAndLinkAll(
+        createConfigWithoutRegistry({
+            checks: { noDuplicatedFiles: { enabled: true } },
+            packages: twoPackageEntries.map((entry) => {
+                return {
+                    ...entry,
+                    checks: { noDuplicatedFiles: { allowList: ['/shared.js'] } }
+                };
+            })
+        })
+    );
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('resolveAndLinkAll() exposes packageConfig.bundleDependencies to noUnusedBundleDependencies', async () => {
+    const { packtory } = createPacktoryUnderTest({
+        resolveAndLink: fake(async (options: { name: string }) => {
+            return createLinkedBundle(options.name);
+        })
+    });
+
+    const result = await packtory.resolveAndLinkAll(
+        createConfigWithoutRegistry({
+            checks: { noUnusedBundleDependencies: { enabled: true } },
+            packages: [
+                { name: 'package-b', entryPoints: [{ js: 'package-b/index.js' }] },
+                {
+                    name: 'package-a',
+                    entryPoints: [{ js: 'package-a/index.js' }],
+                    bundleDependencies: ['package-b']
+                }
+            ]
+        })
+    );
+
+    assert.deepStrictEqual(
+        result,
+        Result.err({
+            type: 'checks',
+            issues: ['Unused bundle dependency "package-b" declared by package "package-a"']
+        })
+    );
+});
+
+test('resolveAndLinkAll() prefers per-package mainPackageJson over common when running checks', async () => {
+    const { packtory } = createPacktoryUnderTest({
+        resolveAndLink: fake(async (options: { name: string }) => {
+            return linkedBundle({
+                name: options.name,
+                contents: [
+                    {
+                        ...bundleResource(`/${options.name}/index.js`, { targetFilePath: 'index.js' }),
+                        isSubstituted: false
+                    }
+                ],
+                entryPoints: [
+                    {
+                        js: {
+                            sourceFilePath: `/${options.name}/index.js`,
+                            targetFilePath: 'index.js',
+                            content: '',
+                            isExecutable: false
+                        }
+                    }
+                ],
+                externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
+            });
+        })
+    });
+
+    const result = await packtory.resolveAndLinkAll({
+        commonPackageSettings: {
+            sourcesFolder: '/src',
+            mainPackageJson: { type: 'module', devDependencies: { 'runtime-dep': '1.0.0' } },
+            publishSettings: { access: 'public' }
+        },
+        checks: { noDevDependencyImports: { enabled: true } },
+        packages: [
+            {
+                name: 'package-a',
+                mainPackageJson: { type: 'module', dependencies: { 'runtime-dep': '1.0.0' } },
+                entryPoints: [{ js: 'package-a/index.js' }]
+            }
+        ]
+    });
+
+    assert.strictEqual(result.isOk, true);
+});
+
+test('resolveAndLinkAll() runs checks when commonPackageSettings is omitted', async () => {
+    const { packtory } = createPacktoryThatSharesSourceFile();
+
+    const result = await packtory.resolveAndLinkAll({
+        checks: { noDuplicatedFiles: { enabled: true } },
+        packages: [
+            {
+                name: 'package-a',
+                sourcesFolder: '/src',
+                mainPackageJson: { type: 'module' },
+                publishSettings: { access: 'public' },
+                entryPoints: [{ js: 'package-a/index.js' }]
+            },
+            {
+                name: 'package-b',
+                sourcesFolder: '/src',
+                mainPackageJson: { type: 'module' },
+                publishSettings: { access: 'public' },
+                entryPoints: [{ js: 'package-b/index.js' }]
+            }
+        ]
+    });
 
     assert.deepStrictEqual(
         result,

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -81,16 +81,26 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         validated: ConfigWithGraph<PacktoryConfigWithoutRegistry>,
         resolvedPackages: readonly ResolvedPackage[]
     ): Result<readonly ResolvedPackage[], CheckError> {
-        const { packtoryConfig: config, packageConfigs } = validated;
+        const { packtoryConfig: config } = validated;
         const perPackageSettings = new Map(
             config.packages.map((packageConfig) => {
                 return [packageConfig.name, packageConfig.checks];
             })
         );
+        const commonMainPackageJson = config.commonPackageSettings?.mainPackageJson;
+        const effectivePackageConfigs = mapToObj(config.packages, (packageConfig) => {
+            return [
+                packageConfig.name,
+                {
+                    ...packageConfig,
+                    mainPackageJson: packageConfig.mainPackageJson ?? commonMainPackageJson
+                }
+            ];
+        });
         const checkIssues = runChecks({
             settings: config.checks ?? {},
             perPackageSettings,
-            packageConfigs,
+            packageConfigs: effectivePackageConfigs,
             bundles: resolvedPackages.map((resolvedPackage) => {
                 return resolvedPackage.linkedBundle;
             })

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -81,8 +81,14 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         config: PacktoryConfigWithoutRegistry,
         resolvedPackages: readonly ResolvedPackage[]
     ): Result<readonly ResolvedPackage[], CheckError> {
+        const perPackageSettings = new Map(
+            config.packages.map((packageConfig) => {
+                return [packageConfig.name, packageConfig.checks];
+            })
+        );
         const checkIssues = runChecks({
             settings: config.checks ?? {},
+            perPackageSettings,
             bundles: resolvedPackages.map((resolvedPackage) => {
                 return resolvedPackage.linkedBundle;
             })

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -78,9 +78,10 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
     }
 
     function buildChecksResult(
-        config: PacktoryConfigWithoutRegistry,
+        validated: ConfigWithGraph<PacktoryConfigWithoutRegistry>,
         resolvedPackages: readonly ResolvedPackage[]
     ): Result<readonly ResolvedPackage[], CheckError> {
+        const { packtoryConfig: config, packageConfigs } = validated;
         const perPackageSettings = new Map(
             config.packages.map((packageConfig) => {
                 return [packageConfig.name, packageConfig.checks];
@@ -89,6 +90,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         const checkIssues = runChecks({
             settings: config.checks ?? {},
             perPackageSettings,
+            packageConfigs,
             bundles: resolvedPackages.map((resolvedPackage) => {
                 return resolvedPackage.linkedBundle;
             })
@@ -133,7 +135,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
             return Result.err({ type: 'partial', error: runResult.error });
         }
 
-        return buildChecksResult(config.packtoryConfig, runResult.value);
+        return buildChecksResult(config, runResult.value);
     }
 
     async function determineVersionAndPublishAll(

--- a/source/test-libraries/check-bundle-fixture.ts
+++ b/source/test-libraries/check-bundle-fixture.ts
@@ -1,0 +1,11 @@
+import type { LinkedBundle } from '../linker/linked-bundle.ts';
+import { bundleResource, linkedBundle } from './bundle-fixtures.ts';
+
+export function checkBundle(name: string, filePaths: readonly string[]): LinkedBundle {
+    return linkedBundle({
+        name,
+        contents: filePaths.map((filePath) => {
+            return { ...bundleResource(filePath, { targetFilePath: filePath }), isSubstituted: false };
+        })
+    });
+}


### PR DESCRIPTION
## Summary

- Restructures the checks framework so every rule owns its own `globalSchema` / `perPackageSchema` / `run`. Top-level `checks` and per-package `checks` are assembled from the rule registry; `enabled` lives only at the top level.
- Migrates `noDuplicatedFiles` to a per-package consent allowList: a duplicate is allowed only when every owning bundle's allowList covers it. The `{filePath, packages}` form is gone.
- Adds five new rules:
  - **requiredFiles** — bundle must contain configured files (matched on `targetFilePath`); global default + per-package extension.
  - **maxBundleSize** — UTF-8 byte length cap, global default + per-package override.
  - **noUnusedBundleDependencies** — flags declared `bundleDependencies` / `bundlePeerDependencies` whose imports were never substituted.
  - **noDevDependencyImports** — flags external deps reachable from source that are only declared in `mainPackageJson.devDependencies`.
  - **uniqueTargetPaths** — flags within-bundle `targetFilePath` collisions that the artifact writer would otherwise silently overwrite.
- Documents the framework and every shipped rule in the main readme.