### PR TITLE
Fix CLI spinner final publish state

### DIFF
--- a/source/build-support/check-mutation-timeouts.entry-point.ts
+++ b/source/build-support/check-mutation-timeouts.entry-point.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import { createFileManager } from '../file-manager/file-manager.ts';
 import { runMutationTimeoutCheck } from './check-mutation-timeouts.ts';
 
-process.exitCode = await runMutationTimeoutCheck(process.argv);
+process.exitCode = await runMutationTimeoutCheck(process.argv, {
+    fileManager: createFileManager({ hostFileSystem: fs.promises })
+});

--- a/source/build-support/check-mutation-timeouts.entry-point.ts
+++ b/source/build-support/check-mutation-timeouts.entry-point.ts
@@ -3,5 +3,8 @@ import { createFileManager } from '../file-manager/file-manager.ts';
 import { runMutationTimeoutCheck } from './check-mutation-timeouts.ts';
 
 process.exitCode = await runMutationTimeoutCheck(process.argv, {
-    fileManager: createFileManager({ hostFileSystem: fs.promises })
+    fileManager: createFileManager({ hostFileSystem: fs.promises }),
+    stderrWrite: (message) => {
+        process.stderr.write(message);
+    }
 });

--- a/source/build-support/check-mutation-timeouts.test.ts
+++ b/source/build-support/check-mutation-timeouts.test.ts
@@ -5,7 +5,6 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { test } from 'mocha';
-import { stub } from 'sinon';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
     checkMutationTimeoutReport,
