### PR TITLE
Fix non-interactive terminal UI

### DIFF
--- a/source/command-line-interface/line-spinner-renderer.test.ts
+++ b/source/command-line-interface/line-spinner-renderer.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert';
+import { stripVTControlCharacters } from 'node:util';
+import { test } from 'mocha';
+import { fake } from 'sinon';
+import { createLineSpinnerRenderer } from './line-spinner-renderer.ts';
+
+function createRendererWithLog() {
+    const log = fake();
+    return {
+        log,
+        renderer: createLineSpinnerRenderer({
+            log: (message) => {
+                log(stripVTControlCharacters(message));
+            }
+        })
+    };
+}
+
+function createRendererWithoutLog() {
+    return createLineSpinnerRenderer({
+        log: () => {
+            // noop
+        }
+    });
+}
+
+function expectErrorMessage(callback: () => void, expectedMessage: string): void {
+    try {
+        callback();
+        assert.fail('Expected callback should fail but it did not');
+    } catch (error: unknown) {
+        assert.strictEqual((error as Error).message, expectedMessage);
+    }
+}
+
+test('add() logs the initial spinner message as a plain line', () => {
+    const { log, renderer } = createRendererWithLog();
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+
+    assert.strictEqual(log.callCount, 1);
+    assert.deepStrictEqual(log.firstCall.args, ['pkg-a: Scheduled ...']);
+});
+
+test('updateMessage() logs message updates as plain lines', () => {
+    const { log, renderer } = createRendererWithLog();
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+    renderer.updateMessage('the-id', 'Building package with version 1.2.3');
+
+    assert.strictEqual(log.callCount, 2);
+    assert.deepStrictEqual(log.secondCall.args, ['pkg-a: Building package with version 1.2.3']);
+});
+
+test('add() throws when adding two spinners with the same id', () => {
+    const renderer = createRendererWithoutLog();
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+
+    expectErrorMessage(() => {
+        renderer.add('the-id', 'pkg-a', 'Scheduled again');
+    }, 'Spinner with id the-id already exists');
+});
+
+test('updateMessage() throws when trying to change the message of a non-existing spinner', () => {
+    const renderer = createRendererWithoutLog();
+
+    expectErrorMessage(() => {
+        renderer.updateMessage('the-id', 'Building package with version 1.2.3');
+    }, 'Spinner with id the-id does not exist');
+});
+
+test('stop() logs a success line with the final message', () => {
+    const { log, renderer } = createRendererWithLog();
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+    renderer.stop('the-id', 'success', 'First version 1.2.3 has been published');
+
+    assert.strictEqual(log.callCount, 2);
+    assert.deepStrictEqual(log.secondCall.args, ['✔ pkg-a: First version 1.2.3 has been published']);
+});
+
+test('stop() logs a failure line with the final message', () => {
+    const { log, renderer } = createRendererWithLog();
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+    renderer.stop('the-id', 'failure', 'publish failed');
+
+    assert.strictEqual(log.callCount, 2);
+    assert.deepStrictEqual(log.secondCall.args, ['✖ pkg-a: publish failed']);
+});
+
+test('stop() throws when trying to stop a spinner that does not exist', () => {
+    const renderer = createRendererWithoutLog();
+
+    expectErrorMessage(() => {
+        renderer.stop('the-id', 'failure', 'publish failed');
+    }, 'Spinner with id the-id does not exist');
+});
+
+test('stopAll() clears tracked spinners without logging cancellation lines', () => {
+    const { log, renderer } = createRendererWithLog();
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+    renderer.stopAll();
+
+    assert.strictEqual(log.callCount, 1);
+
+    renderer.add('the-id', 'pkg-a', 'Scheduled again');
+
+    assert.strictEqual(log.callCount, 2);
+    assert.deepStrictEqual(log.secondCall.args, ['pkg-a: Scheduled again']);
+});

