### PR TITLE
Introduce a FakeFileManager test library

### DIFF
--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -3,6 +3,7 @@ import { test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { LinkedBundleResource } from '../linker/linked-bundle.ts';
 import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
+import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
     type ArtifactsBuilder,
     type ArtifactsBuilderDependencies,
@@ -22,40 +23,39 @@ function bundleWithContents(
 }
 
 type Overrides = {
-    readonly readFile?: SinonSpy;
-    readonly checkReadability?: SinonSpy;
-    readonly copyFile?: SinonSpy;
-    readonly writeFile?: SinonSpy;
+    readonly fileManager?: FakeFileManager;
     readonly tarballBuilder?: { readonly build?: SinonSpy };
 };
-
-function createSpy<TSpy extends SinonSpy>(spy: TSpy | undefined, fallback: () => TSpy): TSpy {
-    return spy ?? fallback();
-}
 
 function createTarballBuilderDependencies(overrides: Overrides['tarballBuilder'] = {}): {
     readonly build: SinonSpy;
 } {
     return {
-        build: createSpy(overrides.build, () => {
-            return fake.resolves(Buffer.from([-1]));
-        })
+        build: overrides.build ?? fake.resolves(Buffer.from([-1]))
     };
 }
 
-function artifactsBuilderFactory(overrides: Overrides = {}): ArtifactsBuilder {
+function artifactsBuilderFactory(overrides: Overrides = {}): {
+    readonly builder: ArtifactsBuilder;
+    readonly fileManager: FakeFileManager;
+} {
+    const fileManager = overrides.fileManager ?? createFakeFileManager();
     const dependencies: ArtifactsBuilderDependencies = {
-        fileManager: {
-            readFile: createSpy(overrides.readFile, fake),
-            checkReadability: createSpy(overrides.checkReadability, fake),
-            copyFile: createSpy(overrides.copyFile, fake),
-            writeFile: createSpy(overrides.writeFile, fake),
-            getTransferableFileDescriptionFromPath: fake()
-        },
+        fileManager,
         tarballBuilder: createTarballBuilderDependencies(overrides.tarballBuilder)
     };
 
-    return createArtifactsBuilder(dependencies);
+    return { builder: createArtifactsBuilder(dependencies), fileManager };
+}
+
+function builderWithUnreadableTargetFolder(): {
+    readonly builder: ArtifactsBuilder;
+    readonly fileManager: FakeFileManager;
+} {
+    const fileManager = createFakeFileManager({
+        simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+    });
+    return artifactsBuilderFactory({ fileManager });
 }
 
 function makeContent(targetFilePath: string, content: string, isSubstituted = false): LinkedBundleResource {
@@ -74,7 +74,7 @@ function makeContent(targetFilePath: string, content: string, isSubstituted = fa
 
 test('buildTarball() returns the tarData', async () => {
     const tarballBuilder = { build: fake.resolves(Buffer.from([42])) };
-    const builder = artifactsBuilderFactory({ tarballBuilder });
+    const { builder } = artifactsBuilderFactory({ tarballBuilder });
     const result = await builder.buildTarball(bundleWithContents([]));
 
     assert.deepStrictEqual(result, {
@@ -84,7 +84,7 @@ test('buildTarball() returns the tarData', async () => {
 
 test('buildTarball() passes all given contents to the tarballBuilder', async () => {
     const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
-    const builder = artifactsBuilderFactory({ tarballBuilder });
+    const { builder } = artifactsBuilderFactory({ tarballBuilder });
     const contents: LinkedBundleResource[] = [
         makeContent('bar.txt', 'bar'),
         makeContent('baz.txt', 'baz'),
@@ -104,45 +104,51 @@ test('buildTarball() passes all given contents to the tarballBuilder', async () 
 });
 
 test('buildFolder() writes only the manifest when the given bundle has no contents', async () => {
-    const writeFile = fake.resolves(undefined);
-    const checkReadability = fake.resolves({ isReadable: false });
-    const builder = artifactsBuilderFactory({ writeFile, checkReadability });
+    const { builder, fileManager } = builderWithUnreadableTargetFolder();
 
     await builder.buildFolder(bundleWithContents([], 'package.json'), '/the/target/folder');
 
-    assert.strictEqual(writeFile.callCount, 1);
-    assert.deepStrictEqual(writeFile.firstCall.args, ['/the/target/folder/package.json', '{}']);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+        filePath: '/the/target/folder/package.json',
+        content: '{}'
+    });
 });
 
 test('buildFolder() throws when the target folder already exists', async () => {
-    const checkReadability = fake.resolves({ isReadable: true });
-    const builder = artifactsBuilderFactory({ checkReadability });
+    const fileManager = createFakeFileManager({
+        simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }]
+    });
+    const { builder } = artifactsBuilderFactory({ fileManager });
 
     try {
         await builder.buildFolder(bundleWithContents([]), '/the/target/folder');
         assert.fail('Expected buildFolder() to throw but it did not');
     } catch (error: unknown) {
-        assert.strictEqual(checkReadability.callCount, 1);
-        assert.deepStrictEqual(checkReadability.firstCall.args, ['/the/target/folder']);
+        assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/the/target/folder' });
         assert.strictEqual((error as Error).message, 'Folder /the/target/folder already exists');
     }
 });
 
 test('buildFolder() writes the source of a source bundle content to the given target folder', async () => {
-    const writeFile = fake.resolves(undefined);
-    const checkReadability = fake.resolves({ isReadable: false });
-    const builder = artifactsBuilderFactory({ writeFile, checkReadability });
+    const { builder, fileManager } = builderWithUnreadableTargetFolder();
     const contents: LinkedBundleResource[] = [makeContent('bar/baz.txt', 'the-content')];
     await builder.buildFolder(bundleWithContents(contents, 'package.json'), '/the/target/folder');
 
-    assert.strictEqual(writeFile.callCount, 2);
-    assert.deepStrictEqual(writeFile.firstCall.args, ['/the/target/folder/package.json', '{}']);
-    assert.deepStrictEqual(writeFile.secondCall.args, ['/the/target/folder/bar/baz.txt', 'the-content']);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
+    assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+        filePath: '/the/target/folder/package.json',
+        content: '{}'
+    });
+    assert.deepStrictEqual(fileManager.getWriteFileCall(1), {
+        filePath: '/the/target/folder/bar/baz.txt',
+        content: 'the-content'
+    });
 });
 
 test('collectContents() returns the list of file descriptions of the given bundle', () => {
-    const readFile = fake.resolves('bar');
-    const builder = artifactsBuilderFactory({ readFile });
+    const { builder } = artifactsBuilderFactory();
     const contents: LinkedBundleResource[] = [
         makeContent('bar.txt', 'bar'),
         makeContent('baz.txt', 'baz'),
@@ -159,7 +165,7 @@ test('collectContents() returns the list of file descriptions of the given bundl
 });
 
 test('collectContents() appends extra files after the bundle contents and applies the prefix to them', () => {
-    const builder = artifactsBuilderFactory();
+    const { builder } = artifactsBuilderFactory();
     const result = builder.collectContents(bundleWithContents([], 'package.json'), 'package', [
         { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
     ]);
@@ -172,7 +178,7 @@ test('collectContents() appends extra files after the bundle contents and applie
 
 test('buildTarball() forwards extra files to the tarball builder alongside the bundle contents', async () => {
     const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
-    const builder = artifactsBuilderFactory({ tarballBuilder });
+    const { builder } = artifactsBuilderFactory({ tarballBuilder });
     await builder.buildTarball(bundleWithContents([makeContent('bar.txt', 'bar')], 'package.json'), [
         { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
     ]);
@@ -187,16 +193,15 @@ test('buildTarball() forwards extra files to the tarball builder alongside the b
 });
 
 test('buildFolder() writes extra files alongside the bundle contents into the target folder', async () => {
-    const writeable = { writeFile: fake.resolves(undefined), checkReadability: fake.resolves({ isReadable: false }) };
-    const builder = artifactsBuilderFactory(writeable);
+    const { builder, fileManager } = builderWithUnreadableTargetFolder();
 
     await builder.buildFolder(bundleWithContents([], 'package.json'), '/the/target/folder', [
         { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
     ]);
 
-    assert.strictEqual(writeable.writeFile.callCount, 2);
-    assert.deepStrictEqual(writeable.writeFile.secondCall.args, [
-        '/the/target/folder/sbom.cdx.json',
-        '{"bomFormat":"CycloneDX"}'
-    ]);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
+    assert.deepStrictEqual(fileManager.getWriteFileCall(1), {
+        filePath: '/the/target/folder/sbom.cdx.json',
+        content: '{"bomFormat":"CycloneDX"}'
+    });
 });

--- a/source/dependency-scanner/source-map-file-locator.property.ts
+++ b/source/dependency-scanner/source-map-file-locator.property.ts
@@ -1,17 +1,16 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
 import { test } from 'mocha';
-import { fake } from 'sinon';
 import { Maybe } from 'true-myth';
-import { createSourceMapFileLocator, type SourceMapFileLocatorDependencies } from './source-map-file-locator.ts';
+import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
+import { createSourceMapFileLocator } from './source-map-file-locator.ts';
 
 function createLocator(readFileContent: string, isReadable: boolean) {
-    return createSourceMapFileLocator({
-        fileManager: {
-            readFile: fake.resolves(readFileContent),
-            checkReadability: fake.resolves({ isReadable })
-        }
-    } as unknown as SourceMapFileLocatorDependencies);
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: readFileContent }],
+        simulatedCheckReadabilityResponses: [{ value: { isReadable } }]
+    });
+    return createSourceMapFileLocator({ fileManager });
 }
 
 test('locate() returns Maybe.nothing() for malformed or missing source-map comments', async () => {

--- a/source/dependency-scanner/source-map-file-locator.test.ts
+++ b/source/dependency-scanner/source-map-file-locator.test.ts
@@ -1,49 +1,46 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
-import {
-    createSourceMapFileLocator,
-    type SourceMapFileLocator,
-    type SourceMapFileLocatorDependencies
-} from './source-map-file-locator.ts';
+import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
+import { createSourceMapFileLocator, type SourceMapFileLocator } from './source-map-file-locator.ts';
 
 type Overrides = {
-    readonly readFile?: SinonSpy;
-    readonly checkReadability?: SinonSpy;
+    readonly readFileContent?: string;
+    readonly isReadable?: boolean;
 };
 
-function sourceMapFileLocatorFactory(overrides: Overrides = {}): SourceMapFileLocator {
-    const { readFile = fake.resolves(''), checkReadability = fake.resolves(null) } = overrides;
-    const fakeDependencies = {
-        fileManager: {
-            readFile,
-            checkReadability
-        }
-    } as unknown as SourceMapFileLocatorDependencies;
+function sourceMapFileLocatorFactory(overrides: Overrides = {}): {
+    readonly locator: SourceMapFileLocator;
+    readonly fileManager: FakeFileManager;
+} {
+    const { readFileContent = '', isReadable = false } = overrides;
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: readFileContent }],
+        simulatedCheckReadabilityResponses: [{ value: { isReadable } }]
+    });
 
-    return createSourceMapFileLocator(fakeDependencies);
+    return {
+        locator: createSourceMapFileLocator({ fileManager }),
+        fileManager
+    };
 }
 
 test('reads the content of the given source file', async () => {
-    const readFile = fake.resolves('');
-    const locator = sourceMapFileLocatorFactory({ readFile });
+    const { locator, fileManager } = sourceMapFileLocatorFactory();
 
     await locator.locate('/foo/bar.js');
 
-    assert.strictEqual(readFile.callCount, 1);
-    assert.deepStrictEqual(readFile.firstCall.args, ['/foo/bar.js']);
+    assert.strictEqual(fileManager.getReadFileCallCount(), 1);
+    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/foo/bar.js' });
 });
 
 async function expectLocateReturnsNothingWithoutCheckReadability(content: string): Promise<void> {
-    const readFile = fake.resolves(content);
-    const checkReadability = fake.resolves({ isReadable: true });
-    const locator = sourceMapFileLocatorFactory({ readFile, checkReadability });
+    const { locator, fileManager } = sourceMapFileLocatorFactory({ readFileContent: content, isReadable: true });
 
     const result = await locator.locate('/foo/bar.js');
 
     assert.deepStrictEqual(result, Maybe.nothing());
-    assert.strictEqual(checkReadability.callCount, 0);
+    assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 0);
 }
 
 test('returns nothing when there is no external source mapping URL referenced in the given file', async () => {
@@ -65,41 +62,45 @@ test('returns nothing when the sourceMappingURL comment does not contain a file 
 });
 
 test('reads the named capture group value as the source map file name', async () => {
-    const readFile = fake.resolves('foo\n//# sourceMappingURL=../maps/baz.map.js');
-    const checkReadability = fake.resolves({ isReadable: false });
-    const locator = sourceMapFileLocatorFactory({ readFile, checkReadability });
+    const { locator, fileManager } = sourceMapFileLocatorFactory({
+        readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
+        isReadable: false
+    });
 
     const result = await locator.locate('/foo/bar.js');
 
     assert.deepStrictEqual(result, Maybe.nothing());
-    assert.deepStrictEqual(checkReadability.firstCall.args, ['/maps/baz.map.js']);
+    assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js' });
 });
 
 test('uses the full sourceMappingURL capture up to the end of the line', async () => {
-    const readFile = fake.resolves('foo\n//# sourceMappingURL=../maps/baz.map.js?hash=1');
-    const checkReadability = fake.resolves({ isReadable: false });
-    const locator = sourceMapFileLocatorFactory({ readFile, checkReadability });
+    const { locator, fileManager } = sourceMapFileLocatorFactory({
+        readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js?hash=1',
+        isReadable: false
+    });
 
     await locator.locate('/foo/bar.js');
 
-    assert.deepStrictEqual(checkReadability.firstCall.args, ['/maps/baz.map.js?hash=1']);
+    assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js?hash=1' });
 });
 
 test('checks if the referenced source mapping file is readable on the file system', async () => {
-    const readFile = fake.resolves('foo\n//# sourceMappingURL=baz.map.js');
-    const checkReadability = fake.resolves({ isReadable: false });
-    const locator = sourceMapFileLocatorFactory({ readFile, checkReadability });
+    const { locator, fileManager } = sourceMapFileLocatorFactory({
+        readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
+        isReadable: false
+    });
 
     await locator.locate('/foo/bar.js');
 
-    assert.strictEqual(checkReadability.callCount, 1);
-    assert.deepStrictEqual(checkReadability.firstCall.args, ['/foo/baz.map.js']);
+    assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
+    assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/foo/baz.map.js' });
 });
 
 test('returns the path to the referenced source map file when it is readable', async () => {
-    const readFile = fake.resolves('foo\n//# sourceMappingURL=../maps/baz.map.js');
-    const checkReadability = fake.resolves({ isReadable: true });
-    const locator = sourceMapFileLocatorFactory({ readFile, checkReadability });
+    const { locator } = sourceMapFileLocatorFactory({
+        readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
+        isReadable: true
+    });
 
     const result = await locator.locate('/foo/bar.js');
 
@@ -107,9 +108,10 @@ test('returns the path to the referenced source map file when it is readable', a
 });
 
 test('returns nothing when there is an external source mapping file referenced but it can’t be read', async () => {
-    const readFile = fake.resolves('foo\n//# sourceMappingURL=baz.map.js');
-    const checkReadability = fake.resolves({ isReadable: false });
-    const locator = sourceMapFileLocatorFactory({ readFile, checkReadability });
+    const { locator } = sourceMapFileLocatorFactory({
+        readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
+        isReadable: false
+    });
 
     const result = await locator.locate('/foo/bar.js');
 

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -3,6 +3,7 @@ import { test } from 'mocha';
 import { fake, stub, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
 import { createDependencyGraph } from '../dependency-scanner/dependency-graph.ts';
+import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
     createResourceResolver,
     type ResourceResolver,
@@ -58,27 +59,32 @@ function createGraph(params: {
 
 type Overrides = {
     readonly scan?: SinonSpy;
-    readonly getTransferableFileDescriptionFromPath?: SinonSpy;
+    readonly transferableFileDescriptionResponder?: (
+        sourceFilePath: string,
+        targetFilePath: string
+    ) => TransferableFile;
 };
 
 function createResolver(overrides: Overrides = {}): {
     readonly resolver: ResourceResolver;
     readonly scan: SinonSpy;
-    readonly getTransferableFileDescriptionFromPath: SinonSpy;
 } {
     const scan = overrides.scan ?? fake();
-    const getTransferableFileDescriptionFromPath =
-        overrides.getTransferableFileDescriptionFromPath ?? fake(createTransferableFile);
+    const responder = overrides.transferableFileDescriptionResponder ?? createTransferableFile;
+    const fileManager = createFakeFileManager({
+        transferableFileDescriptionResponder: (sourceFilePath, targetFilePath) => {
+            return { value: responder(sourceFilePath, targetFilePath) };
+        }
+    });
 
-    const dependencies = {
-        dependencyScanner: { scan },
-        fileManager: { getTransferableFileDescriptionFromPath }
-    } as unknown as ResourceResolverDependencies;
+    const dependencies: ResourceResolverDependencies = {
+        dependencyScanner: { scan } as unknown as ResourceResolverDependencies['dependencyScanner'],
+        fileManager
+    };
 
     return {
         resolver: createResourceResolver(dependencies),
-        scan,
-        getTransferableFileDescriptionFromPath
+        scan
     };
 }
 
@@ -180,9 +186,9 @@ test('resolve() throws when an entry point resource cannot be resolved from the 
     const scan = fake.resolves(graph);
     const { resolver } = createResolver({
         scan,
-        getTransferableFileDescriptionFromPath: fake(async () => {
+        transferableFileDescriptionResponder: () => {
             return createTransferableFile('/src/not-the-entry.js');
-        })
+        }
     });
 
     try {

--- a/source/sbom/license-resolver.test.ts
+++ b/source/sbom/license-resolver.test.ts
@@ -1,93 +1,64 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import { fake, type SinonSpy } from 'sinon';
-import type { FileManager } from '../file-manager/file-manager.ts';
+import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { createLicenseResolver } from './license-resolver.ts';
 
-type FileManagerOverrides = {
-    readonly checkReadability?: SinonSpy;
-    readonly readFile?: SinonSpy;
-};
-
-function createFileManager(overrides: FileManagerOverrides = {}): FileManager {
-    return {
-        checkReadability: overrides.checkReadability ?? fake.resolves({ isReadable: true }),
-        readFile: overrides.readFile ?? fake.resolves('{}'),
-        writeFile: fake(),
-        copyFile: fake(),
-        getTransferableFileDescriptionFromPath: fake()
-    };
-}
-
-test('resolveLicense() returns the SPDX expression when the dependency’s package.json has a string license', async () => {
-    const fileManager = createFileManager({
-        readFile: fake.resolves(JSON.stringify({ license: 'MIT' }))
+async function expectResolvedLicense(packageJsonContent: string): Promise<string | undefined> {
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: packageJsonContent }]
     });
     const resolver = createLicenseResolver({ fileManager });
 
-    const result = await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+    return resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+}
+
+test('resolveLicense() returns the SPDX expression when the dependency’s package.json has a string license', async () => {
+    const result = await expectResolvedLicense(JSON.stringify({ license: 'MIT' }));
 
     assert.strictEqual(result, 'MIT');
 });
 
 test('resolveLicense() reads from the dependency’s package.json under node_modules', async () => {
-    const readFile = fake.resolves(JSON.stringify({ license: 'MIT' }));
-    const fileManager = createFileManager({ readFile });
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: JSON.stringify({ license: 'MIT' }) }]
+    });
     const resolver = createLicenseResolver({ fileManager });
 
     await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
 
-    assert.strictEqual(readFile.callCount, 1);
-    assert.deepStrictEqual(readFile.firstCall.args, ['/project/node_modules/lodash/package.json']);
+    assert.strictEqual(fileManager.getReadFileCallCount(), 1);
+    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/project/node_modules/lodash/package.json' });
 });
 
 test('resolveLicense() returns undefined when the dependency’s package.json does not declare a license', async () => {
-    const fileManager = createFileManager({
-        readFile: fake.resolves(JSON.stringify({}))
-    });
-    const resolver = createLicenseResolver({ fileManager });
-
-    const result = await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+    const result = await expectResolvedLicense(JSON.stringify({}));
 
     assert.strictEqual(result, undefined);
 });
 
 test('resolveLicense() returns undefined when the license field is not a non-empty string', async () => {
-    const fileManager = createFileManager({
-        readFile: fake.resolves(JSON.stringify({ license: '' }))
-    });
-    const resolver = createLicenseResolver({ fileManager });
-
-    const result = await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+    const result = await expectResolvedLicense(JSON.stringify({ license: '' }));
 
     assert.strictEqual(result, undefined);
 });
 
 test('resolveLicense() returns undefined when the license field is an object', async () => {
-    const fileManager = createFileManager({
-        readFile: fake.resolves(JSON.stringify({ license: { type: 'MIT', url: 'https://example.test' } }))
-    });
-    const resolver = createLicenseResolver({ fileManager });
-
-    const result = await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+    const result = await expectResolvedLicense(
+        JSON.stringify({ license: { type: 'MIT', url: 'https://example.test' } })
+    );
 
     assert.strictEqual(result, undefined);
 });
 
 test('resolveLicense() preserves a free-text license string verbatim', async () => {
-    const fileManager = createFileManager({
-        readFile: fake.resolves(JSON.stringify({ license: 'See LICENSE.txt for details' }))
-    });
-    const resolver = createLicenseResolver({ fileManager });
-
-    const result = await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+    const result = await expectResolvedLicense(JSON.stringify({ license: 'See LICENSE.txt for details' }));
 
     assert.strictEqual(result, 'See LICENSE.txt for details');
 });
 
 test('resolveLicense() throws a descriptive error when the dependency is not installed', async () => {
-    const fileManager = createFileManager({
-        checkReadability: fake.resolves({ isReadable: false })
+    const fileManager = createFakeFileManager({
+        simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
     });
     const resolver = createLicenseResolver({ fileManager });
 

--- a/source/sbom/tool-version.test.ts
+++ b/source/sbom/tool-version.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
-import type { FileManager } from '../file-manager/file-manager.ts';
+import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { createPacktoryToolVersionResolver } from './tool-version.ts';
 
 const unresolvableExpectedMessage =
@@ -18,52 +18,49 @@ const missingVersionExpectedMessage =
 
 type FactoryOverrides = {
     readonly resolvePackagePath?: SinonSpy;
-    readonly readFile?: SinonSpy;
+    readonly fileManager?: FakeFileManager;
 };
-
-function createFileManager(readFile: SinonSpy): FileManager {
-    return {
-        readFile,
-        checkReadability: fake.resolves({ isReadable: true }),
-        writeFile: fake(),
-        copyFile: fake(),
-        getTransferableFileDescriptionFromPath: fake()
-    };
-}
 
 function createResolver(overrides: FactoryOverrides = {}): {
     readonly resolve: () => Promise<string>;
     readonly resolvePackagePath: SinonSpy;
-    readonly readFile: SinonSpy;
+    readonly fileManager: FakeFileManager;
 } {
     const resolvePackagePath = overrides.resolvePackagePath ?? fake.returns(undefined);
-    const readFile = overrides.readFile ?? fake.resolves('{}');
+    const fileManager =
+        overrides.fileManager ?? createFakeFileManager({ simulatedReadFileResponses: [{ value: '{}' }] });
     const resolve = createPacktoryToolVersionResolver({
-        fileManager: createFileManager(readFile),
+        fileManager,
         resolvePackagePath
     });
-    return { resolve, resolvePackagePath, readFile };
+    return { resolve, resolvePackagePath, fileManager };
 }
 
 test('returns the version from @packtory/cli when its package.json resolves inside node_modules', async () => {
     const resolvePackagePath = fake((specifier: string) => {
         return specifier === '@packtory/cli/package.json' ? '/repo/node_modules/@packtory/cli/package.json' : undefined;
     });
-    const readFile = fake.resolves(JSON.stringify({ name: '@packtory/cli', version: '1.2.3' }));
-    const { resolve } = createResolver({ resolvePackagePath, readFile });
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: JSON.stringify({ name: '@packtory/cli', version: '1.2.3' }) }]
+    });
+    const { resolve } = createResolver({ resolvePackagePath, fileManager });
 
     const result = await resolve();
 
     assert.strictEqual(result, '1.2.3');
-    assert.deepStrictEqual(readFile.firstCall.args, ['/repo/node_modules/@packtory/cli/package.json']);
+    assert.deepStrictEqual(fileManager.getReadFileCall(0), {
+        filePath: '/repo/node_modules/@packtory/cli/package.json'
+    });
 });
 
 test('falls back to packtory when @packtory/cli is not resolvable', async () => {
     const resolvePackagePath = fake((specifier: string) => {
         return specifier === 'packtory/package.json' ? '/repo/node_modules/packtory/package.json' : undefined;
     });
-    const readFile = fake.resolves(JSON.stringify({ name: 'packtory', version: '4.5.6' }));
-    const { resolve } = createResolver({ resolvePackagePath, readFile });
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: JSON.stringify({ name: 'packtory', version: '4.5.6' }) }]
+    });
+    const { resolve } = createResolver({ resolvePackagePath, fileManager });
 
     const result = await resolve();
 
@@ -83,21 +80,23 @@ test('throws when neither @packtory/cli nor packtory can be resolved', async () 
 
 test('throws when the resolved package.json path is not inside a node_modules folder', async () => {
     const resolvePackagePath = fake.returns('/repo/source/sbom/package.json');
-    const { resolve, readFile } = createResolver({ resolvePackagePath });
+    const { resolve, fileManager } = createResolver({ resolvePackagePath });
 
     try {
         await resolve();
         assert.fail('Expected resolve() to throw but it did not');
     } catch (error: unknown) {
         assert.strictEqual((error as Error).message, outsideNodeModulesExpectedMessage);
-        assert.strictEqual(readFile.callCount, 0);
+        assert.strictEqual(fileManager.getReadFileCallCount(), 0);
     }
 });
 
 test('throws when the resolved package.json has no version field', async () => {
     const resolvePackagePath = fake.returns('/repo/node_modules/packtory/package.json');
-    const readFile = fake.resolves(JSON.stringify({ name: 'packtory' }));
-    const { resolve } = createResolver({ resolvePackagePath, readFile });
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: JSON.stringify({ name: 'packtory' }) }]
+    });
+    const { resolve } = createResolver({ resolvePackagePath, fileManager });
 
     try {
         await resolve();

--- a/source/test-libraries/fake-file-manager.ts
+++ b/source/test-libraries/fake-file-manager.ts
@@ -1,0 +1,212 @@
+import type { TransferableFileDescription } from '../file-manager/file-description.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
+
+type SimulatedSuccess<TValue> = {
+    readonly value: TValue;
+    readonly error?: undefined;
+};
+
+type SimulatedError = {
+    readonly error: Error;
+};
+
+type SimulatedResponse<TValue> = SimulatedError | SimulatedSuccess<TValue>;
+
+type SimulatedVoidResponse = SimulatedError | { readonly error?: undefined };
+
+type ReadabilityResult = {
+    readonly isReadable: boolean;
+};
+
+type ReadFileCall = {
+    readonly filePath: string;
+};
+
+type WriteFileCall = {
+    readonly filePath: string;
+    readonly content: string;
+};
+
+type CopyFileCall = {
+    readonly from: string;
+    readonly to: string;
+};
+
+type CheckReadabilityCall = {
+    readonly fileOrFolderPath: string;
+};
+
+type TransferableFileDescriptionCall = {
+    readonly sourceFilePath: string;
+    readonly targetFilePath: string;
+};
+
+type TransferableFileDescriptionResponder = (
+    sourceFilePath: string,
+    targetFilePath: string
+) => SimulatedResponse<TransferableFileDescription>;
+
+type FakeFileManagerOptions = {
+    readonly simulatedReadFileResponses?: readonly SimulatedResponse<string>[];
+    readonly simulatedCheckReadabilityResponses?: readonly SimulatedResponse<ReadabilityResult>[];
+    readonly simulatedTransferableFileDescriptionResponses?: readonly SimulatedResponse<TransferableFileDescription>[];
+    readonly transferableFileDescriptionResponder?: TransferableFileDescriptionResponder;
+    readonly simulatedWriteFileResponses?: readonly SimulatedVoidResponse[];
+    readonly simulatedCopyFileResponses?: readonly SimulatedVoidResponse[];
+};
+
+export type FakeFileManager = FileManager & {
+    readonly getReadFileCallCount: () => number;
+    readonly getReadFileCall: (index: number) => ReadFileCall;
+    readonly getAllReadFileCalls: () => readonly ReadFileCall[];
+
+    readonly getWriteFileCallCount: () => number;
+    readonly getWriteFileCall: (index: number) => WriteFileCall;
+    readonly getAllWriteFileCalls: () => readonly WriteFileCall[];
+
+    readonly getCopyFileCallCount: () => number;
+    readonly getCopyFileCall: (index: number) => CopyFileCall;
+    readonly getAllCopyFileCalls: () => readonly CopyFileCall[];
+
+    readonly getCheckReadabilityCallCount: () => number;
+    readonly getCheckReadabilityCall: (index: number) => CheckReadabilityCall;
+    readonly getAllCheckReadabilityCalls: () => readonly CheckReadabilityCall[];
+
+    readonly getTransferableFileDescriptionCallCount: () => number;
+    readonly getTransferableFileDescriptionCall: (index: number) => TransferableFileDescriptionCall;
+    readonly getAllTransferableFileDescriptionCalls: () => readonly TransferableFileDescriptionCall[];
+};
+
+const defaultReadFileResponse: SimulatedResponse<string> = { value: '' };
+const defaultCheckReadabilityResponse: SimulatedResponse<ReadabilityResult> = { value: { isReadable: true } };
+const defaultVoidResponse: SimulatedVoidResponse = {};
+
+function resolveValueResponse<TValue>(response: SimulatedResponse<TValue>): TValue {
+    if (response.error !== undefined) {
+        throw response.error;
+    }
+    return response.value;
+}
+
+function resolveVoidResponse(response: SimulatedVoidResponse): void {
+    if (response.error !== undefined) {
+        throw response.error;
+    }
+}
+
+function getCallAtIndex<TCall>(calls: readonly TCall[], methodName: string, index: number): TCall {
+    const call = calls[index];
+
+    if (call === undefined) {
+        throw new TypeError(`No ${methodName} call collected at index ${index}`);
+    }
+
+    return call;
+}
+
+export function createFakeFileManager(options: FakeFileManagerOptions = {}): FakeFileManager {
+    const {
+        simulatedReadFileResponses = [],
+        simulatedCheckReadabilityResponses = [],
+        simulatedTransferableFileDescriptionResponses = [],
+        transferableFileDescriptionResponder,
+        simulatedWriteFileResponses = [],
+        simulatedCopyFileResponses = []
+    } = options;
+
+    const readFileCalls: ReadFileCall[] = [];
+    const writeFileCalls: WriteFileCall[] = [];
+    const copyFileCalls: CopyFileCall[] = [];
+    const checkReadabilityCalls: CheckReadabilityCall[] = [];
+    const transferableFileDescriptionCalls: TransferableFileDescriptionCall[] = [];
+
+    return {
+        async readFile(filePath) {
+            const response = simulatedReadFileResponses[readFileCalls.length] ?? defaultReadFileResponse;
+            readFileCalls.push({ filePath });
+            return resolveValueResponse(response);
+        },
+
+        async writeFile(filePath, content) {
+            const response = simulatedWriteFileResponses[writeFileCalls.length] ?? defaultVoidResponse;
+            writeFileCalls.push({ filePath, content });
+            resolveVoidResponse(response);
+        },
+
+        async copyFile(from, to) {
+            const response = simulatedCopyFileResponses[copyFileCalls.length] ?? defaultVoidResponse;
+            copyFileCalls.push({ from, to });
+            resolveVoidResponse(response);
+        },
+
+        async checkReadability(fileOrFolderPath) {
+            const response =
+                simulatedCheckReadabilityResponses[checkReadabilityCalls.length] ?? defaultCheckReadabilityResponse;
+            checkReadabilityCalls.push({ fileOrFolderPath });
+            return resolveValueResponse(response);
+        },
+
+        async getTransferableFileDescriptionFromPath(sourceFilePath, targetFilePath) {
+            const fallbackResponse: SimulatedResponse<TransferableFileDescription> = {
+                value: { sourceFilePath, targetFilePath, content: '', isExecutable: false }
+            };
+            const responderResponse = transferableFileDescriptionResponder?.(sourceFilePath, targetFilePath);
+            const response =
+                responderResponse ??
+                simulatedTransferableFileDescriptionResponses[transferableFileDescriptionCalls.length] ??
+                fallbackResponse;
+            transferableFileDescriptionCalls.push({ sourceFilePath, targetFilePath });
+            return resolveValueResponse(response);
+        },
+
+        getReadFileCallCount() {
+            return readFileCalls.length;
+        },
+        getReadFileCall(index) {
+            return getCallAtIndex(readFileCalls, 'readFile', index);
+        },
+        getAllReadFileCalls() {
+            return readFileCalls;
+        },
+
+        getWriteFileCallCount() {
+            return writeFileCalls.length;
+        },
+        getWriteFileCall(index) {
+            return getCallAtIndex(writeFileCalls, 'writeFile', index);
+        },
+        getAllWriteFileCalls() {
+            return writeFileCalls;
+        },
+
+        getCopyFileCallCount() {
+            return copyFileCalls.length;
+        },
+        getCopyFileCall(index) {
+            return getCallAtIndex(copyFileCalls, 'copyFile', index);
+        },
+        getAllCopyFileCalls() {
+            return copyFileCalls;
+        },
+
+        getCheckReadabilityCallCount() {
+            return checkReadabilityCalls.length;
+        },
+        getCheckReadabilityCall(index) {
+            return getCallAtIndex(checkReadabilityCalls, 'checkReadability', index);
+        },
+        getAllCheckReadabilityCalls() {
+            return checkReadabilityCalls;
+        },
+
+        getTransferableFileDescriptionCallCount() {
+            return transferableFileDescriptionCalls.length;
+        },
+        getTransferableFileDescriptionCall(index) {
+            return getCallAtIndex(transferableFileDescriptionCalls, 'getTransferableFileDescriptionFromPath', index);
+        },
+        getAllTransferableFileDescriptionCalls() {
+            return transferableFileDescriptionCalls;
+        }
+    };
+}


### PR DESCRIPTION
Replace hand-rolled Sinon spy bundles for the FileManager interface across six test files with a single createFakeFileManager helper. The fake implements the real FileManager and exposes per-method call accessors and queue-based simulated responses, modelled on the http-client fake from storefront2.