### PR TITLE
Replace custom helpers with remeda equivalents

### DIFF
--- a/source/build-support/mutation-timeout/mutation-report-schema.ts
+++ b/source/build-support/mutation-timeout/mutation-report-schema.ts
@@ -1,3 +1,5 @@
+import { isArray, isDefined, isPlainObject } from 'remeda';
+
 type MutationLocation = {
     readonly start: {
         readonly line: number;
@@ -18,17 +20,13 @@ export type MutationReport = {
     readonly files?: Readonly<Record<string, MutationReportFile | undefined>>;
 };
 
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-    return Object.prototype.toString.call(value) === '[object Object]';
-}
-
 function parseMutationLocation(value: unknown): MutationLocation | undefined {
-    if (!isRecord(value)) {
+    if (!isPlainObject(value)) {
         return undefined;
     }
 
     const { start } = value;
-    if (!isRecord(start) || typeof start.line !== 'number' || typeof start.column !== 'number') {
+    if (!isPlainObject(start) || typeof start.line !== 'number' || typeof start.column !== 'number') {
         return undefined;
     }
 
@@ -41,7 +39,7 @@ function parseMutationLocation(value: unknown): MutationLocation | undefined {
 }
 
 function parseMutant(value: unknown): ParsedMutant | undefined {
-    if (!isRecord(value)) {
+    if (!isPlainObject(value)) {
         return undefined;
     }
 
@@ -57,17 +55,13 @@ function parseMutant(value: unknown): ParsedMutant | undefined {
     return { status: value.status, location };
 }
 
-function isDefined<T>(value: T | undefined): value is T {
-    return value !== undefined;
-}
-
 function parseMutationReportFile(value: unknown): MutationReportFile | undefined {
-    if (!isRecord(value)) {
+    if (!isPlainObject(value)) {
         return undefined;
     }
 
     const { mutants } = value;
-    if (!Array.isArray(mutants)) {
+    if (!isArray(mutants)) {
         return {};
     }
 
@@ -77,7 +71,7 @@ function parseMutationReportFile(value: unknown): MutationReportFile | undefined
 }
 
 export function parseMutationReport(value: unknown): MutationReport {
-    if (!isRecord(value) || !isRecord(value.files)) {
+    if (!isPlainObject(value) || !isPlainObject(value.files)) {
         return {};
     }
 

--- a/source/bundle-emitter/repository-url-normalizer.ts
+++ b/source/bundle-emitter/repository-url-normalizer.ts
@@ -1,18 +1,15 @@
 import HostedGitInfo from 'hosted-git-info';
+import { isPlainObject } from 'remeda';
 
 function isNonEmptyString(value: unknown): value is string {
     return typeof value === 'string' && value.length > 0;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function extractRawUrl(input: unknown): string | undefined {
     if (isNonEmptyString(input)) {
         return input;
     }
-    if (isRecord(input) && isNonEmptyString(input.url)) {
+    if (isPlainObject(input) && isNonEmptyString(input.url)) {
         return input.url;
     }
     return undefined;

--- a/source/checks/rules/required-files.ts
+++ b/source/checks/rules/required-files.ts
@@ -1,3 +1,4 @@
+import { unique } from 'remeda';
 import { z } from 'zod/mini';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import { nonEmptyStringSchema } from '../../config/base-validations.ts';
@@ -24,7 +25,7 @@ function effectiveRequiredFiles(
     globalConfig: GlobalConfig,
     perPackageConfig: PerPackageConfig | undefined
 ): readonly string[] {
-    return Array.from(new Set([...(globalConfig.files ?? []), ...(perPackageConfig?.files ?? [])]));
+    return unique([...(globalConfig.files ?? []), ...(perPackageConfig?.files ?? [])]);
 }
 
 function findMissingFiles(bundle: AnalyzedBundle, requiredFiles: readonly string[]): readonly string[] {

--- a/source/checks/rules/unique-target-paths.ts
+++ b/source/checks/rules/unique-target-paths.ts
@@ -1,3 +1,4 @@
+import { groupBy } from 'remeda';
 import type { z } from 'zod/mini';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import {
@@ -14,21 +15,21 @@ type PerPackageConfig = z.infer<typeof emptyPerPackageSchema>;
 type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 function findCollidingTargetPaths(bundle: AnalyzedBundle): readonly string[] {
-    const sourcesByTarget = new Map<string, string[]>();
-    for (const resource of bundle.contents) {
-        const { targetFilePath, sourceFilePath } = resource.fileDescription;
-        const sources = sourcesByTarget.get(targetFilePath) ?? [];
-        sources.push(sourceFilePath);
-        sourcesByTarget.set(targetFilePath, sources);
-    }
+    const sourcesByTarget = groupBy(bundle.contents, (resource) => {
+        return resource.fileDescription.targetFilePath;
+    });
 
-    return Array.from(sourcesByTarget.entries()).flatMap(([targetFilePath, sources]) => {
-        if (sources.length <= 1) {
+    return Object.entries(sourcesByTarget).flatMap(([targetFilePath, resources]) => {
+        if (resources.length <= 1) {
             return [];
         }
-        const sortedSources = sources.toSorted((left, right) => {
-            return left.localeCompare(right);
-        });
+        const sortedSources = resources
+            .map((resource) => {
+                return resource.fileDescription.sourceFilePath;
+            })
+            .toSorted((left, right) => {
+                return left.localeCompare(right);
+            });
         return [`Package "${bundle.name}" maps multiple sources to "${targetFilePath}": ${sortedSources.join(', ')}`];
     });
 }

--- a/source/command-line-interface/config-loader.ts
+++ b/source/command-line-interface/config-loader.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { isPlainObject } from 'remeda';
+import { hasProp, isPlainObject } from 'remeda';
 
 export type ConfigLoaderDependencies = {
     readonly currentWorkingDirectory: string;
@@ -14,13 +14,6 @@ type UnknownFunction = (...args: unknown[]) => unknown;
 
 function isFunction(value: unknown): value is UnknownFunction {
     return typeof value === 'function';
-}
-
-function hasOwn<K extends PropertyKey>(
-    value: Readonly<Record<PropertyKey, unknown>>,
-    key: K
-): value is Readonly<Record<K, unknown> & Record<PropertyKey, unknown>> {
-    return Object.hasOwn(value, key);
 }
 
 export function createConfigLoader(dependencies: ConfigLoaderDependencies): ConfigLoader {
@@ -41,11 +34,11 @@ export function createConfigLoader(dependencies: ConfigLoaderDependencies): Conf
         async load() {
             const module = await importConfigModule();
 
-            if (hasOwn(module, 'config')) {
+            if (hasProp(module, 'config')) {
                 return module.config;
             }
 
-            if (hasOwn(module, 'buildConfig')) {
+            if (hasProp(module, 'buildConfig')) {
                 const { buildConfig } = module;
                 if (isFunction(buildConfig)) {
                     return buildConfig();

--- a/source/dependency-scanner/dependency-graph.property.ts
+++ b/source/dependency-scanner/dependency-graph.property.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
 import { test } from 'mocha';
+import { unique } from 'remeda';
 import { Maybe } from 'true-myth';
 import {
     createDependencyGraph,
@@ -117,7 +118,7 @@ test('mergeDependencyFiles() preserves uniqueness by file path', () => {
                 return file.filePath;
             });
 
-            assert.deepStrictEqual(mergedPaths, Array.from(new Set(mergedPaths)));
+            assert.deepStrictEqual(mergedPaths, unique(mergedPaths));
         }),
         { numRuns: 5 }
     );

--- a/source/dependency-scanner/host-method-binding.test.ts
+++ b/source/dependency-scanner/host-method-binding.test.ts
@@ -1,20 +1,8 @@
 import assert from 'node:assert';
 import { test } from 'mocha';
+import { isString } from 'remeda';
 import type { FileSystemHost } from 'ts-morph';
-import { bindRequiredMethod, isBoolean, isString, syncMethodNames } from './host-method-binding.ts';
-
-test('isBoolean returns true only for boolean primitives', () => {
-    assert.strictEqual(isBoolean(true), true);
-    assert.strictEqual(isBoolean(false), true);
-    assert.strictEqual(isBoolean('true'), false);
-    assert.strictEqual(isBoolean(1), false);
-});
-
-test('isString returns true only for string primitives', () => {
-    assert.strictEqual(isString('x'), true);
-    assert.strictEqual(isString(''), true);
-    assert.strictEqual(isString(undefined), false);
-});
+import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
 
 test('syncMethodNames maps each async name to its synchronous counterpart', () => {
     assert.deepStrictEqual(syncMethodNames, {

--- a/source/dependency-scanner/host-method-binding.ts
+++ b/source/dependency-scanner/host-method-binding.ts
@@ -6,14 +6,6 @@ export const syncMethodNames = {
     readFile: 'readFileSync'
 } as const;
 
-export function isBoolean(value: unknown): value is boolean {
-    return typeof value === 'boolean';
-}
-
-export function isString(value: unknown): value is string {
-    return typeof value === 'string';
-}
-
 export function bindRequiredMethod<Result>(
     object: FileSystemHost,
     methodName: string,

--- a/source/dependency-scanner/typescript-file-host.ts
+++ b/source/dependency-scanner/typescript-file-host.ts
@@ -1,7 +1,8 @@
 import type { FileSystemHost } from 'ts-morph';
+import { isBoolean } from 'remeda';
 import type { MainPackageJson } from '../config/package-json.ts';
 import { isDeclarationFile, isTypesRootFolder } from './file-host-predicates.ts';
-import { bindRequiredMethod, isBoolean, syncMethodNames } from './host-method-binding.ts';
+import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
 import { createVirtualPackageJsonHost } from './virtual-package-json-host.ts';
 
 export type FileSystemAdaptersDependencies = {

--- a/source/dependency-scanner/virtual-package-json-host.ts
+++ b/source/dependency-scanner/virtual-package-json-host.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import type { FileSystemHost } from 'ts-morph';
+import { isBoolean, isString } from 'remeda';
 import type { MainPackageJson } from '../config/package-json.ts';
-import { bindRequiredMethod, isBoolean, isString, syncMethodNames } from './host-method-binding.ts';
+import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
 
 const packageJsonIndentationSpaces = 2;
 

--- a/source/packtory/stages/package-resolution-stage.ts
+++ b/source/packtory/stages/package-resolution-stage.ts
@@ -1,3 +1,4 @@
+import { mapValues } from 'remeda';
 import type { Result } from 'true-myth';
 import type { ValidConfigWithoutRegistryResult } from '../../config/validation.ts';
 import { resolveRootsAndSurface } from '../../resource-resolver/resource-resolve-options.ts';
@@ -39,11 +40,9 @@ function emitInputsResolved(
     const normalizedInputs = resolveRootsAndSurface(options);
     dependencies.progressBroadcaster.provider.emit('inputsResolved', {
         packageName: options.name,
-        roots: Object.fromEntries(
-            Object.entries(normalizedInputs.roots).map(([rootId, root]) => {
-                return [rootId, root.js];
-            })
-        ),
+        roots: mapValues(normalizedInputs.roots, (root) => {
+            return root.js;
+        }),
         sourceFileCount: 0,
         siblingVersions: {}
     });

--- a/source/report/aggregator/report-event-handlers.ts
+++ b/source/report/aggregator/report-event-handlers.ts
@@ -1,3 +1,4 @@
+import { sumBy } from 'remeda';
 import type { EliminatedSourceFile, ProgressBroadcastConsumer } from '../../progress/progress-broadcaster.ts';
 import { createEmptyMutablePackageReport, type MutablePackageReport } from './report-types.ts';
 
@@ -89,9 +90,9 @@ function registerOutcomeHandlers(state: AggregatorState, subscribe: Subscribe): 
         };
     });
     subscribe('artifactsCollected', (payload) => {
-        const totalBytes = payload.entries.reduce((sum, item) => {
-            return sum + item.sizeBytes;
-        }, 0);
+        const totalBytes = sumBy(payload.entries, (item) => {
+            return item.sizeBytes;
+        });
         getOrCreate(state, payload.packageName).outputs = {
             tarball: { entries: payload.entries, totalBytes }
         };

--- a/source/version-manager/manifest/builder.property.ts
+++ b/source/version-manager/manifest/builder.property.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
 import { test } from 'mocha';
+import { hasProp } from 'remeda';
 import type { AdditionalPackageJsonAttributes } from '../../config/package-json.ts';
 import type { VersionedBundle } from '../versioned-bundle.ts';
 import { buildPackageManifest } from './builder.ts';
@@ -50,7 +51,7 @@ const bundleArbitrary: fc.Arbitrary<VersionedBundle> = fc
     })
     .filter((bundle) => {
         return Object.keys(bundle.dependencies).every((name) => {
-            return !Object.hasOwn(bundle.peerDependencies, name);
+            return !hasProp(bundle.peerDependencies, name);
         });
     })
     .map((bundle) => {
@@ -143,10 +144,10 @@ test('buildPackageManifest() preserves additional attributes without leaking dep
             });
 
             Object.keys(bundle.dependencies).forEach((dependencyName) => {
-                assert.strictEqual(Object.hasOwn(manifest.peerDependencies ?? {}, dependencyName), false);
+                assert.strictEqual(hasProp(manifest.peerDependencies ?? {}, dependencyName), false);
             });
             Object.keys(bundle.peerDependencies).forEach((dependencyName) => {
-                assert.strictEqual(Object.hasOwn(manifest.dependencies ?? {}, dependencyName), false);
+                assert.strictEqual(hasProp(manifest.dependencies ?? {}, dependencyName), false);
             });
         })
     );

--- a/source/version-manager/manifest/builder.ts
+++ b/source/version-manager/manifest/builder.ts
@@ -1,12 +1,12 @@
 import type { PackageJson } from 'type-fest';
-import { isEmpty } from 'remeda';
+import { hasProp, isDefined, isEmpty, pickBy } from 'remeda';
 import type { VersionedBundle, BundlePackageJson } from '../versioned-bundle.ts';
 
 type SideEffectsValue = string[] | false;
 
 // eslint-disable-next-line sonarjs/function-return-type -- distinct semantics for emit-false, emit-array, and omit
 function resolveSideEffectsValue(bundle: VersionedBundle): SideEffectsValue | undefined {
-    if (Object.hasOwn(bundle.additionalAttributes, 'sideEffects')) {
+    if (hasProp(bundle.additionalAttributes, 'sideEffects')) {
         return undefined;
     }
     const field = bundle.sideEffectsField;
@@ -42,11 +42,7 @@ function buildImportsEntry(
 function toPackageJsonBinTargets(
     binField: Exclude<NonNullable<VersionedBundle['binField']>, string>
 ): Readonly<Record<string, string>> {
-    return Object.fromEntries(
-        Object.entries(binField).flatMap(([name, target]) => {
-            return target === undefined ? [] : [[name, target]];
-        })
-    );
+    return pickBy(binField, isDefined);
 }
 
 function buildBinEntry(binField: VersionedBundle['binField']): Record<PropertyKey, never> | { bin: PackageJsonBin } {

--- a/source/version-manager/manifest/serialize.ts
+++ b/source/version-manager/manifest/serialize.ts
@@ -1,16 +1,9 @@
+import { isArray, isPlainObject } from 'remeda';
 import type { PackageJson } from 'type-fest';
 import { compareValues } from './sort-values.ts';
 
 const indentationSize = 4;
 type RecordEntry = readonly [string, unknown];
-
-function isArray(value: unknown): value is unknown[] {
-    return Array.isArray(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
 
 function assertNoCircularStructures(value: unknown): void {
     const visitedObjects = new Set<unknown>();
@@ -41,7 +34,7 @@ function deepSortValue(value: unknown, path: readonly string[] = []): unknown {
         return shouldPreserveArrayOrder(path) ? mapped : mapped.toSorted(compareValues);
     }
 
-    if (isRecord(value)) {
+    if (isPlainObject(value)) {
         return Object.fromEntries(
             Object.entries(value)
                 .map<RecordEntry>(([key, nestedValue]) => {


### PR DESCRIPTION
Migrate hand-rolled type guards, dedup/sum/group reductions, and fromEntries round-trips to remeda 2.34.1 functions:

- Object.hasOwn / custom hasOwn -> hasProp
- Custom isRecord / isPlainObject duplicates -> isPlainObject
- Custom isString / isBoolean / isDefined / isArray -> remeda equivalents
- Array.from(new Set(...)) -> unique
- Hand-written reduce sum -> sumBy
- fromEntries+flatMap(value-undefined-filter) -> pickBy
- fromEntries+entries+map -> mapValues
- Manual Map<string, T[]> bucket loop -> groupBy

Where remeda lacks an exact equivalent (instanceof Object semantics, loose function invocation), the local helper is retained.