@@ -136,6 +135,9 @@ async function runCheckWithCollectedErrors(
     const errors: string[] = [];
     const exitCode = await runMutationTimeoutCheck(argv, {
         fileManager,
+        stderrWrite: (message) => {
+            errors.push(message);
+        },
         writeError: (message) => {
             errors.push(message);
             writeError?.(message);
@@ -262,7 +264,9 @@ test('checkMutationTimeoutReport throws when a mutant status is not a string', a
         singleMutantReport({ location: { start: { line: 1, column: 2 } } }),
         async (reportPath) => {
             const fileManager = createFakeFileManager({
-                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport({ location: { start: { line: 1, column: 2 } } })) }]
+                simulatedReadFileResponses: [
+                    { value: JSON.stringify(singleMutantReport({ location: { start: { line: 1, column: 2 } } })) }
+                ]
             });
             await expectCheckError(
                 checkMutationTimeoutReport(reportPath, fileManager),
@@ -287,7 +291,10 @@ test('checkMutationTimeoutReport throws a missing-file error with the ENOENT cau
         const fileManager = createFakeFileManager({
             simulatedReadFileResponses: [
                 {
-                    error: createReadFileError('ENOENT', `ENOENT: no such file or directory, open '${defaultMissingReportPath}'`)
+                    error: createReadFileError(
+                        'ENOENT',
+                        `ENOENT: no such file or directory, open '${defaultMissingReportPath}'`
+                    )
                 }
             ]
         });
@@ -369,30 +376,24 @@ test('runMutationTimeoutCheck writes missing-file errors and returns exit code 1
 
 test('runMutationTimeoutCheck uses the default stderr writer when no custom writer is passed', async () => {
     const writes: string[] = [];
-    const writeStub = stub(process.stderr, 'write').callsFake((chunk) => {
-        writes.push(String(chunk));
-        return true;
+    const exitCode = await runMutationTimeoutCheck(['node', 'check', '/definitely/missing/mutation-report.json'], {
+        fileManager: createFakeFileManager({
+            simulatedReadFileResponses: [
+                {
+                    error: createReadFileError(
+                        'ENOENT',
+                        "ENOENT: no such file or directory, open '/definitely/missing/mutation-report.json'"
+                    )
+                }
+            ]
+        }),
+        stderrWrite: (message) => {
+            writes.push(message);
+        }
     });
 
-    try {
-        const exitCode = await runMutationTimeoutCheck(['node', 'check', '/definitely/missing/mutation-report.json'], {
-            fileManager: createFakeFileManager({
-                simulatedReadFileResponses: [
-                    {
-                        error: createReadFileError(
-                            'ENOENT',
-                            'ENOENT: no such file or directory, open \'/definitely/missing/mutation-report.json\''
-                        )
-                    }
-                ]
-            })
-        });
-
-        assert.strictEqual(exitCode, 1);
-        assert.deepStrictEqual(writes, ['Mutation report not found at "/definitely/missing/mutation-report.json"\n']);
-    } finally {
-        writeStub.restore();
-    }
+    assert.strictEqual(exitCode, 1);
+    assert.deepStrictEqual(writes, ['Mutation report not found at "/definitely/missing/mutation-report.json"\n']);
 });
 
 test('runMutationTimeoutCheck writes invalid JSON errors and returns exit code 1', async () => {
@@ -413,6 +414,9 @@ test('runMutationTimeoutCheck stringifies non-Error failures', async () => {
     const errors: string[] = [];
     const exitCode = await runMutationTimeoutCheck(createArgvThrowingNonErrorOnReportPath(), {
         fileManager: createFakeFileManager(),
+        stderrWrite: () => {
+            throw new Error('stderrWrite should not be used when writeError is injected');
+        },
         writeError: (message) => {
             errors.push(message);
         }

--- a/source/build-support/check-mutation-timeouts.test.ts
+++ b/source/build-support/check-mutation-timeouts.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { test } from 'mocha';
 import { stub } from 'sinon';
+import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
     checkMutationTimeoutReport,
     collectTimeoutMutants,
@@ -99,9 +100,18 @@ function createArgvThrowingNonErrorOnReportPath(): readonly string[] {
     return argv;
 }
 
+function createReadFileError(code: string, message: string): Error & { readonly code: string } {
+    return Object.assign(new Error(message), { code });
+}
+
 async function expectCheckResult(report: unknown, expected: string | undefined): Promise<void> {
     await withTemporaryReport(report, async (reportPath) => {
-        assert.strictEqual(await checkMutationTimeoutReport(reportPath), expected);
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: JSON.stringify(report) }]
+        });
+
+        assert.strictEqual(await checkMutationTimeoutReport(reportPath, fileManager), expected);
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: reportPath });
     });
 }
 
@@ -120,12 +130,16 @@ async function expectCheckError(operation: Promise<unknown>, expectedMessage: Re
 
 async function runCheckWithCollectedErrors(
     argv: readonly string[],
+    fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{}' }] }),
     writeError?: (message: string) => void
 ): Promise<{ readonly exitCode: number; readonly errors: readonly string[] }> {
     const errors: string[] = [];
-    const exitCode = await runMutationTimeoutCheck(argv, (message) => {
-        errors.push(message);
-        writeError?.(message);
+    const exitCode = await runMutationTimeoutCheck(argv, {
+        fileManager,
+        writeError: (message) => {
+            errors.push(message);
+            writeError?.(message);
+        }
     });
     return { exitCode, errors };
 }
@@ -213,7 +227,32 @@ test('checkMutationTimeoutReport ignores malformed file reports and malformed mu
             }
         },
         async (reportPath) => {
-            assert.strictEqual(await checkMutationTimeoutReport(reportPath), timeoutReportMessage('source/c.ts', 3, 4));
+            const fileManager = createFakeFileManager({
+                simulatedReadFileResponses: [
+                    {
+                        value: JSON.stringify({
+                            files: {
+                                'source/a.ts': null,
+                                'source/b.ts': { mutants: 'invalid' },
+                                'source/c.ts': {
+                                    mutants: [
+                                        null,
+                                        { status: 'Timeout', location: null },
+                                        { status: 'Timeout', location: { start: { line: '3', column: 4 } } },
+                                        { status: 'Timeout', location: { start: { line: 3, column: '4' } } },
+                                        { status: 'Timeout', location: { start: { line: 3, column: 4 } } }
+                                    ]
+                                }
+                            }
+                        })
+                    }
+                ]
+            });
+
+            assert.strictEqual(
+                await checkMutationTimeoutReport(reportPath, fileManager),
+                timeoutReportMessage('source/c.ts', 3, 4)
+            );
         }
     );
 });
@@ -222,8 +261,11 @@ test('checkMutationTimeoutReport throws when a mutant status is not a string', a
     await withTemporaryReport(
         singleMutantReport({ location: { start: { line: 1, column: 2 } } }),
         async (reportPath) => {
+            const fileManager = createFakeFileManager({
+                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport({ location: { start: { line: 1, column: 2 } } })) }]
+            });
             await expectCheckError(
-                checkMutationTimeoutReport(reportPath),
+                checkMutationTimeoutReport(reportPath, fileManager),
                 'Mutation report contains a mutant without a string status'
             );
         }
@@ -232,13 +274,24 @@ test('checkMutationTimeoutReport throws when a mutant status is not a string', a
 
 test('checkMutationTimeoutReport returns undefined for malformed top-level report shapes', async () => {
     await withTemporaryReport(null, async (reportPath) => {
-        assert.strictEqual(await checkMutationTimeoutReport(reportPath), undefined);
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: 'null' }]
+        });
+
+        assert.strictEqual(await checkMutationTimeoutReport(reportPath, fileManager), undefined);
     });
 });
 
 test('checkMutationTimeoutReport throws a missing-file error with the ENOENT cause preserved', async () => {
     try {
-        await checkMutationTimeoutReport(defaultMissingReportPath);
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [
+                {
+                    error: createReadFileError('ENOENT', `ENOENT: no such file or directory, open '${defaultMissingReportPath}'`)
+                }
+            ]
+        });
+        await checkMutationTimeoutReport(defaultMissingReportPath, fileManager);
         assert.fail('Expected checkMutationTimeoutReport() to throw but it did not');
     } catch (error: unknown) {
         assert.strictEqual((error as Error).message, `Mutation report not found at "${defaultMissingReportPath}"`);
@@ -249,13 +302,21 @@ test('checkMutationTimeoutReport throws a missing-file error with the ENOENT cau
 
 test('checkMutationTimeoutReport rethrows invalid JSON parse errors unchanged', async () => {
     await withTemporaryFile('mutation-report.json', '{', async (reportPath) => {
-        await expectCheckError(checkMutationTimeoutReport(reportPath), "Expected property name or '}'");
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: '{' }]
+        });
+        await expectCheckError(checkMutationTimeoutReport(reportPath, fileManager), "Expected property name or '}'");
     });
 });
 
 test('runMutationTimeoutCheck writes the failure message and returns exit code 1 when timeouts exist', async () => {
     await withTemporaryReport(singleMutantReport(timeoutMutant), async (reportPath) => {
-        const result = await runCheckWithCollectedErrors(['node', 'check', reportPath]);
+        const result = await runCheckWithCollectedErrors(
+            ['node', 'check', reportPath],
+            createFakeFileManager({
+                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(timeoutMutant)) }]
+            })
+        );
 
         assert.strictEqual(result.exitCode, 1);
         assert.deepStrictEqual(result.errors, [timeoutReportMessage()]);
@@ -264,7 +325,12 @@ test('runMutationTimeoutCheck writes the failure message and returns exit code 1
 
 test('runMutationTimeoutCheck returns exit code 0 and writes nothing when no timeouts exist', async () => {
     await withTemporaryReport(singleMutantReport(killedMutant), async (reportPath) => {
-        const result = await runCheckWithCollectedErrors(['node', 'check', reportPath]);
+        const result = await runCheckWithCollectedErrors(
+            ['node', 'check', reportPath],
+            createFakeFileManager({
+                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
+            })
+        );
 
         assert.strictEqual(result.exitCode, 0);
         assert.deepStrictEqual(result.errors, []);
@@ -272,23 +338,30 @@ test('runMutationTimeoutCheck returns exit code 0 and writes nothing when no tim
 });
 
 test('runMutationTimeoutCheck uses the default report path when argv omits an explicit report path', async () => {
-    await withDefaultReport(singleMutantReport(killedMutant), async (directory) => {
-        const originalWorkingDirectory = process.cwd();
-
-        process.chdir(directory);
-        try {
-            const result = await runCheckWithCollectedErrors(['node', 'check']);
-
-            assert.strictEqual(result.exitCode, 0);
-            assert.deepStrictEqual(result.errors, []);
-        } finally {
-            process.chdir(originalWorkingDirectory);
-        }
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
     });
+    const result = await runCheckWithCollectedErrors(['node', 'check'], fileManager);
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.deepStrictEqual(result.errors, []);
+    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: defaultReportFilePath });
 });
 
 test('runMutationTimeoutCheck writes missing-file errors and returns exit code 1', async () => {
-    const result = await runCheckWithCollectedErrors(['node', 'check', defaultMissingReportPath]);
+    const result = await runCheckWithCollectedErrors(
+        ['node', 'check', defaultMissingReportPath],
+        createFakeFileManager({
+            simulatedReadFileResponses: [
+                {
+                    error: createReadFileError(
+                        'ENOENT',
+                        `ENOENT: no such file or directory, open '${defaultMissingReportPath}'`
+                    )
+                }
+            ]
+        })
+    );
 
     assert.strictEqual(result.exitCode, 1);
     assert.deepStrictEqual(result.errors, [`Mutation report not found at "${defaultMissingReportPath}"`]);
@@ -302,7 +375,18 @@ test('runMutationTimeoutCheck uses the default stderr writer when no custom writ
     });
 
     try {
-        const exitCode = await runMutationTimeoutCheck(['node', 'check', '/definitely/missing/mutation-report.json']);
+        const exitCode = await runMutationTimeoutCheck(['node', 'check', '/definitely/missing/mutation-report.json'], {
+            fileManager: createFakeFileManager({
+                simulatedReadFileResponses: [
+                    {
+                        error: createReadFileError(
+                            'ENOENT',
+                            'ENOENT: no such file or directory, open \'/definitely/missing/mutation-report.json\''
+                        )
+                    }
+                ]
+            })
+        });
 
         assert.strictEqual(exitCode, 1);
         assert.deepStrictEqual(writes, ['Mutation report not found at "/definitely/missing/mutation-report.json"\n']);
@@ -313,7 +397,12 @@ test('runMutationTimeoutCheck uses the default stderr writer when no custom writ
 
 test('runMutationTimeoutCheck writes invalid JSON errors and returns exit code 1', async () => {
     await withTemporaryFile('mutation-report.json', '{', async (reportPath) => {
-        const result = await runCheckWithCollectedErrors(['node', 'check', reportPath]);
+        const result = await runCheckWithCollectedErrors(
+            ['node', 'check', reportPath],
+            createFakeFileManager({
+                simulatedReadFileResponses: [{ value: '{' }]
+            })
+        );
 
         assert.strictEqual(result.exitCode, 1);
         assert.ok((result.errors[0] ?? '').includes("Expected property name or '}'"));
@@ -322,8 +411,11 @@ test('runMutationTimeoutCheck writes invalid JSON errors and returns exit code 1
 
 test('runMutationTimeoutCheck stringifies non-Error failures', async () => {
     const errors: string[] = [];
-    const exitCode = await runMutationTimeoutCheck(createArgvThrowingNonErrorOnReportPath(), (message) => {
-        errors.push(message);
+    const exitCode = await runMutationTimeoutCheck(createArgvThrowingNonErrorOnReportPath(), {
+        fileManager: createFakeFileManager(),
+        writeError: (message) => {
+            errors.push(message);
+        }
     });
 
     assert.strictEqual(exitCode, 1);

--- a/source/build-support/check-mutation-timeouts.test.ts
+++ b/source/build-support/check-mutation-timeouts.test.ts
@@ -227,23 +227,20 @@ test('checkMutationTimeoutReport returns a failure message for timeout mutants',
 });
 
 test('checkMutationTimeoutReport ignores malformed file reports and malformed mutants', async () => {
-    await withTemporaryReport(
-        malformedTimeoutReport,
-        async (reportPath) => {
-            const fileManager = createFakeFileManager({
-                simulatedReadFileResponses: [
-                    {
-                        value: JSON.stringify(malformedTimeoutReport)
-                    }
-                ]
-            });
+    await withTemporaryReport(malformedTimeoutReport, async (reportPath) => {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [
+                {
+                    value: JSON.stringify(malformedTimeoutReport)
+                }
+            ]
+        });
 
-            assert.strictEqual(
-                await checkMutationTimeoutReport(reportPath, fileManager),
-                timeoutReportMessage('source/c.ts', 3, 4)
-            );
-        }
-    );
+        assert.strictEqual(
+            await checkMutationTimeoutReport(reportPath, fileManager),
+            timeoutReportMessage('source/c.ts', 3, 4)
+        );
+    });
 });
 
 test('checkMutationTimeoutReport throws when a mutant status is not a string', async () => {

--- a/source/build-support/check-mutation-timeouts.test.ts
+++ b/source/build-support/check-mutation-timeouts.test.ts
@@ -19,6 +19,21 @@ const defaultMissingReportPath = '/definitely/missing/mutation-report.json';
 
 const killedMutant = { status: 'Killed', location: { start: { line: 1, column: 2 } } };
 const timeoutMutant = { status: 'Timeout', location: { start: { line: 7, column: 8 } } };
+const malformedTimeoutReport = {
+    files: {
+        'source/a.ts': null,
+        'source/b.ts': { mutants: 'invalid' },
+        'source/c.ts': {
+            mutants: [
+                null,
+                { status: 'Timeout', location: null },
+                { status: 'Timeout', location: { start: { line: '3', column: 4 } } },
+                { status: 'Timeout', location: { start: { line: 3, column: '4' } } },
+                { status: 'Timeout', location: { start: { line: 3, column: 4 } } }
+            ]
+        }
+    }
+};
 
 function timeoutReportMessage(filePath = 'source/a.ts', line = 7, column = 8): string {
     return ['Mutation report contains 1 timeout mutant.', `- ${filePath}:${line}:${column}`].join('\n');
@@ -213,40 +228,12 @@ test('checkMutationTimeoutReport returns a failure message for timeout mutants',
 
 test('checkMutationTimeoutReport ignores malformed file reports and malformed mutants', async () => {
     await withTemporaryReport(
-        {
-            files: {
-                'source/a.ts': null,
-                'source/b.ts': { mutants: 'invalid' },
-                'source/c.ts': {
-                    mutants: [
-                        null,
-                        { status: 'Timeout', location: null },
-                        { status: 'Timeout', location: { start: { line: '3', column: 4 } } },
-                        { status: 'Timeout', location: { start: { line: 3, column: '4' } } },
-                        { status: 'Timeout', location: { start: { line: 3, column: 4 } } }
-                    ]
-                }
-            }
-        },
+        malformedTimeoutReport,
         async (reportPath) => {
             const fileManager = createFakeFileManager({
                 simulatedReadFileResponses: [
                     {
-                        value: JSON.stringify({
-                            files: {
-                                'source/a.ts': null,
-                                'source/b.ts': { mutants: 'invalid' },
-                                'source/c.ts': {
-                                    mutants: [
-                                        null,
-                                        { status: 'Timeout', location: null },
-                                        { status: 'Timeout', location: { start: { line: '3', column: 4 } } },
-                                        { status: 'Timeout', location: { start: { line: 3, column: '4' } } },
-                                        { status: 'Timeout', location: { start: { line: 3, column: 4 } } }
-                                    ]
-                                }
-                            }
-                        })
+                        value: JSON.stringify(malformedTimeoutReport)
                     }
                 ]
             });

--- a/source/build-support/check-mutation-timeouts.ts
+++ b/source/build-support/check-mutation-timeouts.ts
@@ -30,11 +30,22 @@ export type TimeoutMutant = {
 };
 
 export type ErrorWriter = (message: string) => void;
+type StderrWriter = (message: string) => void;
 
 export type MutationTimeoutCheckDependencies = {
     readonly fileManager: Pick<FileManager, 'readFile'>;
+    readonly stderrWrite: StderrWriter;
     readonly writeError?: ErrorWriter;
 };
+
+function resolveErrorWriter(dependencies: MutationTimeoutCheckDependencies): ErrorWriter {
+    return (
+        dependencies.writeError ??
+        ((message) => {
+            dependencies.stderrWrite(`${message}\n`);
+        })
+    );
+}
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
     return Object.prototype.toString.call(value) === '[object Object]';
@@ -180,11 +191,7 @@ export async function runMutationTimeoutCheck(
     argv: readonly string[],
     dependencies: MutationTimeoutCheckDependencies
 ): Promise<number> {
-    const writeError =
-        dependencies.writeError ??
-        ((message) => {
-            process.stderr.write(`${message}\n`);
-        });
+    const writeError = resolveErrorWriter(dependencies);
     try {
         const reportPath = argv[reportPathArgIndex] ?? defaultReportPath;
         const failureMessage = await checkMutationTimeoutReport(reportPath, dependencies.fileManager);

--- a/source/build-support/check-mutation-timeouts.ts
+++ b/source/build-support/check-mutation-timeouts.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import type { FileManager } from '../file-manager/file-manager.ts';
 
 const defaultReportPath = 'target/stryker/mutation-report.json';
 const reportPathArgIndex = 2;
@@ -30,6 +30,11 @@ export type TimeoutMutant = {
 };
 
 export type ErrorWriter = (message: string) => void;
+
+export type MutationTimeoutCheckDependencies = {
+    readonly fileManager: Pick<FileManager, 'readFile'>;
+    readonly writeError?: ErrorWriter;
+};
 
 function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
     return Object.prototype.toString.call(value) === '[object Object]';
@@ -148,9 +153,12 @@ export function formatMutationTimeoutError(timeouts: readonly TimeoutMutant[]): 
     ].join('\n');
 }
 
-async function readMutationReport(reportPath: string): Promise<MutationReport> {
+async function readMutationReport(
+    reportPath: string,
+    fileManager: Pick<FileManager, 'readFile'>
+): Promise<MutationReport> {
     try {
-        return parseMutationReport(JSON.parse(await readFile(reportPath, 'utf8')) as unknown);
+        return parseMutationReport(JSON.parse(await fileManager.readFile(reportPath)) as unknown);
     } catch (error) {
         if (isErrorWithCode(error, 'ENOENT')) {
             throw new Error(`Mutation report not found at "${reportPath}"`, { cause: error });
@@ -160,20 +168,26 @@ async function readMutationReport(reportPath: string): Promise<MutationReport> {
     }
 }
 
-export async function checkMutationTimeoutReport(reportPath: string): Promise<string | undefined> {
-    const report = await readMutationReport(reportPath);
+export async function checkMutationTimeoutReport(
+    reportPath: string,
+    fileManager: Pick<FileManager, 'readFile'>
+): Promise<string | undefined> {
+    const report = await readMutationReport(reportPath, fileManager);
     return formatMutationTimeoutError(collectTimeoutMutants(report));
 }
 
 export async function runMutationTimeoutCheck(
     argv: readonly string[],
-    writeError: ErrorWriter = (message) => {
-        process.stderr.write(`${message}\n`);
-    }
+    dependencies: MutationTimeoutCheckDependencies
 ): Promise<number> {
+    const writeError =
+        dependencies.writeError ??
+        ((message) => {
+            process.stderr.write(`${message}\n`);
+        });
     try {
         const reportPath = argv[reportPathArgIndex] ?? defaultReportPath;
-        const failureMessage = await checkMutationTimeoutReport(reportPath);
+        const failureMessage = await checkMutationTimeoutReport(reportPath, dependencies.fileManager);
 
         if (failureMessage !== undefined) {
             writeError(failureMessage);

--- a/source/command-line-interface/preview-io.test.ts
+++ b/source/command-line-interface/preview-io.test.ts
@@ -278,6 +278,22 @@ test('createDefaultPreviewIo exposes the default preview helpers', () => {
     assert.ok(previewIo.createTemporaryPreviewHtmlPath().includes('packtory-preview-'));
 });
 
+test('createDefaultPreviewIo falls back to the default spawn process when no custom spawner is injected', async () => {
+    const previewIo = createDefaultPreviewIo({
+        platform: 'linux',
+        shell: 'sh',
+        pager: 'cat >/dev/null',
+        stdoutIsTTY: true,
+        randomUuid: () => 'uuid-123',
+        tmpdir: () => '/tmp'
+    });
+
+    assert.strictEqual(
+        await withPromiseDeadline(previewIo.pagePreviewOutput('hello'), 'default preview io fallback spawner'),
+        true
+    );
+});
+
 test('defaultSpawnProcess delegates to child_process.spawn with array args', async () => {
     const child = defaultSpawnProcess(process.execPath, ['-e', 'process.exit(0)'], {
         stdio: ['pipe', 'inherit', 'inherit']

--- a/source/command-line-interface/preview-io.test.ts
+++ b/source/command-line-interface/preview-io.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { test } from 'mocha';
 import { withPromiseDeadline } from '../test-libraries/promise-with-deadline.ts';
 import { createPreviewIo, defaultSpawnProcess, type SpawnedProcess, type SpawnOptions } from './preview-io-shared.ts';
-import { previewIo as defaultPreviewIo } from './preview-io.ts';
+import { createDefaultPreviewIo } from './preview-io.ts';
 
 type FakeSpawnResult = {
     readonly command: string;
@@ -264,11 +264,18 @@ test('openPreviewFile ignores an error emitted after the success path has alread
     assert.strictEqual(firstCall.child.wasUnrefCalled, true);
 });
 
-test('previewIo export exposes the default preview helpers', () => {
-    assert.strictEqual(typeof defaultPreviewIo.createTemporaryPreviewHtmlPath, 'function');
-    assert.strictEqual(typeof defaultPreviewIo.pagePreviewOutput, 'function');
-    assert.strictEqual(typeof defaultPreviewIo.openPreviewFile, 'function');
-    assert.ok(defaultPreviewIo.createTemporaryPreviewHtmlPath().includes('packtory-preview-'));
+test('createDefaultPreviewIo exposes the default preview helpers', () => {
+    const previewIo = createDefaultPreviewIo({
+        platform: 'linux',
+        shell: 'sh',
+        pager: undefined,
+        stdoutIsTTY: true
+    });
+
+    assert.strictEqual(typeof previewIo.createTemporaryPreviewHtmlPath, 'function');
+    assert.strictEqual(typeof previewIo.pagePreviewOutput, 'function');
+    assert.strictEqual(typeof previewIo.openPreviewFile, 'function');
+    assert.ok(previewIo.createTemporaryPreviewHtmlPath().includes('packtory-preview-'));
 });
 
 test('defaultSpawnProcess delegates to child_process.spawn with array args', async () => {

--- a/source/command-line-interface/preview-io.ts
+++ b/source/command-line-interface/preview-io.ts
@@ -1,15 +1,18 @@
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
-import { createPreviewIo, defaultSpawnProcess } from './preview-io-shared.ts';
+import { createPreviewIo, defaultSpawnProcess, type PreviewIo, type PreviewIoDependencies } from './preview-io-shared.ts';
 
-export const previewIo = createPreviewIo({
-    spawnProcess: defaultSpawnProcess,
-    randomUuid: randomUUID,
-    tmpdir: os.tmpdir,
-    platform: process.platform,
-    // eslint-disable-next-line node/no-process-env -- preview pager/open behavior is intentionally driven by the caller environment
-    shell: process.env.SHELL,
-    // eslint-disable-next-line node/no-process-env -- preview pager/open behavior is intentionally driven by the caller environment
-    pager: process.env.PAGER,
-    stdoutIsTTY: process.stdout.isTTY
-});
+type DefaultPreviewIoDependencies = Pick<PreviewIoDependencies, 'platform' | 'shell' | 'pager' | 'stdoutIsTTY'> &
+    Partial<Pick<PreviewIoDependencies, 'spawnProcess' | 'randomUuid' | 'tmpdir'>>;
+
+export function createDefaultPreviewIo(dependencies: DefaultPreviewIoDependencies): PreviewIo {
+    return createPreviewIo({
+        spawnProcess: dependencies.spawnProcess ?? defaultSpawnProcess,
+        randomUuid: dependencies.randomUuid ?? randomUUID,
+        tmpdir: dependencies.tmpdir ?? os.tmpdir,
+        platform: dependencies.platform,
+        shell: dependencies.shell,
+        pager: dependencies.pager,
+        stdoutIsTTY: dependencies.stdoutIsTTY
+    });
+}

--- a/source/command-line-interface/preview-io.ts
+++ b/source/command-line-interface/preview-io.ts
@@ -1,9 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import os from 'node:os';
-import { createPreviewIo, defaultSpawnProcess, type PreviewIo, type PreviewIoDependencies } from './preview-io-shared.ts';
+import {
+    createPreviewIo,
+    defaultSpawnProcess,
+    type PreviewIo,
+    type PreviewIoDependencies
+} from './preview-io-shared.ts';
 
-type DefaultPreviewIoDependencies = Pick<PreviewIoDependencies, 'platform' | 'shell' | 'pager' | 'stdoutIsTTY'> &
-    Partial<Pick<PreviewIoDependencies, 'spawnProcess' | 'randomUuid' | 'tmpdir'>>;
+type DefaultPreviewIoDependencies = Partial<Pick<PreviewIoDependencies, 'randomUuid' | 'spawnProcess' | 'tmpdir'>> &
+    Pick<PreviewIoDependencies, 'pager' | 'platform' | 'shell' | 'stdoutIsTTY'>;
 
 export function createDefaultPreviewIo(dependencies: DefaultPreviewIoDependencies): PreviewIo {
     return createPreviewIo({

--- a/source/command-line-interface/runner.test.ts
+++ b/source/command-line-interface/runner.test.ts
@@ -11,6 +11,7 @@ import {
     createBuildResultFixture,
     createPackageReportFixture
 } from '../test-libraries/preview-fixtures.ts';
+import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { toOutcome } from '../test-libraries/result-helpers.ts';
 import {
     createCommandLineInterfaceRunner,
@@ -22,7 +23,7 @@ type Overrides = {
     readonly buildAndPublishAll?: SinonSpy;
     readonly loadConfig?: SinonSpy;
     readonly log?: SinonSpy;
-    readonly writeReportFile?: SinonSpy;
+    readonly fileManager?: FakeFileManager;
     readonly pageOutput?: SinonSpy;
     readonly openFile?: SinonSpy;
     readonly createTemporaryFilePath?: () => string;
@@ -67,6 +68,7 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
     const progressBroadcaster = overrides.progressBroadcaster ?? createProgressBroadcaster();
     const log = createSpy(overrides.log, fake);
     const pageOutput = overrides.pageOutput ?? fake.resolves(undefined);
+    const fileManager = overrides.fileManager ?? createFakeFileManager();
     const dependencies: CommandLineInterfaceRunnerDependencies = {
         packtory: {
             buildAndPublishAll: createSpy(overrides.buildAndPublishAll, () => {
@@ -84,9 +86,7 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
         },
         progressBroadcaster: progressBroadcaster.consumer,
         spinnerRenderer: createSpinnerRenderer(overrides.spinnerRenderer),
-        writeReportFile: createSpy(overrides.writeReportFile, () => {
-            return fake.resolves(undefined);
-        }),
+        fileManager,
         pageOutput: async (message) => {
             pageOutput(stripVTControlCharacters(message));
         },
@@ -365,7 +365,7 @@ test('stops all spinners when buildAndPublishAll finishes without errors', async
     const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { stopAll } });
 
     await runner.run(['foo', 'bar', 'publish']);
-    assert.ok(stopAll.callCount >= 1);
+    assert.strictEqual(stopAll.callCount, 1);
 });
 
 test('adds a spinner when progressBroadcaster receives a "scheduled" event', async () => {
@@ -489,76 +489,76 @@ test('publish with --report-html requests collectReport: true', async () => {
     await expectCollectReportFlag('--report-html');
 });
 
-async function runPublishWithReport(extraArgs: readonly string[]): Promise<SinonSpy> {
-    const writeReportFile = fake.resolves(undefined);
+async function runPublishWithReport(extraArgs: readonly string[]): Promise<FakeFileManager> {
+    const fileManager = createFakeFileManager();
     const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll, writeReportFile });
+    const runner = runnerFactory({ buildAndPublishAll, fileManager });
     await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
-    return writeReportFile;
+    return fileManager;
 }
 
 test('publish writes packtory-report.json when --report-json is set and getReport returns a report', async () => {
-    const writeReportFile = await runPublishWithReport(['--report-json']);
+    const fileManager = await runPublishWithReport(['--report-json']);
 
-    assert.strictEqual(writeReportFile.callCount, 1);
-    assert.strictEqual(writeReportFile.firstCall.args[0], 'packtory-report.json');
-    const writtenContent = String(writeReportFile.firstCall.args[1]);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, 'packtory-report.json');
+    const writtenContent = fileManager.getWriteFileCall(0).content;
     assert.ok(writtenContent.endsWith('\n'), 'json report must end with a newline');
     assert.deepStrictEqual(JSON.parse(writtenContent), sampleReport);
 });
 
 test('publish writes packtory-report.html when --report-html is set and getReport returns a report', async () => {
-    const writeReportFile = await runPublishWithReport(['--report-html']);
+    const fileManager = await runPublishWithReport(['--report-html']);
 
-    assert.strictEqual(writeReportFile.callCount, 1);
-    assert.strictEqual(writeReportFile.firstCall.args[0], 'packtory-report.html');
-    const writtenContent = String(writeReportFile.firstCall.args[1]);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, 'packtory-report.html');
+    const writtenContent = fileManager.getWriteFileCall(0).content;
     assert.ok(writtenContent.startsWith('<!doctype html>'), 'html report must start with doctype');
     assert.ok(writtenContent.includes('Dry run'));
 });
 
 test('publish writes report html in publish mode when dry-run is disabled', async () => {
-    const writeReportFile = await runPublishWithReport(['--report-html', '--no-dry-run']);
+    const fileManager = await runPublishWithReport(['--report-html', '--no-dry-run']);
 
-    const writtenContent = String(writeReportFile.firstCall.args[1]);
+    const writtenContent = fileManager.getWriteFileCall(0).content;
     assert.ok(writtenContent.includes('Publish'));
     assert.ok(!writtenContent.includes('<div class="mode-label">Dry run</div>'));
 });
 
 test('publish writes both report files when --report-json and --report-html are set', async () => {
-    const writeReportFile = await runPublishWithReport(['--report-json', '--report-html']);
+    const fileManager = await runPublishWithReport(['--report-json', '--report-html']);
 
-    const writtenPaths = writeReportFile.getCalls().map((call): unknown => {
-        return call.args[0];
+    const writtenPaths = fileManager.getAllWriteFileCalls().map((call): unknown => {
+        return call.filePath;
     });
     assert.deepStrictEqual(writtenPaths, ['packtory-report.json', 'packtory-report.html']);
 });
 
 test('publish writes no report files when neither flag is set', async () => {
-    const writeReportFile = await runPublishWithReport([]);
+    const fileManager = await runPublishWithReport([]);
 
-    assert.strictEqual(writeReportFile.callCount, 0);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
 });
 
 test('publish writes no report files when getReport returns undefined even with --report-json set', async () => {
-    const writeReportFile = fake.resolves(undefined);
+    const fileManager = createFakeFileManager();
     const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll, writeReportFile });
+    const runner = runnerFactory({ buildAndPublishAll, fileManager });
 
     await runner.run(['foo', 'bar', 'publish', '--report-json']);
 
-    assert.strictEqual(writeReportFile.callCount, 0);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
 });
 
 test('publish writes the report even when the build failed', async () => {
-    const writeReportFile = fake.resolves(undefined);
+    const fileManager = createFakeFileManager();
     const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'config', issues: ['boom'] })));
-    const runner = runnerFactory({ buildAndPublishAll, writeReportFile });
+    const runner = runnerFactory({ buildAndPublishAll, fileManager });
 
     const exitCode = await runner.run(['foo', 'bar', 'publish', '--report-json']);
 
     assert.strictEqual(exitCode, 1);
-    assert.strictEqual(writeReportFile.callCount, 1);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
 });
 
 test('preview pages previewable output and does not print it directly to stdout', async () => {
@@ -634,12 +634,12 @@ test('preview treats partial failures with no successful packages as failure-onl
 
 test('preview --open writes a temporary html report and invokes the opener', async () => {
     const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-    const writeReportFile = fake.resolves(undefined);
+    const fileManager = createFakeFileManager();
     const openFile = fake.resolves(true);
     const log = fake();
     const runner = runnerFactory({
         buildAndPublishAll,
-        writeReportFile,
+        fileManager,
         openFile,
         log,
         createTemporaryFilePath: () => '/tmp/packtory-preview-test.html'
@@ -648,9 +648,9 @@ test('preview --open writes a temporary html report and invokes the opener', asy
     const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
 
     assert.strictEqual(exitCode, 0);
-    assert.strictEqual(writeReportFile.callCount, 1);
-    assert.deepStrictEqual(writeReportFile.firstCall.args[0], '/tmp/packtory-preview-test.html');
-    assert.match(String(writeReportFile.firstCall.args[1]), /^<!doctype html>/);
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    assert.deepStrictEqual(fileManager.getWriteFileCall(0).filePath, '/tmp/packtory-preview-test.html');
+    assert.match(fileManager.getWriteFileCall(0).content, /^<!doctype html>/);
     assert.strictEqual(openFile.callCount, 1);
     assert.deepStrictEqual(openFile.firstCall.args, ['/tmp/packtory-preview-test.html']);
     assert.strictEqual(log.callCount, 0);
@@ -685,21 +685,21 @@ test('preview builds an empty fallback report when getReport returns undefined',
 });
 
 test('preview --open writes an empty fallback report when getReport returns undefined', async () => {
-    const writeReportFile = fake.resolves(undefined);
+    const fileManager = createFakeFileManager();
     const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
     const runner = runnerFactory({
         buildAndPublishAll,
-        writeReportFile,
+        fileManager,
         createTemporaryFilePath: () => '/tmp/packtory-preview-fallback.html'
     });
 
     const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
 
     assert.strictEqual(exitCode, 1);
-    assert.strictEqual(writeReportFile.callCount, 1);
-    assert.strictEqual(writeReportFile.firstCall.args[0], '/tmp/packtory-preview-fallback.html');
+    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, '/tmp/packtory-preview-fallback.html');
     assert.match(
-        String(writeReportFile.firstCall.args[1]),
+        fileManager.getWriteFileCall(0).content,
         /&quot;aggregate&quot;: \{\s+&quot;crossBundleLinks&quot;: \[\]/u
     );
 });

--- a/source/command-line-interface/runner.ts
+++ b/source/command-line-interface/runner.ts
@@ -9,19 +9,18 @@ import type { PartialError } from '../packtory/scheduler.ts';
 import { buildPreviewDocument } from '../report/preview-document.ts';
 import { renderHtmlReport } from '../report/html-renderer.ts';
 import { renderFailureOnlyTerminalPreview, renderTerminalPreview } from '../report/terminal-preview-renderer.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
 import type { TerminalSpinnerRenderer } from './terminal-spinner-renderer.ts';
 import type { ConfigLoader } from './config-loader.ts';
 
 type PublishPartialError = PartialError<BuildAndPublishResult>;
-
-type ReportWriter = (filePath: string, content: string) => Promise<void>;
 
 export type CommandLineInterfaceRunnerDependencies = {
     readonly packtory: Packtory;
     readonly progressBroadcaster: ProgressBroadcastConsumer;
     readonly spinnerRenderer: TerminalSpinnerRenderer;
     readonly configLoader: ConfigLoader;
-    readonly writeReportFile: ReportWriter;
+    readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
     readonly pageOutput: (content: string) => Promise<void>;
     readonly openFile: (filePath: string) => Promise<boolean>;
     readonly createTemporaryFilePath: () => string;
@@ -159,7 +158,7 @@ const jsonIndentSpaces = 2;
 
 // eslint-disable-next-line @typescript-eslint/max-params -- report persistence needs shared flags plus build outcome/report data
 async function writeReports(
-    writeReportFile: ReportWriter,
+    fileManager: Pick<FileManager, 'readFile' | 'writeFile'>,
     report: BuildReport | undefined,
     result: Awaited<ReturnType<Packtory['buildAndPublishAll']>>['result'],
     flags: { readonly reportJson: boolean; readonly reportHtml: boolean },
@@ -169,11 +168,11 @@ async function writeReports(
         return;
     }
     if (flags.reportJson) {
-        await writeReportFile('packtory-report.json', `${JSON.stringify(report, undefined, jsonIndentSpaces)}\n`);
+        await fileManager.writeFile('packtory-report.json', `${JSON.stringify(report, undefined, jsonIndentSpaces)}\n`);
     }
     if (flags.reportHtml) {
-        const document = await buildPreviewDocument({ report, result, dryRun });
-        await writeReportFile('packtory-report.html', renderHtmlReport(document));
+        const document = await buildPreviewDocument({ report, result, dryRun, fileManager });
+        await fileManager.writeFile('packtory-report.html', renderHtmlReport(document));
     }
 }
 
@@ -182,13 +181,13 @@ type PublishHandlerDeps = {
     readonly packtory: Packtory;
     readonly spinnerRenderer: TerminalSpinnerRenderer;
     readonly configLoader: ConfigLoader;
-    readonly writeReportFile: ReportWriter;
+    readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
     readonly flags: { readonly noDryRun: boolean; readonly reportJson: boolean; readonly reportHtml: boolean };
 };
 
 async function reportOutcome(
     log: PublishHandlerDeps['log'],
-    writeReportFile: ReportWriter,
+    fileManager: PublishHandlerDeps['fileManager'],
     outcome: Awaited<ReturnType<Packtory['buildAndPublishAll']>>,
     flags: PublishHandlerDeps['flags']
 ): Promise<number> {
@@ -199,23 +198,35 @@ async function reportOutcome(
     } else {
         printSuccessSummary(log, outcome.result.value);
     }
-    await writeReports(writeReportFile, outcome.getReport(), outcome.result, flags, !flags.noDryRun);
+    await writeReports(fileManager, outcome.getReport(), outcome.result, flags, !flags.noDryRun);
     return exitCode;
 }
 
+async function stopSpinnersAndReportOutcome(args: {
+    readonly flags: PublishHandlerDeps['flags'];
+    readonly log: PublishHandlerDeps['log'];
+    readonly outcome: Awaited<ReturnType<Packtory['buildAndPublishAll']>>;
+    readonly spinnerRenderer: TerminalSpinnerRenderer;
+    readonly fileManager: PublishHandlerDeps['fileManager'];
+}): Promise<number> {
+    args.spinnerRenderer.stopAll();
+    return await reportOutcome(args.log, args.fileManager, args.outcome, args.flags);
+}
+
 async function runPublishHandler(deps: PublishHandlerDeps): Promise<number> {
-    const { log, packtory, spinnerRenderer, configLoader, writeReportFile, flags } = deps;
-    const config = await configLoader.load();
-    const collectReport = flags.reportJson || flags.reportHtml;
+    const { log, packtory, spinnerRenderer, configLoader, fileManager, flags } = deps;
+    let shouldStopSpinners = true;
     try {
-        const outcome = await packtory.buildAndPublishAll(config, {
+        const outcome = await packtory.buildAndPublishAll(await configLoader.load(), {
             dryRun: !flags.noDryRun,
-            collectReport
+            collectReport: flags.reportJson || flags.reportHtml
         });
-        spinnerRenderer.stopAll();
-        return await reportOutcome(log, writeReportFile, outcome, flags);
+        shouldStopSpinners = false;
+        return await stopSpinnersAndReportOutcome({ spinnerRenderer, log, fileManager, outcome, flags });
     } finally {
-        spinnerRenderer.stopAll();
+        if (shouldStopSpinners) {
+            spinnerRenderer.stopAll();
+        }
         printDryRunNote(log, { noDryRun: flags.noDryRun });
     }
 }
@@ -241,7 +252,7 @@ type PreviewHandlerDeps = {
     readonly packtory: Packtory;
     readonly spinnerRenderer: TerminalSpinnerRenderer;
     readonly configLoader: ConfigLoader;
-    readonly writeReportFile: ReportWriter;
+    readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
     readonly flags: PreviewFlags;
 };
 
@@ -255,7 +266,7 @@ async function runPreviewHandler(deps: PreviewHandlerDeps): Promise<number> {
         packtory,
         spinnerRenderer,
         configLoader,
-        writeReportFile,
+        fileManager,
         flags
     } = deps;
     try {
@@ -269,11 +280,12 @@ async function runPreviewHandler(deps: PreviewHandlerDeps): Promise<number> {
         const document = await buildPreviewDocument({
             report,
             result: outcome.result,
-            dryRun: true
+            dryRun: true,
+            fileManager
         });
         if (flags.open) {
             const filePath = createTemporaryFilePath();
-            await writeReportFile(filePath, renderHtmlReport(document));
+            await fileManager.writeFile(filePath, renderHtmlReport(document));
             const opened = await openFile(filePath);
             if (!opened) {
                 log(filePath);
@@ -308,7 +320,7 @@ export function createCommandLineInterfaceRunner(
         progressBroadcaster,
         spinnerRenderer,
         configLoader,
-        writeReportFile,
+        fileManager,
         pageOutput,
         openFile,
         createTemporaryFilePath
@@ -333,7 +345,7 @@ export function createCommandLineInterfaceRunner(
                         packtory,
                         spinnerRenderer,
                         configLoader,
-                        writeReportFile,
+                        fileManager,
                         flags: { noDryRun, reportJson, reportHtml }
                     });
                     exitCode = handlerExitCode;
@@ -354,7 +366,7 @@ export function createCommandLineInterfaceRunner(
                         packtory,
                         spinnerRenderer,
                         configLoader,
-                        writeReportFile,
+                        fileManager,
                         flags: { open }
                     });
                     exitCode = handlerExitCode;

--- a/source/command-line-interface/spinner-boot.test.ts
+++ b/source/command-line-interface/spinner-boot.test.ts
@@ -11,6 +11,8 @@ test('bootSpinnerRuntime spawns the worker via the supplied spawn function', () 
         spawnWorker: (request) => {
             spawnWorker(request);
         },
+        stdoutFileDescriptor: 1,
+        stdoutColumns: 80,
         initialLabel: 'lbl',
         initialMessage: 'msg'
     });
@@ -26,6 +28,8 @@ test('bootSpinnerRuntime writes the initial label and message to slot zero', () 
         spawnWorker: () => {
             // noop
         },
+        stdoutFileDescriptor: 1,
+        stdoutColumns: 80,
         initialLabel: 'packtory',
         initialMessage: 'Starting …'
     });
@@ -43,6 +47,8 @@ test('bootSpinnerRuntime leaves all other slots empty', () => {
         spawnWorker: () => {
             // noop
         },
+        stdoutFileDescriptor: 1,
+        stdoutColumns: 80,
         initialLabel: 'lbl',
         initialMessage: 'msg'
     });
@@ -59,6 +65,7 @@ test('bootSpinnerRuntime leaves all other slots empty', () => {
 test('bootSpinnerRuntime forwards runtime options like intervalMs and stdoutColumns', () => {
     const runtime = bootSpinnerRuntime({
         intervalMs: 25,
+        stdoutFileDescriptor: 1,
         stdoutColumns: 132,
         spawnWorker: () => {
             // noop

--- a/source/command-line-interface/spinner-boot.ts
+++ b/source/command-line-interface/spinner-boot.ts
@@ -11,5 +11,6 @@ export function bootSpinnerRuntime(options: SpinnerBootOptions): SpinnerRuntime 
     const runtime = createSpinnerRuntime(options);
     runtime.accessors.writeSlot(bootSlotIndex, 'running', options.initialLabel, options.initialMessage);
     runtime.accessors.bumpSlotGeneration(bootSlotIndex);
+    runtime.accessors.markMutation();
     return runtime;
 }

--- a/source/command-line-interface/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner-shared-state.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import { stub } from 'sinon';
 import { runNodeProbe } from '../test-libraries/run-node-probe.ts';
 import {
     createSpinnerSharedAccessors,
@@ -9,12 +8,26 @@ import {
 } from './spinner-shared-state.ts';
 
 const probeTestTimeoutMs = 10_000;
-type Int32Atomics = {
-    load: (typedArray: Int32Array, index: number) => number;
-    wait: (typedArray: Int32Array, index: number, value: number, timeout?: number) => 'not-equal' | 'ok' | 'timed-out';
+type WaitResult = 'not-equal' | 'ok' | 'timed-out';
+
+type AtomicsLike = {
+    readonly add: (typedArray: Int32Array | Uint32Array, index: number, value: number) => number;
+    readonly load: (typedArray: Int32Array | Uint32Array, index: number) => number;
+    readonly notify: (typedArray: Int32Array, index: number, count?: number) => number;
+    readonly store: (typedArray: Int32Array | Uint32Array, index: number, value: number) => number;
+    readonly wait: (typedArray: Int32Array, index: number, value: number, timeout?: number) => WaitResult;
 };
 
-function createAccessors(slotCount = 4, dependencies: { readonly now?: () => number } = {}): SpinnerSharedAccessors {
+type ControlledAtomics = AtomicsLike & {
+    loadCallCount: number;
+    waitCallCount: number;
+    readonly waitCalls: (readonly [number, number, number | undefined])[];
+};
+
+function createAccessors(
+    slotCount = 4,
+    dependencies: { readonly now?: () => number; readonly atomics?: AtomicsLike } = {}
+): SpinnerSharedAccessors {
     const layout = createSpinnerSharedLayout(slotCount);
     const buffer = new SharedArrayBuffer(layout.bufferByteLength);
     return createSpinnerSharedAccessors(buffer, layout, dependencies);
@@ -30,6 +43,57 @@ function createNow(values: readonly number[]): () => number {
         }
         return value;
     };
+}
+
+type ControlledAtomicsOverrides = {
+    readonly load?: (typedArray: Int32Array | Uint32Array, index: number, realLoad: AtomicsLike['load']) => number;
+    readonly wait?: (args: {
+        readonly typedArray: Int32Array;
+        readonly index: number;
+        readonly value: number;
+        readonly timeout: number | undefined;
+        readonly realWait: AtomicsLike['wait'];
+    }) => WaitResult;
+};
+
+function createControlledAtomics(overrides: ControlledAtomicsOverrides = {}): ControlledAtomics {
+    const realAdd: AtomicsLike['add'] = (typedArray, index, value) => {
+        return Atomics.add(typedArray, index, value);
+    };
+    const realLoad: AtomicsLike['load'] = (typedArray, index) => {
+        return Atomics.load(typedArray, index);
+    };
+    const realNotify: AtomicsLike['notify'] = (typedArray, index, count) => {
+        return Atomics.notify(typedArray, index, count);
+    };
+    const realStore: AtomicsLike['store'] = (typedArray, index, value) => {
+        return Atomics.store(typedArray, index, value);
+    };
+    const realWait: AtomicsLike['wait'] = (typedArray, index, value, timeout) => {
+        return Atomics.wait(typedArray, index, value, timeout);
+    };
+    const controlled: ControlledAtomics = {
+        loadCallCount: 0,
+        waitCallCount: 0,
+        waitCalls: [],
+        add: realAdd,
+        load(typedArray, index) {
+            controlled.loadCallCount += 1;
+            return overrides.load?.(typedArray, index, realLoad) ?? realLoad(typedArray, index);
+        },
+        notify: realNotify,
+        store: realStore,
+        wait(typedArray, index, value, timeout) {
+            controlled.waitCallCount += 1;
+            controlled.waitCalls.push([index, value, timeout]);
+            return (
+                overrides.wait?.({ typedArray, index, value, timeout, realWait }) ??
+                realWait(typedArray, index, value, timeout)
+            );
+        }
+    };
+
+    return controlled;
 }
 
 test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', () => {
@@ -75,6 +139,20 @@ test('waitForRenderedMutation returns true once the render was acknowledged', ()
     assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
 });
 
+test('waitForRenderedMutation returns immediately without waiting when the render is already caught up', () => {
+    let mutation = 0;
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            return index === 4 ? mutation : realLoad(typedArray, index);
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow([100, 100]), atomics });
+    mutation = accessors.markMutation();
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 0);
+});
+
 test('waitForRenderedMutation times out when the render was not acknowledged', () => {
     const accessors = createAccessors();
     const mutation = accessors.markMutation();
@@ -83,129 +161,246 @@ test('waitForRenderedMutation times out when the render was not acknowledged', (
 });
 
 test('waitForRenderedMutation returns once the render catches up between loop checks', () => {
-    const accessors = createAccessors();
-    const mutation = accessors.markMutation();
-    const int32Atomics = Atomics as Int32Atomics;
-    const realLoad = int32Atomics.load.bind(int32Atomics);
-    const loadStub = stub(int32Atomics, 'load');
     let renderedMutationLoadCount = 0;
-
-    loadStub.callsFake((typedArray, index) => {
-        if (index === 4) {
-            renderedMutationLoadCount += 1;
-            if (renderedMutationLoadCount === 1) {
-                return 0;
+    let mutation = 0;
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                renderedMutationLoadCount += 1;
+                if (renderedMutationLoadCount === 1) {
+                    return 0;
+                }
+                return mutation;
             }
-            return mutation;
+            return realLoad(typedArray, index);
         }
-        return realLoad(typedArray, index);
     });
+    const accessors = createAccessors(4, { atomics });
+    mutation = accessors.markMutation();
 
-    try {
-        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-    } finally {
-        loadStub.restore();
-    }
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
 });
 
 test('waitForRenderedMutation waits with the current rendered mutation and the remaining timeout', () => {
-    const accessors = createAccessors(4, { now: createNow([100, 105, 110]) });
-    const mutation = accessors.markMutation();
-    const int32Atomics = Atomics as Int32Atomics;
-    const realLoad = int32Atomics.load.bind(int32Atomics);
-    const loadStub = stub(int32Atomics, 'load');
-    const waitStub = stub(int32Atomics, 'wait').returns('timed-out');
     let renderedMutationLoadCount = 0;
-    loadStub.callsFake((typedArray, index) => {
-        if (index === 4) {
-            renderedMutationLoadCount += 1;
-            return 0;
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                renderedMutationLoadCount += 1;
+                return 0;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return 'timed-out';
         }
-        return realLoad(typedArray, index);
     });
+    const accessors = createAccessors(4, { now: createNow([100, 105, 110]), atomics });
+    const mutation = accessors.markMutation();
 
-    try {
-        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
-        assert.strictEqual(waitStub.callCount, 1);
-        assert.strictEqual(renderedMutationLoadCount, 2);
-        assert.deepStrictEqual(waitStub.firstCall.args.slice(1), [4, 0, 5]);
-    } finally {
-        waitStub.restore();
-        loadStub.restore();
-    }
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+    assert.strictEqual(atomics.waitCallCount, 1);
+    assert.strictEqual(renderedMutationLoadCount, 2);
+    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
 });
 
 test('waitForRenderedMutation returns true after a wait once the rendered mutation reaches the target', () => {
-    const accessors = createAccessors(4, { now: createNow([100, 100, 100]) });
-    const mutation = accessors.markMutation();
-    const int32Atomics = Atomics as Int32Atomics;
-    const realLoad = int32Atomics.load.bind(int32Atomics);
-    const loadStub = stub(int32Atomics, 'load');
-    const waitStub = stub(int32Atomics, 'wait').returns('ok');
     let renderedMutationLoadCount = 0;
-    loadStub.callsFake((typedArray, index) => {
-        if (index === 4) {
-            renderedMutationLoadCount += 1;
-            return renderedMutationLoadCount === 1 ? 0 : mutation;
+    let mutation = 0;
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                renderedMutationLoadCount += 1;
+                return renderedMutationLoadCount === 1 ? 0 : mutation;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return 'ok';
         }
-        return realLoad(typedArray, index);
     });
+    const accessors = createAccessors(4, { now: createNow([100, 100, 100]), atomics });
+    mutation = accessors.markMutation();
 
-    try {
-        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-        assert.strictEqual(waitStub.callCount, 1);
-        assert.deepStrictEqual(waitStub.firstCall.args.slice(1), [4, 0, 10]);
-    } finally {
-        waitStub.restore();
-        loadStub.restore();
-    }
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 1);
+    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+});
+
+test('waitForRenderedMutation keeps waiting after a timeout when the rendered mutation still makes progress', () => {
+    const waitResults: WaitResult[] = ['timed-out', 'ok'];
+    let mutation = 0;
+    const renderedMutations = [0, 1, 1];
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                return renderedMutations.shift() ?? mutation;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return waitResults.shift() ?? 'ok';
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow([100, 100, 101, 101, 102]), atomics });
+    mutation = accessors.markMutation() + 1;
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 2);
+    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+    assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 9]);
 });
 
 test('waitForRenderedMutation returns false when the remaining timeout grows without render progress', () => {
-    const accessors = createAccessors(4, { now: createNow([100, 105, 90]) });
-    const mutation = accessors.markMutation();
-    const int32Atomics = Atomics as Int32Atomics;
-    const realLoad = int32Atomics.load.bind(int32Atomics);
-    const loadStub = stub(int32Atomics, 'load');
-    const waitStub = stub(int32Atomics, 'wait').returns('ok');
     let renderedMutationLoadCount = 0;
-
-    loadStub.callsFake((typedArray, index) => {
-        if (index === 4) {
-            renderedMutationLoadCount += 1;
-            return 0;
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                renderedMutationLoadCount += 1;
+                return 0;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return 'ok';
         }
-        return realLoad(typedArray, index);
     });
+    const accessors = createAccessors(4, { now: createNow([100, 105, 90]), atomics });
+    const mutation = accessors.markMutation();
 
-    try {
-        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
-        assert.strictEqual(waitStub.callCount, 1);
-        assert.strictEqual(renderedMutationLoadCount, 2);
-    } finally {
-        waitStub.restore();
-        loadStub.restore();
-    }
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+    assert.strictEqual(atomics.waitCallCount, 1);
+    assert.strictEqual(renderedMutationLoadCount, 2);
+});
+
+test('waitForRenderedMutation keeps polling when no progress was made but the remaining timeout still shrank', () => {
+    let mutation = 0;
+    const renderedMutations = [0, 0, 0];
+    const waitResults: WaitResult[] = ['ok', 'ok'];
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                return renderedMutations.shift() ?? mutation;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return waitResults.shift() ?? 'ok';
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow([100, 100, 101, 101, 102]), atomics });
+    mutation = accessors.markMutation();
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 2);
+    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+    assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 9]);
+});
+
+test('waitForRenderedMutation keeps polling when no progress was made and the remaining timeout stayed the same', () => {
+    let mutation = 0;
+    const renderedMutations = [0, 0, 0];
+    const waitResults: WaitResult[] = ['ok', 'ok'];
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                return renderedMutations.shift() ?? mutation;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return waitResults.shift() ?? 'ok';
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow([100, 100, 100, 100, 101]), atomics });
+    mutation = accessors.markMutation();
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 2);
+    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+    assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 10]);
+});
+
+test('waitForRenderedMutation keeps polling when progress was made even if the remaining timeout grows', () => {
+    let mutation = 0;
+    const renderedMutations = [0, 1, 1];
+    const waitResults: WaitResult[] = ['ok', 'ok'];
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                return renderedMutations.shift() ?? mutation;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return waitResults.shift() ?? 'ok';
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow([100, 105, 90, 90, 91]), atomics });
+    mutation = accessors.markMutation() + 1;
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 2);
+    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
+    assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 10]);
+});
+
+test('waitForRenderedMutation returns true when a wait step reaches the target mutation exactly', () => {
+    const renderedMutations = [0];
+    const waitResults: WaitResult[] = ['ok', 'timed-out'];
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                return renderedMutations.shift() ?? 0;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return waitResults.shift() ?? 'timed-out';
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow([100, 100, 101, 102, 110]), atomics });
+    const mutation = accessors.markMutation();
+    renderedMutations.push(mutation, 0, 0);
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(atomics.waitCallCount, 1);
 });
 
 test('waitForRenderedMutation times out immediately when the timeout has already elapsed', () => {
-    const accessors = createAccessors(4, { now: createNow([100, 110]) });
-    const mutation = accessors.markMutation();
-    const int32Atomics = Atomics as Int32Atomics;
-    const realLoad = int32Atomics.load.bind(int32Atomics);
-    const loadStub = stub(int32Atomics, 'load');
-    const waitStub = stub(int32Atomics, 'wait');
-    loadStub.callsFake((typedArray, index) => {
-        return index === 4 ? 0 : realLoad(typedArray, index);
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            return index === 4 ? 0 : realLoad(typedArray, index);
+        }
     });
+    const accessors = createAccessors(4, { now: createNow([100, 110]), atomics });
+    const mutation = accessors.markMutation();
 
-    try {
-        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
-        assert.strictEqual(waitStub.callCount, 0);
-    } finally {
-        waitStub.restore();
-        loadStub.restore();
-    }
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+    assert.strictEqual(atomics.waitCallCount, 0);
+});
+
+test('waitForRenderedMutation stops after the maximum number of polling attempts', () => {
+    const now = (() => {
+        let current = 0;
+        return () => {
+            current += 1;
+            return current;
+        };
+    })();
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            return index === 4 ? 0 : realLoad(typedArray, index);
+        },
+        wait() {
+            return 'ok';
+        }
+    });
+    const accessors = createAccessors(4, { now, atomics });
+    const mutation = accessors.markMutation();
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 1000), false);
+    assert.strictEqual(atomics.waitCallCount, 256);
 });
 
 test('isShutdownRequested returns false until requestShutdown is called', () => {
@@ -347,60 +542,52 @@ test('requestShutdown does not change the stored columns or interval', () => {
 });
 
 test('readSlot retries when the slot generation moves between the bracketing samples', () => {
-    const accessors = createAccessors();
+    let accessors = createAccessors();
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            const result = realLoad(typedArray, index);
+            if (index === 0 && atomics.loadCallCount === 1) {
+                accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
+                accessors.bumpSlotGeneration(0);
+            }
+            return result;
+        }
+    });
+    accessors = createAccessors(4, { atomics });
     accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
     accessors.bumpSlotGeneration(0);
 
-    const realLoad = Atomics.load.bind(Atomics);
-    const loadStub = stub(Atomics, 'load');
-    loadStub.callsFake((typedArray, index) => {
-        const result = realLoad(typedArray, index);
-        if (loadStub.callCount === 1) {
-            accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
-            accessors.bumpSlotGeneration(0);
-        }
-        return result;
+    const slot = accessors.readSlot(0);
+
+    assert.deepStrictEqual(slot, {
+        state: 'succeeded',
+        label: 'final-label',
+        message: 'final-message'
     });
-
-    try {
-        const slot = accessors.readSlot(0);
-
-        assert.deepStrictEqual(slot, {
-            state: 'succeeded',
-            label: 'final-label',
-            message: 'final-message'
-        });
-        assert.ok(
-            loadStub.callCount >= 3,
-            `expected the seqlock retry path to read the generation at least three times, got ${loadStub.callCount}`
-        );
-    } finally {
-        loadStub.restore();
-    }
+    assert.ok(
+        atomics.loadCallCount >= 3,
+        `expected the seqlock retry path to read the generation at least three times, got ${atomics.loadCallCount}`
+    );
 });
 
 test('readSlot throws when the slot generation never stabilizes', () => {
-    const accessors = createAccessors();
+    let accessors = createAccessors();
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            const result = realLoad(typedArray, index);
+            if (typedArray.constructor === Int32Array && index === 0) {
+                accessors.bumpSlotGeneration(0);
+            }
+            return result;
+        }
+    });
+    accessors = createAccessors(4, { atomics });
     accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
 
-    const realLoad = Atomics.load.bind(Atomics);
-    const loadStub = stub(Atomics, 'load');
-    loadStub.callsFake((typedArray, index) => {
-        const result = realLoad(typedArray, index);
-        if (typedArray.constructor === Int32Array && index === 0) {
-            accessors.bumpSlotGeneration(0);
-        }
-        return result;
-    });
-
-    try {
-        assert.throws(() => {
-            accessors.readSlot(0);
-        }, /^Error: Failed to read a stable spinner slot snapshot$/u);
-        assert.strictEqual(loadStub.callCount, 1025);
-    } finally {
-        loadStub.restore();
-    }
+    assert.throws(() => {
+        accessors.readSlot(0);
+    }, /^Error: Failed to read a stable spinner slot snapshot$/u);
+    assert.strictEqual(atomics.loadCallCount, 1025);
 });
 
 test('readSlot completes promptly when a seqlock retry is needed', async () => {
@@ -413,22 +600,30 @@ test('readSlot completes promptly when a seqlock retry is needed', async () => {
 
             const layout = createSpinnerSharedLayout(1);
             const buffer = new SharedArrayBuffer(layout.bufferByteLength);
-            const accessors = createSpinnerSharedAccessors(buffer, layout);
+            let accessors = createSpinnerSharedAccessors(buffer, layout);
 
             accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
             accessors.bumpSlotGeneration(0);
 
-            const realLoad = Atomics.load.bind(Atomics);
             let callCount = 0;
-            Atomics.load = (...args) => {
-                const value = realLoad(...args);
-                callCount += 1;
-                if (callCount === 1) {
-                    accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
-                    accessors.bumpSlotGeneration(0);
-                }
-                return value;
+            const atomics = {
+                add: Atomics.add,
+                load(...args) {
+                    const value = Atomics.load(...args);
+                    callCount += 1;
+                    if (callCount === 1) {
+                        accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
+                        accessors.bumpSlotGeneration(0);
+                    }
+                    return value;
+                },
+                notify: Atomics.notify,
+                store: Atomics.store,
+                wait: Atomics.wait
             };
+            accessors = createSpinnerSharedAccessors(buffer, layout, { atomics });
+            accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
+            accessors.bumpSlotGeneration(0);
 
             console.log(JSON.stringify(accessors.readSlot(0)));
         `,

--- a/source/command-line-interface/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner-shared-state.test.ts
@@ -96,6 +96,37 @@ function createControlledAtomics(overrides: ControlledAtomicsOverrides = {}): Co
     return controlled;
 }
 
+type WaitScenario = {
+    readonly now: readonly number[];
+    readonly renderedMutations: readonly number[];
+    readonly waitResults?: readonly WaitResult[];
+    readonly targetOffset?: number;
+};
+
+function runWaitScenario(scenario: WaitScenario): {
+    readonly atomics: ControlledAtomics;
+    readonly mutation: number;
+    readonly result: boolean;
+} {
+    const waitResults = [...(scenario.waitResults ?? [])];
+    const renderedMutations = [...scenario.renderedMutations];
+    let mutation = 0;
+    const atomics = createControlledAtomics({
+        load(typedArray, index, realLoad) {
+            if (index === 4) {
+                return renderedMutations.shift() ?? mutation;
+            }
+            return realLoad(typedArray, index);
+        },
+        wait() {
+            return waitResults.shift() ?? 'ok';
+        }
+    });
+    const accessors = createAccessors(4, { now: createNow(scenario.now), atomics });
+    mutation = accessors.markMutation() + (scenario.targetOffset ?? 0);
+    return { atomics, mutation, result: accessors.waitForRenderedMutation(mutation, 10) };
+}
+
 test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', () => {
     const layout = createSpinnerSharedLayout(2);
 
@@ -228,24 +259,14 @@ test('waitForRenderedMutation returns true after a wait once the rendered mutati
 });
 
 test('waitForRenderedMutation keeps waiting after a timeout when the rendered mutation still makes progress', () => {
-    const waitResults: WaitResult[] = ['timed-out', 'ok'];
-    let mutation = 0;
-    const renderedMutations = [0, 1, 1];
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                return renderedMutations.shift() ?? mutation;
-            }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return waitResults.shift() ?? 'ok';
-        }
+    const { atomics, result } = runWaitScenario({
+        now: [100, 100, 101, 101, 102],
+        renderedMutations: [0, 1, 1],
+        waitResults: ['timed-out', 'ok'],
+        targetOffset: 1
     });
-    const accessors = createAccessors(4, { now: createNow([100, 100, 101, 101, 102]), atomics });
-    mutation = accessors.markMutation() + 1;
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(result, true);
     assert.strictEqual(atomics.waitCallCount, 2);
     assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
     assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 9]);
@@ -274,72 +295,40 @@ test('waitForRenderedMutation returns false when the remaining timeout grows wit
 });
 
 test('waitForRenderedMutation keeps polling when no progress was made but the remaining timeout still shrank', () => {
-    let mutation = 0;
-    const renderedMutations = [0, 0, 0];
-    const waitResults: WaitResult[] = ['ok', 'ok'];
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                return renderedMutations.shift() ?? mutation;
-            }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return waitResults.shift() ?? 'ok';
-        }
+    const { atomics, result } = runWaitScenario({
+        now: [100, 100, 101, 101, 102],
+        renderedMutations: [0, 0, 0],
+        waitResults: ['ok', 'ok']
     });
-    const accessors = createAccessors(4, { now: createNow([100, 100, 101, 101, 102]), atomics });
-    mutation = accessors.markMutation();
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(result, true);
     assert.strictEqual(atomics.waitCallCount, 2);
     assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
     assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 9]);
 });
 
 test('waitForRenderedMutation keeps polling when no progress was made and the remaining timeout stayed the same', () => {
-    let mutation = 0;
-    const renderedMutations = [0, 0, 0];
-    const waitResults: WaitResult[] = ['ok', 'ok'];
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                return renderedMutations.shift() ?? mutation;
-            }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return waitResults.shift() ?? 'ok';
-        }
+    const { atomics, result } = runWaitScenario({
+        now: [100, 100, 100, 100, 101],
+        renderedMutations: [0, 0, 0],
+        waitResults: ['ok', 'ok']
     });
-    const accessors = createAccessors(4, { now: createNow([100, 100, 100, 100, 101]), atomics });
-    mutation = accessors.markMutation();
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(result, true);
     assert.strictEqual(atomics.waitCallCount, 2);
     assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
     assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 10]);
 });
 
 test('waitForRenderedMutation keeps polling when progress was made even if the remaining timeout grows', () => {
-    let mutation = 0;
-    const renderedMutations = [0, 1, 1];
-    const waitResults: WaitResult[] = ['ok', 'ok'];
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                return renderedMutations.shift() ?? mutation;
-            }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return waitResults.shift() ?? 'ok';
-        }
+    const { atomics, result } = runWaitScenario({
+        now: [100, 105, 90, 90, 91],
+        renderedMutations: [0, 1, 1],
+        waitResults: ['ok', 'ok'],
+        targetOffset: 1
     });
-    const accessors = createAccessors(4, { now: createNow([100, 105, 90, 90, 91]), atomics });
-    mutation = accessors.markMutation() + 1;
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    assert.strictEqual(result, true);
     assert.strictEqual(atomics.waitCallCount, 2);
     assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
     assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 10]);

--- a/source/command-line-interface/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner-shared-state.test.ts
@@ -108,8 +108,8 @@ function runWaitScenario(scenario: WaitScenario): {
     readonly mutation: number;
     readonly result: boolean;
 } {
-    const waitResults = [...(scenario.waitResults ?? [])];
-    const renderedMutations = [...scenario.renderedMutations];
+    const waitResults = Array.from(scenario.waitResults ?? []);
+    const renderedMutations = Array.from(scenario.renderedMutations);
     let mutation = 0;
     const atomics = createControlledAtomics({
         load(typedArray, index, realLoad) {

--- a/source/command-line-interface/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner-shared-state.test.ts
@@ -9,20 +9,36 @@ import {
 } from './spinner-shared-state.ts';
 
 const probeTestTimeoutMs = 10_000;
+type Int32Atomics = {
+    load: (typedArray: Int32Array, index: number) => number;
+    wait: (typedArray: Int32Array, index: number, value: number, timeout?: number) => 'not-equal' | 'ok' | 'timed-out';
+};
 
-function createAccessors(slotCount = 4): SpinnerSharedAccessors {
+function createAccessors(slotCount = 4, dependencies: { readonly now?: () => number } = {}): SpinnerSharedAccessors {
     const layout = createSpinnerSharedLayout(slotCount);
     const buffer = new SharedArrayBuffer(layout.bufferByteLength);
-    return createSpinnerSharedAccessors(buffer, layout);
+    return createSpinnerSharedAccessors(buffer, layout, dependencies);
+}
+
+function createNow(values: readonly number[]): () => number {
+    let index = 0;
+    return () => {
+        const value = values[index] ?? values.at(-1);
+        index += 1;
+        if (value === undefined) {
+            throw new Error('No timestamp configured for test clock');
+        }
+        return value;
+    };
 }
 
 test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', () => {
     const layout = createSpinnerSharedLayout(2);
 
     assert.strictEqual(layout.slotCount, 2);
-    assert.strictEqual(layout.headerByteLength, 16);
+    assert.strictEqual(layout.headerByteLength, 24);
     assert.strictEqual(layout.slotByteLength, 384);
-    assert.strictEqual(layout.bufferByteLength, 16 + 2 * 384);
+    assert.strictEqual(layout.bufferByteLength, 24 + 2 * 384);
 });
 
 test('setColumns and getColumns round-trip the value', () => {
@@ -39,6 +55,157 @@ test('setIntervalMs and getIntervalMs round-trip the value', () => {
     accessors.setIntervalMs(50);
 
     assert.strictEqual(accessors.getIntervalMs(), 50);
+});
+
+test('markMutation increments and getLatestMutation reads the latest mutation number', () => {
+    const accessors = createAccessors();
+
+    assert.strictEqual(accessors.getLatestMutation(), 0);
+    assert.strictEqual(accessors.markMutation(), 1);
+    assert.strictEqual(accessors.markMutation(), 2);
+    assert.strictEqual(accessors.getLatestMutation(), 2);
+});
+
+test('waitForRenderedMutation returns true once the render was acknowledged', () => {
+    const accessors = createAccessors();
+    const mutation = accessors.markMutation();
+
+    accessors.acknowledgeRender(mutation);
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+});
+
+test('waitForRenderedMutation times out when the render was not acknowledged', () => {
+    const accessors = createAccessors();
+    const mutation = accessors.markMutation();
+
+    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 1), false);
+});
+
+test('waitForRenderedMutation returns once the render catches up between loop checks', () => {
+    const accessors = createAccessors();
+    const mutation = accessors.markMutation();
+    const int32Atomics = Atomics as Int32Atomics;
+    const realLoad = int32Atomics.load.bind(int32Atomics);
+    const loadStub = stub(int32Atomics, 'load');
+    let renderedMutationLoadCount = 0;
+
+    loadStub.callsFake((typedArray, index) => {
+        if (index === 4) {
+            renderedMutationLoadCount += 1;
+            if (renderedMutationLoadCount === 1) {
+                return 0;
+            }
+            return mutation;
+        }
+        return realLoad(typedArray, index);
+    });
+
+    try {
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    } finally {
+        loadStub.restore();
+    }
+});
+
+test('waitForRenderedMutation waits with the current rendered mutation and the remaining timeout', () => {
+    const accessors = createAccessors(4, { now: createNow([100, 105, 110]) });
+    const mutation = accessors.markMutation();
+    const int32Atomics = Atomics as Int32Atomics;
+    const realLoad = int32Atomics.load.bind(int32Atomics);
+    const loadStub = stub(int32Atomics, 'load');
+    const waitStub = stub(int32Atomics, 'wait').returns('timed-out');
+    let renderedMutationLoadCount = 0;
+    loadStub.callsFake((typedArray, index) => {
+        if (index === 4) {
+            renderedMutationLoadCount += 1;
+            return 0;
+        }
+        return realLoad(typedArray, index);
+    });
+
+    try {
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+        assert.strictEqual(waitStub.callCount, 1);
+        assert.strictEqual(renderedMutationLoadCount, 2);
+        assert.deepStrictEqual(waitStub.firstCall.args.slice(1), [4, 0, 5]);
+    } finally {
+        waitStub.restore();
+        loadStub.restore();
+    }
+});
+
+test('waitForRenderedMutation returns true after a wait once the rendered mutation reaches the target', () => {
+    const accessors = createAccessors(4, { now: createNow([100, 100, 100]) });
+    const mutation = accessors.markMutation();
+    const int32Atomics = Atomics as Int32Atomics;
+    const realLoad = int32Atomics.load.bind(int32Atomics);
+    const loadStub = stub(int32Atomics, 'load');
+    const waitStub = stub(int32Atomics, 'wait').returns('ok');
+    let renderedMutationLoadCount = 0;
+    loadStub.callsFake((typedArray, index) => {
+        if (index === 4) {
+            renderedMutationLoadCount += 1;
+            return renderedMutationLoadCount === 1 ? 0 : mutation;
+        }
+        return realLoad(typedArray, index);
+    });
+
+    try {
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+        assert.strictEqual(waitStub.callCount, 1);
+        assert.deepStrictEqual(waitStub.firstCall.args.slice(1), [4, 0, 10]);
+    } finally {
+        waitStub.restore();
+        loadStub.restore();
+    }
+});
+
+test('waitForRenderedMutation returns false when the remaining timeout grows without render progress', () => {
+    const accessors = createAccessors(4, { now: createNow([100, 105, 90]) });
+    const mutation = accessors.markMutation();
+    const int32Atomics = Atomics as Int32Atomics;
+    const realLoad = int32Atomics.load.bind(int32Atomics);
+    const loadStub = stub(int32Atomics, 'load');
+    const waitStub = stub(int32Atomics, 'wait').returns('ok');
+    let renderedMutationLoadCount = 0;
+
+    loadStub.callsFake((typedArray, index) => {
+        if (index === 4) {
+            renderedMutationLoadCount += 1;
+            return 0;
+        }
+        return realLoad(typedArray, index);
+    });
+
+    try {
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+        assert.strictEqual(waitStub.callCount, 1);
+        assert.strictEqual(renderedMutationLoadCount, 2);
+    } finally {
+        waitStub.restore();
+        loadStub.restore();
+    }
+});
+
+test('waitForRenderedMutation times out immediately when the timeout has already elapsed', () => {
+    const accessors = createAccessors(4, { now: createNow([100, 110]) });
+    const mutation = accessors.markMutation();
+    const int32Atomics = Atomics as Int32Atomics;
+    const realLoad = int32Atomics.load.bind(int32Atomics);
+    const loadStub = stub(int32Atomics, 'load');
+    const waitStub = stub(int32Atomics, 'wait');
+    loadStub.callsFake((typedArray, index) => {
+        return index === 4 ? 0 : realLoad(typedArray, index);
+    });
+
+    try {
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+        assert.strictEqual(waitStub.callCount, 0);
+    } finally {
+        waitStub.restore();
+        loadStub.restore();
+    }
 });
 
 test('isShutdownRequested returns false until requestShutdown is called', () => {

--- a/source/command-line-interface/spinner-shared-state.ts
+++ b/source/command-line-interface/spinner-shared-state.ts
@@ -85,11 +85,26 @@ export type SpinnerSharedAccessors = {
     };
 };
 
+type AtomicsLike = {
+    readonly add: (typedArray: Int32Array | Uint32Array, index: number, value: number) => number;
+    readonly load: (typedArray: Int32Array | Uint32Array, index: number) => number;
+    readonly notify: (typedArray: Int32Array, index: number, count?: number) => number;
+    readonly store: (typedArray: Int32Array | Uint32Array, index: number, value: number) => number;
+    readonly wait: (
+        typedArray: Int32Array,
+        index: number,
+        value: number,
+        timeout?: number
+    ) => 'not-equal' | 'ok' | 'timed-out';
+};
+
 type SpinnerSharedDependencies = {
+    readonly atomics: AtomicsLike;
     readonly now: () => number;
 };
 
 const defaultSpinnerSharedDependencies: SpinnerSharedDependencies = {
+    atomics: Atomics,
     now: Date.now
 };
 
@@ -128,27 +143,34 @@ type Views = {
     readonly slotData: (slotIndex: number) => DataView;
 };
 
-function waitForRenderedMutationStep(
-    headerInt32: Int32Array,
-    expectedMutation: number,
-    timeoutMs: number,
-    readRemainingMs: () => number
-): {
+function waitForRenderedMutationStep(args: {
+    readonly atomics: AtomicsLike;
+    readonly headerInt32: Int32Array;
+    readonly expectedMutation: number;
+    readonly timeoutMs: number;
+    readonly readRemainingMs: () => number;
+}): {
     readonly current: number;
     readonly remainingMs: number;
     readonly timedOutWithoutProgress: boolean;
 } {
-    const waitResult = Atomics.wait(headerInt32, headerRenderedMutationIndex, expectedMutation, timeoutMs);
-    const current = Atomics.load(headerInt32, headerRenderedMutationIndex);
+    const waitResult = args.atomics.wait(
+        args.headerInt32,
+        headerRenderedMutationIndex,
+        args.expectedMutation,
+        args.timeoutMs
+    );
+    const current = args.atomics.load(args.headerInt32, headerRenderedMutationIndex);
 
     return {
         current,
-        remainingMs: readRemainingMs(),
-        timedOutWithoutProgress: waitResult === 'timed-out' && current === expectedMutation
+        remainingMs: args.readRemainingMs(),
+        timedOutWithoutProgress: waitResult === 'timed-out' && current === args.expectedMutation
     };
 }
 
 function readRenderedMutationState(
+    atomics: AtomicsLike,
     headerInt32: Int32Array,
     readRemainingMs: () => number
 ): {
@@ -156,7 +178,7 @@ function readRenderedMutationState(
     readonly remainingMs: number;
 } {
     return {
-        current: Atomics.load(headerInt32, headerRenderedMutationIndex),
+        current: atomics.load(headerInt32, headerRenderedMutationIndex),
         remainingMs: readRemainingMs()
     };
 }
@@ -231,7 +253,7 @@ export function createSpinnerSharedAccessors(
     layout: SpinnerSharedLayout,
     dependencies: Partial<SpinnerSharedDependencies> = {}
 ): SpinnerSharedAccessors {
-    const { now } = { ...defaultSpinnerSharedDependencies, ...dependencies };
+    const { atomics, now } = { ...defaultSpinnerSharedDependencies, ...dependencies };
     const views = createViews(buffer, layout);
 
     function writeStateByte(slotIndex: number, stateByte: number): void {
@@ -239,7 +261,7 @@ export function createSpinnerSharedAccessors(
     }
 
     function readSlotGeneration(slotIndex: number): number {
-        return Atomics.load(views.slotInt32(slotIndex), slotGenerationIndex);
+        return atomics.load(views.slotInt32(slotIndex), slotGenerationIndex);
     }
 
     function readSlotAttempt(slotIndex: number): {
@@ -256,47 +278,48 @@ export function createSpinnerSharedAccessors(
         layout,
         buffer,
         setColumns(columns) {
-            Atomics.store(views.headerUint32, headerColumnsIndex, columns);
+            atomics.store(views.headerUint32, headerColumnsIndex, columns);
         },
         getColumns() {
-            return Atomics.load(views.headerUint32, headerColumnsIndex);
+            return atomics.load(views.headerUint32, headerColumnsIndex);
         },
         setIntervalMs(intervalMs) {
-            Atomics.store(views.headerUint32, headerIntervalIndex, intervalMs);
+            atomics.store(views.headerUint32, headerIntervalIndex, intervalMs);
         },
         getIntervalMs() {
-            return Atomics.load(views.headerUint32, headerIntervalIndex);
+            return atomics.load(views.headerUint32, headerIntervalIndex);
         },
         markMutation() {
-            return Atomics.add(views.headerInt32, headerMutationIndex, 1) + 1;
+            return atomics.add(views.headerInt32, headerMutationIndex, 1) + 1;
         },
         getLatestMutation() {
-            return Atomics.load(views.headerInt32, headerMutationIndex);
+            return atomics.load(views.headerInt32, headerMutationIndex);
         },
         acknowledgeRender(mutation) {
-            Atomics.store(views.headerInt32, headerRenderedMutationIndex, mutation);
-            Atomics.notify(views.headerInt32, headerRenderedMutationIndex);
+            atomics.store(views.headerInt32, headerRenderedMutationIndex, mutation);
+            atomics.notify(views.headerInt32, headerRenderedMutationIndex);
         },
         waitForRenderedMutation(mutation, timeoutMs) {
             const deadline = now() + timeoutMs;
             const readRemainingMs = (): number => {
                 return deadline - now();
             };
-            let state = readRenderedMutationState(views.headerInt32, readRemainingMs);
+            let state = readRenderedMutationState(atomics, views.headerInt32, readRemainingMs);
             let remainingAttempts = Math.min(maximumRenderedMutationWaitAttempts, Math.max(Math.ceil(timeoutMs), 1));
 
             for (
                 ;
                 shouldContinueWaitingForRenderedMutation(state, mutation) && remainingAttempts > 0;
-                state = readRenderedMutationState(views.headerInt32, readRemainingMs), remainingAttempts -= 1
+                state = readRenderedMutationState(atomics, views.headerInt32, readRemainingMs), remainingAttempts -= 1
             ) {
                 const waitTimeoutMs = Math.min(state.remainingMs, timeoutMs);
-                const step = waitForRenderedMutationStep(
-                    views.headerInt32,
-                    state.current,
-                    waitTimeoutMs,
+                const step = waitForRenderedMutationStep({
+                    atomics,
+                    headerInt32: views.headerInt32,
+                    expectedMutation: state.current,
+                    timeoutMs: waitTimeoutMs,
                     readRemainingMs
-                );
+                });
                 if (shouldAbortWaitingForRenderedMutation(state, step, mutation)) {
                     return step.current >= mutation;
                 }
@@ -305,13 +328,13 @@ export function createSpinnerSharedAccessors(
             return state.current >= mutation;
         },
         requestShutdown() {
-            Atomics.store(views.headerInt32, headerControlIndex, controlShutdownValue);
+            atomics.store(views.headerInt32, headerControlIndex, controlShutdownValue);
         },
         isShutdownRequested() {
-            return Atomics.load(views.headerInt32, headerControlIndex) !== controlIdleValue;
+            return atomics.load(views.headerInt32, headerControlIndex) !== controlIdleValue;
         },
         bumpSlotGeneration(slotIndex) {
-            Atomics.add(views.slotInt32(slotIndex), slotGenerationIndex, 1);
+            atomics.add(views.slotInt32(slotIndex), slotGenerationIndex, 1);
         },
         writeSlot(slotIndex, state, label, message) {
             writeStateByte(slotIndex, stateToByte(state));

--- a/source/command-line-interface/spinner-shared-state.ts
+++ b/source/command-line-interface/spinner-shared-state.ts
@@ -1,4 +1,4 @@
-const headerByteLength = 16;
+const headerByteLength = 24;
 const slotByteLength = 384;
 const labelByteLength = 64;
 const messageByteLength = 256;
@@ -12,11 +12,14 @@ const slotMessageOffset = slotLabelOffset + labelByteLength;
 const headerControlIndex = 0;
 const headerColumnsIndex = 1;
 const headerIntervalIndex = 2;
+const headerMutationIndex = 3;
+const headerRenderedMutationIndex = 4;
 const slotGenerationIndex = 0;
 
 const controlShutdownValue = 1;
 const controlIdleValue = 0;
 const maximumReadSlotAttempts = 1024;
+const maximumRenderedMutationWaitAttempts = 256;
 
 const slotStateEmpty = 0;
 const slotStateRunning = 1;
@@ -67,6 +70,10 @@ export type SpinnerSharedAccessors = {
     readonly getColumns: () => number;
     readonly setIntervalMs: (intervalMs: number) => void;
     readonly getIntervalMs: () => number;
+    readonly markMutation: () => number;
+    readonly getLatestMutation: () => number;
+    readonly acknowledgeRender: (mutation: number) => void;
+    readonly waitForRenderedMutation: (mutation: number, timeoutMs: number) => boolean;
     readonly requestShutdown: () => void;
     readonly isShutdownRequested: () => boolean;
     readonly bumpSlotGeneration: (slotIndex: number) => void;
@@ -76,6 +83,14 @@ export type SpinnerSharedAccessors = {
         readonly label: string;
         readonly message: string;
     };
+};
+
+type SpinnerSharedDependencies = {
+    readonly now: () => number;
+};
+
+const defaultSpinnerSharedDependencies: SpinnerSharedDependencies = {
+    now: Date.now
 };
 
 function stateToByte(state: SlotState): number {
@@ -112,6 +127,58 @@ type Views = {
     readonly slotBytes: (slotIndex: number) => Uint8Array;
     readonly slotData: (slotIndex: number) => DataView;
 };
+
+function waitForRenderedMutationStep(
+    headerInt32: Int32Array,
+    expectedMutation: number,
+    timeoutMs: number,
+    readRemainingMs: () => number
+): {
+    readonly current: number;
+    readonly remainingMs: number;
+    readonly timedOutWithoutProgress: boolean;
+} {
+    const waitResult = Atomics.wait(headerInt32, headerRenderedMutationIndex, expectedMutation, timeoutMs);
+    const current = Atomics.load(headerInt32, headerRenderedMutationIndex);
+
+    return {
+        current,
+        remainingMs: readRemainingMs(),
+        timedOutWithoutProgress: waitResult === 'timed-out' && current === expectedMutation
+    };
+}
+
+function readRenderedMutationState(
+    headerInt32: Int32Array,
+    readRemainingMs: () => number
+): {
+    readonly current: number;
+    readonly remainingMs: number;
+} {
+    return {
+        current: Atomics.load(headerInt32, headerRenderedMutationIndex),
+        remainingMs: readRemainingMs()
+    };
+}
+
+function shouldContinueWaitingForRenderedMutation(
+    state: ReturnType<typeof readRenderedMutationState>,
+    mutation: number
+): boolean {
+    return state.current < mutation && state.remainingMs > 0;
+}
+
+function shouldAbortWaitingForRenderedMutation(
+    state: ReturnType<typeof readRenderedMutationState>,
+    step: ReturnType<typeof waitForRenderedMutationStep>,
+    mutation: number
+): boolean {
+    return (
+        (step.current === state.current && step.remainingMs > state.remainingMs) ||
+        step.current >= mutation ||
+        step.timedOutWithoutProgress
+    );
+}
 
 function createViews(buffer: SharedArrayBuffer, layout: SpinnerSharedLayout): Views {
     const headerInt32 = new Int32Array(buffer);
@@ -161,8 +228,10 @@ function readSlotContent(
 
 export function createSpinnerSharedAccessors(
     buffer: SharedArrayBuffer,
-    layout: SpinnerSharedLayout
+    layout: SpinnerSharedLayout,
+    dependencies: Partial<SpinnerSharedDependencies> = {}
 ): SpinnerSharedAccessors {
+    const { now } = { ...defaultSpinnerSharedDependencies, ...dependencies };
     const views = createViews(buffer, layout);
 
     function writeStateByte(slotIndex: number, stateByte: number): void {
@@ -197,6 +266,43 @@ export function createSpinnerSharedAccessors(
         },
         getIntervalMs() {
             return Atomics.load(views.headerUint32, headerIntervalIndex);
+        },
+        markMutation() {
+            return Atomics.add(views.headerInt32, headerMutationIndex, 1) + 1;
+        },
+        getLatestMutation() {
+            return Atomics.load(views.headerInt32, headerMutationIndex);
+        },
+        acknowledgeRender(mutation) {
+            Atomics.store(views.headerInt32, headerRenderedMutationIndex, mutation);
+            Atomics.notify(views.headerInt32, headerRenderedMutationIndex);
+        },
+        waitForRenderedMutation(mutation, timeoutMs) {
+            const deadline = now() + timeoutMs;
+            const readRemainingMs = (): number => {
+                return deadline - now();
+            };
+            let state = readRenderedMutationState(views.headerInt32, readRemainingMs);
+            let remainingAttempts = Math.min(maximumRenderedMutationWaitAttempts, Math.max(Math.ceil(timeoutMs), 1));
+
+            for (
+                ;
+                shouldContinueWaitingForRenderedMutation(state, mutation) && remainingAttempts > 0;
+                state = readRenderedMutationState(views.headerInt32, readRemainingMs), remainingAttempts -= 1
+            ) {
+                const waitTimeoutMs = Math.min(state.remainingMs, timeoutMs);
+                const step = waitForRenderedMutationStep(
+                    views.headerInt32,
+                    state.current,
+                    waitTimeoutMs,
+                    readRemainingMs
+                );
+                if (shouldAbortWaitingForRenderedMutation(state, step, mutation)) {
+                    return step.current >= mutation;
+                }
+            }
+
+            return state.current >= mutation;
         },
         requestShutdown() {
             Atomics.store(views.headerInt32, headerControlIndex, controlShutdownValue);

--- a/source/command-line-interface/spinner-shared-state.ts
+++ b/source/command-line-interface/spinner-shared-state.ts
@@ -103,10 +103,9 @@ type SpinnerSharedDependencies = {
     readonly now: () => number;
 };
 
-const defaultSpinnerSharedDependencies: SpinnerSharedDependencies = {
-    atomics: Atomics,
-    now: Date.now
-};
+function getCurrentTimeInMilliseconds(): number {
+    return Date.now();
+}
 
 function stateToByte(state: SlotState): number {
     return stateToByteMap[state];
@@ -253,7 +252,8 @@ export function createSpinnerSharedAccessors(
     layout: SpinnerSharedLayout,
     dependencies: Partial<SpinnerSharedDependencies> = {}
 ): SpinnerSharedAccessors {
-    const { atomics, now } = { ...defaultSpinnerSharedDependencies, ...dependencies };
+    const atomics = dependencies.atomics ?? Atomics;
+    const now = dependencies.now ?? getCurrentTimeInMilliseconds;
     const views = createViews(buffer, layout);
 
     function writeStateByte(slotIndex: number, stateByte: number): void {

--- a/source/command-line-interface/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner-worker-backend.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import { fake } from 'sinon';
+import { fake, stub } from 'sinon';
 import {
     createSpinnerSharedAccessors,
     createSpinnerSharedLayout,
@@ -44,6 +44,7 @@ test('createSpinnerRuntime hands the spawn helper the buffer, slot count and std
     const runtime = createSpinnerRuntime({
         slotCount: 2,
         stdoutFileDescriptor: 5,
+        stdoutColumns: 120,
         spawnWorker: (request) => {
             spawnWorker(request);
         }
@@ -56,10 +57,12 @@ test('createSpinnerRuntime hands the spawn helper the buffer, slot count and std
     assert.strictEqual(request.stdoutFileDescriptor, 5);
 });
 
-test('createSpinnerRuntime falls back to defaults when no options are provided', () => {
+test('createSpinnerRuntime falls back to default slot and interval settings', () => {
     const spawnWorker = fake();
 
     const runtime = createSpinnerRuntime({
+        stdoutFileDescriptor: 1,
+        stdoutColumns: 80,
         spawnWorker: (request) => {
             spawnWorker(request);
         }
@@ -67,7 +70,7 @@ test('createSpinnerRuntime falls back to defaults when no options are provided',
 
     assert.strictEqual(runtime.slotCount, 64);
     assert.strictEqual(runtime.accessors.getIntervalMs(), 80);
-    assert.ok(runtime.accessors.getColumns() > 0);
+    assert.strictEqual(runtime.accessors.getColumns(), 80);
 });
 
 test('createWorkerSpinnerBackend.add stores a running slot in the supplied runtime', () => {
@@ -77,6 +80,7 @@ test('createWorkerSpinnerBackend.add stores a running slot in the supplied runti
     backend.add(2, 'pkg', 'starting');
 
     assert.deepStrictEqual(accessors.readSlot(2), { state: 'running', label: 'pkg', message: 'starting' });
+    assert.strictEqual(accessors.getLatestMutation(), 1);
 });
 
 test('createWorkerSpinnerBackend.update writes a new running slot value', () => {
@@ -87,6 +91,7 @@ test('createWorkerSpinnerBackend.update writes a new running slot value', () => 
     backend.update(0, 'pkg', 'two');
 
     assert.deepStrictEqual(accessors.readSlot(0), { state: 'running', label: 'pkg', message: 'two' });
+    assert.strictEqual(accessors.getLatestMutation(), 2);
 });
 
 test('createWorkerSpinnerBackend.finish records the finished status', () => {
@@ -96,6 +101,7 @@ test('createWorkerSpinnerBackend.finish records the finished status', () => {
     backend.finish(1, 'succeeded', 'pkg', 'done');
 
     assert.deepStrictEqual(accessors.readSlot(1), { state: 'succeeded', label: 'pkg', message: 'done' });
+    assert.strictEqual(accessors.getLatestMutation(), 1);
 });
 
 test('createWorkerSpinnerBackend.add throws when the slot index is at or beyond the runtime capacity', () => {
@@ -132,4 +138,39 @@ test('createWorkerSpinnerBackend.shutdown forwards the shutdown signal to the su
     backend.shutdown();
 
     assert.strictEqual(accessors.isShutdownRequested(), true);
+    assert.strictEqual(accessors.getLatestMutation(), 1);
+});
+
+test('createWorkerSpinnerBackend.shutdown waits for the render acknowledgement when the worker interval is positive', () => {
+    const { runtime, accessors } = buildRuntime();
+    accessors.setIntervalMs(25);
+    const waitForRenderedMutation = stub(accessors, 'waitForRenderedMutation').returns(true);
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.shutdown();
+
+    assert.strictEqual(waitForRenderedMutation.callCount, 1);
+    assert.deepStrictEqual(waitForRenderedMutation.firstCall.args, [1, 100]);
+});
+
+test('createWorkerSpinnerBackend.shutdown uses the interval-derived timeout when it exceeds the minimum', () => {
+    const { runtime, accessors } = buildRuntime();
+    accessors.setIntervalMs(80);
+    const waitForRenderedMutation = stub(accessors, 'waitForRenderedMutation').returns(true);
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.shutdown();
+
+    assert.strictEqual(waitForRenderedMutation.callCount, 1);
+    assert.deepStrictEqual(waitForRenderedMutation.firstCall.args, [1, 320]);
+});
+
+test('createWorkerSpinnerBackend.shutdown skips waiting when the worker interval is zero', () => {
+    const { runtime, accessors } = buildRuntime();
+    const waitForRenderedMutation = stub(accessors, 'waitForRenderedMutation').returns(true);
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.shutdown();
+
+    assert.strictEqual(waitForRenderedMutation.callCount, 0);
 });

--- a/source/command-line-interface/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner-worker-backend.test.ts
@@ -34,6 +34,24 @@ function buildRuntimeWithFakeAccessors(overrides: Partial<SpinnerSharedAccessors
     return { runtime: { accessors, slotCount: 4 }, accessors };
 }
 
+function collectShutdownWaitCalls(intervalMs = 0): readonly (readonly [number, number])[] {
+    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
+    const { runtime } = buildRuntimeWithFakeAccessors({
+        getIntervalMs: () => {
+            return intervalMs;
+        },
+        waitForRenderedMutation: (mutation, timeoutMs) => {
+            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
+            return true;
+        }
+    });
+    const backend = createWorkerSpinnerBackend({ runtime });
+
+    backend.shutdown();
+
+    return waitForRenderedMutationCalls;
+}
+
 test('createSpinnerRuntime sets the shared buffer up with the resolved interval and column count', () => {
     const spawnWorker = fake();
 
@@ -156,52 +174,13 @@ test('createWorkerSpinnerBackend.shutdown forwards the shutdown signal to the su
 });
 
 test('createWorkerSpinnerBackend.shutdown waits for the render acknowledgement when the worker interval is positive', () => {
-    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
-    const { runtime } = buildRuntimeWithFakeAccessors({
-        getIntervalMs: () => {
-            return 25;
-        },
-        waitForRenderedMutation: (mutation, timeoutMs) => {
-            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
-            return true;
-        }
-    });
-    const backend = createWorkerSpinnerBackend({ runtime });
-
-    backend.shutdown();
-
-    assert.deepStrictEqual(waitForRenderedMutationCalls, [[1, 100]]);
+    assert.deepStrictEqual(collectShutdownWaitCalls(25), [[1, 100]]);
 });
 
 test('createWorkerSpinnerBackend.shutdown uses the interval-derived timeout when it exceeds the minimum', () => {
-    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
-    const { runtime } = buildRuntimeWithFakeAccessors({
-        getIntervalMs: () => {
-            return 80;
-        },
-        waitForRenderedMutation: (mutation, timeoutMs) => {
-            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
-            return true;
-        }
-    });
-    const backend = createWorkerSpinnerBackend({ runtime });
-
-    backend.shutdown();
-
-    assert.deepStrictEqual(waitForRenderedMutationCalls, [[1, 320]]);
+    assert.deepStrictEqual(collectShutdownWaitCalls(80), [[1, 320]]);
 });
 
 test('createWorkerSpinnerBackend.shutdown skips waiting when the worker interval is zero', () => {
-    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
-    const { runtime } = buildRuntimeWithFakeAccessors({
-        waitForRenderedMutation: (mutation, timeoutMs) => {
-            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
-            return true;
-        }
-    });
-    const backend = createWorkerSpinnerBackend({ runtime });
-
-    backend.shutdown();
-
-    assert.deepStrictEqual(waitForRenderedMutationCalls, []);
+    assert.deepStrictEqual(collectShutdownWaitCalls(), []);
 });

--- a/source/command-line-interface/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner-worker-backend.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import { fake, stub } from 'sinon';
+import { fake } from 'sinon';
 import {
     createSpinnerSharedAccessors,
     createSpinnerSharedLayout,
@@ -18,6 +18,20 @@ function buildRuntime(slotCount = 4): { runtime: SpinnerRuntime; accessors: Spin
     const buffer = new SharedArrayBuffer(layout.bufferByteLength);
     const accessors = createSpinnerSharedAccessors(buffer, layout);
     return { runtime: { accessors, slotCount }, accessors };
+}
+
+function buildRuntimeWithFakeAccessors(overrides: Partial<SpinnerSharedAccessors> = {}): {
+    runtime: SpinnerRuntime;
+    accessors: SpinnerSharedAccessors;
+} {
+    const accessors = {
+        ...createSpinnerSharedAccessors(
+            new SharedArrayBuffer(createSpinnerSharedLayout(4).bufferByteLength),
+            createSpinnerSharedLayout(4)
+        ),
+        ...overrides
+    };
+    return { runtime: { accessors, slotCount: 4 }, accessors };
 }
 
 test('createSpinnerRuntime sets the shared buffer up with the resolved interval and column count', () => {
@@ -142,35 +156,52 @@ test('createWorkerSpinnerBackend.shutdown forwards the shutdown signal to the su
 });
 
 test('createWorkerSpinnerBackend.shutdown waits for the render acknowledgement when the worker interval is positive', () => {
-    const { runtime, accessors } = buildRuntime();
-    accessors.setIntervalMs(25);
-    const waitForRenderedMutation = stub(accessors, 'waitForRenderedMutation').returns(true);
+    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
+    const { runtime } = buildRuntimeWithFakeAccessors({
+        getIntervalMs: () => {
+            return 25;
+        },
+        waitForRenderedMutation: (mutation, timeoutMs) => {
+            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
+            return true;
+        }
+    });
     const backend = createWorkerSpinnerBackend({ runtime });
 
     backend.shutdown();
 
-    assert.strictEqual(waitForRenderedMutation.callCount, 1);
-    assert.deepStrictEqual(waitForRenderedMutation.firstCall.args, [1, 100]);
+    assert.deepStrictEqual(waitForRenderedMutationCalls, [[1, 100]]);
 });
 
 test('createWorkerSpinnerBackend.shutdown uses the interval-derived timeout when it exceeds the minimum', () => {
-    const { runtime, accessors } = buildRuntime();
-    accessors.setIntervalMs(80);
-    const waitForRenderedMutation = stub(accessors, 'waitForRenderedMutation').returns(true);
+    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
+    const { runtime } = buildRuntimeWithFakeAccessors({
+        getIntervalMs: () => {
+            return 80;
+        },
+        waitForRenderedMutation: (mutation, timeoutMs) => {
+            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
+            return true;
+        }
+    });
     const backend = createWorkerSpinnerBackend({ runtime });
 
     backend.shutdown();
 
-    assert.strictEqual(waitForRenderedMutation.callCount, 1);
-    assert.deepStrictEqual(waitForRenderedMutation.firstCall.args, [1, 320]);
+    assert.deepStrictEqual(waitForRenderedMutationCalls, [[1, 320]]);
 });
 
 test('createWorkerSpinnerBackend.shutdown skips waiting when the worker interval is zero', () => {
-    const { runtime, accessors } = buildRuntime();
-    const waitForRenderedMutation = stub(accessors, 'waitForRenderedMutation').returns(true);
+    const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
+    const { runtime } = buildRuntimeWithFakeAccessors({
+        waitForRenderedMutation: (mutation, timeoutMs) => {
+            waitForRenderedMutationCalls.push([mutation, timeoutMs]);
+            return true;
+        }
+    });
     const backend = createWorkerSpinnerBackend({ runtime });
 
     backend.shutdown();
 
-    assert.strictEqual(waitForRenderedMutation.callCount, 0);
+    assert.deepStrictEqual(waitForRenderedMutationCalls, []);
 });

--- a/source/command-line-interface/spinner-worker-backend.ts
+++ b/source/command-line-interface/spinner-worker-backend.ts
@@ -8,7 +8,8 @@ import type { SpinnerBackend } from './terminal-spinner-renderer.ts';
 
 const defaultSlotCount = 64;
 const defaultIntervalMs = 80;
-const defaultColumns = 80;
+const shutdownFlushIntervals = 4;
+const minimumShutdownFlushTimeoutMs = 100;
 
 export type WorkerSpawnRequest = {
     readonly buffer: SharedArrayBuffer;
@@ -21,8 +22,8 @@ type WorkerSpawner = (request: WorkerSpawnRequest) => void;
 export type SpinnerRuntimeOptions = {
     readonly slotCount?: number;
     readonly intervalMs?: number;
-    readonly stdoutFileDescriptor?: number;
-    readonly stdoutColumns?: number;
+    readonly stdoutFileDescriptor: number;
+    readonly stdoutColumns: number;
     readonly spawnWorker: WorkerSpawner;
 };
 
@@ -43,9 +44,8 @@ function resolveOptions(options: SpinnerRuntimeOptions): ResolvedOptions {
     return {
         slotCount: options.slotCount ?? defaultSlotCount,
         intervalMs: options.intervalMs ?? defaultIntervalMs,
-        stdoutFileDescriptor: options.stdoutFileDescriptor ?? process.stdout.fd,
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process.stdout.columns is undefined at runtime when stdout is not a TTY, despite the type declaring it as number
-        stdoutColumns: options.stdoutColumns ?? process.stdout.columns ?? defaultColumns,
+        stdoutFileDescriptor: options.stdoutFileDescriptor,
+        stdoutColumns: options.stdoutColumns,
         spawnWorker: options.spawnWorker
     };
 }
@@ -80,6 +80,7 @@ type SlotUpdate = {
 function writeSlot(accessors: SpinnerSharedAccessors, update: SlotUpdate): void {
     accessors.writeSlot(update.slotIndex, update.state, update.label, update.message);
     accessors.bumpSlotGeneration(update.slotIndex);
+    accessors.markMutation();
 }
 
 export type WorkerSpinnerBackendDependencies = {
@@ -88,6 +89,10 @@ export type WorkerSpinnerBackendDependencies = {
 
 export function createWorkerSpinnerBackend(dependencies: WorkerSpinnerBackendDependencies): SpinnerBackend {
     const { runtime } = dependencies;
+    const shutdownFlushTimeoutMs = Math.max(
+        runtime.accessors.getIntervalMs() * shutdownFlushIntervals,
+        minimumShutdownFlushTimeoutMs
+    );
 
     function ensureSlotIndexFits(slotIndex: number): void {
         if (slotIndex >= runtime.slotCount) {
@@ -112,6 +117,10 @@ export function createWorkerSpinnerBackend(dependencies: WorkerSpinnerBackendDep
         },
         shutdown() {
             runtime.accessors.requestShutdown();
+            const shutdownMutation = runtime.accessors.markMutation();
+            if (runtime.accessors.getIntervalMs() > 0) {
+                runtime.accessors.waitForRenderedMutation(shutdownMutation, shutdownFlushTimeoutMs);
+            }
         }
     };
 }

--- a/source/command-line-interface/spinner-worker-loop.test.ts
+++ b/source/command-line-interface/spinner-worker-loop.test.ts
@@ -275,6 +275,16 @@ test('startSpinnerWorker skips writing to stdout while there is nothing to rende
     assert.strictEqual(harness.writes().length, 0);
 });
 
+test('startSpinnerWorker acknowledges a pending mutation even when there is nothing to render', () => {
+    const harness = createHarness(2);
+    const mutation = harness.accessors.markMutation();
+
+    harness.tick();
+
+    assert.strictEqual(harness.writes().length, 0);
+    assert.strictEqual(harness.accessors.waitForRenderedMutation(mutation, 1), true);
+});
+
 test('startSpinnerWorker rewinds the cursor up by the previously rendered line count before redrawing', () => {
     const { harness } = setupRunningSlotHarnessAndTick();
     harness.tick();
@@ -299,13 +309,18 @@ test('startSpinnerWorker writes a final tick and clears the interval after a shu
     const harness = createHarness(1);
     harness.accessors.setColumns(80);
     harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+    harness.accessors.bumpSlotGeneration(0);
+    const runningMutation = harness.accessors.markMutation();
 
     harness.tick();
     harness.accessors.requestShutdown();
+    const shutdownMutation = harness.accessors.markMutation();
     harness.tick();
 
     assert.strictEqual(harness.clearIntervalCalls().length, 1);
     assert.strictEqual(harness.clearIntervalCalls()[0], 'ticker-handle');
+    assert.strictEqual(harness.accessors.waitForRenderedMutation(runningMutation, 1), true);
+    assert.strictEqual(harness.accessors.waitForRenderedMutation(shutdownMutation, 1), true);
 });
 
 test('isSpinnerWorkerInput accepts a well-formed payload', () => {

--- a/source/command-line-interface/spinner-worker-loop.ts
+++ b/source/command-line-interface/spinner-worker-loop.ts
@@ -95,6 +95,31 @@ function buildRedrawSequence(state: RenderState, columns: number, expectedLineCo
     return output;
 }
 
+type RenderTickOutput = {
+    readonly expectedLineCount: number;
+    readonly snapshots: readonly SlotSnapshot[];
+    readonly sequence: string | undefined;
+    readonly targetMutation: number;
+};
+
+function buildRenderTickOutput(accessors: SpinnerSharedAccessors, state: RenderState): RenderTickOutput {
+    const targetMutation = accessors.getLatestMutation();
+    const snapshots = readAllSnapshots(accessors);
+    const highestActive = findHighestActiveSlotIndex(snapshots);
+    const shouldSkipWrite = highestActive < 0 && state.renderedLineCount === 0;
+    if (shouldSkipWrite) {
+        return { expectedLineCount: 0, snapshots, sequence: undefined, targetMutation };
+    }
+
+    const expectedLineCount = Math.max(state.renderedLineCount, highestActive + 1);
+    return {
+        expectedLineCount,
+        snapshots,
+        sequence: buildRedrawSequence({ ...state, snapshots }, accessors.getColumns(), expectedLineCount),
+        targetMutation
+    };
+}
+
 export function startSpinnerWorker<Handle>(
     input: SpinnerWorkerInput,
     dependencies: SpinnerWorkerDependencies<Handle>
@@ -108,17 +133,14 @@ export function startSpinnerWorker<Handle>(
     };
 
     function renderTick(): void {
-        const snapshots = readAllSnapshots(accessors);
-        const highestActive = findHighestActiveSlotIndex(snapshots);
-        if (highestActive < 0 && state.renderedLineCount === 0) {
-            return;
+        const output = buildRenderTickOutput(accessors, state);
+        state.snapshots = output.snapshots;
+        if (output.sequence !== undefined) {
+            dependencies.write(input.stdoutFileDescriptor, output.sequence);
+            state.renderedLineCount = output.expectedLineCount;
+            state.frameIndex += 1;
         }
-        const expectedLineCount = Math.max(state.renderedLineCount, highestActive + 1);
-        state.snapshots = snapshots;
-        const sequence = buildRedrawSequence(state, accessors.getColumns(), expectedLineCount);
-        dependencies.write(input.stdoutFileDescriptor, sequence);
-        state.renderedLineCount = expectedLineCount;
-        state.frameIndex += 1;
+        accessors.acknowledgeRender(output.targetMutation);
     }
 
     const intervalMs = accessors.getIntervalMs();

--- a/source/dead-code-eliminator/reachability/reachability.test.ts
+++ b/source/dead-code-eliminator/reachability/reachability.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import { stub } from 'sinon';
 import { runNodeProbe } from '../../test-libraries/run-node-probe.ts';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { extractTopLevelBindings } from './binding-extractor.ts';
@@ -182,6 +181,27 @@ test('expandWith preserves localReachable bindings that the external seeds do no
     assert.ok(reachable.has(bindingId('entry.ts', 'other')));
 });
 
+test('expandWith reuses the injected visitedHas dependency', () => {
+    const files = [
+        fileBindingsFor('entry.ts', 'function helper() { return pub(); }\nexport function pub() { return helper(); }')
+    ];
+    const index = buildReachabilityIndex(
+        { files, entryPointFilePaths: new Set<string>() },
+        {
+            visitedHas(visited, value) {
+                if (typeof value === 'string' && value.includes('::')) {
+                    return false;
+                }
+                return visited.has(value);
+            }
+        }
+    );
+
+    assert.throws(() => {
+        index.expandWith(new Set([bindingId('entry.ts', 'pub')]));
+    }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
+});
+
 test('does not record any unresolved binding ids when a function references its own parameters', () => {
     const files = [fileBindingsFor('entry.ts', 'export function pub(x: number) { return x; }')];
     const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
@@ -232,21 +252,14 @@ test('buildReachabilityIndex throws when traversal exceeds the iteration budget'
     const files = [
         fileBindingsFor('entry.ts', 'function helper() { return pub(); }\nexport function pub() { return helper(); }')
     ];
-    const realHas = Set.prototype.has;
-    const hasStub = stub(Set.prototype, 'has');
-    hasStub.callsFake(function (this: ReadonlySet<unknown>, value: unknown) {
+    const visitedHas = <T>(visited: ReadonlySet<T>, value: T): boolean => {
         if (typeof value === 'string' && value.includes('::')) {
             return false;
         }
-        // eslint-disable-next-line functional/no-this-expressions -- stubbing Set.prototype.has requires the receiver
-        return Reflect.apply(realHas, this, [value]);
-    });
+        return visited.has(value);
+    };
 
-    try {
-        assert.throws(() => {
-            buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-        }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
-    } finally {
-        hasStub.restore();
-    }
+    assert.throws(() => {
+        buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) }, { visitedHas });
+    }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
 });

--- a/source/dead-code-eliminator/reachability/reachability.ts
+++ b/source/dead-code-eliminator/reachability/reachability.ts
@@ -28,6 +28,10 @@ export type ReachabilityIndex = {
     readonly expandWith: (externalSeeds: ReadonlySet<string> | undefined) => ReadonlySet<string>;
 };
 
+type ReachabilityDependencies = {
+    readonly visitedHas: <T>(visited: ReadonlySet<T>, value: T) => boolean;
+};
+
 type DeclarationNodeIndex = ReadonlyMap<TsMorphNode, string>;
 type SymbolReference = NonNullable<ReturnType<Identifier['getSymbol']>>;
 
@@ -149,13 +153,16 @@ function createTraversalState<T>(
 function enqueueUnvisitedNeighbors<T>(
     current: T,
     expand: (current: T) => Iterable<T>,
-    visited: Set<T>,
-    queue: T[]
+    traversalState: {
+        readonly visited: Set<T>;
+        readonly queue: T[];
+    },
+    visitedHas: ReachabilityDependencies['visitedHas']
 ): void {
     for (const neighbor of expand(current)) {
-        if (!visited.has(neighbor)) {
-            visited.add(neighbor);
-            queue.push(neighbor);
+        if (!visitedHas(traversalState.visited, neighbor)) {
+            traversalState.visited.add(neighbor);
+            traversalState.queue.push(neighbor);
         }
     }
 }
@@ -164,10 +171,17 @@ function bfsClosure<T>(
     seeds: Iterable<T>,
     expand: (current: T) => Iterable<T>,
     initialVisited: ReadonlySet<T>,
-    maximumNodeCount: number
+    options: {
+        readonly maximumNodeCount: number;
+        readonly dependencies: ReachabilityDependencies;
+    }
 ): Set<T> {
     const seedList = Array.from(seeds);
-    const maximumIterations = getMaximumTraversalIterations(initialVisited.size, seedList.length, maximumNodeCount);
+    const maximumIterations = getMaximumTraversalIterations(
+        initialVisited.size,
+        seedList.length,
+        options.maximumNodeCount
+    );
     const traversalState = createTraversalState(initialVisited, seedList);
 
     for (const remainingIterations of createTraversalBudget(maximumIterations)) {
@@ -176,7 +190,7 @@ function bfsClosure<T>(
             break;
         }
         assertTraversalIteration(remainingIterations);
-        enqueueUnvisitedNeighbors(current, expand, traversalState.visited, traversalState.queue);
+        enqueueUnvisitedNeighbors(current, expand, traversalState, options.dependencies.visitedHas);
     }
 
     return traversalState.visited;
@@ -214,8 +228,17 @@ function gatherLocalSeeds(
 }
 
 const emptyStringSet: ReadonlySet<string> = new Set<string>();
+const defaultReachabilityDependencies: ReachabilityDependencies = {
+    visitedHas(visited, value) {
+        return visited.has(value);
+    }
+};
 
-export function buildReachabilityIndex(input: ReachabilityInput): ReachabilityIndex {
+export function buildReachabilityIndex(
+    input: ReachabilityInput,
+    dependencies: Partial<ReachabilityDependencies> = {}
+): ReachabilityIndex {
+    const resolvedDependencies = { ...defaultReachabilityDependencies, ...dependencies };
     const declarationIndex = buildDeclarationNodeIndex(input.files);
     const nodeById = buildNodeById(input.files);
     const maximumNodeCount = nodeById.size;
@@ -229,7 +252,10 @@ export function buildReachabilityIndex(input: ReachabilityInput): ReachabilityIn
         declarationIndex,
         input.deadCodeElimination
     );
-    const localReachable = bfsClosure(localSeeds, expand, emptyStringSet, maximumNodeCount);
+    const localReachable = bfsClosure(localSeeds, expand, emptyStringSet, {
+        maximumNodeCount,
+        dependencies: resolvedDependencies
+    });
     return {
         localReachable,
         bindingIdsByFile: buildBindingsByFile(input.files),
@@ -237,7 +263,10 @@ export function buildReachabilityIndex(input: ReachabilityInput): ReachabilityIn
             if (externalSeeds === undefined || externalSeeds.size === 0) {
                 return localReachable;
             }
-            return bfsClosure(externalSeeds, expand, localReachable, maximumNodeCount);
+            return bfsClosure(externalSeeds, expand, localReachable, {
+                maximumNodeCount,
+                dependencies: resolvedDependencies
+            });
         }
     };
 }

--- a/source/dead-code-eliminator/side-effect-classifier.ts
+++ b/source/dead-code-eliminator/side-effect-classifier.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- The purity classifier is maintained as a single table-driven module. */
 import {
     Node as TsMorphNode,
     SyntaxKind,
@@ -336,36 +335,6 @@ const expressionPurityRules: ReadonlyMap<SyntaxKind, PurityRule> = new Map<Synta
         }
     ],
     [
-        SyntaxKind.AsExpression,
-        (expression, recurse) => {
-            return recurse(expression.asKindOrThrow(SyntaxKind.AsExpression).getExpression());
-        }
-    ],
-    [
-        SyntaxKind.SatisfiesExpression,
-        (expression, recurse) => {
-            return recurse(expression.asKindOrThrow(SyntaxKind.SatisfiesExpression).getExpression());
-        }
-    ],
-    [
-        SyntaxKind.ParenthesizedExpression,
-        (expression, recurse) => {
-            return recurse(expression.asKindOrThrow(SyntaxKind.ParenthesizedExpression).getExpression());
-        }
-    ],
-    [
-        SyntaxKind.TypeAssertionExpression,
-        (expression, recurse) => {
-            return recurse(expression.asKindOrThrow(SyntaxKind.TypeAssertionExpression).getExpression());
-        }
-    ],
-    [
-        SyntaxKind.NonNullExpression,
-        (expression, recurse) => {
-            return recurse(expression.asKindOrThrow(SyntaxKind.NonNullExpression).getExpression());
-        }
-    ],
-    [
         SyntaxKind.PrefixUnaryExpression,
         (expression, recurse) => {
             const unary = expression.asKindOrThrow(SyntaxKind.PrefixUnaryExpression);
@@ -397,14 +366,15 @@ const expressionPurityRules: ReadonlyMap<SyntaxKind, PurityRule> = new Map<Synta
 ]);
 
 function isPureExpression(expression: Expression, settings: DeadCodeEliminationSettings | undefined): boolean {
+    const unwrapped = unwrapExpression(expression);
     const recurse = (candidate: Expression): boolean => {
         return isPureExpression(candidate, settings);
     };
-    const kind = expression.getKind();
+    const kind = unwrapped.getKind();
     if (pureLeafKinds.has(kind)) {
         return true;
     }
-    return expressionPurityRules.get(kind)?.(expression, recurse, settings) ?? false;
+    return expressionPurityRules.get(kind)?.(unwrapped, recurse, settings) ?? false;
 }
 
 function memberHasDecorators(member: TsMorphNode): boolean {

--- a/source/directed-graph/graph.test.ts
+++ b/source/directed-graph/graph.test.ts
@@ -34,14 +34,7 @@ test('addNode() throws when adding a node with an id that already exist', () => 
 });
 
 test('connect() throws when the from and to node don’t exist', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    try {
-        graph.connect({ from: 'a', to: 'b' });
-        assert.fail('Expected connect() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "a" does not exist');
-    }
+    expectGraphMethodToThrow('connect', () => {}, 'Node with id "a" does not exist');
 });
 
 function expectGraphMethodToThrow(
@@ -70,42 +63,29 @@ test('connect() throws when the from node doesn’t exist but the to node does',
 });
 
 test('connect() throws when the to node doesn’t exist but the from node does', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-
-    try {
-        graph.connect({ from: 'a', to: 'b' });
-        assert.fail('Expected connect() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "b" does not exist');
-    }
+    expectGraphMethodToThrow(
+        'connect',
+        (graph) => {
+            graph.addNode('a', 'foo');
+        },
+        'Node with id "b" does not exist'
+    );
 });
 
 test('connect() throws when both nodes exist but there is already a connection', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-    graph.addNode('b', 'bar');
-    graph.connect({ from: 'a', to: 'b' });
-
-    try {
-        graph.connect({ from: 'a', to: 'b' });
-        assert.fail('Expected connect() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Edge from "a" to "b" already exists');
-    }
+    expectGraphMethodToThrow(
+        'connect',
+        (graph) => {
+            graph.addNode('a', 'foo');
+            graph.addNode('b', 'bar');
+            graph.connect({ from: 'a', to: 'b' });
+        },
+        'Edge from "a" to "b" already exists'
+    );
 });
 
 test('disconnect() throws when the from and to node don’t exist', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    try {
-        graph.disconnect({ from: 'a', to: 'b' });
-        assert.fail('Expected disconnect() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "a" does not exist');
-    }
+    expectGraphMethodToThrow('disconnect', () => {}, 'Node with id "a" does not exist');
 });
 
 test('disconnect() throws when the from node doesn’t exist but the to node does', () => {
@@ -119,30 +99,24 @@ test('disconnect() throws when the from node doesn’t exist but the to node doe
 });
 
 test('disconnect() throws when the to node doesn’t exist but the from node does', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-
-    try {
-        graph.disconnect({ from: 'a', to: 'b' });
-        assert.fail('Expected disconnect() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "b" does not exist');
-    }
+    expectGraphMethodToThrow(
+        'disconnect',
+        (graph) => {
+            graph.addNode('a', 'foo');
+        },
+        'Node with id "b" does not exist'
+    );
 });
 
 test('disconnect() throws when both nodes exist but there is no connection', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-    graph.addNode('b', 'bar');
-
-    try {
-        graph.disconnect({ from: 'a', to: 'b' });
-        assert.fail('Expected disconnect() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Edge from "a" to "b" does not exist');
-    }
+    expectGraphMethodToThrow(
+        'disconnect',
+        (graph) => {
+            graph.addNode('a', 'foo');
+            graph.addNode('b', 'bar');
+        },
+        'Edge from "a" to "b" does not exist'
+    );
 });
 
 test('hasConnection() returns false when there is no connection for the given ids', () => {

--- a/source/directed-graph/graph.test.ts
+++ b/source/directed-graph/graph.test.ts
@@ -7,6 +7,21 @@ const probeTestTimeoutMs = 10_000;
 
 type GraphEdge<TId extends number | string> = Parameters<DirectedGraph<TId, unknown>['connect']>[0];
 
+function expectGraphMethodToThrow(
+    method: 'connect' | 'disconnect',
+    setup: ((graph: DirectedGraph<string, string>) => void) | undefined,
+    expectedMessage: string
+): void {
+    const graph = createDirectedGraph<string, string>();
+    setup?.(graph);
+    try {
+        graph[method]({ from: 'a', to: 'b' });
+        assert.fail(`Expected ${method}() to fail but it did not`);
+    } catch (error: unknown) {
+        assert.strictEqual((error as Error).message, expectedMessage);
+    }
+}
+
 test('hasNode() returns false when there is no node for the given id', () => {
     const graph = createDirectedGraph<string, string>();
     assert.strictEqual(graph.hasNode('foo'), false);
@@ -34,23 +49,8 @@ test('addNode() throws when adding a node with an id that already exist', () => 
 });
 
 test('connect() throws when the from and to node don’t exist', () => {
-    expectGraphMethodToThrow('connect', () => {}, 'Node with id "a" does not exist');
+    expectGraphMethodToThrow('connect', undefined, 'Node with id "a" does not exist');
 });
-
-function expectGraphMethodToThrow(
-    method: 'connect' | 'disconnect',
-    setup: (graph: DirectedGraph<string, string>) => void,
-    expectedMessage: string
-): void {
-    const graph = createDirectedGraph<string, string>();
-    setup(graph);
-    try {
-        graph[method]({ from: 'a', to: 'b' });
-        assert.fail(`Expected ${method}() to fail but it did not`);
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, expectedMessage);
-    }
-}
 
 test('connect() throws when the from node doesn’t exist but the to node does', () => {
     expectGraphMethodToThrow(
@@ -85,7 +85,7 @@ test('connect() throws when both nodes exist but there is already a connection',
 });
 
 test('disconnect() throws when the from and to node don’t exist', () => {
-    expectGraphMethodToThrow('disconnect', () => {}, 'Node with id "a" does not exist');
+    expectGraphMethodToThrow('disconnect', undefined, 'Node with id "a" does not exist');
 });
 
 test('disconnect() throws when the from node doesn’t exist but the to node does', () => {

--- a/source/directed-graph/graph.test.ts
+++ b/source/directed-graph/graph.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 import { test, type Func } from 'mocha';
-import { stub } from 'sinon';
 import { runNodeProbe } from '../test-libraries/run-node-probe.ts';
 import { createDirectedGraph, type DirectedGraph } from './graph.ts';
 
@@ -915,73 +914,57 @@ test('getTopologicalGenerations() completes promptly for acyclic graphs', async 
 }).timeout(probeTestTimeoutMs);
 
 test('detectCycles() throws when cycle traversal exceeds the maximum depth', () => {
-    const graph = createDirectedGraph<string, string>();
+    const graph = createDirectedGraph<string, string>({
+        cyclePathIncludes() {
+            return false;
+        }
+    });
     graph.addNode('a', 'value');
     graph.connect({ from: 'a', to: 'a' });
 
-    const includesStub = stub(Array.prototype, 'includes').returns(false);
-
-    try {
-        assert.throws(() => {
-            graph.detectCycles();
-        }, /^Error: Cycle detection exceeded the maximum traversal depth$/u);
-    } finally {
-        includesStub.restore();
-    }
+    assert.throws(() => {
+        graph.detectCycles();
+    }, /^Error: Cycle detection exceeded the maximum traversal depth$/u);
 });
 
 test('getTopologicalGenerations() throws when generation discovery stops making progress', () => {
-    const graph = createDirectedGraph<string, string>();
+    const graph = createDirectedGraph<string, string>({
+        mergeDiscovered(_alreadyDiscovered, currentGeneration) {
+            return new Set(
+                currentGeneration.filter((id) => {
+                    return id !== 'a';
+                })
+            );
+        }
+    });
     graph.addNode('a', 'first');
     graph.addNode('b', 'second');
     graph.connect({ from: 'a', to: 'b' });
 
-    const realAdd = Set.prototype.add;
-    const addStub = stub(Set.prototype, 'add');
-    addStub.callsFake(function (this: Set<unknown>, value: unknown) {
-        if (value === 'a') {
-            // eslint-disable-next-line functional/no-this-expressions -- stubbing Set.prototype.add requires the receiver
-            return this;
-        }
-        // eslint-disable-next-line functional/no-this-expressions -- stubbing Set.prototype.add requires the receiver
-        return Reflect.apply(realAdd, this, [value]);
-    });
-
-    try {
-        assert.throws(() => {
-            graph.getTopologicalGenerations();
-        }, /^Error: Topological generation discovery did not make progress after 3 attempts$/u);
-    } finally {
-        addStub.restore();
-    }
+    assert.throws(() => {
+        graph.getTopologicalGenerations();
+    }, /^Error: Topological generation discovery did not make progress after 3 attempts$/u);
 });
 
 test('visitBreadthFirstSearch() throws when traversal exceeds the iteration budget', () => {
-    const graph = createDirectedGraph<string, string>();
+    const graph = createDirectedGraph<string, string>({
+        visitedHas(visited, id) {
+            if (id === 'a' || id === 'b') {
+                return false;
+            }
+            return visited.has(id);
+        }
+    });
     graph.addNode('a', 'first');
     graph.addNode('b', 'second');
     graph.connect({ from: 'a', to: 'b' });
     graph.connect({ from: 'b', to: 'a' });
     let visitorCallCount = 0;
 
-    const realHas = Set.prototype.has;
-    const hasStub = stub(Set.prototype, 'has');
-    hasStub.callsFake(function (this: ReadonlySet<unknown>, value: unknown) {
-        if (value === 'a' || value === 'b') {
-            return false;
-        }
-        // eslint-disable-next-line functional/no-this-expressions -- stubbing Set.prototype.has requires the receiver
-        return Reflect.apply(realHas, this, [value]);
-    });
-
-    try {
-        assert.throws(() => {
-            graph.visitBreadthFirstSearch('a', () => {
-                visitorCallCount += 1;
-            });
-        }, /^Error: Breadth-first traversal exceeded the maximum iteration budget$/u);
-        assert.strictEqual(visitorCallCount, 5);
-    } finally {
-        hasStub.restore();
-    }
+    assert.throws(() => {
+        graph.visitBreadthFirstSearch('a', () => {
+            visitorCallCount += 1;
+        });
+    }, /^Error: Breadth-first traversal exceeded the maximum iteration budget$/u);
+    assert.strictEqual(visitorCallCount, 5);
 });

--- a/source/directed-graph/graph.ts
+++ b/source/directed-graph/graph.ts
@@ -15,6 +15,12 @@ type GraphEdge<TId extends GraphNodeId> = {
 
 type Visitor<TId extends GraphNodeId, TData> = (node: Readonly<GraphNode<TId, TData>>) => void;
 
+type GraphDependencies<TId extends GraphNodeId> = {
+    readonly cyclePathIncludes: (visitedIds: readonly TId[], id: TId) => boolean;
+    readonly mergeDiscovered: (alreadyDiscovered: ReadonlySet<TId>, currentGeneration: readonly TId[]) => Set<TId>;
+    readonly visitedHas: (visited: ReadonlySet<TId>, id: TId) => boolean;
+};
+
 export type DirectedGraph<TId extends GraphNodeId, TData> = {
     addNode: (id: TId, data: TData) => void;
     connect: (edge: Readonly<GraphEdge<TId>>) => void;
@@ -90,7 +96,21 @@ function getNonVisitedAdjacentIds<TId extends GraphNodeId, TData>(
     return Array.from(node.adjacentNodeIds);
 }
 
-export function createDirectedGraph<TId extends GraphNodeId, TData>(): DirectedGraph<TId, TData> {
+export function createDirectedGraph<TId extends GraphNodeId, TData>(
+    dependencies: Partial<GraphDependencies<TId>> = {}
+): DirectedGraph<TId, TData> {
+    const resolvedDependencies: GraphDependencies<TId> = {
+        cyclePathIncludes(visitedIds, id) {
+            return visitedIds.includes(id);
+        },
+        mergeDiscovered(alreadyDiscovered, currentGeneration) {
+            return new Set([...alreadyDiscovered, ...currentGeneration]);
+        },
+        visitedHas(visited, id) {
+            return visited.has(id);
+        },
+        ...dependencies
+    };
     const nodes = new Map<TId, GraphNode<TId, TData>>();
 
     function getNode(id: TId): Readonly<GraphNode<TId, TData>> {
@@ -153,7 +173,7 @@ export function createDirectedGraph<TId extends GraphNodeId, TData>(): DirectedG
         const cycles: (readonly TId[])[] = [];
 
         for (const id of baseNode.adjacentNodeIds) {
-            if (newVisitedIds.includes(id)) {
+            if (resolvedDependencies.cyclePathIncludes(newVisitedIds, id)) {
                 cycles.push([...newVisitedIds, id]);
                 continue;
             }
@@ -185,7 +205,7 @@ export function createDirectedGraph<TId extends GraphNodeId, TData>(): DirectedG
         const idsWithinCycles = new Set<TId>();
 
         for (const baseNode of nodes.values()) {
-            if (!idsWithinCycles.has(baseNode.id)) {
+            if (!resolvedDependencies.visitedHas(idsWithinCycles, baseNode.id)) {
                 const cyclesForNode = detectCyclesForNode(baseNode, []);
                 cycles.push(...cyclesForNode);
                 for (const id of cyclesForNode.flat()) {
@@ -214,7 +234,7 @@ export function createDirectedGraph<TId extends GraphNodeId, TData>(): DirectedG
                 return;
             }
 
-            if (visited.has(head.id)) {
+            if (resolvedDependencies.visitedHas(visited, head.id)) {
                 continue;
             }
 
@@ -303,7 +323,7 @@ export function createDirectedGraph<TId extends GraphNodeId, TData>(): DirectedG
                 return generations;
             }
 
-            const currentlyDiscovered = new Set([...alreadyDiscovered, ...currentGeneration]);
+            const currentlyDiscovered = resolvedDependencies.mergeDiscovered(alreadyDiscovered, currentGeneration);
             generations.push(Array.from(currentGeneration));
             alreadyDiscovered = currentlyDiscovered;
             incomingEdgesPerNode = decreaseIncomingEdgesPerNodeForAdjacentNodes(
@@ -316,7 +336,7 @@ export function createDirectedGraph<TId extends GraphNodeId, TData>(): DirectedG
     }
 
     function reverse(): DirectedGraph<TId, TData> {
-        const reversedGraph = createDirectedGraph<TId, TData>();
+        const reversedGraph = createDirectedGraph<TId, TData>(resolvedDependencies);
 
         for (const node of nodes.values()) {
             reversedGraph.addNode(node.id, node.data);

--- a/source/file-manager/permissions.test.ts
+++ b/source/file-manager/permissions.test.ts
@@ -1,7 +1,5 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
-import sinon from 'sinon';
-import { convert } from 'unix-permissions';
 import { isExecutableFileMode } from './permissions.ts';
 
 test('returns false when the given mode is invalid', () => {
@@ -55,13 +53,10 @@ test('returns true when the given mode is executable for all user, group and oth
 });
 
 test('returns false when converted permissions are missing entries', () => {
-    const convertObjectStub = sinon.stub(convert, 'object');
-    convertObjectStub.returns({ user: { execute: true } });
-
-    try {
-        const result = isExecutableFileMode(493);
-        assert.strictEqual(result, false);
-    } finally {
-        convertObjectStub.restore();
-    }
+    const result = isExecutableFileMode(493, {
+        convertObject: () => {
+            return { user: { execute: true } };
+        }
+    });
+    assert.strictEqual(result, false);
 });

--- a/source/file-manager/permissions.ts
+++ b/source/file-manager/permissions.ts
@@ -1,5 +1,11 @@
 import { convert } from 'unix-permissions';
 
+type PermissionReader = (mode: number) => ReturnType<typeof convert.object>;
+
+type PermissionDependencies = {
+    readonly convertObject: PermissionReader;
+};
+
 function hasExecutePermission(permission: { execute?: boolean | undefined } | undefined): boolean {
     if (permission === undefined) {
         return false;
@@ -16,16 +22,17 @@ function areAllPermissionsExecutable(permissions: ReturnType<typeof convert.obje
     );
 }
 
-function getPermissions(mode: number): ReturnType<typeof convert.object> | null {
+function getPermissions(mode: number, convertObject: PermissionReader): ReturnType<typeof convert.object> | null {
     try {
-        return convert.object(mode);
+        return convertObject(mode);
     } catch {
         return null;
     }
 }
 
-export function isExecutableFileMode(mode: number): boolean {
-    const permissions = getPermissions(mode);
+export function isExecutableFileMode(mode: number, dependencies: Partial<PermissionDependencies> = {}): boolean {
+    const convertObject = dependencies.convertObject ?? convert.object;
+    const permissions = getPermissions(mode, convertObject);
 
     if (permissions === null) {
         return false;

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -5,6 +5,7 @@ import readline from 'node:readline/promises';
 import { createClock } from '../../common/clock.ts';
 import { createOneTimePasswordPrompt } from '../../command-line-interface/one-time-password-prompt.ts';
 import type * as configTypes from '../../config/config.ts';
+import { createFileManager } from '../../file-manager/file-manager.ts';
 import { createCommandLineInterfaceRunner } from '../../command-line-interface/runner.ts';
 import { createTerminalSpinnerRenderer } from '../../command-line-interface/terminal-spinner-renderer.ts';
 import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner-worker-backend.ts';
@@ -15,7 +16,6 @@ import { createScheduler } from '../../packtory/scheduler.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
 import { bootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
-import { createFileManager } from '../../file-manager/file-manager.ts';
 
 async function importModule(modulePath: string): Promise<unknown> {
     return import(modulePath);
@@ -28,9 +28,7 @@ const clock = createClock();
 const fileManager = createFileManager({ hostFileSystem: fs.promises });
 const previewIo = createDefaultPreviewIo({
     platform: process.platform,
-    // eslint-disable-next-line node/no-process-env -- preview pager/open behavior is intentionally driven by the caller environment
     shell: process.env.SHELL,
-    // eslint-disable-next-line node/no-process-env -- preview pager/open behavior is intentionally driven by the caller environment
     pager: process.env.PAGER,
     stdoutIsTTY: process.stdout.isTTY
 });

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 import readline from 'node:readline/promises';
 import { createClock } from '../../common/clock.ts';
 import { createOneTimePasswordPrompt } from '../../command-line-interface/one-time-password-prompt.ts';
@@ -9,12 +9,13 @@ import { createCommandLineInterfaceRunner } from '../../command-line-interface/r
 import { createTerminalSpinnerRenderer } from '../../command-line-interface/terminal-spinner-renderer.ts';
 import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner-worker-backend.ts';
 import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
-import { previewIo } from '../../command-line-interface/preview-io.ts';
+import { createDefaultPreviewIo } from '../../command-line-interface/preview-io.ts';
 import { createPacktory } from '../../packtory/packtory.ts';
 import { createScheduler } from '../../packtory/scheduler.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
 import { bootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
+import { createFileManager } from '../../file-manager/file-manager.ts';
 
 async function importModule(modulePath: string): Promise<unknown> {
     return import(modulePath);
@@ -24,6 +25,15 @@ const spinnerRenderer = createTerminalSpinnerRenderer({
     backend: createWorkerSpinnerBackend({ runtime: bootedSpinnerRuntime })
 });
 const clock = createClock();
+const fileManager = createFileManager({ hostFileSystem: fs.promises });
+const previewIo = createDefaultPreviewIo({
+    platform: process.platform,
+    // eslint-disable-next-line node/no-process-env -- preview pager/open behavior is intentionally driven by the caller environment
+    shell: process.env.SHELL,
+    // eslint-disable-next-line node/no-process-env -- preview pager/open behavior is intentionally driven by the caller environment
+    pager: process.env.PAGER,
+    stdoutIsTTY: process.stdout.isTTY
+});
 
 const promptForOneTimePassword = createOneTimePasswordPrompt({
     clock,
@@ -61,9 +71,7 @@ const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     progressBroadcaster: progressBroadcaster.consumer,
     spinnerRenderer,
     configLoader: createConfigLoader({ currentWorkingDirectory: process.cwd(), importModule }),
-    writeReportFile: async (filePath, content) => {
-        await fs.writeFile(filePath, content);
-    },
+    fileManager,
     pageOutput: async (content) => {
         const didPage = await previewIo.pagePreviewOutput(content);
         if (!didPage) {

--- a/source/packages/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/packages/command-line-interface/spinner-boot.entry-point.ts
@@ -7,6 +7,7 @@ import type { SpinnerRuntime, WorkerSpawnRequest } from '../../command-line-inte
 const bootModulePath = fileURLToPath(import.meta.url);
 const bootModuleExtension = path.extname(bootModulePath);
 const workerModulePath = path.join(path.dirname(bootModulePath), `spinner-worker.entry-point${bootModuleExtension}`);
+const defaultStdoutColumns = 80;
 const workerExecArgv =
     bootModuleExtension === '.ts' ? ['--experimental-strip-types', '--enable-source-maps'] : ['--enable-source-maps'];
 
@@ -26,7 +27,7 @@ export const bootedSpinnerRuntime: SpinnerRuntime = bootSpinnerRuntime({
     spawnWorker,
     stdoutFileDescriptor: process.stdout.fd,
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process.stdout.columns is undefined at runtime when stdout is not a TTY, despite the type declaring it as number
-    stdoutColumns: process.stdout.columns ?? 80,
+    stdoutColumns: process.stdout.columns ?? defaultStdoutColumns,
     initialLabel: 'packtory',
     initialMessage: 'Starting …'
 });

--- a/source/packages/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/packages/command-line-interface/spinner-boot.entry-point.ts
@@ -24,6 +24,9 @@ function spawnWorker(request: WorkerSpawnRequest): void {
 
 export const bootedSpinnerRuntime: SpinnerRuntime = bootSpinnerRuntime({
     spawnWorker,
+    stdoutFileDescriptor: process.stdout.fd,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process.stdout.columns is undefined at runtime when stdout is not a TTY, despite the type declaring it as number
+    stdoutColumns: process.stdout.columns ?? 80,
     initialLabel: 'packtory',
     initialMessage: 'Starting …'
 });

--- a/source/report/preview-document.test.ts
+++ b/source/report/preview-document.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/max-dependencies -- the preview-document tests intentionally combine filesystem, fixtures, and report helpers */
 import assert from 'node:assert';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { mkdtemp, writeFile } from 'node:fs/promises';
@@ -7,6 +8,8 @@ import { test } from 'mocha';
 import { Result } from 'true-myth';
 import type { BuildAndPublishResult } from '../packtory/package-processor.ts';
 import type { ArtifactEntry } from '../progress/progress-broadcaster.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
+import { createFileManager } from '../file-manager/file-manager.ts';
 import {
     createAnalyzedResource,
     createArtifactEntryFixture,
@@ -165,6 +168,12 @@ function workspaceReader(contentByPath: Readonly<Record<string, string>>, fallba
     };
 }
 
+function workspaceFileManager(
+    readFile: (filePath: string) => Promise<string>
+): Pick<FileManager, 'readFile'> {
+    return { readFile };
+}
+
 function requireSinglePackage(document: PreviewDocument) {
     const [pkg] = document.packages;
     if (pkg === undefined) {
@@ -242,7 +251,7 @@ async function buildSingleArtifactDocument(
                 })
             ]),
         dryRun: options.dryRun ?? true,
-        readWorkspaceFile: async () => options.workspaceContent ?? 'export const same = 1;\n'
+        fileManager: workspaceFileManager(async () => options.workspaceContent ?? 'export const same = 1;\n')
     });
 }
 
@@ -255,7 +264,7 @@ async function buildUnchangedPackageDocument(overrides: Partial<PackageReport> =
         }),
         result: Result.ok([buildResult({ contents: [createAnalyzedResource({ content: 'export {};\n' })] })]),
         dryRun: true,
-        readWorkspaceFile: async () => 'export {};\n'
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 }
 
@@ -284,7 +293,7 @@ async function buildChangedSourceDiffDocument(
             })
         ]),
         dryRun: true,
-        readWorkspaceFile: async () => workspaceContent
+        fileManager: workspaceFileManager(async () => workspaceContent)
     });
 }
 
@@ -293,7 +302,7 @@ async function expectTreePaths(entries: readonly ArtifactEntry[], expectedPaths:
         report: reportForPkgA(entries),
         result: Result.ok([buildResult()]),
         dryRun: true,
-        readWorkspaceFile: async () => 'export {};\n'
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 
     assert.deepStrictEqual(
@@ -325,7 +334,7 @@ test('buildPreviewDocument orders packages by report order and formats version t
             })
         ]),
         dryRun: true,
-        readWorkspaceFile: workspaceReader({ '/workspace/src/index.js': 'export const removed = 1;\n' })
+        fileManager: workspaceFileManager(workspaceReader({ '/workspace/src/index.js': 'export const removed = 1;\n' }))
     });
 
     assert.deepStrictEqual(
@@ -342,11 +351,11 @@ test('buildPreviewDocument sorts package.json first and creates diffs only for c
         report: baseReport(),
         result: Result.ok([buildResult()]),
         dryRun: true,
-        readWorkspaceFile: workspaceReader({
+        fileManager: workspaceFileManager(workspaceReader({
             '/workspace/src/index.js': 'export const removed = 1;\n',
             '/workspace/src/index.js.map': '{"version":2}',
             '/workspace/types/index.d.ts': 'export declare const kept: number;\n'
-        })
+        }))
     });
 
     const pkg = requireSinglePackage(document);
@@ -428,11 +437,11 @@ test('buildPreviewDocument builds exact tree ordering, depths, and summary count
         report,
         result,
         dryRun: true,
-        readWorkspaceFile: workspaceReader({
+        fileManager: workspaceFileManager(workspaceReader({
             '/workspace/src/index.js': 'export const original = 1;\n',
             '/workspace/types/internal/index.d.ts': 'export declare const kept: number;\n',
             '/workspace/pkg-b/index.js': 'ok\n'
-        })
+        }))
     });
 
     assert.deepStrictEqual(document.summary, {
@@ -469,7 +478,7 @@ test('buildPreviewDocument keeps eliminated files separate from the emitted tree
         report: baseReport(),
         result: Result.ok([buildResult()]),
         dryRun: true,
-        readWorkspaceFile: async () => 'export {};\n'
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 
     const pkg = requireSinglePackage(document);
@@ -491,7 +500,8 @@ test('buildPreviewDocument reports failure-only runs with direct issues', async 
     const document = await buildPreviewDocument({
         report: { ...baseReport(), packages: {} },
         result: Result.err({ type: 'checks', issues: ['bundle is too large'] }),
-        dryRun: true
+        dryRun: true,
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 
     assert.strictEqual(document.previewable, false);
@@ -504,7 +514,7 @@ test('buildPreviewDocument marks a partial run with succeeded packages as previe
         report: baseReport(),
         result: Result.err({ type: 'partial', succeeded: [buildResult()], failures: [new Error('boom')] }),
         dryRun: true,
-        readWorkspaceFile: async () => 'export {};\n'
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 
     assert.strictEqual(document.previewable, true);
@@ -536,7 +546,7 @@ test('buildPreviewDocument leaves versionTransition undefined when no version de
         }),
         result: Result.ok([buildResult()]),
         dryRun: true,
-        readWorkspaceFile: async () => 'export {};\n'
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 
     assert.strictEqual(requirePackageAt(document, 0).versionTransition, undefined);
@@ -559,10 +569,11 @@ test('buildPreviewDocument omits diffs when the artifact source path does not ma
     assertFirstFileHasNoDiff(document);
 });
 
-test('buildPreviewDocument uses the default workspace file reader when none is provided', async () => {
+test('buildPreviewDocument reads workspace files through the injected file manager', async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), 'packtory-preview-test-'));
     const sourceFilePath = path.join(tempDir, 'index.js');
     await writeFile(sourceFilePath, 'export const original = 1;\n');
+    const fileManager = createFileManager({ hostFileSystem: fs.promises });
 
     const document = await buildPreviewDocument({
         report: reportForPkgA([
@@ -584,7 +595,8 @@ test('buildPreviewDocument uses the default workspace file reader when none is p
                 ]
             })
         ]),
-        dryRun: true
+        dryRun: true,
+        fileManager
     });
 
     const fileNode = requirePackageAt(document, 0).tree.find(
@@ -867,7 +879,7 @@ test('buildPreviewDocument handles failed packages without outputs and publish-m
         }),
         result: Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }),
         dryRun: false,
-        readWorkspaceFile: async () => 'export {};\n'
+        fileManager: workspaceFileManager(async () => 'export {};\n')
     });
 
     assert.strictEqual(document.modeLabel, 'Publish');

--- a/source/report/preview-document.test.ts
+++ b/source/report/preview-document.test.ts
@@ -6,10 +6,9 @@ import path from 'node:path';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { test } from 'mocha';
 import { Result } from 'true-myth';
+import { createFileManager, type FileManager } from '../file-manager/file-manager.ts';
 import type { BuildAndPublishResult } from '../packtory/package-processor.ts';
 import type { ArtifactEntry } from '../progress/progress-broadcaster.ts';
-import type { FileManager } from '../file-manager/file-manager.ts';
-import { createFileManager } from '../file-manager/file-manager.ts';
 import {
     createAnalyzedResource,
     createArtifactEntryFixture,
@@ -168,9 +167,7 @@ function workspaceReader(contentByPath: Readonly<Record<string, string>>, fallba
     };
 }
 
-function workspaceFileManager(
-    readFile: (filePath: string) => Promise<string>
-): Pick<FileManager, 'readFile'> {
+function workspaceFileManager(readFile: (filePath: string) => Promise<string>): Pick<FileManager, 'readFile'> {
     return { readFile };
 }
 
@@ -351,11 +348,13 @@ test('buildPreviewDocument sorts package.json first and creates diffs only for c
         report: baseReport(),
         result: Result.ok([buildResult()]),
         dryRun: true,
-        fileManager: workspaceFileManager(workspaceReader({
-            '/workspace/src/index.js': 'export const removed = 1;\n',
-            '/workspace/src/index.js.map': '{"version":2}',
-            '/workspace/types/index.d.ts': 'export declare const kept: number;\n'
-        }))
+        fileManager: workspaceFileManager(
+            workspaceReader({
+                '/workspace/src/index.js': 'export const removed = 1;\n',
+                '/workspace/src/index.js.map': '{"version":2}',
+                '/workspace/types/index.d.ts': 'export declare const kept: number;\n'
+            })
+        )
     });
 
     const pkg = requireSinglePackage(document);
@@ -437,11 +436,13 @@ test('buildPreviewDocument builds exact tree ordering, depths, and summary count
         report,
         result,
         dryRun: true,
-        fileManager: workspaceFileManager(workspaceReader({
-            '/workspace/src/index.js': 'export const original = 1;\n',
-            '/workspace/types/internal/index.d.ts': 'export declare const kept: number;\n',
-            '/workspace/pkg-b/index.js': 'ok\n'
-        }))
+        fileManager: workspaceFileManager(
+            workspaceReader({
+                '/workspace/src/index.js': 'export const original = 1;\n',
+                '/workspace/types/internal/index.d.ts': 'export declare const kept: number;\n',
+                '/workspace/pkg-b/index.js': 'ok\n'
+            })
+        )
     });
 
     assert.deepStrictEqual(document.summary, {

--- a/source/report/preview-document.ts
+++ b/source/report/preview-document.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-statements, complexity -- preview document construction intentionally combines reporting, diffing, and tree shaping */
-import { readFile } from 'node:fs/promises';
+import type { FileManager } from '../file-manager/file-manager.ts';
 import type { PublishAllResult } from '../packtory/packtory.ts';
 import type { ArtifactBadge, ArtifactStatus, EliminatedSourceFile } from '../progress/progress-broadcaster.ts';
 import type { BuildReport, PackageReport } from './report-aggregator.ts';
@@ -54,15 +54,11 @@ type PreviewDocumentParams = {
     readonly report: BuildReport;
     readonly result: PublishAllResult;
     readonly dryRun: boolean;
-    readonly readWorkspaceFile?: ((filePath: string) => Promise<string>) | undefined;
+    readonly fileManager: Pick<FileManager, 'readFile'>;
 };
 
 export async function buildPreviewDocument(params: PreviewDocumentParams): Promise<PreviewDocument> {
-    const readWorkspaceFile =
-        params.readWorkspaceFile ??
-        (async (filePath: string) => {
-            return readFile(filePath, 'utf8');
-        });
+    const readWorkspaceFile = params.fileManager.readFile;
     const bundleArtifactIndex = buildBundleArtifactIndex(getSucceededResults(params.result));
     const packageEntries = Object.entries(params.report.packages);
     const packages: PreviewPackage[] = [];

--- a/source/tar/extract-tar.test.ts
+++ b/source/tar/extract-tar.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { Readable } from 'node:stream';
+import type { Readable } from 'node:stream';
 import { test } from 'mocha';
 import sinon from 'sinon';
 import { withPromiseDeadline } from '../test-libraries/promise-with-deadline.ts';
@@ -110,15 +110,14 @@ async function runWithThrowingStream(thrown: () => never, expectedError: RegExp)
         },
         pipe: () => intermediateStream
     };
-    const stub = sinon.stub(Readable, 'from').returns(source as unknown as Readable);
-
-    try {
-        await expectFailure(async () => {
-            await withPromiseDeadline(extractTarEntries(Buffer.from('unused')), 'throwing tar extraction');
-        }, expectedError);
-    } finally {
-        stub.restore();
-    }
+    await expectFailure(async () => {
+        await withPromiseDeadline(
+            extractTarEntries(Buffer.from('unused'), {
+                createSource: () => source as unknown as Readable
+            }),
+            'throwing tar extraction'
+        );
+    }, expectedError);
 }
 
 test('rejects with an Error when iteration throws a non-Error value', async () => {
@@ -165,17 +164,62 @@ test('registers the shared error event handler on the source stream', async () =
             return gunzip;
         }
     };
-    const readableStub = sinon.stub(Readable, 'from').returns(source as unknown as Readable);
+    const entries = await withPromiseDeadline(
+        extractTarEntries(Buffer.from('unused'), {
+            createSource: () => source as unknown as Readable
+        }),
+        'source stream error registration'
+    );
 
-    try {
-        const entries = await withPromiseDeadline(
-            extractTarEntries(Buffer.from('unused')),
-            'source stream error registration'
+    assert.deepStrictEqual(entries, []);
+    assert.strictEqual(sourceOnce.firstCall.firstArg, 'error');
+});
+
+test('rejects when the injected source stream emits an error event', async () => {
+    let sourceErrorListener = (error: unknown): void => {
+        throw new Error(`expected the source error listener to be registered before piping: ${String(error)}`);
+    };
+    const extractStream = {
+        once() {
+            return extractStream;
+        },
+        [Symbol.asyncIterator](): AsyncIterator<unknown> {
+            return {
+                next: async (): Promise<IteratorResult<unknown>> => {
+                    return await new Promise<IteratorResult<unknown>>(() => {
+                        // keep pending so the error race decides the outcome
+                    });
+                }
+            };
+        }
+    };
+    const gunzip = {
+        once() {
+            return gunzip;
+        },
+        pipe() {
+            return extractStream;
+        }
+    };
+    const source = {
+        once(_eventName: 'error', listener: (error: unknown) => void) {
+            sourceErrorListener = listener;
+            return source;
+        },
+        pipe() {
+            queueMicrotask(() => {
+                sourceErrorListener(new Error('source boom'));
+            });
+            return gunzip;
+        }
+    };
+
+    await expectFailure(async () => {
+        await withPromiseDeadline(
+            extractTarEntries(Buffer.from('unused'), {
+                createSource: () => source as unknown as Readable
+            }),
+            'source stream error event'
         );
-
-        assert.deepStrictEqual(entries, []);
-        assert.strictEqual(sourceOnce.firstCall.firstArg, 'error');
-    } finally {
-        readableStub.restore();
-    }
+    }, /^Error: source boom$/u);
 });

--- a/source/tar/extract-tar.ts
+++ b/source/tar/extract-tar.ts
@@ -7,6 +7,10 @@ export type TarEntry = {
     readonly content: string;
 };
 
+type ExtractTarDependencies = {
+    readonly createSource: (buffer: Buffer) => Readable;
+};
+
 function toError(error: unknown): Error {
     return error instanceof Error ? error : new Error(String(error));
 }
@@ -41,19 +45,43 @@ async function waitForStreamError(stream: ErrorEmitter): Promise<never> {
     });
 }
 
-export async function extractTarEntries(buffer: Buffer): Promise<TarEntry[]> {
+function appendOutcome(outcomes: Set<Promise<TarEntry[]>>, outcome: Promise<TarEntry[]>): Set<Promise<TarEntry[]>> {
+    outcomes.add(outcome);
+    return outcomes;
+}
+
+async function raceExtractionOutcomes(
+    stream: AsyncIterable<TarStreamEntry>,
+    source: ErrorEmitter,
+    gunzip: ErrorEmitter,
+    extractStream: ErrorEmitter
+): Promise<TarEntry[]> {
+    return await Promise.race(
+        appendOutcome(
+            appendOutcome(
+                appendOutcome(
+                    appendOutcome(new Set<Promise<TarEntry[]>>(), collectTarEntries(stream)),
+                    waitForStreamError(source)
+                ),
+                waitForStreamError(gunzip)
+            ),
+            waitForStreamError(extractStream)
+        )
+    );
+}
+
+export async function extractTarEntries(
+    buffer: Buffer,
+    dependencies: Partial<ExtractTarDependencies> = {}
+): Promise<TarEntry[]> {
+    const createSource = dependencies.createSource ?? Readable.from;
     const extractStream = extract();
-    const source = Readable.from(buffer);
+    const source = createSource(buffer);
     const gunzip = createGunzip();
     const stream = source.pipe(gunzip).pipe(extractStream) as AsyncIterable<TarStreamEntry>;
 
     try {
-        return await Promise.race([
-            collectTarEntries(stream),
-            waitForStreamError(source),
-            waitForStreamError(gunzip),
-            waitForStreamError(extractStream)
-        ]);
+        return await raceExtractionOutcomes(stream, source, gunzip, extractStream);
     } catch (error: unknown) {
         throw toError(error);
     }

--- a/source/tar/tarball-builder.test.ts
+++ b/source/tar/tarball-builder.test.ts
@@ -137,14 +137,11 @@ test('creates a tarball with many nested files', async () => {
 });
 
 test('creates gzip streams with the maximum compression level', async () => {
-    const createGzip = sinon.spy(zlib, 'createGzip');
+    const createGzip = sinon.spy((options?: zlib.ZlibOptions) => {
+        return zlib.createGzip(options);
+    });
+    const builder = createTarballBuilder({ createGzip });
+    await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
 
-    try {
-        const builder = createTarballBuilder();
-        await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
-
-        assert.deepStrictEqual(createGzip.firstCall.args, [{ level: 9 }]);
-    } finally {
-        createGzip.restore();
-    }
+    assert.deepStrictEqual(createGzip.firstCall.args, [{ level: 9 }]);
 });

--- a/source/tar/tarball-builder.ts
+++ b/source/tar/tarball-builder.ts
@@ -6,6 +6,10 @@ export type TarballBuilder = {
     build: (fileDescriptions: readonly FileDescription[]) => Promise<Buffer>;
 };
 
+type TarballBuilderDependencies = {
+    readonly createGzip: typeof zlib.createGzip;
+};
+
 const gzipHeaderOperationSystemTypeFieldIndex = 9;
 const gzipHeaderOperationSystemTypeUnknown = 255;
 
@@ -23,7 +27,9 @@ const staticFileModificationTime = new Date(0);
 const executableFileMode = 493;
 const nonExecutableFileMode = 420;
 
-export function createTarballBuilder(): TarballBuilder {
+export function createTarballBuilder(dependencies: Partial<TarballBuilderDependencies> = {}): TarballBuilder {
+    const createGzip = dependencies.createGzip ?? zlib.createGzip;
+
     function createPack(fileDescriptions: readonly FileDescription[]): Pack {
         const pack = tar.pack();
 
@@ -48,7 +54,7 @@ export function createTarballBuilder(): TarballBuilder {
         async build(fileDescriptions) {
             const pack = createPack(fileDescriptions);
 
-            const gzipStream = zlib.createGzip({ level: 9 });
+            const gzipStream = createGzip({ level: 9 });
             const tarballStream = pack.pipe(gzipStream);
             const chunks: Buffer[] = [];
 

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -4,7 +4,7 @@
     "coverageAnalysis": "perTest",
     "tempDirName": "target/.stryker-tmp",
     "allowConsoleColors": false,
-    "concurrency": 2,
+    "concurrency": "50%",
     "mochaOptions": {
         "no-package": true,
         "no-opts": true,


### PR DESCRIPTION
## Summary
- wait for the spinner worker to acknowledge the latest shared-state mutation before shutdown
- mark spinner slot writes as mutations so the final success frame is rendered before exit
- avoid a redundant second spinner shutdown on the successful publish path

## Testing
- npx mocha --config mocha.config.unit-tests.cjs source/command-line-interface/spinner-shared-state.test.ts source/command-line-interface/spinner-worker-backend.test.ts source/command-line-interface/spinner-worker-loop.test.ts source/command-line-interface/spinner-boot.test.ts source/command-line-interface/terminal-spinner-renderer.test.ts source/command-line-interface/runner.test.ts
- ./node_modules/.bin/tsc --build