--- a/source/command-line-interface/line-spinner-renderer.ts
+++ b/source/command-line-interface/line-spinner-renderer.ts
@@ -1,0 +1,60 @@
+import { bold, green, red } from 'yoctocolors';
+import type { TerminalSpinnerRenderer } from './terminal-spinner-renderer.ts';
+
+type Status = 'failure' | 'success';
+
+export type LineSpinnerRendererDependencies = {
+    readonly log: (message: string) => void;
+};
+
+function getErrorSymbol(): string {
+    return bold(red('✖'));
+}
+
+function getSuccessSymbol(): string {
+    return bold(green('✔'));
+}
+
+function renderProgressLine(label: string, message: string): string {
+    return `${label}: ${message}`;
+}
+
+function renderStopLine(status: Status, label: string, message: string): string {
+    const symbol = status === 'success' ? getSuccessSymbol() : getErrorSymbol();
+    return `${symbol} ${renderProgressLine(label, message)}`;
+}
+
+export function createLineSpinnerRenderer(dependencies: LineSpinnerRendererDependencies): TerminalSpinnerRenderer {
+    const { log } = dependencies;
+    const labelsById = new Map<string, string>();
+
+    function getLabel(id: string): string {
+        const label = labelsById.get(id);
+        if (label !== undefined) {
+            return label;
+        }
+        throw new Error(`Spinner with id ${id} does not exist`);
+    }
+
+    return {
+        add(id, label, message) {
+            if (labelsById.has(id)) {
+                throw new Error(`Spinner with id ${id} already exists`);
+            }
+            labelsById.set(id, label);
+            log(renderProgressLine(label, message));
+        },
+
+        updateMessage(id, message) {
+            log(renderProgressLine(getLabel(id), message));
+        },
+
+        stop(id, status, message) {
+            log(renderStopLine(status, getLabel(id), message));
+        },
+
+        stopAll() {
+            labelsById.clear();
+        }
+    };
+}

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -3,11 +3,15 @@
 import fs from 'node:fs';
 import readline from 'node:readline/promises';
 import { createClock } from '../../common/clock.ts';
+import { createLineSpinnerRenderer } from '../../command-line-interface/line-spinner-renderer.ts';
 import { createOneTimePasswordPrompt } from '../../command-line-interface/one-time-password-prompt.ts';
 import type * as configTypes from '../../config/config.ts';
 import { createFileManager } from '../../file-manager/file-manager.ts';
 import { createCommandLineInterfaceRunner } from '../../command-line-interface/runner.ts';
-import { createTerminalSpinnerRenderer } from '../../command-line-interface/terminal-spinner-renderer.ts';
+import {
+    createTerminalSpinnerRenderer,
+    type TerminalSpinnerRenderer
+} from '../../command-line-interface/terminal-spinner-renderer.ts';
 import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner-worker-backend.ts';
 import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
 import { createDefaultPreviewIo } from '../../command-line-interface/preview-io.ts';
@@ -15,15 +19,23 @@ import { createPacktory } from '../../packtory/packtory.ts';
 import { createScheduler } from '../../packtory/scheduler.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
-import { bootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
+import { createBootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
 
 async function importModule(modulePath: string): Promise<unknown> {
     return import(modulePath);
 }
 
-const spinnerRenderer = createTerminalSpinnerRenderer({
-    backend: createWorkerSpinnerBackend({ runtime: bootedSpinnerRuntime })
-});
+function createSpinnerRenderer(): TerminalSpinnerRenderer {
+    if (!process.stdout.isTTY) {
+        return createLineSpinnerRenderer({ log: console.log });
+    }
+
+    return createTerminalSpinnerRenderer({
+        backend: createWorkerSpinnerBackend({ runtime: createBootedSpinnerRuntime() })
+    });
+}
+
+const spinnerRenderer = createSpinnerRenderer();
 const clock = createClock();
 const fileManager = createFileManager({ hostFileSystem: fs.promises });
 const previewIo = createDefaultPreviewIo({

--- a/source/packages/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/packages/command-line-interface/spinner-boot.entry-point.ts
@@ -23,11 +23,13 @@ function spawnWorker(request: WorkerSpawnRequest): void {
     worker.unref();
 }
 
-export const bootedSpinnerRuntime: SpinnerRuntime = bootSpinnerRuntime({
-    spawnWorker,
-    stdoutFileDescriptor: process.stdout.fd,
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process.stdout.columns is undefined at runtime when stdout is not a TTY, despite the type declaring it as number
-    stdoutColumns: process.stdout.columns ?? defaultStdoutColumns,
-    initialLabel: 'packtory',
-    initialMessage: 'Starting …'
-});
+export function createBootedSpinnerRuntime(): SpinnerRuntime {
+    return bootSpinnerRuntime({
+        spawnWorker,
+        stdoutFileDescriptor: process.stdout.fd,
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- process.stdout.columns is undefined at runtime when stdout is not a TTY, despite the type declaring it as number
+        stdoutColumns: process.stdout.columns ?? defaultStdoutColumns,
+        initialLabel: 'packtory',
+        initialMessage: 'Starting …'
+    });
+}


### PR DESCRIPTION
## Summary
- switch the CLI to plain line-based progress output when stdout is not a TTY
- lazily boot the spinner worker so non-interactive runs do not start terminal redraw machinery
- add unit coverage for the non-interactive renderer path

## Verification
- npx just compile
- npx just lint
- npx just test-unit-with-coverage
- npx just test-types