### PR TITLE
Wrap every test file in a top-level suite

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,12 @@ export default [
     },
     {
         ...mochaConfig,
-        files: ['**/*.test.ts', '**/*.property.ts', 'integration-tests/**/*.ts']
+        files: ['**/*.test.ts', '**/*.property.ts', 'integration-tests/**/*.ts'],
+        rules: {
+            ...mochaConfig.rules,
+            // mirrors upcoming @enormora/eslint-config-mocha default; remove once that release lands
+            'mocha/no-setup-in-describe': 'off'
+        }
     },
     {
         ...nodeConfigFileConfig,
@@ -101,11 +106,6 @@ export default [
             'sonarjs/no-alphabetical-sort': 'off',
             'unicorn/no-array-reverse': 'off',
             'unicorn/no-array-sort': 'off'
-        },
-        settings: {
-            mocha: {
-                interface: 'TDD'
-            }
         }
     },
     {

--- a/integration-tests/package-processor/additional-files.test.ts
+++ b/integration-tests/package-processor/additional-files.test.ts
@@ -1,102 +1,104 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis, emptyAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('includes additional files in the bundle contents', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/additional-files');
-    const additionalFileSourcePath = path.join(fixture, 'docs/additional-info.txt');
+suite('additional-files', function () {
+    test('includes additional files in the bundle contents', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/additional-files');
+        const additionalFileSourcePath = path.join(fixture, 'docs/additional-info.txt');
 
-    const result = await packageProcessor.build({
-        name: 'additional-files-package',
-        version: '1.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [
-            {
-                sourceFilePath: additionalFileSourcePath,
-                targetFilePath: 'docs/additional-info.txt'
-            }
-        ],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: []
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'additional-files-package',
-                sideEffects: false,
-                type: 'module',
-                version: '1.0.0'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
+        const result = await packageProcessor.build({
+            name: 'additional-files-package',
+            version: '1.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [
                 {
-                    directDependencies: new Set([path.join(fixture, 'src/greeting.js')]),
-                    fileDescription: {
-                        content:
-                            "import { greeting } from './greeting.js';\n\nexport function run() {\n    return greeting();\n}\n",
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        isExecutable: false,
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('greeting', 'run')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export function greeting() {\n    return 'hello from src';\n}\n",
-                        sourceFilePath: path.join(fixture, 'src/greeting.js'),
-                        isExecutable: false,
-                        targetFilePath: 'greeting.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('greeting')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: 'This file should be included in the bundle.\n',
-                        sourceFilePath: additionalFileSourcePath,
-                        isExecutable: false,
-                        targetFilePath: 'docs/additional-info.txt'
-                    },
-                    isExplicitlyIncluded: true,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
+                    sourceFilePath: additionalFileSourcePath,
+                    targetFilePath: 'docs/additional-info.txt'
                 }
             ],
-            dependencies: {},
-            mainFile: {
-                content:
-                    "import { greeting } from './greeting.js';\n\nexport function run() {\n    return greeting();\n}\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
-            name: 'additional-files-package',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            version: '1.0.0',
-            typesMainFile: undefined
-        })
-    );
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: []
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'additional-files-package',
+                    sideEffects: false,
+                    type: 'module',
+                    version: '1.0.0'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/greeting.js')]),
+                        fileDescription: {
+                            content:
+                                "import { greeting } from './greeting.js';\n\nexport function run() {\n    return greeting();\n}\n",
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            isExecutable: false,
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('greeting', 'run')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export function greeting() {\n    return 'hello from src';\n}\n",
+                            sourceFilePath: path.join(fixture, 'src/greeting.js'),
+                            isExecutable: false,
+                            targetFilePath: 'greeting.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('greeting')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: 'This file should be included in the bundle.\n',
+                            sourceFilePath: additionalFileSourcePath,
+                            isExecutable: false,
+                            targetFilePath: 'docs/additional-info.txt'
+                        },
+                        isExplicitlyIncluded: true,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content:
+                        "import { greeting } from './greeting.js';\n\nexport function run() {\n    return greeting();\n}\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'additional-files-package',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                version: '1.0.0',
+                typesMainFile: undefined
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/cyclic-dependencies.test.ts
+++ b/integration-tests/package-processor/cyclic-dependencies.test.ts
@@ -1,96 +1,98 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('correctly detects cyclic dependencies and avoids an infinite loop', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm-cyclic');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: false,
-                version: '42.0.0',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/bar.js')]),
-                    fileDescription: {
-                        content:
-                            "import { bar } from './bar';\n\nexport const foo = 'foo';\nexport const foo2 = bar;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar', 'foo', 'foo2')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content:
-                            "import { foo } from './foo';\n\nexport const bar = 'bar';\nexport const bar2 = foo;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/bar.js'),
-                        targetFilePath: 'bar.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo', 'bar', 'bar2')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { foo } from './foo';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
+suite('cyclic-dependencies', function () {
+    test('correctly detects cyclic dependencies and avoids an infinite loop', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm-cyclic');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    version: '42.0.0',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/bar.js')]),
+                        fileDescription: {
+                            content:
+                                "import { bar } from './bar';\n\nexport const foo = 'foo';\nexport const foo2 = bar;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar', 'foo', 'foo2')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content:
+                                "import { foo } from './foo';\n\nexport const bar = 'bar';\nexport const bar2 = foo;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.js'),
+                            targetFilePath: 'bar.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo', 'bar', 'bar2')
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { foo } from './foo';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/declaration-files.test.ts
+++ b/integration-tests/package-processor/declaration-files.test.ts
@@ -1,140 +1,142 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('adds declaration files correctly to the bundle', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-and-d-ts');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: {
-            main: {
-                js: path.join(fixture, 'src/entry.js'),
-                declarationFile: path.join(fixture, 'src/entry.d.ts')
-            }
-        },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: false,
-                version: '42.0.0',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './foo.js';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/bar.js')]),
-                    fileDescription: {
-                        content: "import { bar } from './bar.js';\nexport const foo = 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar', 'foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export const bar = 'bar';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/bar.js'),
-                        targetFilePath: 'bar.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.d.ts')]),
-                    fileDescription: {
-                        content: "export declare const foo: import('./foo.js').Foo;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
-                        targetFilePath: 'entry.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/baz.d.ts')]),
-                    fileDescription: {
-                        content: "import { Baz } from './baz.js';\nexport type Foo = string;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
-                        targetFilePath: 'foo.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('Baz', 'Foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: 'export type Baz = number;\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/baz.d.ts'),
-                        targetFilePath: 'baz.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('Baz')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { foo } from './foo.js';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
+suite('declaration-files', function () {
+    test('adds declaration files correctly to the bundle', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-and-d-ts');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: {
-                content: "export declare const foo: import('./foo.js').Foo;\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
-                targetFilePath: 'entry.d.ts'
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: {
+                main: {
+                    js: path.join(fixture, 'src/entry.js'),
+                    declarationFile: path.join(fixture, 'src/entry.d.ts')
+                }
             },
-            version: '42.0.0'
-        })
-    );
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    version: '42.0.0',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './foo.js';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/bar.js')]),
+                        fileDescription: {
+                            content: "import { bar } from './bar.js';\nexport const foo = 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar', 'foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export const bar = 'bar';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.js'),
+                            targetFilePath: 'bar.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.d.ts')]),
+                        fileDescription: {
+                            content: "export declare const foo: import('./foo.js').Foo;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
+                            targetFilePath: 'entry.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/baz.d.ts')]),
+                        fileDescription: {
+                            content: "import { Baz } from './baz.js';\nexport type Foo = string;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
+                            targetFilePath: 'foo.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('Baz', 'Foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: 'export type Baz = number;\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/baz.d.ts'),
+                            targetFilePath: 'baz.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('Baz')
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { foo } from './foo.js';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: {
+                    content: "export declare const foo: import('./foo.js').Foo;\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
+                    targetFilePath: 'entry.d.ts'
+                },
+                version: '42.0.0'
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/module-types.test.ts
+++ b/integration-tests/package-processor/module-types.test.ts
@@ -1,16 +1,38 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis, emptyAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('rejects packages whose mainPackageJson.type is not "module"', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-cjs');
+suite('module-types', function () {
+    test('rejects packages whose mainPackageJson.type is not "module"', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-cjs');
 
-    try {
-        await packageProcessor.build({
+        try {
+            await packageProcessor.build({
+                name: 'the-package-name',
+                version: '42.0.0',
+                sourcesFolder: path.join(fixture, 'src'),
+                roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+                mainPackageJson: await loadPackageJson(fixture),
+                includeSourceMapFiles: false,
+                additionalFiles: [],
+                bundleDependencies: [],
+                bundlePeerDependencies: [],
+                additionalPackageJsonAttributes: {},
+                allowMutableSpecifiers: []
+            });
+            assert.fail('Expected packageProcessor.build() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'mainPackageJson.type must be "module"');
+        }
+    });
+
+    test('correctly resolves ESM files', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
             version: '42.0.0',
             sourcesFolder: path.join(fixture, 'src'),
@@ -21,239 +43,219 @@ test('rejects packages whose mainPackageJson.type is not "module"', async () => 
             bundleDependencies: [],
             bundlePeerDependencies: [],
             additionalPackageJsonAttributes: {},
-            allowMutableSpecifiers: []
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
         });
-        assert.fail('Expected packageProcessor.build() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'mainPackageJson.type must be "module"');
-    }
-});
 
-test('correctly resolves ESM files', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: false,
-                version: '42.0.0',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    version: '42.0.0',
+                    type: 'module'
                 },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export const foo = 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { foo } from './foo';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
-            name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
-});
-
-test('correctly resolves ESM files with export from statements', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm-export-from');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: false,
-                version: '42.0.0',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "export * from './foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
                 },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export const foo = 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
                     },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "export * from './foo';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
-            name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
-});
-
-test('correctly resolves ESM files with plain import statements', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm-plain-import');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: ['./foo.js'],
-                version: '42.0.0',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import './foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "console.log('foo');\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: {
-                        survivingBindings: new Set<string>(),
-                        sideEffectStatements: [{ line: 1, kind: 'expression statement' }],
-                        sideEffectImports: new Set<string>()
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export const foo = 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
                     }
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import './foo';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { foo } from './foo';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
+
+    test('correctly resolves ESM files with export from statements', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm-export-from');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: ['./foo.js'],
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    version: '42.0.0',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "export * from './foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export const foo = 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "export * from './foo';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
+
+    test('correctly resolves ESM files with plain import statements', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-esm-plain-import');
+        const result = await packageProcessor.build({
+            name: 'the-package-name',
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: ['./foo.js'],
+                    version: '42.0.0',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import './foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "console.log('foo');\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: {
+                            survivingBindings: new Set<string>(),
+                            sideEffectStatements: [{ line: 1, kind: 'expression statement' }],
+                            sideEffectImports: new Set<string>()
+                        }
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import './foo';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: ['./foo.js'],
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/multiple-packages.test.ts
+++ b/integration-tests/package-processor/multiple-packages.test.ts
@@ -1,404 +1,406 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis, emptyAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('bundles and substitutes multiple packages correctly', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/multiple-packages-with-substitution');
-    const firstBundle = await packageProcessor.build({
-        name: 'first',
-        version: '1.2.3',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: {
-            main: {
-                js: path.join(fixture, 'src/entry1.js'),
-                declarationFile: path.join(fixture, 'src/entry1.d.ts')
-            }
-        },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: true,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-    const secondBundle = await packageProcessor.build({
-        name: 'second',
-        version: '2.3.4',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: {
-            main: {
-                js: path.join(fixture, 'src/entry2.js'),
-                declarationFile: path.join(fixture, 'src/entry2.d.ts')
-            }
-        },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: true,
-        bundleDependencies: [firstBundle],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        additionalFiles: [],
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-    const thirdBundle = await packageProcessor.build({
-        name: 'third',
-        version: '3.4.5',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: {
-            main: {
-                js: path.join(fixture, 'src/entry3.js'),
-                declarationFile: path.join(fixture, 'src/entry3.d.ts')
-            }
-        },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: true,
-        bundleDependencies: [firstBundle],
-        bundlePeerDependencies: [secondBundle],
-        additionalPackageJsonAttributes: {},
-        additionalFiles: [],
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        firstBundle,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'first',
-                sideEffects: false,
-                version: '1.2.3',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([
-                        path.join(fixture, 'src/qux.js'),
-                        path.join(fixture, 'src/entry1.js.map')
-                    ]),
-                    fileDescription: {
-                        content: "import { qux } from './qux.js';\n//# sourceMappingURL=entry1.js.map\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry1.js'),
-                        targetFilePath: 'entry1.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('qux')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/qux.js.map')]),
-                    fileDescription: {
-                        content: "export const qux = 'qux';\n//# sourceMappingURL=qux.js.map\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/qux.js'),
-                        targetFilePath: 'qux.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('qux')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry1.js.map'),
-                        targetFilePath: 'entry1.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/qux.js.map'),
-                        targetFilePath: 'qux.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.d.ts')]),
-                    fileDescription: {
-                        content: "export declare const foo: import('./foo.js').Foo;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry1.d.ts'),
-                        targetFilePath: 'entry1.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/baz.d.ts')]),
-                    fileDescription: {
-                        content: "import { Baz } from './baz.js';\nexport type Foo = string;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
-                        targetFilePath: 'foo.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('Baz', 'Foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: 'export type Baz = number;\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/baz.d.ts'),
-                        targetFilePath: 'baz.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('Baz')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { qux } from './qux.js';\n//# sourceMappingURL=entry1.js.map\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry1.js'),
-                targetFilePath: 'entry1.js'
-            },
+suite('multiple-packages', function () {
+    test('bundles and substitutes multiple packages correctly', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/multiple-packages-with-substitution');
+        const firstBundle = await packageProcessor.build({
             name: 'first',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: {
-                content: "export declare const foo: import('./foo.js').Foo;\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry1.d.ts'),
-                targetFilePath: 'entry1.d.ts'
-            },
-            version: '1.2.3'
-        })
-    );
-    assert.deepStrictEqual(
-        secondBundle,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                dependencies: { first: '1.2.3' },
-                name: 'second',
-                sideEffects: false,
-                version: '2.3.4',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([
-                        path.join(fixture, 'src/bar.js'),
-                        path.join(fixture, 'src/entry2.js.map')
-                    ]),
-                    fileDescription: {
-                        content: "import { bar } from './bar.js';\n//# sourceMappingURL=entry2.js.map\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry2.js'),
-                        targetFilePath: 'entry2.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/bar.js.map')]),
-                    fileDescription: {
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/bar.js'),
-                        targetFilePath: 'bar.js',
-                        content:
-                            "import { qux } from 'first/qux.js';\nexport const bar = 'bar';\n//# sourceMappingURL=bar.js.map\n"
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: true,
-                    analysis: bindingAnalysis('qux', 'bar')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry2.js.map'),
-                        targetFilePath: 'entry2.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/bar.js.map'),
-                        targetFilePath: 'bar.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry2.d.ts'),
-                        targetFilePath: 'entry2.d.ts',
-                        content: "export declare const foo: import('first/foo.d.ts').Foo;\n"
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: true,
-                    analysis: bindingAnalysis('foo')
+            version: '1.2.3',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: {
+                main: {
+                    js: path.join(fixture, 'src/entry1.js'),
+                    declarationFile: path.join(fixture, 'src/entry1.d.ts')
                 }
-            ],
-            dependencies: { first: '1.2.3' },
-            mainFile: {
-                content: "import { bar } from './bar.js';\n//# sourceMappingURL=entry2.js.map\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry2.js'),
-                targetFilePath: 'entry2.js'
             },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: true,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+        const secondBundle = await packageProcessor.build({
             name: 'second',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: {
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry2.d.ts'),
-                targetFilePath: 'entry2.d.ts',
-                content: "export declare const foo: import('./foo.js').Foo;\n"
-            },
-            version: '2.3.4'
-        })
-    );
-    assert.deepStrictEqual(
-        thirdBundle,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                dependencies: { first: '1.2.3' },
-                peerDependencies: { second: '2.3.4' },
-                name: 'third',
-                sideEffects: false,
-                version: '3.4.5',
-                type: 'module'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([
-                        path.join(fixture, 'src/foo.js'),
-                        path.join(fixture, 'src/entry3.js.map')
-                    ]),
-                    fileDescription: {
-                        content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry3.js.map\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry3.js'),
-                        targetFilePath: 'entry3.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js.map')]),
-                    fileDescription: {
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js',
-                        content:
-                            "import { bar } from 'second/bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n"
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: true,
-                    analysis: bindingAnalysis('bar', 'foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry3.js.map'),
-                        targetFilePath: 'entry3.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js.map'),
-                        targetFilePath: 'foo.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry3.d.ts'),
-                        targetFilePath: 'entry3.d.ts',
-                        content: "export declare const foo: import('first/foo.d.ts').Foo;\n"
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: true,
-                    analysis: bindingAnalysis('foo')
+            version: '2.3.4',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: {
+                main: {
+                    js: path.join(fixture, 'src/entry2.js'),
+                    declarationFile: path.join(fixture, 'src/entry2.d.ts')
                 }
-            ],
-            dependencies: { first: '1.2.3' },
-            mainFile: {
-                content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry3.js.map\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry3.js'),
-                targetFilePath: 'entry3.js'
             },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: true,
+            bundleDependencies: [firstBundle],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            additionalFiles: [],
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+        const thirdBundle = await packageProcessor.build({
             name: 'third',
-            packageType: 'module',
-            peerDependencies: { second: '2.3.4' },
-            sideEffectsField: false,
-            typesMainFile: {
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry3.d.ts'),
-                targetFilePath: 'entry3.d.ts',
-                content: "export declare const foo: import('./foo.js').Foo;\n"
+            version: '3.4.5',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: {
+                main: {
+                    js: path.join(fixture, 'src/entry3.js'),
+                    declarationFile: path.join(fixture, 'src/entry3.d.ts')
+                }
             },
-            version: '3.4.5'
-        })
-    );
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: true,
+            bundleDependencies: [firstBundle],
+            bundlePeerDependencies: [secondBundle],
+            additionalPackageJsonAttributes: {},
+            additionalFiles: [],
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            firstBundle,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'first',
+                    sideEffects: false,
+                    version: '1.2.3',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([
+                            path.join(fixture, 'src/qux.js'),
+                            path.join(fixture, 'src/entry1.js.map')
+                        ]),
+                        fileDescription: {
+                            content: "import { qux } from './qux.js';\n//# sourceMappingURL=entry1.js.map\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry1.js'),
+                            targetFilePath: 'entry1.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('qux')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/qux.js.map')]),
+                        fileDescription: {
+                            content: "export const qux = 'qux';\n//# sourceMappingURL=qux.js.map\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/qux.js'),
+                            targetFilePath: 'qux.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('qux')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry1.js.map'),
+                            targetFilePath: 'entry1.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/qux.js.map'),
+                            targetFilePath: 'qux.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.d.ts')]),
+                        fileDescription: {
+                            content: "export declare const foo: import('./foo.js').Foo;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry1.d.ts'),
+                            targetFilePath: 'entry1.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/baz.d.ts')]),
+                        fileDescription: {
+                            content: "import { Baz } from './baz.js';\nexport type Foo = string;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
+                            targetFilePath: 'foo.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('Baz', 'Foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: 'export type Baz = number;\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/baz.d.ts'),
+                            targetFilePath: 'baz.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('Baz')
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { qux } from './qux.js';\n//# sourceMappingURL=entry1.js.map\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry1.js'),
+                    targetFilePath: 'entry1.js'
+                },
+                name: 'first',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: {
+                    content: "export declare const foo: import('./foo.js').Foo;\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry1.d.ts'),
+                    targetFilePath: 'entry1.d.ts'
+                },
+                version: '1.2.3'
+            })
+        );
+        assert.deepStrictEqual(
+            secondBundle,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    dependencies: { first: '1.2.3' },
+                    name: 'second',
+                    sideEffects: false,
+                    version: '2.3.4',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([
+                            path.join(fixture, 'src/bar.js'),
+                            path.join(fixture, 'src/entry2.js.map')
+                        ]),
+                        fileDescription: {
+                            content: "import { bar } from './bar.js';\n//# sourceMappingURL=entry2.js.map\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry2.js'),
+                            targetFilePath: 'entry2.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/bar.js.map')]),
+                        fileDescription: {
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.js'),
+                            targetFilePath: 'bar.js',
+                            content:
+                                "import { qux } from 'first/qux.js';\nexport const bar = 'bar';\n//# sourceMappingURL=bar.js.map\n"
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: true,
+                        analysis: bindingAnalysis('qux', 'bar')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry2.js.map'),
+                            targetFilePath: 'entry2.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.js.map'),
+                            targetFilePath: 'bar.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry2.d.ts'),
+                            targetFilePath: 'entry2.d.ts',
+                            content: "export declare const foo: import('first/foo.d.ts').Foo;\n"
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: true,
+                        analysis: bindingAnalysis('foo')
+                    }
+                ],
+                dependencies: { first: '1.2.3' },
+                mainFile: {
+                    content: "import { bar } from './bar.js';\n//# sourceMappingURL=entry2.js.map\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry2.js'),
+                    targetFilePath: 'entry2.js'
+                },
+                name: 'second',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: {
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry2.d.ts'),
+                    targetFilePath: 'entry2.d.ts',
+                    content: "export declare const foo: import('./foo.js').Foo;\n"
+                },
+                version: '2.3.4'
+            })
+        );
+        assert.deepStrictEqual(
+            thirdBundle,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    dependencies: { first: '1.2.3' },
+                    peerDependencies: { second: '2.3.4' },
+                    name: 'third',
+                    sideEffects: false,
+                    version: '3.4.5',
+                    type: 'module'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([
+                            path.join(fixture, 'src/foo.js'),
+                            path.join(fixture, 'src/entry3.js.map')
+                        ]),
+                        fileDescription: {
+                            content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry3.js.map\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry3.js'),
+                            targetFilePath: 'entry3.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js.map')]),
+                        fileDescription: {
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js',
+                            content:
+                                "import { bar } from 'second/bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n"
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: true,
+                        analysis: bindingAnalysis('bar', 'foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry3.js.map'),
+                            targetFilePath: 'entry3.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js.map'),
+                            targetFilePath: 'foo.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry3.d.ts'),
+                            targetFilePath: 'entry3.d.ts',
+                            content: "export declare const foo: import('first/foo.d.ts').Foo;\n"
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: true,
+                        analysis: bindingAnalysis('foo')
+                    }
+                ],
+                dependencies: { first: '1.2.3' },
+                mainFile: {
+                    content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry3.js.map\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry3.js'),
+                    targetFilePath: 'entry3.js'
+                },
+                name: 'third',
+                packageType: 'module',
+                peerDependencies: { second: '2.3.4' },
+                sideEffectsField: false,
+                typesMainFile: {
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry3.d.ts'),
+                    targetFilePath: 'entry3.d.ts',
+                    content: "export declare const foo: import('./foo.js').Foo;\n"
+                },
+                version: '3.4.5'
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/nested-folders.test.ts
+++ b/integration-tests/package-processor/nested-folders.test.ts
@@ -1,106 +1,108 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('resolves files in a nested folder structure correctly', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/nested-folders');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: false,
-                type: 'module',
-                version: '42.0.0'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/nested/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './nested/foo.js';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/nested/deep/bar.js')]),
-                    fileDescription: {
-                        content: "import { bar } from './deep/bar.js';\n\nexport const foo = 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/nested/foo.js'),
-                        targetFilePath: 'nested/foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar', 'foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/nested/deep/folder/baz.js')]),
-                    fileDescription: {
-                        content: "import { baz } from './folder/baz.js';\n\nexport const bar = 'bar';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/nested/deep/bar.js'),
-                        targetFilePath: 'nested/deep/bar.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('baz', 'bar')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export const baz = 'baz';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/nested/deep/folder/baz.js'),
-                        targetFilePath: 'nested/deep/folder/baz.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('baz')
-                }
-            ],
-            mainFile: {
-                content: "import { foo } from './nested/foo.js';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
-            dependencies: {},
-            packageType: 'module',
-            peerDependencies: {},
+suite('nested-folders', function () {
+    test('resolves files in a nested folder structure correctly', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/nested-folders');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    type: 'module',
+                    version: '42.0.0'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/nested/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './nested/foo.js';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/nested/deep/bar.js')]),
+                        fileDescription: {
+                            content: "import { bar } from './deep/bar.js';\n\nexport const foo = 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/nested/foo.js'),
+                            targetFilePath: 'nested/foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar', 'foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/nested/deep/folder/baz.js')]),
+                        fileDescription: {
+                            content: "import { baz } from './folder/baz.js';\n\nexport const bar = 'bar';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/nested/deep/bar.js'),
+                            targetFilePath: 'nested/deep/bar.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('baz', 'bar')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export const baz = 'baz';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/nested/deep/folder/baz.js'),
+                            targetFilePath: 'nested/deep/folder/baz.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('baz')
+                    }
+                ],
+                mainFile: {
+                    content: "import { foo } from './nested/foo.js';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                dependencies: {},
+                packageType: 'module',
+                peerDependencies: {},
+                name: 'the-package-name',
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/no-superfluous-files.test.ts
+++ b/integration-tests/package-processor/no-superfluous-files.test.ts
@@ -1,82 +1,84 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('ignores superfluous local files and reference node modules', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/superfluous-files');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                name: 'the-package-name',
-                sideEffects: false,
-                type: 'module',
-                version: '42.0.0'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './foo';\n",
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        isExecutable: false,
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export const foo = 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { foo } from './foo';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
+suite('no-superfluous-files', function () {
+    test('ignores superfluous local files and reference node modules', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/superfluous-files');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
             version: '42.0.0',
-            typesMainFile: undefined
-        })
-    );
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    type: 'module',
+                    version: '42.0.0'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './foo';\n",
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            isExecutable: false,
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export const foo = 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { foo } from './foo';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                version: '42.0.0',
+                typesMainFile: undefined
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/package-json-imports.test.ts
+++ b/integration-tests/package-processor/package-json-imports.test.ts
@@ -1,68 +1,70 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 
-test('resolves package.json#imports from mainPackageJson and emits only surviving non-substituted entries', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/package-json-imports');
-    const sourcesFolder = path.join(fixture, 'src');
-    const mainPackageJson = {
-        type: 'module' as const,
-        imports: {
-            '#shared': './shared.js',
+suite('package-json-imports', function () {
+    test('resolves package.json#imports from mainPackageJson and emits only surviving non-substituted entries', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/package-json-imports');
+        const sourcesFolder = path.join(fixture, 'src');
+        const mainPackageJson = {
+            type: 'module' as const,
+            imports: {
+                '#shared': './shared.js',
+                '#local': './local.js'
+            }
+        };
+
+        const firstBundle = await packageProcessor.build({
+            name: 'first',
+            version: '1.2.3',
+            sourcesFolder,
+            roots: { main: { js: path.join(sourcesFolder, 'entry-first.js') } },
+            mainPackageJson,
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        const secondBundle = await packageProcessor.build({
+            name: 'second',
+            version: '2.3.4',
+            sourcesFolder,
+            roots: { main: { js: path.join(sourcesFolder, 'entry-second.js') } },
+            mainPackageJson,
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [firstBundle],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(firstBundle.packageJson.imports, {
+            '#shared': './shared.js'
+        });
+        assert.deepStrictEqual(secondBundle.packageJson.imports, {
             '#local': './local.js'
+        });
+        assert.deepStrictEqual(secondBundle.packageJson.dependencies, {
+            first: '1.2.3'
+        });
+
+        const rewrittenEntry = secondBundle.contents.find((resource) => {
+            return resource.fileDescription.targetFilePath === 'entry-second.js';
+        });
+        if (rewrittenEntry === undefined) {
+            assert.fail('Expected entry-second.js to be present in the second bundle');
         }
-    };
 
-    const firstBundle = await packageProcessor.build({
-        name: 'first',
-        version: '1.2.3',
-        sourcesFolder,
-        roots: { main: { js: path.join(sourcesFolder, 'entry-first.js') } },
-        mainPackageJson,
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
+        assert.strictEqual(
+            rewrittenEntry.fileDescription.content,
+            "export { shared } from 'first/shared.js';\nexport { local } from '#local';\n"
+        );
     });
-
-    const secondBundle = await packageProcessor.build({
-        name: 'second',
-        version: '2.3.4',
-        sourcesFolder,
-        roots: { main: { js: path.join(sourcesFolder, 'entry-second.js') } },
-        mainPackageJson,
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [firstBundle],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(firstBundle.packageJson.imports, {
-        '#shared': './shared.js'
-    });
-    assert.deepStrictEqual(secondBundle.packageJson.imports, {
-        '#local': './local.js'
-    });
-    assert.deepStrictEqual(secondBundle.packageJson.dependencies, {
-        first: '1.2.3'
-    });
-
-    const rewrittenEntry = secondBundle.contents.find((resource) => {
-        return resource.fileDescription.targetFilePath === 'entry-second.js';
-    });
-    if (rewrittenEntry === undefined) {
-        assert.fail('Expected entry-second.js to be present in the second bundle');
-    }
-
-    assert.strictEqual(
-        rewrittenEntry.fileDescription.content,
-        "export { shared } from 'first/shared.js';\nexport { local } from '#local';\n"
-    );
 });

--- a/integration-tests/package-processor/package-types.test.ts
+++ b/integration-tests/package-processor/package-types.test.ts
@@ -1,167 +1,169 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('includes all required local files and references correct node modules but ignores builtin modules', async () => {
-    const fixture = path.join(
-        process.cwd(),
-        'integration-tests/fixtures/with-local-builtin-and-node-module-dependencies'
-    );
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
+suite('package-types', function () {
+    test('includes all required local files and references correct node modules but ignores builtin modules', async function () {
+        const fixture = path.join(
+            process.cwd(),
+            'integration-tests/fixtures/with-local-builtin-and-node-module-dependencies'
+        );
+        const result = await packageProcessor.build({
+            name: 'the-package-name',
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    dependencies: { 'example-module': '1.2.3' },
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    type: 'module',
+                    version: '42.0.0'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/bar.js')]),
+                        fileDescription: {
+                            content:
+                                "import { bar } from './bar';\nimport path from 'node:path';\n\nexport const foo = 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar', 'path', 'foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "import { example } from 'example-module';\n\nexport const bar = 'bar';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.js'),
+                            targetFilePath: 'bar.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('example', 'bar')
+                    }
+                ],
+                dependencies: {
+                    'example-module': '1.2.3'
+                },
+                mainFile: {
+                    content: "import { foo } from './foo';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
     });
 
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                dependencies: { 'example-module': '1.2.3' },
-                name: 'the-package-name',
-                sideEffects: false,
-                type: 'module',
-                version: '42.0.0'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/bar.js')]),
-                    fileDescription: {
-                        content:
-                            "import { bar } from './bar';\nimport path from 'node:path';\n\nexport const foo = 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar', 'path', 'foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "import { example } from 'example-module';\n\nexport const bar = 'bar';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/bar.js'),
-                        targetFilePath: 'bar.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('example', 'bar')
-                }
-            ],
-            dependencies: {
-                'example-module': '1.2.3'
-            },
-            mainFile: {
-                content: "import { foo } from './foo';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
+    test('includes peer dependencies correctly', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/with-peer-dependencies');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
-});
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
 
-test('includes peer dependencies correctly', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/with-peer-dependencies');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    peerDependencies: { 'example-module': '1.2.3' },
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    type: 'module',
+                    version: '42.0.0'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "import { example } from 'example-module';\nexport const foo = example;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('example', 'foo')
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { example } from 'example-module';\nexport const foo = example;\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {
+                    'example-module': '1.2.3'
+                },
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
     });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                peerDependencies: { 'example-module': '1.2.3' },
-                name: 'the-package-name',
-                sideEffects: false,
-                type: 'module',
-                version: '42.0.0'
-            },
-            manifestFile: {
-                isExecutable: false,
-                content: '',
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "import { example } from 'example-module';\nexport const foo = example;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('example', 'foo')
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { example } from 'example-module';\nexport const foo = example;\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
-            name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {
-                'example-module': '1.2.3'
-            },
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
 });

--- a/integration-tests/package-processor/source-maps.test.ts
+++ b/integration-tests/package-processor/source-maps.test.ts
@@ -1,127 +1,129 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis, emptyAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('adds map files to the bundle when enabled', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-and-source-maps');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: { main: { js: path.join(fixture, 'src/entry.js') } },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: true,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
-                sideEffects: false,
-                type: 'module',
-                name: 'the-package-name',
-                version: '42.0.0'
-            },
-            manifestFile: {
-                content: '',
-                isExecutable: false,
-                filePath: 'package.json'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([
-                        path.join(fixture, 'src/foo.js'),
-                        path.join(fixture, 'src/entry.js.map')
-                    ]),
-                    fileDescription: {
-                        content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry.js.map\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set([
-                        path.join(fixture, 'src/bar.js'),
-                        path.join(fixture, 'src/foo.js.map')
-                    ]),
-                    fileDescription: {
-                        content:
-                            "import { bar } from './bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar', 'foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js.map'),
-                        targetFilePath: 'entry.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export const bar = 'bar';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/bar.js'),
-                        targetFilePath: 'bar.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('bar')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content:
-                            '{"version":3,"file":"foo.js","sourceRoot":"","sources":["./src/foo.ts"],"names":[],"mappings":""}\n',
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js.map'),
-                        targetFilePath: 'foo.js.map'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: emptyAnalysis
-                }
-            ],
-            dependencies: {},
-            mainFile: {
-                content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry.js.map\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
+suite('source-maps', function () {
+    test('adds map files to the bundle when enabled', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/js-and-source-maps');
+        const result = await packageProcessor.build({
             name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: false,
-            typesMainFile: undefined,
-            version: '42.0.0'
-        })
-    );
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: true,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    sideEffects: false,
+                    type: 'module',
+                    name: 'the-package-name',
+                    version: '42.0.0'
+                },
+                manifestFile: {
+                    content: '',
+                    isExecutable: false,
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([
+                            path.join(fixture, 'src/foo.js'),
+                            path.join(fixture, 'src/entry.js.map')
+                        ]),
+                        fileDescription: {
+                            content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry.js.map\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set([
+                            path.join(fixture, 'src/bar.js'),
+                            path.join(fixture, 'src/foo.js.map')
+                        ]),
+                        fileDescription: {
+                            content:
+                                "import { bar } from './bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar', 'foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js.map'),
+                            targetFilePath: 'entry.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export const bar = 'bar';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.js'),
+                            targetFilePath: 'bar.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content:
+                                '{"version":3,"file":"foo.js","sourceRoot":"","sources":["./src/foo.ts"],"names":[],"mappings":""}\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js.map'),
+                            targetFilePath: 'foo.js.map'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: emptyAnalysis
+                    }
+                ],
+                dependencies: {},
+                mainFile: {
+                    content: "import { foo } from './foo.js';\n//# sourceMappingURL=entry.js.map\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
 });

--- a/integration-tests/package-processor/type-roots.test.ts
+++ b/integration-tests/package-processor/type-roots.test.ts
@@ -1,127 +1,129 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
 import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import { asImplicitExportsBundle } from '../modern-bundle.ts';
 
-test('resolves node_modules dependencies correctly when depending on @types/* packages', async () => {
-    const fixture = path.join(process.cwd(), 'integration-tests/fixtures/type-roots-node-modules');
-    const result = await packageProcessor.build({
-        name: 'the-package-name',
-        version: '42.0.0',
-        sourcesFolder: path.join(fixture, 'src'),
-        roots: {
-            main: {
-                js: path.join(fixture, 'src/entry.js'),
-                declarationFile: path.join(fixture, 'src/entry.d.ts')
-            }
-        },
-        mainPackageJson: await loadPackageJson(fixture),
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: {},
-        allowMutableSpecifiers: [],
-        deadCodeElimination: { enabled: false }
-    });
+suite('type-roots', function () {
+    test('resolves node_modules dependencies correctly when depending on @types/* packages', async function () {
+        const fixture = path.join(process.cwd(), 'integration-tests/fixtures/type-roots-node-modules');
+        const result = await packageProcessor.build({
+            name: 'the-package-name',
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: {
+                main: {
+                    js: path.join(fixture, 'src/entry.js'),
+                    declarationFile: path.join(fixture, 'src/entry.d.ts')
+                }
+            },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
 
-    assert.deepStrictEqual(
-        result,
-        asImplicitExportsBundle({
-            additionalAttributes: {},
-            packageJson: {
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    dependencies: {
+                        foo: '21.0.0',
+                        '@types/foo': '42.0.0'
+                    },
+                    name: 'the-package-name',
+                    sideEffects: ['./foo.js'],
+                    version: '42.0.0',
+                    type: 'module'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
+                        fileDescription: {
+                            content: "import { foo } from './foo.js';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "import { bar } from 'foo';\nexport const foo = bar('foo');\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.js'),
+                            targetFilePath: 'foo.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: {
+                            survivingBindings: new Set(['bar', 'foo']),
+                            sideEffectStatements: [{ line: 2, kind: 'variable initializer' }],
+                            sideEffectImports: new Set<string>()
+                        }
+                    },
+                    {
+                        directDependencies: new Set([path.join(fixture, 'src/foo.d.ts')]),
+                        fileDescription: {
+                            content: "export declare const foo: import('./foo.js').Foo;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
+                            targetFilePath: 'entry.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "export type Bar = string;\nexport type { Foo } from 'foo';\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
+                            targetFilePath: 'foo.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('Bar')
+                    }
+                ],
+                manifestFile: {
+                    content: '',
+                    isExecutable: false,
+                    filePath: 'package.json'
+                },
                 dependencies: {
                     foo: '21.0.0',
                     '@types/foo': '42.0.0'
                 },
+                mainFile: {
+                    content: "import { foo } from './foo.js';\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
                 name: 'the-package-name',
-                sideEffects: ['./foo.js'],
-                version: '42.0.0',
-                type: 'module'
-            },
-            contents: [
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.js')]),
-                    fileDescription: {
-                        content: "import { foo } from './foo.js';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.js'),
-                        targetFilePath: 'entry.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: ['./foo.js'],
+                typesMainFile: {
+                    content: "export declare const foo: import('./foo.js').Foo;\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
+                    targetFilePath: 'entry.d.ts'
                 },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "import { bar } from 'foo';\nexport const foo = bar('foo');\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.js'),
-                        targetFilePath: 'foo.js'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: {
-                        survivingBindings: new Set(['bar', 'foo']),
-                        sideEffectStatements: [{ line: 2, kind: 'variable initializer' }],
-                        sideEffectImports: new Set<string>()
-                    }
-                },
-                {
-                    directDependencies: new Set([path.join(fixture, 'src/foo.d.ts')]),
-                    fileDescription: {
-                        content: "export declare const foo: import('./foo.js').Foo;\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
-                        targetFilePath: 'entry.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('foo')
-                },
-                {
-                    directDependencies: new Set(),
-                    fileDescription: {
-                        content: "export type Bar = string;\nexport type { Foo } from 'foo';\n",
-                        isExecutable: false,
-                        sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
-                        targetFilePath: 'foo.d.ts'
-                    },
-                    isExplicitlyIncluded: false,
-                    isSubstituted: false,
-                    analysis: bindingAnalysis('Bar')
-                }
-            ],
-            manifestFile: {
-                content: '',
-                isExecutable: false,
-                filePath: 'package.json'
-            },
-            dependencies: {
-                foo: '21.0.0',
-                '@types/foo': '42.0.0'
-            },
-            mainFile: {
-                content: "import { foo } from './foo.js';\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.js'),
-                targetFilePath: 'entry.js'
-            },
-            name: 'the-package-name',
-            packageType: 'module',
-            peerDependencies: {},
-            sideEffectsField: ['./foo.js'],
-            typesMainFile: {
-                content: "export declare const foo: import('./foo.js').Foo;\n",
-                isExecutable: false,
-                sourceFilePath: path.join(fixture, 'src/entry.d.ts'),
-                targetFilePath: 'entry.d.ts'
-            },
-            version: '42.0.0'
-        })
-    );
+                version: '42.0.0'
+            })
+        );
+    });
 });

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { resolveAndLinkAll } from '../../source/packages/packtory/packtory.entry-point.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import type { PacktoryConfigWithoutRegistry } from '../../source/config/config.ts';
@@ -33,236 +33,240 @@ async function createBaseConfig(fixturePath: string): Promise<PacktoryConfigWith
     };
 }
 
-test('resolveAndLinkAll() reports duplicated files when the rule is enabled', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const config = {
-        ...baseConfig,
-        checks: { noDuplicatedFiles: { enabled: true } }
-    };
+suite('checks', function () {
+    test('resolveAndLinkAll() reports duplicated files when the rule is enabled', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const config = {
+            ...baseConfig,
+            checks: { noDuplicatedFiles: { enabled: true } }
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because of duplicated files');
-        return;
-    }
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because of duplicated files');
+            return;
+        }
 
-    if (result.error.type === 'checks') {
-        assert.deepStrictEqual(result.error.issues, [
-            [
-                `File "${fixturePath}/src/shared/util.js" has shared declarations across multiple packages:`,
-                '  - "sharedValue" → pkg-a, pkg-b'
-            ].join('\n')
-        ]);
-    } else {
-        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
-});
+        if (result.error.type === 'checks') {
+            assert.deepStrictEqual(result.error.issues, [
+                [
+                    `File "${fixturePath}/src/shared/util.js" has shared declarations across multiple packages:`,
+                    '  - "sharedValue" → pkg-a, pkg-b'
+                ].join('\n')
+            ]);
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
 
-test('resolveAndLinkAll succeeds when checks are disabled', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const config = await createBaseConfig(fixturePath);
+    test('resolveAndLinkAll succeeds when checks are disabled', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const config = await createBaseConfig(fixturePath);
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isOk) {
-        assert.fail('Duplicated file rule should not run when disabled');
-    }
+        if (!result.isOk) {
+            assert.fail('Duplicated file rule should not run when disabled');
+        }
 
-    assert.strictEqual(result.value.length, 2);
-});
+        assert.strictEqual(result.value.length, 2);
+    });
 
-test('resolveAndLinkAll succeeds when the global allowList covers the duplicated file', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const sharedFile = `${fixturePath}/src/shared/util.js`;
-    const config = {
-        ...baseConfig,
-        checks: { noDuplicatedFiles: { enabled: true, allowList: [sharedFile] } }
-    };
+    test('resolveAndLinkAll succeeds when the global allowList covers the duplicated file', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const sharedFile = `${fixturePath}/src/shared/util.js`;
+        const config = {
+            ...baseConfig,
+            checks: { noDuplicatedFiles: { enabled: true, allowList: [sharedFile] } }
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isOk) {
-        assert.fail('Globally allow-listed shared file should not fail checks');
-    }
+        if (!result.isOk) {
+            assert.fail('Globally allow-listed shared file should not fail checks');
+        }
 
-    assert.strictEqual(result.value.length, 2);
-});
+        assert.strictEqual(result.value.length, 2);
+    });
 
-test('resolveAndLinkAll succeeds when every owner consents to the duplicated file', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const sharedFile = `${fixturePath}/src/shared/util.js`;
-    const config = {
-        ...baseConfig,
-        checks: { noDuplicatedFiles: { enabled: true } },
-        packages: baseConfig.packages.map((packageConfig) => {
-            return {
-                ...packageConfig,
-                checks: { noDuplicatedFiles: { allowList: [sharedFile] } }
-            };
-        })
-    };
+    test('resolveAndLinkAll succeeds when every owner consents to the duplicated file', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const sharedFile = `${fixturePath}/src/shared/util.js`;
+        const config = {
+            ...baseConfig,
+            checks: { noDuplicatedFiles: { enabled: true } },
+            packages: baseConfig.packages.map((packageConfig) => {
+                return {
+                    ...packageConfig,
+                    checks: { noDuplicatedFiles: { allowList: [sharedFile] } }
+                };
+            })
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isOk) {
-        assert.fail('Owners that all consent to the shared file should not fail checks');
-    }
+        if (!result.isOk) {
+            assert.fail('Owners that all consent to the shared file should not fail checks');
+        }
 
-    assert.strictEqual(result.value.length, 2);
-});
+        assert.strictEqual(result.value.length, 2);
+    });
 
-test('resolveAndLinkAll reports an external dependency that is only declared in devDependencies', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/with-peer-dependencies');
-    const config: PacktoryConfigWithoutRegistry = {
-        commonPackageSettings: {
-            sourcesFolder: path.join(fixturePath, 'src'),
-            mainPackageJson: {
-                type: 'module',
-                devDependencies: { 'example-module': '1.2.3' }
+    test('resolveAndLinkAll reports an external dependency that is only declared in devDependencies', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/with-peer-dependencies');
+        const config: PacktoryConfigWithoutRegistry = {
+            commonPackageSettings: {
+                sourcesFolder: path.join(fixturePath, 'src'),
+                mainPackageJson: {
+                    type: 'module',
+                    devDependencies: { 'example-module': '1.2.3' }
+                },
+                publishSettings: { access: 'public' }
             },
-            publishSettings: { access: 'public' }
-        },
-        checks: { noDevDependencyImports: { enabled: true } },
-        packages: [
-            {
-                name: 'leaky',
-                roots: { main: { js: path.join(fixturePath, 'src/entry.js') } }
-            }
-        ]
-    };
+            checks: { noDevDependencyImports: { enabled: true } },
+            packages: [
+                {
+                    name: 'leaky',
+                    roots: { main: { js: path.join(fixturePath, 'src/entry.js') } }
+                }
+            ]
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because example-module is dev-only');
-        return;
-    }
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because example-module is dev-only');
+            return;
+        }
 
-    if (result.error.type === 'checks') {
-        assert.deepStrictEqual(result.error.issues, [
-            'Package "leaky" imports "example-module" which is only declared in devDependencies of the main package.json'
-        ]);
-    } else {
-        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
-});
+        if (result.error.type === 'checks') {
+            assert.deepStrictEqual(result.error.issues, [
+                'Package "leaky" imports "example-module" which is only declared in devDependencies of the main package.json'
+            ]);
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
 
-test('resolveAndLinkAll reports a declared bundleDependency that is never imported', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/independent-packages');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const config = {
-        ...baseConfig,
-        checks: { noUnusedBundleDependencies: { enabled: true } },
-        packages: [baseConfig.packages[1]!, { ...baseConfig.packages[0]!, bundleDependencies: ['pkg-b'] }]
-    };
+    test('resolveAndLinkAll reports a declared bundleDependency that is never imported', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/independent-packages');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const config = {
+            ...baseConfig,
+            checks: { noUnusedBundleDependencies: { enabled: true } },
+            packages: [baseConfig.packages[1]!, { ...baseConfig.packages[0]!, bundleDependencies: ['pkg-b'] }]
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because pkg-a does not import from pkg-b');
-        return;
-    }
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because pkg-a does not import from pkg-b');
+            return;
+        }
 
-    if (result.error.type === 'checks') {
-        assert.deepStrictEqual(result.error.issues, ['Unused bundle dependency "pkg-b" declared by package "pkg-a"']);
-    } else {
-        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
-});
+        if (result.error.type === 'checks') {
+            assert.deepStrictEqual(result.error.issues, [
+                'Unused bundle dependency "pkg-b" declared by package "pkg-a"'
+            ]);
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
 
-test('resolveAndLinkAll reports a per-package bundle size override that is exceeded', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const config = {
-        ...baseConfig,
-        checks: { maxBundleSize: { enabled: true, bytes: 10_000 } },
-        packages: [
-            {
-                ...baseConfig.packages[0]!,
-                checks: { maxBundleSize: { bytes: 1 } }
-            },
-            baseConfig.packages[1]!
-        ]
-    };
+    test('resolveAndLinkAll reports a per-package bundle size override that is exceeded', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const config = {
+            ...baseConfig,
+            checks: { maxBundleSize: { enabled: true, bytes: 10_000 } },
+            packages: [
+                {
+                    ...baseConfig.packages[0]!,
+                    checks: { maxBundleSize: { bytes: 1 } }
+                },
+                baseConfig.packages[1]!
+            ]
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because pkg-a exceeds its size override');
-        return;
-    }
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because pkg-a exceeds its size override');
+            return;
+        }
 
-    if (result.error.type === 'checks') {
-        assert.strictEqual(result.error.issues.length, 1);
-        assert.match(
-            result.error.issues[0]!,
-            /^Package "pkg-a" exceeds the maximum bundle size: \d+ bytes \(limit: 1 bytes\)$/u
-        );
-    } else {
-        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
-});
+        if (result.error.type === 'checks') {
+            assert.strictEqual(result.error.issues.length, 1);
+            assert.match(
+                result.error.issues[0]!,
+                /^Package "pkg-a" exceeds the maximum bundle size: \d+ bytes \(limit: 1 bytes\)$/u
+            );
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
 
-test('resolveAndLinkAll reports a missing required file for every bundle that lacks it', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const config = {
-        ...baseConfig,
-        checks: { requiredFiles: { enabled: true, files: ['LICENSE'] } }
-    };
+    test('resolveAndLinkAll reports a missing required file for every bundle that lacks it', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const config = {
+            ...baseConfig,
+            checks: { requiredFiles: { enabled: true, files: ['LICENSE'] } }
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because of missing required files');
-        return;
-    }
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because of missing required files');
+            return;
+        }
 
-    if (result.error.type === 'checks') {
-        assert.deepStrictEqual(result.error.issues, [
-            'Package "pkg-a" is missing required file "LICENSE"',
-            'Package "pkg-b" is missing required file "LICENSE"'
-        ]);
-    } else {
-        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
-});
+        if (result.error.type === 'checks') {
+            assert.deepStrictEqual(result.error.issues, [
+                'Package "pkg-a" is missing required file "LICENSE"',
+                'Package "pkg-b" is missing required file "LICENSE"'
+            ]);
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
 
-test('resolveAndLinkAll reports the duplicate when one owner does not consent', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const baseConfig = await createBaseConfig(fixturePath);
-    const sharedFile = `${fixturePath}/src/shared/util.js`;
-    const config = {
-        ...baseConfig,
-        checks: { noDuplicatedFiles: { enabled: true } },
-        packages: [
-            {
-                ...baseConfig.packages[0]!,
-                checks: { noDuplicatedFiles: { allowList: [sharedFile] } }
-            },
-            baseConfig.packages[1]!
-        ]
-    };
+    test('resolveAndLinkAll reports the duplicate when one owner does not consent', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const baseConfig = await createBaseConfig(fixturePath);
+        const sharedFile = `${fixturePath}/src/shared/util.js`;
+        const config = {
+            ...baseConfig,
+            checks: { noDuplicatedFiles: { enabled: true } },
+            packages: [
+                {
+                    ...baseConfig.packages[0]!,
+                    checks: { noDuplicatedFiles: { allowList: [sharedFile] } }
+                },
+                baseConfig.packages[1]!
+            ]
+        };
 
-    const { result } = await resolveAndLinkAll(config);
+        const { result } = await resolveAndLinkAll(config);
 
-    if (!result.isErr) {
-        assert.fail('Expected resolveAndLinkAll to fail because pkg-b did not consent');
-        return;
-    }
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because pkg-b did not consent');
+            return;
+        }
 
-    if (result.error.type === 'checks') {
-        assert.deepStrictEqual(result.error.issues, [
-            [
-                `File "${sharedFile}" has shared declarations across multiple packages:`,
-                '  - "sharedValue" → pkg-a, pkg-b'
-            ].join('\n')
-        ]);
-    } else {
-        assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
-    }
+        if (result.error.type === 'checks') {
+            assert.deepStrictEqual(result.error.issues, [
+                [
+                    `File "${sharedFile}" has shared declarations across multiple packages:`,
+                    '  - "sharedValue" → pkg-a, pkg-b'
+                ].join('\n')
+            ]);
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
 });

--- a/integration-tests/packtory/dead-code-elimination.test.ts
+++ b/integration-tests/packtory/dead-code-elimination.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { resolveAndLinkAll } from '../../source/packages/packtory/packtory.entry-point.ts';
 import { loadPackageJson } from '../load-package-json.ts';
 import type { PacktoryConfigWithoutRegistry } from '../../source/config/config.ts';
@@ -73,76 +73,82 @@ function findResource(
     return match;
 }
 
-test('happy path: removes an unused exported helper from a shared module while keeping the used one', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/dead-code-elimination');
-    const config = await singlePackageConfig(fixturePath);
-    const result = await resolveAndLinkAll(config);
-    const packages = expectOk(result);
-    const pkg = findPackage(packages, 'pkg');
-    const helpers = findResource(pkg, 'shared/helpers.js');
+suite('dead-code-elimination', function () {
+    test('happy path: removes an unused exported helper from a shared module while keeping the used one', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/dead-code-elimination');
+        const config = await singlePackageConfig(fixturePath);
+        const result = await resolveAndLinkAll(config);
+        const packages = expectOk(result);
+        const pkg = findPackage(packages, 'pkg');
+        const helpers = findResource(pkg, 'shared/helpers.js');
 
-    assert.ok(helpers.fileDescription.content.includes('used'), 'used() should remain');
-    assert.strictEqual(helpers.fileDescription.content.includes('unused'), false, 'unused() should be removed by DCE');
-});
+        assert.ok(helpers.fileDescription.content.includes('used'), 'used() should remain');
+        assert.strictEqual(
+            helpers.fileDescription.content.includes('unused'),
+            false,
+            'unused() should be removed by DCE'
+        );
+    });
 
-test('keeps a side-effecting file untouched and lists it in sideEffectsField', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/dead-code-elimination-side-effects');
-    const config = await singlePackageConfig(fixturePath);
-    const result = await resolveAndLinkAll(config);
-    const packages = expectOk(result);
-    const pkg = findPackage(packages, 'pkg');
-    const entry = findResource(pkg, 'pkg/index.js');
+    test('keeps a side-effecting file untouched and lists it in sideEffectsField', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/dead-code-elimination-side-effects');
+        const config = await singlePackageConfig(fixturePath);
+        const result = await resolveAndLinkAll(config);
+        const packages = expectOk(result);
+        const pkg = findPackage(packages, 'pkg');
+        const entry = findResource(pkg, 'pkg/index.js');
 
-    assert.ok(
-        entry.fileDescription.content.includes('unusedHelper'),
-        'unusedHelper must be kept because the file has top-level side effects'
-    );
-    assert.deepStrictEqual(pkg.analyzedBundle.sideEffectsField, ['./pkg/index.js']);
-});
+        assert.ok(
+            entry.fileDescription.content.includes('unusedHelper'),
+            'unusedHelper must be kept because the file has top-level side effects'
+        );
+        assert.deepStrictEqual(pkg.analyzedBundle.sideEffectsField, ['./pkg/index.js']);
+    });
 
-test('preserves a binding in pkg-producer that pkg-consumer imports across bundles', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/dead-code-elimination-cross-bundle');
-    const config = await consumerProducerConfig(fixturePath);
-    const result = await resolveAndLinkAll(config);
-    const packages = expectOk(result);
-    const producer = findPackage(packages, 'pkg-producer');
-    const helpers = findResource(producer, 'pkg-producer/helpers.js');
+    test('preserves a binding in pkg-producer that pkg-consumer imports across bundles', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/dead-code-elimination-cross-bundle');
+        const config = await consumerProducerConfig(fixturePath);
+        const result = await resolveAndLinkAll(config);
+        const packages = expectOk(result);
+        const producer = findPackage(packages, 'pkg-producer');
+        const helpers = findResource(producer, 'pkg-producer/helpers.js');
 
-    assert.ok(
-        helpers.fileDescription.content.includes('consumedExport'),
-        'consumedExport must remain because pkg-consumer imports it across the bundle boundary'
-    );
-    assert.strictEqual(
-        helpers.fileDescription.content.includes('unconsumedExport'),
-        false,
-        'unconsumedExport should be removed since neither pkg-producer entry nor pkg-consumer references it'
-    );
-});
+        assert.ok(
+            helpers.fileDescription.content.includes('consumedExport'),
+            'consumedExport must remain because pkg-consumer imports it across the bundle boundary'
+        );
+        assert.strictEqual(
+            helpers.fileDescription.content.includes('unconsumedExport'),
+            false,
+            'unconsumedExport should be removed since neither pkg-producer entry nor pkg-consumer references it'
+        );
+    });
 
-test('the smart noDuplicatedFiles rule reports shared declarations using symbol names', async () => {
-    const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
-    const config: PacktoryConfigWithoutRegistry = {
-        commonPackageSettings: {
-            sourcesFolder: path.join(fixturePath, 'src'),
-            mainPackageJson: await loadPackageJson(fixturePath),
-            publishSettings: { access: 'public' }
-        },
-        packages: [
-            { name: 'pkg-a', roots: { main: { js: path.join(fixturePath, 'src/pkg-a/index.js') } } },
-            { name: 'pkg-b', roots: { main: { js: path.join(fixturePath, 'src/pkg-b/index.js') } } }
-        ],
-        checks: { noDuplicatedFiles: { enabled: true } }
-    };
-    const { result } = await resolveAndLinkAll(config);
-    if (!result.isErr) {
-        assert.fail('Expected the noDuplicatedFiles rule to fail');
-        return;
-    }
-    if (result.error.type !== 'checks') {
-        assert.fail(`Expected a checks failure, got ${result.error.type}`);
-    }
-    const [issue] = result.error.issues;
-    assert.ok(issue !== undefined);
-    assert.ok(issue.includes('shared/util.js'));
-    assert.ok(issue.includes('"sharedValue"'), 'message should name the shared declaration');
+    test('the smart noDuplicatedFiles rule reports shared declarations using symbol names', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
+        const config: PacktoryConfigWithoutRegistry = {
+            commonPackageSettings: {
+                sourcesFolder: path.join(fixturePath, 'src'),
+                mainPackageJson: await loadPackageJson(fixturePath),
+                publishSettings: { access: 'public' }
+            },
+            packages: [
+                { name: 'pkg-a', roots: { main: { js: path.join(fixturePath, 'src/pkg-a/index.js') } } },
+                { name: 'pkg-b', roots: { main: { js: path.join(fixturePath, 'src/pkg-b/index.js') } } }
+            ],
+            checks: { noDuplicatedFiles: { enabled: true } }
+        };
+        const { result } = await resolveAndLinkAll(config);
+        if (!result.isErr) {
+            assert.fail('Expected the noDuplicatedFiles rule to fail');
+            return;
+        }
+        if (result.error.type !== 'checks') {
+            assert.fail(`Expected a checks failure, got ${result.error.type}`);
+        }
+        const [issue] = result.error.issues;
+        assert.ok(issue !== undefined);
+        assert.ok(issue.includes('shared/util.js'));
+        assert.ok(issue.includes('"sharedValue"'), 'message should name the shared declaration');
+    });
 });

--- a/integration-tests/packtory/publish.test.ts
+++ b/integration-tests/packtory/publish.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkWithRegistry, type RegistryDetails } from '../registry.ts';
 import {
     assertPackageNotPublished,
@@ -44,366 +44,368 @@ async function assertFixturePublishResult(
     );
 }
 
-test(
-    'publishes the initial version of two packages in the first run and updates one of the two packages in the second run because the other did not change',
-    checkWithRegistry(async (registryDetails) => {
-        const firstRunFixture = getFixturePath('multiple-packages-with-substitution');
-        await assertFixturePublishResult(firstRunFixture, registryDetails, expectedSecondPackageFirstRunVersion);
+suite('publish', function () {
+    test(
+        'publishes the initial version of two packages in the first run and updates one of the two packages in the second run because the other did not change',
+        checkWithRegistry(async (registryDetails) => {
+            const firstRunFixture = getFixturePath('multiple-packages-with-substitution');
+            await assertFixturePublishResult(firstRunFixture, registryDetails, expectedSecondPackageFirstRunVersion);
 
-        const secondRunFixture = getFixturePath('multiple-packages-with-substitution-slightly-modified');
-        await assertFixturePublishResult(secondRunFixture, registryDetails, expectedSecondPackageSecondRunVersion);
-    })
-);
+            const secondRunFixture = getFixturePath('multiple-packages-with-substitution-slightly-modified');
+            await assertFixturePublishResult(secondRunFixture, registryDetails, expectedSecondPackageSecondRunVersion);
+        })
+    );
 
-test(
-    'does not publish a new version when the same bundle is published twice unchanged',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+    test(
+        'does not publish a new version when the same bundle is published twice unchanged',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
 
-        assertPublishSucceeded(await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails }));
-        assertPublishSucceeded(await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails }));
+            assertPublishSucceeded(await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails }));
+            assertPublishSucceeded(await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails }));
 
-        const latestVersionOfFirstPackage = await fetchPublishedPackage('first', registryDetails);
-        const latestVersionOfSecondPackage = await fetchPublishedPackage('second', registryDetails);
+            const latestVersionOfFirstPackage = await fetchPublishedPackage('first', registryDetails);
+            const latestVersionOfSecondPackage = await fetchPublishedPackage('second', registryDetails);
 
-        assert.deepStrictEqual(
-            {
-                version: latestVersionOfFirstPackage.version,
-                files: latestVersionOfFirstPackage.files
-            },
-            expectedFirstPackageVersion
-        );
-        assert.deepStrictEqual(
-            {
-                version: latestVersionOfSecondPackage.version,
-                files: latestVersionOfSecondPackage.files
-            },
-            expectedSecondPackageFirstRunVersion
-        );
-    })
-);
+            assert.deepStrictEqual(
+                {
+                    version: latestVersionOfFirstPackage.version,
+                    files: latestVersionOfFirstPackage.files
+                },
+                expectedFirstPackageVersion
+            );
+            assert.deepStrictEqual(
+                {
+                    version: latestVersionOfSecondPackage.version,
+                    files: latestVersionOfSecondPackage.files
+                },
+                expectedSecondPackageFirstRunVersion
+            );
+        })
+    );
 
-test(
-    'publishes the configured manual version and keeps it stable for an unchanged rerun',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1', {
-                versioning: { automatic: false, version: '3.2.1' }
-            })
-        );
+    test(
+        'publishes the configured manual version and keeps it stable for an unchanged rerun',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1', {
+                    versioning: { automatic: false, version: '3.2.1' }
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
 
-        const publishedPackage = await fetchPublishedPackage('first', registryDetails);
+            const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-        assert.strictEqual(publishedPackage.version, '3.2.1');
-        assert.strictEqual(publishedPackage.manifest.version, '3.2.1');
-    })
-);
+            assert.strictEqual(publishedPackage.version, '3.2.1');
+            assert.strictEqual(publishedPackage.manifest.version, '3.2.1');
+        })
+    );
 
-test(
-    'publishes successfully with explicit basic auth against the registry',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(createPackageConfig(fixturePathValue, 'first', 'entry1'));
+    test(
+        'publishes successfully with explicit basic auth against the registry',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(createPackageConfig(fixturePathValue, 'first', 'entry1'));
 
-        assertPublishSucceeded(
-            await publishFixturePackages({
-                fixturePath: fixturePathValue,
-                registryDetails,
-                packages,
-                authMode: 'basic'
-            })
-        );
+            assertPublishSucceeded(
+                await publishFixturePackages({
+                    fixturePath: fixturePathValue,
+                    registryDetails,
+                    packages,
+                    authMode: 'basic'
+                })
+            );
 
-        const publishedPackage = await fetchPublishedPackage('first', registryDetails);
+            const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-        assert.strictEqual(publishedPackage.version, '0.0.1');
-        assert.strictEqual(publishedPackage.manifest.version, '0.0.1');
-    })
-);
+            assert.strictEqual(publishedPackage.version, '0.0.1');
+            assert.strictEqual(publishedPackage.manifest.version, '0.0.1');
+        })
+    );
 
-test(
-    'publishes the configured minimumVersion for the first automatic publish',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1', {
-                versioning: { automatic: true, minimumVersion: '1.2.3' }
-            })
-        );
+    test(
+        'publishes the configured minimumVersion for the first automatic publish',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1', {
+                    versioning: { automatic: true, minimumVersion: '1.2.3' }
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
 
-        const publishedPackage = await fetchPublishedPackage('first', registryDetails);
+            const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-        assert.strictEqual(publishedPackage.version, '1.2.3');
-        assert.strictEqual(publishedPackage.manifest.version, '1.2.3');
-    })
-);
+            assert.strictEqual(publishedPackage.version, '1.2.3');
+            assert.strictEqual(publishedPackage.manifest.version, '1.2.3');
+        })
+    );
 
-test(
-    'publishes bundle peer dependencies into peerDependencies and keeps the substituted imports',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1'),
-            createPackageConfig(fixturePathValue, 'second', 'entry2', { bundleDependencies: ['first'] }),
-            createPackageConfig(fixturePathValue, 'third', 'entry3', {
-                bundleDependencies: ['first'],
-                bundlePeerDependencies: ['second']
-            })
-        );
+    test(
+        'publishes bundle peer dependencies into peerDependencies and keeps the substituted imports',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1'),
+                createPackageConfig(fixturePathValue, 'second', 'entry2', { bundleDependencies: ['first'] }),
+                createPackageConfig(fixturePathValue, 'third', 'entry3', {
+                    bundleDependencies: ['first'],
+                    bundlePeerDependencies: ['second']
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
 
-        const publishedPackage = await fetchPublishedPackage('third', registryDetails);
+            const publishedPackage = await fetchPublishedPackage('third', registryDetails);
 
-        assert.deepStrictEqual(publishedPackage.manifest.dependencies, { first: '0.0.1' });
-        assert.deepStrictEqual(publishedPackage.manifest.peerDependencies, { second: '0.0.1' });
-        assert.strictEqual(
-            getPublishedFile(publishedPackage, 'package/foo.js').content,
-            "import { bar } from 'second/bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n"
-        );
-        assert.strictEqual(
-            getPublishedFile(publishedPackage, 'package/entry3.d.ts').content,
-            "export declare const foo: import('first/foo.d.ts').Foo;\n"
-        );
-    })
-);
+            assert.deepStrictEqual(publishedPackage.manifest.dependencies, { first: '0.0.1' });
+            assert.deepStrictEqual(publishedPackage.manifest.peerDependencies, { second: '0.0.1' });
+            assert.strictEqual(
+                getPublishedFile(publishedPackage, 'package/foo.js').content,
+                "import { bar } from 'second/bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n"
+            );
+            assert.strictEqual(
+                getPublishedFile(publishedPackage, 'package/entry3.d.ts').content,
+                "export declare const foo: import('first/foo.d.ts').Foo;\n"
+            );
+        })
+    );
 
-test(
-    'includes a CycloneDX SBOM next to the manifest when SBOM is enabled',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1', {
-                publishSettings: { access: 'public', sbom: { enabled: true } }
-            }),
-            createPackageConfig(fixturePathValue, 'second', 'entry2', {
-                bundleDependencies: ['first'],
-                publishSettings: { access: 'public', sbom: { enabled: true } }
-            })
-        );
+    test(
+        'includes a CycloneDX SBOM next to the manifest when SBOM is enabled',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1', {
+                    publishSettings: { access: 'public', sbom: { enabled: true } }
+                }),
+                createPackageConfig(fixturePathValue, 'second', 'entry2', {
+                    bundleDependencies: ['first'],
+                    publishSettings: { access: 'public', sbom: { enabled: true } }
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
 
-        const firstPackage = await fetchPublishedPackage('first', registryDetails);
-        const sbomFile = getPublishedFile(firstPackage, 'package/sbom.cdx.json');
-        const sbom = JSON.parse(sbomFile.content) as Record<string, unknown>;
+            const firstPackage = await fetchPublishedPackage('first', registryDetails);
+            const sbomFile = getPublishedFile(firstPackage, 'package/sbom.cdx.json');
+            const sbom = JSON.parse(sbomFile.content) as Record<string, unknown>;
 
-        assert.strictEqual(sbom.bomFormat, 'CycloneDX');
-        assert.strictEqual(sbom.specVersion, '1.6');
-        const metadata = sbom.metadata as { component: { 'bom-ref': string; name: string; version: string } };
-        assert.strictEqual(metadata.component['bom-ref'], 'pkg:npm/first@0.0.1');
-        assert.strictEqual(metadata.component.name, 'first');
-        assert.strictEqual(metadata.component.version, '0.0.1');
-        assert.deepStrictEqual(sbom.components, []);
-    })
-);
+            assert.strictEqual(sbom.bomFormat, 'CycloneDX');
+            assert.strictEqual(sbom.specVersion, '1.6');
+            const metadata = sbom.metadata as { component: { 'bom-ref': string; name: string; version: string } };
+            assert.strictEqual(metadata.component['bom-ref'], 'pkg:npm/first@0.0.1');
+            assert.strictEqual(metadata.component.name, 'first');
+            assert.strictEqual(metadata.component.version, '0.0.1');
+            assert.deepStrictEqual(sbom.components, []);
+        })
+    );
 
-test(
-    'lists every dependency from the published manifest as an SBOM component',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1', {
-                publishSettings: { access: 'public', sbom: { enabled: true } }
-            }),
-            createPackageConfig(fixturePathValue, 'second', 'entry2', {
-                bundleDependencies: ['first'],
-                publishSettings: { access: 'public', sbom: { enabled: true } }
-            })
-        );
+    test(
+        'lists every dependency from the published manifest as an SBOM component',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1', {
+                    publishSettings: { access: 'public', sbom: { enabled: true } }
+                }),
+                createPackageConfig(fixturePathValue, 'second', 'entry2', {
+                    bundleDependencies: ['first'],
+                    publishSettings: { access: 'public', sbom: { enabled: true } }
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
 
-        const secondPackage = await fetchPublishedPackage('second', registryDetails);
-        const sbomFile = getPublishedFile(secondPackage, 'package/sbom.cdx.json');
-        const sbom = JSON.parse(sbomFile.content) as {
-            components: readonly { name: string; version: string; 'bom-ref': string; scope: string }[];
-            dependencies: readonly { ref: string; dependsOn?: readonly string[] }[];
-        };
+            const secondPackage = await fetchPublishedPackage('second', registryDetails);
+            const sbomFile = getPublishedFile(secondPackage, 'package/sbom.cdx.json');
+            const sbom = JSON.parse(sbomFile.content) as {
+                components: readonly { name: string; version: string; 'bom-ref': string; scope: string }[];
+                dependencies: readonly { ref: string; dependsOn?: readonly string[] }[];
+            };
 
-        assert.deepStrictEqual(sbom.components, [
-            {
-                type: 'library',
-                name: 'first',
-                version: '0.0.1',
-                'bom-ref': 'pkg:npm/first@0.0.1',
-                scope: 'required',
-                purl: 'pkg:npm/first@0.0.1'
-            }
-        ]);
-        const rootDep = sbom.dependencies.find((entry) => {
-            return entry.ref === 'pkg:npm/second@0.0.1';
-        });
-        assert.deepStrictEqual(rootDep?.dependsOn, ['pkg:npm/first@0.0.1']);
-    })
-);
+            assert.deepStrictEqual(sbom.components, [
+                {
+                    type: 'library',
+                    name: 'first',
+                    version: '0.0.1',
+                    'bom-ref': 'pkg:npm/first@0.0.1',
+                    scope: 'required',
+                    purl: 'pkg:npm/first@0.0.1'
+                }
+            ]);
+            const rootDep = sbom.dependencies.find((entry) => {
+                return entry.ref === 'pkg:npm/second@0.0.1';
+            });
+            assert.deepStrictEqual(rootDep?.dependsOn, ['pkg:npm/first@0.0.1']);
+        })
+    );
 
-test(
-    'produces byte-identical SBOMs across two unchanged publish runs',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1', {
-                publishSettings: { access: 'public', sbom: { enabled: true } }
-            })
-        );
+    test(
+        'produces byte-identical SBOMs across two unchanged publish runs',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1', {
+                    publishSettings: { access: 'public', sbom: { enabled: true } }
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
-        const firstRun = await fetchPublishedPackage('first', registryDetails);
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
+            const firstRun = await fetchPublishedPackage('first', registryDetails);
 
-        assertPublishSucceeded(
-            await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
-        );
-        const secondRun = await fetchPublishedPackage('first', registryDetails);
+            assertPublishSucceeded(
+                await publishFixturePackages({ fixturePath: fixturePathValue, registryDetails, packages })
+            );
+            const secondRun = await fetchPublishedPackage('first', registryDetails);
 
-        assert.strictEqual(
-            getPublishedFile(secondRun, 'package/sbom.cdx.json').content,
-            getPublishedFile(firstRun, 'package/sbom.cdx.json').content
-        );
-        assert.strictEqual(secondRun.version, firstRun.version);
-    })
-);
+            assert.strictEqual(
+                getPublishedFile(secondRun, 'package/sbom.cdx.json').content,
+                getPublishedFile(firstRun, 'package/sbom.cdx.json').content
+            );
+            assert.strictEqual(secondRun.version, firstRun.version);
+        })
+    );
 
-test(
-    'rejects publishing a bundle whose external dependency uses a mutable git+https specifier',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('with-local-builtin-and-node-module-dependencies');
-        const packages = createPackageConfigList({
-            name: 'mutable-rejection-fixture',
-            roots: { main: { js: `${fixturePathValue}/src/entry.js` } }
-        });
+    test(
+        'rejects publishing a bundle whose external dependency uses a mutable git+https specifier',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('with-local-builtin-and-node-module-dependencies');
+            const packages = createPackageConfigList({
+                name: 'mutable-rejection-fixture',
+                roots: { main: { js: `${fixturePathValue}/src/entry.js` } }
+            });
 
-        const result = await publishFixturePackages({
-            fixturePath: fixturePathValue,
-            registryDetails,
-            packages,
-            mainPackageJsonOverrides: {
-                dependencies: { 'example-module': 'git+https://github.com/our-fork/example-module#v1.0.0' }
-            }
-        });
-
-        if (result.isOk) {
-            assert.fail('Expected publish to fail');
-        }
-        if (result.error.type !== 'partial') {
-            assert.fail(`Expected partial failure, got ${result.error.type}`);
-        }
-        const failureMessages = result.error.failures.map((failure) => {
-            return failure.message;
-        });
-        assert.ok(
-            failureMessages.some((message) => {
-                return message.includes('uses a mutable specifier') && message.includes('example-module');
-            }),
-            `Expected a mutable-specifier failure, got: ${failureMessages.join(' | ')}`
-        );
-
-        await assertPackageNotPublished('mutable-rejection-fixture', registryDetails);
-    })
-);
-
-test(
-    'allows a mutable git+https specifier when the dep is allow-listed and preserves it in the published manifest',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('with-local-builtin-and-node-module-dependencies');
-        const packages = createPackageConfigList({
-            name: 'mutable-allow-list-fixture',
-            roots: { main: { js: `${fixturePathValue}/src/entry.js` } }
-        });
-
-        assertPublishSucceeded(
-            await publishFixturePackages({
+            const result = await publishFixturePackages({
                 fixturePath: fixturePathValue,
                 registryDetails,
                 packages,
                 mainPackageJsonOverrides: {
                     dependencies: { 'example-module': 'git+https://github.com/our-fork/example-module#v1.0.0' }
-                },
-                commonPackageSettings: {
-                    dependencyPolicy: { allowMutableSpecifiers: ['example-module'] }
                 }
-            })
-        );
+            });
 
-        const publishedPackage = await fetchPublishedPackage('mutable-allow-list-fixture', registryDetails);
+            if (result.isOk) {
+                assert.fail('Expected publish to fail');
+            }
+            if (result.error.type !== 'partial') {
+                assert.fail(`Expected partial failure, got ${result.error.type}`);
+            }
+            const failureMessages = result.error.failures.map((failure) => {
+                return failure.message;
+            });
+            assert.ok(
+                failureMessages.some((message) => {
+                    return message.includes('uses a mutable specifier') && message.includes('example-module');
+                }),
+                `Expected a mutable-specifier failure, got: ${failureMessages.join(' | ')}`
+            );
 
-        assert.deepStrictEqual(publishedPackage.manifest.dependencies, {
-            'example-module': 'git+https://github.com/our-fork/example-module#v1.0.0'
-        });
-    })
-);
+            await assertPackageNotPublished('mutable-rejection-fixture', registryDetails);
+        })
+    );
 
-test(
-    'merges common and per-package publish settings in a single happy path',
-    checkWithRegistry(async (registryDetails) => {
-        const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
-        const packages = createPackageConfigList(
-            createPackageConfig(fixturePathValue, 'first', 'entry1', {
-                additionalFiles: [
-                    {
-                        sourceFilePath: `${fixturePathValue}/docs/first.txt`,
-                        targetFilePath: 'docs/first.txt'
+    test(
+        'allows a mutable git+https specifier when the dep is allow-listed and preserves it in the published manifest',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('with-local-builtin-and-node-module-dependencies');
+            const packages = createPackageConfigList({
+                name: 'mutable-allow-list-fixture',
+                roots: { main: { js: `${fixturePathValue}/src/entry.js` } }
+            });
+
+            assertPublishSucceeded(
+                await publishFixturePackages({
+                    fixturePath: fixturePathValue,
+                    registryDetails,
+                    packages,
+                    mainPackageJsonOverrides: {
+                        dependencies: { 'example-module': 'git+https://github.com/our-fork/example-module#v1.0.0' }
+                    },
+                    commonPackageSettings: {
+                        dependencyPolicy: { allowMutableSpecifiers: ['example-module'] }
                     }
-                ],
-                additionalPackageJsonAttributes: {
-                    description: 'first package'
-                }
-            })
-        );
+                })
+            );
 
-        assertPublishSucceeded(
-            await publishFixturePackages({
-                fixturePath: fixturePathValue,
-                registryDetails,
-                packages,
-                commonPackageSettings: {
-                    includeSourceMapFiles: true,
+            const publishedPackage = await fetchPublishedPackage('mutable-allow-list-fixture', registryDetails);
+
+            assert.deepStrictEqual(publishedPackage.manifest.dependencies, {
+                'example-module': 'git+https://github.com/our-fork/example-module#v1.0.0'
+            });
+        })
+    );
+
+    test(
+        'merges common and per-package publish settings in a single happy path',
+        checkWithRegistry(async (registryDetails) => {
+            const fixturePathValue = getFixturePath('multiple-packages-with-substitution');
+            const packages = createPackageConfigList(
+                createPackageConfig(fixturePathValue, 'first', 'entry1', {
                     additionalFiles: [
                         {
-                            sourceFilePath: `${fixturePathValue}/docs/common.txt`,
-                            targetFilePath: 'docs/common.txt'
+                            sourceFilePath: `${fixturePathValue}/docs/first.txt`,
+                            targetFilePath: 'docs/first.txt'
                         }
                     ],
                     additionalPackageJsonAttributes: {
-                        license: 'MIT'
+                        description: 'first package'
                     }
-                }
-            })
-        );
+                })
+            );
 
-        const publishedPackage = await fetchPublishedPackage('first', registryDetails);
+            assertPublishSucceeded(
+                await publishFixturePackages({
+                    fixturePath: fixturePathValue,
+                    registryDetails,
+                    packages,
+                    commonPackageSettings: {
+                        includeSourceMapFiles: true,
+                        additionalFiles: [
+                            {
+                                sourceFilePath: `${fixturePathValue}/docs/common.txt`,
+                                targetFilePath: 'docs/common.txt'
+                            }
+                        ],
+                        additionalPackageJsonAttributes: {
+                            license: 'MIT'
+                        }
+                    }
+                })
+            );
 
-        assert.strictEqual(publishedPackage.manifest.license, 'MIT');
-        assert.strictEqual(publishedPackage.manifest.description, 'first package');
-        assert.strictEqual(
-            getPublishedFile(publishedPackage, 'package/entry1.js.map').content,
-            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n'
-        );
-        assert.strictEqual(
-            getPublishedFile(publishedPackage, 'package/qux.js.map').content,
-            '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n'
-        );
-        assert.strictEqual(getPublishedFile(publishedPackage, 'package/docs/common.txt').content, 'common file\n');
-        assert.strictEqual(getPublishedFile(publishedPackage, 'package/docs/first.txt').content, 'package file\n');
-    })
-);
+            const publishedPackage = await fetchPublishedPackage('first', registryDetails);
+
+            assert.strictEqual(publishedPackage.manifest.license, 'MIT');
+            assert.strictEqual(publishedPackage.manifest.description, 'first package');
+            assert.strictEqual(
+                getPublishedFile(publishedPackage, 'package/entry1.js.map').content,
+                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n'
+            );
+            assert.strictEqual(
+                getPublishedFile(publishedPackage, 'package/qux.js.map').content,
+                '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n'
+            );
+            assert.strictEqual(getPublishedFile(publishedPackage, 'package/docs/common.txt').content, 'common file\n');
+            assert.strictEqual(getPublishedFile(publishedPackage, 'package/docs/first.txt').content, 'package file\n');
+        })
+    );
+});

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { AnalyzedBundleResource } from '../dead-code-eliminator/analyzed-bundle.ts';
 import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
@@ -96,317 +96,319 @@ function makeContent(targetFilePath: string, content: string, isSubstituted = fa
     };
 }
 
-test('buildTarball() returns the tarData', async () => {
-    const tarballBuilder = { build: fake.resolves(Buffer.from([42])) };
-    const { builder } = artifactsBuilderFactory({ tarballBuilder });
-    const result = await builder.buildTarball(bundleWithContents([]));
+suite('artifacts-builder', function () {
+    test('buildTarball() returns the tarData', async function () {
+        const tarballBuilder = { build: fake.resolves(Buffer.from([42])) };
+        const { builder } = artifactsBuilderFactory({ tarballBuilder });
+        const result = await builder.buildTarball(bundleWithContents([]));
 
-    assert.deepStrictEqual(result, {
-        tarData: Buffer.from([42])
+        assert.deepStrictEqual(result, {
+            tarData: Buffer.from([42])
+        });
     });
-});
 
-test('buildTarball() passes all given contents to the tarballBuilder', async () => {
-    const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
-    const { builder } = artifactsBuilderFactory({ tarballBuilder });
-    const contents: AnalyzedBundleResource[] = [
-        makeContent('bar.txt', 'bar'),
-        makeContent('baz.txt', 'baz'),
-        makeContent('qux.txt', 'qux', true)
-    ];
-    await builder.buildTarball(bundleWithContents(contents, 'package.json'));
+    test('buildTarball() passes all given contents to the tarballBuilder', async function () {
+        const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
+        const { builder } = artifactsBuilderFactory({ tarballBuilder });
+        const contents: AnalyzedBundleResource[] = [
+            makeContent('bar.txt', 'bar'),
+            makeContent('baz.txt', 'baz'),
+            makeContent('qux.txt', 'qux', true)
+        ];
+        await builder.buildTarball(bundleWithContents(contents, 'package.json'));
 
-    assert.strictEqual(tarballBuilder.build.callCount, 1);
-    assert.deepStrictEqual(tarballBuilder.build.firstCall.args, [
-        [
+        assert.strictEqual(tarballBuilder.build.callCount, 1);
+        assert.deepStrictEqual(tarballBuilder.build.firstCall.args, [
+            [
+                { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
+                { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
+                { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
+            ]
+        ]);
+    });
+
+    test('buildFolder() writes only the manifest when the given bundle has no contents', async function () {
+        const { builder, fileManager } = builderWithUnreadableTargetFolder();
+
+        await builder.buildFolder(bundleWithContents([], 'package.json'), '/the/target/folder');
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+            filePath: '/the/target/folder/package.json',
+            content: '{}'
+        });
+    });
+
+    test('buildFolder() throws when the target folder already exists', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }]
+        });
+        const { builder } = artifactsBuilderFactory({ fileManager });
+
+        try {
+            await builder.buildFolder(bundleWithContents([]), '/the/target/folder');
+            assert.fail('Expected buildFolder() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
+            assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/the/target/folder' });
+            assert.strictEqual((error as Error).message, 'Folder /the/target/folder already exists');
+        }
+    });
+
+    test('buildFolder() writes the source of a source bundle content to the given target folder', async function () {
+        const { builder, fileManager } = builderWithUnreadableTargetFolder();
+        const contents: AnalyzedBundleResource[] = [makeContent('bar/baz.txt', 'the-content')];
+        await builder.buildFolder(bundleWithContents(contents, 'package.json'), '/the/target/folder');
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+            filePath: '/the/target/folder/package.json',
+            content: '{}'
+        });
+        assert.deepStrictEqual(fileManager.getWriteFileCall(1), {
+            filePath: '/the/target/folder/bar/baz.txt',
+            content: 'the-content'
+        });
+    });
+
+    test('collectContents() returns the list of file descriptions of the given bundle', function () {
+        const { builder } = artifactsBuilderFactory();
+        const contents: AnalyzedBundleResource[] = [
+            makeContent('bar.txt', 'bar'),
+            makeContent('baz.txt', 'baz'),
+            makeContent('qux.txt', 'qux', true)
+        ];
+        const result = builder.collectContents(bundleWithContents(contents, 'package.json'));
+
+        assert.deepStrictEqual(result, [
+            { filePath: 'package.json', content: '{}', isExecutable: false },
+            { filePath: 'bar.txt', content: 'bar', isExecutable: false },
+            { filePath: 'baz.txt', content: 'baz', isExecutable: false },
+            { filePath: 'qux.txt', content: 'qux', isExecutable: false }
+        ]);
+    });
+
+    test('collectContents() appends extra files after the bundle contents and applies the prefix to them', function () {
+        const { builder } = artifactsBuilderFactory();
+        const result = builder.collectContents(bundleWithContents([], 'package.json'), 'package', [
+            { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
+        ]);
+
+        assert.deepStrictEqual(result, [
             { filePath: 'package/package.json', content: '{}', isExecutable: false },
-            { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
-            { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
-            { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
-        ]
-    ]);
-});
-
-test('buildFolder() writes only the manifest when the given bundle has no contents', async () => {
-    const { builder, fileManager } = builderWithUnreadableTargetFolder();
-
-    await builder.buildFolder(bundleWithContents([], 'package.json'), '/the/target/folder');
-
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
-        filePath: '/the/target/folder/package.json',
-        content: '{}'
-    });
-});
-
-test('buildFolder() throws when the target folder already exists', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }]
-    });
-    const { builder } = artifactsBuilderFactory({ fileManager });
-
-    try {
-        await builder.buildFolder(bundleWithContents([]), '/the/target/folder');
-        assert.fail('Expected buildFolder() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
-        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/the/target/folder' });
-        assert.strictEqual((error as Error).message, 'Folder /the/target/folder already exists');
-    }
-});
-
-test('buildFolder() writes the source of a source bundle content to the given target folder', async () => {
-    const { builder, fileManager } = builderWithUnreadableTargetFolder();
-    const contents: AnalyzedBundleResource[] = [makeContent('bar/baz.txt', 'the-content')];
-    await builder.buildFolder(bundleWithContents(contents, 'package.json'), '/the/target/folder');
-
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
-    assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
-        filePath: '/the/target/folder/package.json',
-        content: '{}'
-    });
-    assert.deepStrictEqual(fileManager.getWriteFileCall(1), {
-        filePath: '/the/target/folder/bar/baz.txt',
-        content: 'the-content'
-    });
-});
-
-test('collectContents() returns the list of file descriptions of the given bundle', () => {
-    const { builder } = artifactsBuilderFactory();
-    const contents: AnalyzedBundleResource[] = [
-        makeContent('bar.txt', 'bar'),
-        makeContent('baz.txt', 'baz'),
-        makeContent('qux.txt', 'qux', true)
-    ];
-    const result = builder.collectContents(bundleWithContents(contents, 'package.json'));
-
-    assert.deepStrictEqual(result, [
-        { filePath: 'package.json', content: '{}', isExecutable: false },
-        { filePath: 'bar.txt', content: 'bar', isExecutable: false },
-        { filePath: 'baz.txt', content: 'baz', isExecutable: false },
-        { filePath: 'qux.txt', content: 'qux', isExecutable: false }
-    ]);
-});
-
-test('collectContents() appends extra files after the bundle contents and applies the prefix to them', () => {
-    const { builder } = artifactsBuilderFactory();
-    const result = builder.collectContents(bundleWithContents([], 'package.json'), 'package', [
-        { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
-    ]);
-
-    assert.deepStrictEqual(result, [
-        { filePath: 'package/package.json', content: '{}', isExecutable: false },
-        { filePath: 'package/sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
-    ]);
-});
-
-test('collectContents() forces explicit bin targets to executable', () => {
-    const { builder } = artifactsBuilderFactory();
-    const result = builder.collectContents(
-        bundleWithExplicitBin([makeContent('cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')], {
-            packtory: './cli.js'
-        })
-    );
-
-    assert.deepStrictEqual(result, [
-        { filePath: 'package.json', content: '{}', isExecutable: false },
-        { filePath: 'cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
-    ]);
-});
-
-test('collectContents() forces string bin targets to executable', () => {
-    const { builder } = artifactsBuilderFactory();
-    const result = builder.collectContents(
-        bundleWithExplicitBin([makeContent('cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')], './cli.js')
-    );
-
-    assert.deepStrictEqual(result, [
-        { filePath: 'package.json', content: '{}', isExecutable: false },
-        { filePath: 'cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
-    ]);
-});
-
-test('collectContents() ignores malformed non-string bin entries and still applies valid explicit bin targets', () => {
-    const { builder } = artifactsBuilderFactory();
-    const result = builder.collectContents(
-        bundleWithExplicitBin([makeContent('cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')], {
-            packtory: './cli.js',
-            broken: 123 as never
-        })
-    );
-
-    assert.deepStrictEqual(result, [
-        { filePath: 'package.json', content: '{}', isExecutable: false },
-        { filePath: 'cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
-    ]);
-});
-
-test('collectContents() only strips a leading dot-slash from explicit bin targets', () => {
-    const { builder } = artifactsBuilderFactory();
-    const result = builder.collectContents(
-        bundleWithExplicitBin(
-            [makeContent('nested/./cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')],
-            'nested/./cli.js'
-        )
-    );
-
-    assert.deepStrictEqual(result, [
-        { filePath: 'package.json', content: '{}', isExecutable: false },
-        { filePath: 'nested/./cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
-    ]);
-});
-
-test('buildTarball() forwards extra files to the tarball builder alongside the bundle contents', async () => {
-    const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
-    const { builder } = artifactsBuilderFactory({ tarballBuilder });
-    await builder.buildTarball(bundleWithContents([makeContent('bar.txt', 'bar')], 'package.json'), [
-        { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
-    ]);
-
-    assert.deepStrictEqual(tarballBuilder.build.firstCall.args, [
-        [
-            { filePath: 'package/package.json', content: '{}', isExecutable: false },
-            { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
             { filePath: 'package/sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
-        ]
-    ]);
-});
-
-test('buildFolder() writes extra files alongside the bundle contents into the target folder', async () => {
-    const { builder, fileManager } = builderWithUnreadableTargetFolder();
-
-    await builder.buildFolder(bundleWithContents([], 'package.json'), '/the/target/folder', [
-        { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
-    ]);
-
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
-    assert.deepStrictEqual(fileManager.getWriteFileCall(1), {
-        filePath: '/the/target/folder/sbom.cdx.json',
-        content: '{"bomFormat":"CycloneDX"}'
-    });
-});
-
-function artifactsBuilderWithBroadcaster(): {
-    readonly builder: ArtifactsBuilder;
-    readonly broadcaster: ReturnType<typeof createProgressBroadcaster>;
-} {
-    const broadcaster = createProgressBroadcaster();
-    const dependencies: ArtifactsBuilderDependencies = {
-        fileManager: createFakeFileManager(),
-        tarballBuilder: { build: fake.resolves(Buffer.from([])) },
-        progressBroadcaster: broadcaster.provider
-    };
-    return { builder: createArtifactsBuilder(dependencies), broadcaster };
-}
-
-test('collectContents() emits an artifactsCollected event with the package name when a subscriber is registered', () => {
-    const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
-    const received: { packageName: string }[] = [];
-    broadcaster.consumer.on('artifactsCollected', (payload) => {
-        received.push({ packageName: payload.packageName });
+        ]);
     });
 
-    builder.collectContents(bundleWithContents([makeContent('a.js', 'console.log(0)')], 'package.json'));
-
-    assert.deepStrictEqual(received, [{ packageName: 'the-name' }]);
-});
-
-test('collectContents() emits artifact entries with size and kind classification', () => {
-    const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
-    const received: {
-        entries: readonly {
-            path: string;
-            sizeBytes: number;
-            kind: string;
-            sourcePath?: string;
-            status: string;
-            badges: readonly string[];
-        }[];
-    }[] = [];
-    broadcaster.consumer.on('artifactsCollected', (payload) => {
-        received.push({
-            entries: payload.entries.map((entry) => {
-                return {
-                    path: entry.path,
-                    sizeBytes: entry.sizeBytes,
-                    kind: entry.kind,
-                    ...(entry.sourcePath === undefined ? {} : { sourcePath: entry.sourcePath }),
-                    status: entry.status,
-                    badges: entry.badges
-                };
+    test('collectContents() forces explicit bin targets to executable', function () {
+        const { builder } = artifactsBuilderFactory();
+        const result = builder.collectContents(
+            bundleWithExplicitBin([makeContent('cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')], {
+                packtory: './cli.js'
             })
+        );
+
+        assert.deepStrictEqual(result, [
+            { filePath: 'package.json', content: '{}', isExecutable: false },
+            { filePath: 'cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
+        ]);
+    });
+
+    test('collectContents() forces string bin targets to executable', function () {
+        const { builder } = artifactsBuilderFactory();
+        const result = builder.collectContents(
+            bundleWithExplicitBin([makeContent('cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')], './cli.js')
+        );
+
+        assert.deepStrictEqual(result, [
+            { filePath: 'package.json', content: '{}', isExecutable: false },
+            { filePath: 'cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
+        ]);
+    });
+
+    test('collectContents() ignores malformed non-string bin entries and still applies valid explicit bin targets', function () {
+        const { builder } = artifactsBuilderFactory();
+        const result = builder.collectContents(
+            bundleWithExplicitBin([makeContent('cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')], {
+                packtory: './cli.js',
+                broken: 123 as never
+            })
+        );
+
+        assert.deepStrictEqual(result, [
+            { filePath: 'package.json', content: '{}', isExecutable: false },
+            { filePath: 'cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
+        ]);
+    });
+
+    test('collectContents() only strips a leading dot-slash from explicit bin targets', function () {
+        const { builder } = artifactsBuilderFactory();
+        const result = builder.collectContents(
+            bundleWithExplicitBin(
+                [makeContent('nested/./cli.js', '#!/usr/bin/env node\nconsole.log(0);\n')],
+                'nested/./cli.js'
+            )
+        );
+
+        assert.deepStrictEqual(result, [
+            { filePath: 'package.json', content: '{}', isExecutable: false },
+            { filePath: 'nested/./cli.js', content: '#!/usr/bin/env node\nconsole.log(0);\n', isExecutable: true }
+        ]);
+    });
+
+    test('buildTarball() forwards extra files to the tarball builder alongside the bundle contents', async function () {
+        const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
+        const { builder } = artifactsBuilderFactory({ tarballBuilder });
+        await builder.buildTarball(bundleWithContents([makeContent('bar.txt', 'bar')], 'package.json'), [
+            { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
+        ]);
+
+        assert.deepStrictEqual(tarballBuilder.build.firstCall.args, [
+            [
+                { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
+                { filePath: 'package/sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
+            ]
+        ]);
+    });
+
+    test('buildFolder() writes extra files alongside the bundle contents into the target folder', async function () {
+        const { builder, fileManager } = builderWithUnreadableTargetFolder();
+
+        await builder.buildFolder(bundleWithContents([], 'package.json'), '/the/target/folder', [
+            { filePath: 'sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
+        ]);
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(1), {
+            filePath: '/the/target/folder/sbom.cdx.json',
+            content: '{"bomFormat":"CycloneDX"}'
         });
     });
 
-    builder.collectContents(bundleWithContents([makeContent('a.js', 'abc', true)], 'package.json'));
+    function artifactsBuilderWithBroadcaster(): {
+        readonly builder: ArtifactsBuilder;
+        readonly broadcaster: ReturnType<typeof createProgressBroadcaster>;
+    } {
+        const broadcaster = createProgressBroadcaster();
+        const dependencies: ArtifactsBuilderDependencies = {
+            fileManager: createFakeFileManager(),
+            tarballBuilder: { build: fake.resolves(Buffer.from([])) },
+            progressBroadcaster: broadcaster.provider
+        };
+        return { builder: createArtifactsBuilder(dependencies), broadcaster };
+    }
 
-    assert.deepStrictEqual(received, [
-        {
-            entries: [
-                { path: 'package.json', sizeBytes: 2, kind: 'manifest', status: 'generated', badges: [] },
-                {
-                    path: 'a.js',
-                    sizeBytes: 3,
-                    kind: 'source',
-                    sourcePath: '/foo/bar.txt',
-                    status: 'changed',
-                    badges: ['import-path-rewrite']
-                }
-            ]
-        }
-    ]);
-});
-
-test('collectContents() emits extra generated files in artifactsCollected when subscribed', () => {
-    const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
-    const received: {
-        entries: readonly { path: string; status: string; kind: string }[];
-    }[] = [];
-    broadcaster.consumer.on('artifactsCollected', (payload) => {
-        received.push({
-            entries: payload.entries.map((entry) => {
-                return { path: entry.path, status: entry.status, kind: entry.kind };
-            })
+    test('collectContents() emits an artifactsCollected event with the package name when a subscriber is registered', function () {
+        const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
+        const received: { packageName: string }[] = [];
+        broadcaster.consumer.on('artifactsCollected', (payload) => {
+            received.push({ packageName: payload.packageName });
         });
+
+        builder.collectContents(bundleWithContents([makeContent('a.js', 'console.log(0)')], 'package.json'));
+
+        assert.deepStrictEqual(received, [{ packageName: 'the-name' }]);
     });
 
-    builder.collectContents(bundleWithContents([], 'package.json'), undefined, [
-        { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
-    ]);
+    test('collectContents() emits artifact entries with size and kind classification', function () {
+        const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
+        const received: {
+            entries: readonly {
+                path: string;
+                sizeBytes: number;
+                kind: string;
+                sourcePath?: string;
+                status: string;
+                badges: readonly string[];
+            }[];
+        }[] = [];
+        broadcaster.consumer.on('artifactsCollected', (payload) => {
+            received.push({
+                entries: payload.entries.map((entry) => {
+                    return {
+                        path: entry.path,
+                        sizeBytes: entry.sizeBytes,
+                        kind: entry.kind,
+                        ...(entry.sourcePath === undefined ? {} : { sourcePath: entry.sourcePath }),
+                        status: entry.status,
+                        badges: entry.badges
+                    };
+                })
+            });
+        });
 
-    assert.deepStrictEqual(received, [
-        {
-            entries: [
-                { path: 'package.json', status: 'generated', kind: 'manifest' },
-                { path: 'sbom.cdx.json', status: 'generated', kind: 'sbom' }
-            ]
-        }
-    ]);
-});
+        builder.collectContents(bundleWithContents([makeContent('a.js', 'abc', true)], 'package.json'));
 
-test('collectContents() does NOT emit artifactsCollected when no subscriber is registered', () => {
-    const spying = createSpyingBroadcaster();
-    const dependencies: ArtifactsBuilderDependencies = {
-        fileManager: createFakeFileManager(),
-        tarballBuilder: { build: fake.resolves(Buffer.from([])) },
-        progressBroadcaster: spying.provider
-    };
-    const builder = createArtifactsBuilder(dependencies);
-
-    builder.collectContents(bundleWithContents([], 'package.json'));
-
-    assert.strictEqual(spying.emitSpy.callCount, 0);
-});
-
-test('collectContents() emits exactly once per invocation', () => {
-    const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
-    let callCount = 0;
-    broadcaster.consumer.on('artifactsCollected', () => {
-        callCount += 1;
+        assert.deepStrictEqual(received, [
+            {
+                entries: [
+                    { path: 'package.json', sizeBytes: 2, kind: 'manifest', status: 'generated', badges: [] },
+                    {
+                        path: 'a.js',
+                        sizeBytes: 3,
+                        kind: 'source',
+                        sourcePath: '/foo/bar.txt',
+                        status: 'changed',
+                        badges: ['import-path-rewrite']
+                    }
+                ]
+            }
+        ]);
     });
 
-    builder.collectContents(bundleWithContents([], 'package.json'));
-    builder.collectContents(bundleWithContents([], 'package.json'));
+    test('collectContents() emits extra generated files in artifactsCollected when subscribed', function () {
+        const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
+        const received: {
+            entries: readonly { path: string; status: string; kind: string }[];
+        }[] = [];
+        broadcaster.consumer.on('artifactsCollected', (payload) => {
+            received.push({
+                entries: payload.entries.map((entry) => {
+                    return { path: entry.path, status: entry.status, kind: entry.kind };
+                })
+            });
+        });
 
-    assert.strictEqual(callCount, 2);
+        builder.collectContents(bundleWithContents([], 'package.json'), undefined, [
+            { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
+        ]);
+
+        assert.deepStrictEqual(received, [
+            {
+                entries: [
+                    { path: 'package.json', status: 'generated', kind: 'manifest' },
+                    { path: 'sbom.cdx.json', status: 'generated', kind: 'sbom' }
+                ]
+            }
+        ]);
+    });
+
+    test('collectContents() does NOT emit artifactsCollected when no subscriber is registered', function () {
+        const spying = createSpyingBroadcaster();
+        const dependencies: ArtifactsBuilderDependencies = {
+            fileManager: createFakeFileManager(),
+            tarballBuilder: { build: fake.resolves(Buffer.from([])) },
+            progressBroadcaster: spying.provider
+        };
+        const builder = createArtifactsBuilder(dependencies);
+
+        builder.collectContents(bundleWithContents([], 'package.json'));
+
+        assert.strictEqual(spying.emitSpy.callCount, 0);
+    });
+
+    test('collectContents() emits exactly once per invocation', function () {
+        const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
+        let callCount = 0;
+        broadcaster.consumer.on('artifactsCollected', () => {
+            callCount += 1;
+        });
+
+        builder.collectContents(bundleWithContents([], 'package.json'));
+        builder.collectContents(bundleWithContents([], 'package.json'));
+
+        assert.strictEqual(callCount, 2);
+    });
 });

--- a/source/artifacts/content-collection.test.ts
+++ b/source/artifacts/content-collection.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ArtifactSourcePackage } from '../published-package/published-package.ts';
 import { collectArtifactContents, describeArtifactsForReport } from './content-collection.ts';
 
@@ -33,148 +33,156 @@ function bundle(overrides: Partial<ArtifactSourcePackage> = {}): ArtifactSourceP
     };
 }
 
-test('collectArtifactContents emits just the manifest when the bundle has no contents and no extras', () => {
-    assert.deepStrictEqual(collectArtifactContents(bundle(), undefined, []), [
-        { filePath: 'package.json', content: '{}', isExecutable: false }
-    ]);
-});
+suite('content-collection', function () {
+    test('collectArtifactContents emits just the manifest when the bundle has no contents and no extras', function () {
+        assert.deepStrictEqual(collectArtifactContents(bundle(), undefined, []), [
+            { filePath: 'package.json', content: '{}', isExecutable: false }
+        ]);
+    });
 
-test('collectArtifactContents applies the prefix to the manifest file path', () => {
-    assert.deepStrictEqual(collectArtifactContents(bundle(), 'package', []), [
-        { filePath: 'package/package.json', content: '{}', isExecutable: false }
-    ]);
-});
+    test('collectArtifactContents applies the prefix to the manifest file path', function () {
+        assert.deepStrictEqual(collectArtifactContents(bundle(), 'package', []), [
+            { filePath: 'package/package.json', content: '{}', isExecutable: false }
+        ]);
+    });
 
-test('collectArtifactContents emits bundle contents after the manifest', () => {
-    assert.deepStrictEqual(collectArtifactContents(bundle({ contents: [contentEntry('a.txt', 'a')] }), undefined, []), [
-        { filePath: 'package.json', content: '{}', isExecutable: false },
-        { filePath: 'a.txt', content: 'a', isExecutable: false }
-    ]);
-});
+    test('collectArtifactContents emits bundle contents after the manifest', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(bundle({ contents: [contentEntry('a.txt', 'a')] }), undefined, []),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                { filePath: 'a.txt', content: 'a', isExecutable: false }
+            ]
+        );
+    });
 
-test('collectArtifactContents appends extra files after the bundle contents', () => {
-    assert.deepStrictEqual(
-        collectArtifactContents(bundle({ contents: [contentEntry('a.txt', 'a')] }), undefined, [
-            { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
-        ]),
-        [
-            { filePath: 'package.json', content: '{}', isExecutable: false },
-            { filePath: 'a.txt', content: 'a', isExecutable: false },
-            { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
-        ]
-    );
-});
+    test('collectArtifactContents appends extra files after the bundle contents', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(bundle({ contents: [contentEntry('a.txt', 'a')] }), undefined, [
+                { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
+            ]),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                { filePath: 'a.txt', content: 'a', isExecutable: false },
+                { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
+            ]
+        );
+    });
 
-test('collectArtifactContents applies the prefix to bundle contents and extra files', () => {
-    assert.deepStrictEqual(
-        collectArtifactContents(bundle({ contents: [contentEntry('a.txt', 'a')] }), 'package', [
-            { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
-        ]),
-        [
-            { filePath: 'package/package.json', content: '{}', isExecutable: false },
-            { filePath: 'package/a.txt', content: 'a', isExecutable: false },
-            { filePath: 'package/sbom.cdx.json', content: '{}', isExecutable: false }
-        ]
-    );
-});
+    test('collectArtifactContents applies the prefix to bundle contents and extra files', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(bundle({ contents: [contentEntry('a.txt', 'a')] }), 'package', [
+                { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
+            ]),
+            [
+                { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                { filePath: 'package/a.txt', content: 'a', isExecutable: false },
+                { filePath: 'package/sbom.cdx.json', content: '{}', isExecutable: false }
+            ]
+        );
+    });
 
-test('collectArtifactContents forces explicit bin targets to executable', () => {
-    assert.deepStrictEqual(
-        collectArtifactContents(
-            bundle({ contents: [contentEntry('cli.js', '#!/usr/bin/env node')], binField: { 'pkg-a': './cli.js' } }),
-            undefined,
-            []
-        ),
-        [
-            { filePath: 'package.json', content: '{}', isExecutable: false },
-            { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true }
-        ]
-    );
-});
+    test('collectArtifactContents forces explicit bin targets to executable', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(
+                bundle({
+                    contents: [contentEntry('cli.js', '#!/usr/bin/env node')],
+                    binField: { 'pkg-a': './cli.js' }
+                }),
+                undefined,
+                []
+            ),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true }
+            ]
+        );
+    });
 
-test('collectArtifactContents forces a string bin target to executable', () => {
-    assert.deepStrictEqual(
-        collectArtifactContents(
-            bundle({ contents: [contentEntry('cli.js', '#!/usr/bin/env node')], binField: './cli.js' }),
-            undefined,
-            []
-        ),
-        [
-            { filePath: 'package.json', content: '{}', isExecutable: false },
-            { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true }
-        ]
-    );
-});
+    test('collectArtifactContents forces a string bin target to executable', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(
+                bundle({ contents: [contentEntry('cli.js', '#!/usr/bin/env node')], binField: './cli.js' }),
+                undefined,
+                []
+            ),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true }
+            ]
+        );
+    });
 
-test('collectArtifactContents ignores non-string bin entries and applies valid ones', () => {
-    assert.deepStrictEqual(
-        collectArtifactContents(
-            bundle({
-                contents: [contentEntry('cli.js', '#!/usr/bin/env node')],
-                binField: { 'pkg-a': './cli.js', broken: 123 as never }
-            }),
-            undefined,
-            []
-        ),
-        [
-            { filePath: 'package.json', content: '{}', isExecutable: false },
-            { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true }
-        ]
-    );
-});
+    test('collectArtifactContents ignores non-string bin entries and applies valid ones', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(
+                bundle({
+                    contents: [contentEntry('cli.js', '#!/usr/bin/env node')],
+                    binField: { 'pkg-a': './cli.js', broken: 123 as never }
+                }),
+                undefined,
+                []
+            ),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true }
+            ]
+        );
+    });
 
-test('collectArtifactContents only strips a leading dot-slash from explicit bin targets', () => {
-    assert.deepStrictEqual(
-        collectArtifactContents(
-            bundle({
-                contents: [contentEntry('nested/./cli.js', '#!/usr/bin/env node')],
-                binField: 'nested/./cli.js'
-            }),
-            undefined,
-            []
-        ),
-        [
-            { filePath: 'package.json', content: '{}', isExecutable: false },
-            { filePath: 'nested/./cli.js', content: '#!/usr/bin/env node', isExecutable: true }
-        ]
-    );
-});
+    test('collectArtifactContents only strips a leading dot-slash from explicit bin targets', function () {
+        assert.deepStrictEqual(
+            collectArtifactContents(
+                bundle({
+                    contents: [contentEntry('nested/./cli.js', '#!/usr/bin/env node')],
+                    binField: 'nested/./cli.js'
+                }),
+                undefined,
+                []
+            ),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                { filePath: 'nested/./cli.js', content: '#!/usr/bin/env node', isExecutable: true }
+            ]
+        );
+    });
 
-test('describeArtifactsForReport carries sourceFilePath and isSubstituted for bundle entries', () => {
-    assert.deepStrictEqual(
-        describeArtifactsForReport(
-            bundle({ contents: [contentEntry('a.txt', 'a', { isSubstituted: true })] }),
-            undefined,
-            []
-        ),
-        [
-            { filePath: 'package.json', content: '{}', isExecutable: false },
-            {
-                filePath: 'a.txt',
-                content: 'a',
-                isExecutable: false,
-                sourceFilePath: '/src/a.txt',
-                isSubstituted: true
-            }
-        ]
-    );
-});
+    test('describeArtifactsForReport carries sourceFilePath and isSubstituted for bundle entries', function () {
+        assert.deepStrictEqual(
+            describeArtifactsForReport(
+                bundle({ contents: [contentEntry('a.txt', 'a', { isSubstituted: true })] }),
+                undefined,
+                []
+            ),
+            [
+                { filePath: 'package.json', content: '{}', isExecutable: false },
+                {
+                    filePath: 'a.txt',
+                    content: 'a',
+                    isExecutable: false,
+                    sourceFilePath: '/src/a.txt',
+                    isSubstituted: true
+                }
+            ]
+        );
+    });
 
-test('describeArtifactsForReport applies the prefix to manifest, contents, and extra files', () => {
-    assert.deepStrictEqual(
-        describeArtifactsForReport(bundle({ contents: [contentEntry('a.txt', 'a')] }), 'package', [
-            { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
-        ]),
-        [
-            { filePath: 'package/package.json', content: '{}', isExecutable: false },
-            {
-                filePath: 'package/a.txt',
-                content: 'a',
-                isExecutable: false,
-                sourceFilePath: '/src/a.txt',
-                isSubstituted: false
-            },
-            { filePath: 'package/sbom.cdx.json', content: '{}', isExecutable: false }
-        ]
-    );
+    test('describeArtifactsForReport applies the prefix to manifest, contents, and extra files', function () {
+        assert.deepStrictEqual(
+            describeArtifactsForReport(bundle({ contents: [contentEntry('a.txt', 'a')] }), 'package', [
+                { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false }
+            ]),
+            [
+                { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                {
+                    filePath: 'package/a.txt',
+                    content: 'a',
+                    isExecutable: false,
+                    sourceFilePath: '/src/a.txt',
+                    isSubstituted: false
+                },
+                { filePath: 'package/sbom.cdx.json', content: '{}', isExecutable: false }
+            ]
+        );
+    });
 });

--- a/source/artifacts/folder-writer.test.ts
+++ b/source/artifacts/folder-writer.test.ts
@@ -1,49 +1,51 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { writeArtifactsToFolder } from './folder-writer.ts';
 
-test('writeArtifactsToFolder throws when the target folder is already readable', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }]
+suite('folder-writer', function () {
+    test('writeArtifactsToFolder throws when the target folder is already readable', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }]
+        });
+
+        try {
+            await writeArtifactsToFolder(fileManager, '/target', []);
+            assert.fail('Expected writeArtifactsToFolder() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Folder /target already exists');
+        }
     });
 
-    try {
-        await writeArtifactsToFolder(fileManager, '/target', []);
-        assert.fail('Expected writeArtifactsToFolder() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Folder /target already exists');
-    }
-});
+    test('writeArtifactsToFolder writes each entry to the joined target path', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+        });
 
-test('writeArtifactsToFolder writes each entry to the joined target path', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+        await writeArtifactsToFolder(fileManager, '/target', [
+            { filePath: 'a.txt', content: 'a', isExecutable: false },
+            { filePath: 'nested/b.txt', content: 'b', isExecutable: false }
+        ]);
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), { filePath: '/target/a.txt', content: 'a' });
+        assert.deepStrictEqual(fileManager.getWriteFileCall(1), { filePath: '/target/nested/b.txt', content: 'b' });
     });
 
-    await writeArtifactsToFolder(fileManager, '/target', [
-        { filePath: 'a.txt', content: 'a', isExecutable: false },
-        { filePath: 'nested/b.txt', content: 'b', isExecutable: false }
-    ]);
+    test('writeArtifactsToFolder records each entry on the file manager in order', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+        });
 
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 2);
-    assert.deepStrictEqual(fileManager.getWriteFileCall(0), { filePath: '/target/a.txt', content: 'a' });
-    assert.deepStrictEqual(fileManager.getWriteFileCall(1), { filePath: '/target/nested/b.txt', content: 'b' });
-});
+        await writeArtifactsToFolder(fileManager, '/target', [
+            { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true },
+            { filePath: 'data.txt', content: 'data', isExecutable: false }
+        ]);
 
-test('writeArtifactsToFolder records each entry on the file manager in order', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+            filePath: '/target/cli.js',
+            content: '#!/usr/bin/env node'
+        });
+        assert.deepStrictEqual(fileManager.getWriteFileCall(1), { filePath: '/target/data.txt', content: 'data' });
     });
-
-    await writeArtifactsToFolder(fileManager, '/target', [
-        { filePath: 'cli.js', content: '#!/usr/bin/env node', isExecutable: true },
-        { filePath: 'data.txt', content: 'data', isExecutable: false }
-    ]);
-
-    assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
-        filePath: '/target/cli.js',
-        content: '#!/usr/bin/env node'
-    });
-    assert.deepStrictEqual(fileManager.getWriteFileCall(1), { filePath: '/target/data.txt', content: 'data' });
 });

--- a/source/build-support/mutation-timeout/check-mutation-timeouts.test.ts
+++ b/source/build-support/mutation-timeout/check-mutation-timeouts.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
     killedMutant,
@@ -9,41 +9,43 @@ import {
 } from '../../test-libraries/mutation-report-fixtures.ts';
 import { checkMutationTimeoutReport } from './check-mutation-timeouts.ts';
 
-test('checkMutationTimeoutReport returns undefined for a report without timeout mutants', async () => {
-    await withTemporaryReportDirectory(
-        'mutation-report.json',
-        JSON.stringify(singleMutantReport(killedMutant)),
-        async (reportPath) => {
-            const fileManager = createFakeFileManager({
-                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
-            });
+suite('check-mutation-timeouts', function () {
+    test('checkMutationTimeoutReport returns undefined for a report without timeout mutants', async function () {
+        await withTemporaryReportDirectory(
+            'mutation-report.json',
+            JSON.stringify(singleMutantReport(killedMutant)),
+            async (reportPath) => {
+                const fileManager = createFakeFileManager({
+                    simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
+                });
 
-            assert.strictEqual(await checkMutationTimeoutReport(reportPath, fileManager), undefined);
-        }
-    );
-});
+                assert.strictEqual(await checkMutationTimeoutReport(reportPath, fileManager), undefined);
+            }
+        );
+    });
 
-test('checkMutationTimeoutReport returns the formatted failure message for timeout mutants', async () => {
-    await withTemporaryReportDirectory(
-        'mutation-report.json',
-        JSON.stringify(singleMutantReport(timeoutMutant)),
-        async (reportPath) => {
-            const fileManager = createFakeFileManager({
-                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(timeoutMutant)) }]
-            });
+    test('checkMutationTimeoutReport returns the formatted failure message for timeout mutants', async function () {
+        await withTemporaryReportDirectory(
+            'mutation-report.json',
+            JSON.stringify(singleMutantReport(timeoutMutant)),
+            async (reportPath) => {
+                const fileManager = createFakeFileManager({
+                    simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(timeoutMutant)) }]
+                });
 
-            assert.strictEqual(
-                await checkMutationTimeoutReport(reportPath, fileManager),
-                ['Mutation report contains 1 timeout mutant.', '- source/a.ts:7:8'].join('\n')
-            );
-        }
-    );
-});
+                assert.strictEqual(
+                    await checkMutationTimeoutReport(reportPath, fileManager),
+                    ['Mutation report contains 1 timeout mutant.', '- source/a.ts:7:8'].join('\n')
+                );
+            }
+        );
+    });
 
-test('checkMutationTimeoutReport passes the requested report path to the file manager', async () => {
-    const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{}' }] });
+    test('checkMutationTimeoutReport passes the requested report path to the file manager', async function () {
+        const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{}' }] });
 
-    await checkMutationTimeoutReport('some/path.json', fileManager);
+        await checkMutationTimeoutReport('some/path.json', fileManager);
 
-    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: 'some/path.json' });
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: 'some/path.json' });
+    });
 });

--- a/source/build-support/mutation-timeout/mutation-report-reader.test.ts
+++ b/source/build-support/mutation-timeout/mutation-report-reader.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import { readMutationReport } from './mutation-report-reader.ts';
 
@@ -7,70 +7,72 @@ function createReadFileError(code: string, message: string): Error & { readonly 
     return Object.assign(new Error(message), { code });
 }
 
-test('readMutationReport parses the JSON report from the file manager', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedReadFileResponses: [{ value: JSON.stringify({ files: { 'source/a.ts': { mutants: [] } } }) }]
+suite('mutation-report-reader', function () {
+    test('readMutationReport parses the JSON report from the file manager', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: JSON.stringify({ files: { 'source/a.ts': { mutants: [] } } }) }]
+        });
+
+        assert.deepStrictEqual(await readMutationReport('mutation-report.json', fileManager), {
+            files: { 'source/a.ts': { mutants: [] } }
+        });
     });
 
-    assert.deepStrictEqual(await readMutationReport('mutation-report.json', fileManager), {
-        files: { 'source/a.ts': { mutants: [] } }
-    });
-});
+    test('readMutationReport passes the requested report path to the file manager', async function () {
+        const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{}' }] });
 
-test('readMutationReport passes the requested report path to the file manager', async () => {
-    const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{}' }] });
+        await readMutationReport('some/path.json', fileManager);
 
-    await readMutationReport('some/path.json', fileManager);
-
-    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: 'some/path.json' });
-});
-
-test('readMutationReport throws a missing-report error when the file manager raises ENOENT', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedReadFileResponses: [
-            { error: createReadFileError('ENOENT', "ENOENT: no such file or directory, open '/missing.json'") }
-        ]
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: 'some/path.json' });
     });
 
-    try {
-        await readMutationReport('/missing.json', fileManager);
-        assert.fail('Expected readMutationReport() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Mutation report not found at "/missing.json"');
-    }
-});
+    test('readMutationReport throws a missing-report error when the file manager raises ENOENT', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [
+                { error: createReadFileError('ENOENT', "ENOENT: no such file or directory, open '/missing.json'") }
+            ]
+        });
 
-test('readMutationReport preserves the original ENOENT error as cause', async () => {
-    const cause = createReadFileError('ENOENT', "ENOENT: no such file or directory, open '/missing.json'");
-    const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ error: cause }] });
+        try {
+            await readMutationReport('/missing.json', fileManager);
+            assert.fail('Expected readMutationReport() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Mutation report not found at "/missing.json"');
+        }
+    });
 
-    try {
-        await readMutationReport('/missing.json', fileManager);
-        assert.fail('Expected readMutationReport() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).cause, cause);
-    }
-});
+    test('readMutationReport preserves the original ENOENT error as cause', async function () {
+        const cause = createReadFileError('ENOENT', "ENOENT: no such file or directory, open '/missing.json'");
+        const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ error: cause }] });
 
-test('readMutationReport rethrows non-ENOENT file system errors unchanged', async () => {
-    const cause = createReadFileError('EACCES', 'permission denied');
-    const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ error: cause }] });
+        try {
+            await readMutationReport('/missing.json', fileManager);
+            assert.fail('Expected readMutationReport() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).cause, cause);
+        }
+    });
 
-    try {
-        await readMutationReport('/locked.json', fileManager);
-        assert.fail('Expected readMutationReport() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(error, cause);
-    }
-});
+    test('readMutationReport rethrows non-ENOENT file system errors unchanged', async function () {
+        const cause = createReadFileError('EACCES', 'permission denied');
+        const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ error: cause }] });
 
-test('readMutationReport rethrows invalid JSON parse errors as SyntaxError', async () => {
-    const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{' }] });
+        try {
+            await readMutationReport('/locked.json', fileManager);
+            assert.fail('Expected readMutationReport() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(error, cause);
+        }
+    });
 
-    try {
-        await readMutationReport('mutation-report.json', fileManager);
-        assert.fail('Expected readMutationReport() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(error instanceof SyntaxError, true);
-    }
+    test('readMutationReport rethrows invalid JSON parse errors as SyntaxError', async function () {
+        const fileManager = createFakeFileManager({ simulatedReadFileResponses: [{ value: '{' }] });
+
+        try {
+            await readMutationReport('mutation-report.json', fileManager);
+            assert.fail('Expected readMutationReport() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(error instanceof SyntaxError, true);
+        }
+    });
 });

--- a/source/build-support/mutation-timeout/mutation-report-schema.test.ts
+++ b/source/build-support/mutation-timeout/mutation-report-schema.test.ts
@@ -1,98 +1,100 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { parseMutationReport } from './mutation-report-schema.ts';
 
-test('parseMutationReport returns an empty report for a non-object input', () => {
-    assert.deepStrictEqual(parseMutationReport(null), {});
-});
-
-test('parseMutationReport returns an empty report when files is missing', () => {
-    assert.deepStrictEqual(parseMutationReport({}), {});
-});
-
-test('parseMutationReport returns an empty report when files is not an object', () => {
-    assert.deepStrictEqual(parseMutationReport({ files: 'invalid' }), {});
-});
-
-test('parseMutationReport replaces a non-object file report with undefined', () => {
-    assert.deepStrictEqual(parseMutationReport({ files: { 'source/a.ts': null } }), {
-        files: { 'source/a.ts': undefined }
+suite('mutation-report-schema', function () {
+    test('parseMutationReport returns an empty report for a non-object input', function () {
+        assert.deepStrictEqual(parseMutationReport(null), {});
     });
-});
 
-test('parseMutationReport returns an empty file entry when mutants is not an array', () => {
-    assert.deepStrictEqual(parseMutationReport({ files: { 'source/a.ts': { mutants: 'invalid' } } }), {
-        files: { 'source/a.ts': {} }
+    test('parseMutationReport returns an empty report when files is missing', function () {
+        assert.deepStrictEqual(parseMutationReport({}), {});
     });
-});
 
-test('parseMutationReport skips non-object mutants', () => {
-    assert.deepStrictEqual(parseMutationReport({ files: { 'source/a.ts': { mutants: [null, 'string'] } } }), {
-        files: { 'source/a.ts': { mutants: [] } }
+    test('parseMutationReport returns an empty report when files is not an object', function () {
+        assert.deepStrictEqual(parseMutationReport({ files: 'invalid' }), {});
     });
-});
 
-test('parseMutationReport skips mutants whose location is not an object', () => {
-    assert.deepStrictEqual(
-        parseMutationReport({
-            files: { 'source/a.ts': { mutants: [{ status: 'Timeout', location: null }] } }
-        }),
-        { files: { 'source/a.ts': { mutants: [] } } }
-    );
-});
-
-test('parseMutationReport skips mutants whose location.start.line is not a number', () => {
-    assert.deepStrictEqual(
-        parseMutationReport({
-            files: {
-                'source/a.ts': {
-                    mutants: [{ status: 'Timeout', location: { start: { line: '3', column: 4 } } }]
-                }
-            }
-        }),
-        { files: { 'source/a.ts': { mutants: [] } } }
-    );
-});
-
-test('parseMutationReport skips mutants whose location.start.column is not a number', () => {
-    assert.deepStrictEqual(
-        parseMutationReport({
-            files: {
-                'source/a.ts': {
-                    mutants: [{ status: 'Timeout', location: { start: { line: 3, column: '4' } } }]
-                }
-            }
-        }),
-        { files: { 'source/a.ts': { mutants: [] } } }
-    );
-});
-
-test('parseMutationReport throws when a mutant has no string status', () => {
-    try {
-        parseMutationReport({
-            files: { 'source/a.ts': { mutants: [{ location: { start: { line: 1, column: 2 } } }] } }
+    test('parseMutationReport replaces a non-object file report with undefined', function () {
+        assert.deepStrictEqual(parseMutationReport({ files: { 'source/a.ts': null } }), {
+            files: { 'source/a.ts': undefined }
         });
-        assert.fail('Expected parseMutationReport() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Mutation report contains a mutant without a string status');
-    }
-});
+    });
 
-test('parseMutationReport preserves a valid mutant with status and location', () => {
-    assert.deepStrictEqual(
-        parseMutationReport({
-            files: {
-                'source/a.ts': {
-                    mutants: [{ status: 'Timeout', location: { start: { line: 3, column: 4 } } }]
+    test('parseMutationReport returns an empty file entry when mutants is not an array', function () {
+        assert.deepStrictEqual(parseMutationReport({ files: { 'source/a.ts': { mutants: 'invalid' } } }), {
+            files: { 'source/a.ts': {} }
+        });
+    });
+
+    test('parseMutationReport skips non-object mutants', function () {
+        assert.deepStrictEqual(parseMutationReport({ files: { 'source/a.ts': { mutants: [null, 'string'] } } }), {
+            files: { 'source/a.ts': { mutants: [] } }
+        });
+    });
+
+    test('parseMutationReport skips mutants whose location is not an object', function () {
+        assert.deepStrictEqual(
+            parseMutationReport({
+                files: { 'source/a.ts': { mutants: [{ status: 'Timeout', location: null }] } }
+            }),
+            { files: { 'source/a.ts': { mutants: [] } } }
+        );
+    });
+
+    test('parseMutationReport skips mutants whose location.start.line is not a number', function () {
+        assert.deepStrictEqual(
+            parseMutationReport({
+                files: {
+                    'source/a.ts': {
+                        mutants: [{ status: 'Timeout', location: { start: { line: '3', column: 4 } } }]
+                    }
                 }
-            }
-        }),
-        {
-            files: {
-                'source/a.ts': {
-                    mutants: [{ status: 'Timeout', location: { start: { line: 3, column: 4 } } }]
+            }),
+            { files: { 'source/a.ts': { mutants: [] } } }
+        );
+    });
+
+    test('parseMutationReport skips mutants whose location.start.column is not a number', function () {
+        assert.deepStrictEqual(
+            parseMutationReport({
+                files: {
+                    'source/a.ts': {
+                        mutants: [{ status: 'Timeout', location: { start: { line: 3, column: '4' } } }]
+                    }
                 }
-            }
+            }),
+            { files: { 'source/a.ts': { mutants: [] } } }
+        );
+    });
+
+    test('parseMutationReport throws when a mutant has no string status', function () {
+        try {
+            parseMutationReport({
+                files: { 'source/a.ts': { mutants: [{ location: { start: { line: 1, column: 2 } } }] } }
+            });
+            assert.fail('Expected parseMutationReport() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Mutation report contains a mutant without a string status');
         }
-    );
+    });
+
+    test('parseMutationReport preserves a valid mutant with status and location', function () {
+        assert.deepStrictEqual(
+            parseMutationReport({
+                files: {
+                    'source/a.ts': {
+                        mutants: [{ status: 'Timeout', location: { start: { line: 3, column: 4 } } }]
+                    }
+                }
+            }),
+            {
+                files: {
+                    'source/a.ts': {
+                        mutants: [{ status: 'Timeout', location: { start: { line: 3, column: 4 } } }]
+                    }
+                }
+            }
+        );
+    });
 });

--- a/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
+++ b/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { execFile } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
     killedMutant,
@@ -89,121 +89,123 @@ async function runCheckWithCollectedErrors(
     return { exitCode, errors };
 }
 
-test('runMutationTimeoutCheck writes the failure message and returns exit code 1 when timeouts exist', async () => {
-    await withTemporaryReport(singleMutantReport(timeoutMutant), async (reportPath) => {
-        const result = await runCheckWithCollectedErrors(
-            ['node', 'check', reportPath],
-            createFakeFileManager({
-                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(timeoutMutant)) }]
-            })
-        );
+suite('mutation-timeout-cli-runner', function () {
+    test('runMutationTimeoutCheck writes the failure message and returns exit code 1 when timeouts exist', async function () {
+        await withTemporaryReport(singleMutantReport(timeoutMutant), async (reportPath) => {
+            const result = await runCheckWithCollectedErrors(
+                ['node', 'check', reportPath],
+                createFakeFileManager({
+                    simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(timeoutMutant)) }]
+                })
+            );
 
-        assert.strictEqual(result.exitCode, 1);
-        assert.deepStrictEqual(result.errors, [timeoutReportMessage()]);
+            assert.strictEqual(result.exitCode, 1);
+            assert.deepStrictEqual(result.errors, [timeoutReportMessage()]);
+        });
     });
-});
 
-test('runMutationTimeoutCheck returns exit code 0 and writes nothing when no timeouts exist', async () => {
-    await withTemporaryReport(singleMutantReport(killedMutant), async (reportPath) => {
-        const result = await runCheckWithCollectedErrors(
-            ['node', 'check', reportPath],
-            createFakeFileManager({
-                simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
-            })
-        );
+    test('runMutationTimeoutCheck returns exit code 0 and writes nothing when no timeouts exist', async function () {
+        await withTemporaryReport(singleMutantReport(killedMutant), async (reportPath) => {
+            const result = await runCheckWithCollectedErrors(
+                ['node', 'check', reportPath],
+                createFakeFileManager({
+                    simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
+                })
+            );
+
+            assert.strictEqual(result.exitCode, 0);
+            assert.deepStrictEqual(result.errors, []);
+        });
+    });
+
+    test('runMutationTimeoutCheck uses the default report path when argv omits an explicit report path', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
+        });
+        const result = await runCheckWithCollectedErrors(['node', 'check'], fileManager);
 
         assert.strictEqual(result.exitCode, 0);
         assert.deepStrictEqual(result.errors, []);
-    });
-});
-
-test('runMutationTimeoutCheck uses the default report path when argv omits an explicit report path', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedReadFileResponses: [{ value: JSON.stringify(singleMutantReport(killedMutant)) }]
-    });
-    const result = await runCheckWithCollectedErrors(['node', 'check'], fileManager);
-
-    assert.strictEqual(result.exitCode, 0);
-    assert.deepStrictEqual(result.errors, []);
-    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: defaultReportFilePath });
-});
-
-test('runMutationTimeoutCheck writes missing-file errors and returns exit code 1', async () => {
-    const result = await runCheckWithCollectedErrors(
-        ['node', 'check', defaultMissingReportPath],
-        createFakeFileManager({
-            simulatedReadFileResponses: [
-                {
-                    error: createReadFileError(
-                        'ENOENT',
-                        `ENOENT: no such file or directory, open '${defaultMissingReportPath}'`
-                    )
-                }
-            ]
-        })
-    );
-
-    assert.strictEqual(result.exitCode, 1);
-    assert.deepStrictEqual(result.errors, [`Mutation report not found at "${defaultMissingReportPath}"`]);
-});
-
-test('runMutationTimeoutCheck uses the default stderr writer when no custom writer is passed', async () => {
-    const writes: string[] = [];
-    const exitCode = await runMutationTimeoutCheck(['node', 'check', '/definitely/missing/mutation-report.json'], {
-        fileManager: createFakeFileManager({
-            simulatedReadFileResponses: [
-                {
-                    error: createReadFileError(
-                        'ENOENT',
-                        "ENOENT: no such file or directory, open '/definitely/missing/mutation-report.json'"
-                    )
-                }
-            ]
-        }),
-        stderrWrite: (message) => {
-            writes.push(message);
-        }
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: defaultReportFilePath });
     });
 
-    assert.strictEqual(exitCode, 1);
-    assert.deepStrictEqual(writes, ['Mutation report not found at "/definitely/missing/mutation-report.json"\n']);
-});
-
-test('runMutationTimeoutCheck writes invalid JSON errors and returns exit code 1', async () => {
-    await withTemporaryReportDirectory('mutation-report.json', '{', async (reportPath) => {
+    test('runMutationTimeoutCheck writes missing-file errors and returns exit code 1', async function () {
         const result = await runCheckWithCollectedErrors(
-            ['node', 'check', reportPath],
+            ['node', 'check', defaultMissingReportPath],
             createFakeFileManager({
-                simulatedReadFileResponses: [{ value: '{' }]
+                simulatedReadFileResponses: [
+                    {
+                        error: createReadFileError(
+                            'ENOENT',
+                            `ENOENT: no such file or directory, open '${defaultMissingReportPath}'`
+                        )
+                    }
+                ]
             })
         );
 
         assert.strictEqual(result.exitCode, 1);
-        assert.ok((result.errors[0] ?? '').includes("Expected property name or '}'"));
-    });
-});
-
-test('runMutationTimeoutCheck stringifies non-Error failures', async () => {
-    const errors: string[] = [];
-    const exitCode = await runMutationTimeoutCheck(createArgvThrowingNonErrorOnReportPath(), {
-        fileManager: createFakeFileManager(),
-        stderrWrite: () => {
-            throw new Error('stderrWrite should not be used when writeError is injected');
-        },
-        writeError: (message) => {
-            errors.push(message);
-        }
+        assert.deepStrictEqual(result.errors, [`Mutation report not found at "${defaultMissingReportPath}"`]);
     });
 
-    assert.strictEqual(exitCode, 1);
-    assert.deepStrictEqual(errors, ['boom']);
-});
+    test('runMutationTimeoutCheck uses the default stderr writer when no custom writer is passed', async function () {
+        const writes: string[] = [];
+        const exitCode = await runMutationTimeoutCheck(['node', 'check', '/definitely/missing/mutation-report.json'], {
+            fileManager: createFakeFileManager({
+                simulatedReadFileResponses: [
+                    {
+                        error: createReadFileError(
+                            'ENOENT',
+                            "ENOENT: no such file or directory, open '/definitely/missing/mutation-report.json'"
+                        )
+                    }
+                ]
+            }),
+            stderrWrite: (message) => {
+                writes.push(message);
+            }
+        });
 
-test('CLI uses the default report path and exits with code 0 when there are no timeout mutants', async () => {
-    await withDefaultReport(singleMutantReport(killedMutant), async (directory) => {
-        const result = await runCheckerCli([], directory);
+        assert.strictEqual(exitCode, 1);
+        assert.deepStrictEqual(writes, ['Mutation report not found at "/definitely/missing/mutation-report.json"\n']);
+    });
 
-        assert.strictEqual(result.exitCode, 0);
-        assert.strictEqual(result.standardError, '');
+    test('runMutationTimeoutCheck writes invalid JSON errors and returns exit code 1', async function () {
+        await withTemporaryReportDirectory('mutation-report.json', '{', async (reportPath) => {
+            const result = await runCheckWithCollectedErrors(
+                ['node', 'check', reportPath],
+                createFakeFileManager({
+                    simulatedReadFileResponses: [{ value: '{' }]
+                })
+            );
+
+            assert.strictEqual(result.exitCode, 1);
+            assert.ok((result.errors[0] ?? '').includes("Expected property name or '}'"));
+        });
+    });
+
+    test('runMutationTimeoutCheck stringifies non-Error failures', async function () {
+        const errors: string[] = [];
+        const exitCode = await runMutationTimeoutCheck(createArgvThrowingNonErrorOnReportPath(), {
+            fileManager: createFakeFileManager(),
+            stderrWrite: () => {
+                throw new Error('stderrWrite should not be used when writeError is injected');
+            },
+            writeError: (message) => {
+                errors.push(message);
+            }
+        });
+
+        assert.strictEqual(exitCode, 1);
+        assert.deepStrictEqual(errors, ['boom']);
+    });
+
+    test('CLI uses the default report path and exits with code 0 when there are no timeout mutants', async function () {
+        await withDefaultReport(singleMutantReport(killedMutant), async (directory) => {
+            const result = await runCheckerCli([], directory);
+
+            assert.strictEqual(result.exitCode, 0);
+            assert.strictEqual(result.standardError, '');
+        });
     });
 });

--- a/source/build-support/mutation-timeout/timeout-error-formatter.test.ts
+++ b/source/build-support/mutation-timeout/timeout-error-formatter.test.ts
@@ -1,24 +1,26 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { formatMutationTimeoutError } from './timeout-error-formatter.ts';
 
-test('formatMutationTimeoutError returns undefined when no timeout mutants exist', () => {
-    assert.strictEqual(formatMutationTimeoutError([]), undefined);
-});
+suite('timeout-error-formatter', function () {
+    test('formatMutationTimeoutError returns undefined when no timeout mutants exist', function () {
+        assert.strictEqual(formatMutationTimeoutError([]), undefined);
+    });
 
-test('formatMutationTimeoutError formats a singular header for one timeout mutant', () => {
-    assert.strictEqual(
-        formatMutationTimeoutError([{ filePath: 'source/a.ts', line: 3, column: 4 }]),
-        ['Mutation report contains 1 timeout mutant.', '- source/a.ts:3:4'].join('\n')
-    );
-});
+    test('formatMutationTimeoutError formats a singular header for one timeout mutant', function () {
+        assert.strictEqual(
+            formatMutationTimeoutError([{ filePath: 'source/a.ts', line: 3, column: 4 }]),
+            ['Mutation report contains 1 timeout mutant.', '- source/a.ts:3:4'].join('\n')
+        );
+    });
 
-test('formatMutationTimeoutError pluralizes the header for multiple timeout mutants', () => {
-    assert.strictEqual(
-        formatMutationTimeoutError([
-            { filePath: 'source/a.ts', line: 3, column: 4 },
-            { filePath: 'source/b.ts', line: 5, column: 6 }
-        ]),
-        ['Mutation report contains 2 timeout mutants.', '- source/a.ts:3:4', '- source/b.ts:5:6'].join('\n')
-    );
+    test('formatMutationTimeoutError pluralizes the header for multiple timeout mutants', function () {
+        assert.strictEqual(
+            formatMutationTimeoutError([
+                { filePath: 'source/a.ts', line: 3, column: 4 },
+                { filePath: 'source/b.ts', line: 5, column: 6 }
+            ]),
+            ['Mutation report contains 2 timeout mutants.', '- source/a.ts:3:4', '- source/b.ts:5:6'].join('\n')
+        );
+    });
 });

--- a/source/build-support/mutation-timeout/timeout-mutant-collector.test.ts
+++ b/source/build-support/mutation-timeout/timeout-mutant-collector.test.ts
@@ -1,63 +1,65 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { collectTimeoutMutants } from './timeout-mutant-collector.ts';
 
-test('collectTimeoutMutants returns an empty array when the report has no files', () => {
-    assert.deepStrictEqual(collectTimeoutMutants({}), []);
-});
+suite('timeout-mutant-collector', function () {
+    test('collectTimeoutMutants returns an empty array when the report has no files', function () {
+        assert.deepStrictEqual(collectTimeoutMutants({}), []);
+    });
 
-test('collectTimeoutMutants returns an empty array when a file entry is undefined', () => {
-    assert.deepStrictEqual(collectTimeoutMutants({ files: { 'source/a.ts': undefined } }), []);
-});
+    test('collectTimeoutMutants returns an empty array when a file entry is undefined', function () {
+        assert.deepStrictEqual(collectTimeoutMutants({ files: { 'source/a.ts': undefined } }), []);
+    });
 
-test('collectTimeoutMutants returns an empty array when a file report has no mutants', () => {
-    assert.deepStrictEqual(collectTimeoutMutants({ files: { 'source/a.ts': {} } }), []);
-});
+    test('collectTimeoutMutants returns an empty array when a file report has no mutants', function () {
+        assert.deepStrictEqual(collectTimeoutMutants({ files: { 'source/a.ts': {} } }), []);
+    });
 
-test('collectTimeoutMutants ignores mutants whose status is not Timeout', () => {
-    assert.deepStrictEqual(
-        collectTimeoutMutants({
-            files: {
-                'source/a.ts': {
-                    mutants: [{ status: 'Killed', location: { start: { line: 1, column: 2 } } }]
+    test('collectTimeoutMutants ignores mutants whose status is not Timeout', function () {
+        assert.deepStrictEqual(
+            collectTimeoutMutants({
+                files: {
+                    'source/a.ts': {
+                        mutants: [{ status: 'Killed', location: { start: { line: 1, column: 2 } } }]
+                    }
                 }
-            }
-        }),
-        []
-    );
-});
+            }),
+            []
+        );
+    });
 
-test('collectTimeoutMutants returns the file path with line and column for a Timeout mutant', () => {
-    assert.deepStrictEqual(
-        collectTimeoutMutants({
-            files: {
-                'source/a.ts': {
-                    mutants: [{ status: 'Timeout', location: { start: { line: 3, column: 4 } } }]
+    test('collectTimeoutMutants returns the file path with line and column for a Timeout mutant', function () {
+        assert.deepStrictEqual(
+            collectTimeoutMutants({
+                files: {
+                    'source/a.ts': {
+                        mutants: [{ status: 'Timeout', location: { start: { line: 3, column: 4 } } }]
+                    }
                 }
-            }
-        }),
-        [{ filePath: 'source/a.ts', line: 3, column: 4 }]
-    );
-});
+            }),
+            [{ filePath: 'source/a.ts', line: 3, column: 4 }]
+        );
+    });
 
-test('collectTimeoutMutants returns every Timeout mutant across multiple files in order', () => {
-    assert.deepStrictEqual(
-        collectTimeoutMutants({
-            files: {
-                'source/a.ts': {
-                    mutants: [
-                        { status: 'Killed', location: { start: { line: 1, column: 2 } } },
-                        { status: 'Timeout', location: { start: { line: 3, column: 4 } } }
-                    ]
-                },
-                'source/b.ts': {
-                    mutants: [{ status: 'Timeout', location: { start: { line: 5, column: 6 } } }]
+    test('collectTimeoutMutants returns every Timeout mutant across multiple files in order', function () {
+        assert.deepStrictEqual(
+            collectTimeoutMutants({
+                files: {
+                    'source/a.ts': {
+                        mutants: [
+                            { status: 'Killed', location: { start: { line: 1, column: 2 } } },
+                            { status: 'Timeout', location: { start: { line: 3, column: 4 } } }
+                        ]
+                    },
+                    'source/b.ts': {
+                        mutants: [{ status: 'Timeout', location: { start: { line: 5, column: 6 } } }]
+                    }
                 }
-            }
-        }),
-        [
-            { filePath: 'source/a.ts', line: 3, column: 4 },
-            { filePath: 'source/b.ts', line: 5, column: 6 }
-        ]
-    );
+            }),
+            [
+                { filePath: 'source/a.ts', line: 3, column: 4 },
+                { filePath: 'source/b.ts', line: 5, column: 6 }
+            ]
+        );
+    });
 });

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
 import type { PublishSettings } from '../config/publish-settings.ts';
@@ -80,261 +80,263 @@ function createPublishedBundleScenario(): {
     };
 }
 
-test('determineCurrentVersion() fetches the latest version when automatic versioning is enabled', async () => {
-    const fetchLatestVersion = fake.resolves(Maybe.nothing());
-    const emitter = emitterFactory({ fetchLatestVersion });
+suite('emitter', function () {
+    test('determineCurrentVersion() fetches the latest version when automatic versioning is enabled', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.nothing());
+        const emitter = emitterFactory({ fetchLatestVersion });
 
-    await emitter.determineCurrentVersion({
-        name: 'the-name',
-        registrySettings,
-        versioning: { automatic: true }
+        await emitter.determineCurrentVersion({
+            name: 'the-name',
+            registrySettings,
+            versioning: { automatic: true }
+        });
+
+        assert.strictEqual(fetchLatestVersion.callCount, 1);
+        assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
     });
 
-    assert.strictEqual(fetchLatestVersion.callCount, 1);
-    assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
-});
+    test('determineCurrentVersion() returns the fetched version when automatic versioning is enabled', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: 'the-version' }));
+        const emitter = emitterFactory({ fetchLatestVersion });
 
-test('determineCurrentVersion() returns the fetched version when automatic versioning is enabled', async () => {
-    const fetchLatestVersion = fake.resolves(Maybe.just({ version: 'the-version' }));
-    const emitter = emitterFactory({ fetchLatestVersion });
+        const result = await emitter.determineCurrentVersion({
+            name: 'the-name',
+            registrySettings,
+            versioning: { automatic: true }
+        });
 
-    const result = await emitter.determineCurrentVersion({
-        name: 'the-name',
-        registrySettings,
-        versioning: { automatic: true }
+        assert.deepStrictEqual(result, Maybe.just('the-version'));
     });
 
-    assert.deepStrictEqual(result, Maybe.just('the-version'));
-});
+    test('determineCurrentVersion() doesn’t fetches the latest version when manual versioning is enabled', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.nothing());
+        const emitter = emitterFactory({ fetchLatestVersion });
 
-test('determineCurrentVersion() doesn’t fetches the latest version when manual versioning is enabled', async () => {
-    const fetchLatestVersion = fake.resolves(Maybe.nothing());
-    const emitter = emitterFactory({ fetchLatestVersion });
+        await emitter.determineCurrentVersion({
+            name: 'the-name',
+            registrySettings,
+            versioning: { automatic: false, version: '' }
+        });
 
-    await emitter.determineCurrentVersion({
-        name: 'the-name',
-        registrySettings,
-        versioning: { automatic: false, version: '' }
+        assert.strictEqual(fetchLatestVersion.callCount, 0);
     });
 
-    assert.strictEqual(fetchLatestVersion.callCount, 0);
-});
+    test('determineCurrentVersion() returns the given version when manual versioning is enabled', async function () {
+        const emitter = emitterFactory({});
 
-test('determineCurrentVersion() returns the given version when manual versioning is enabled', async () => {
-    const emitter = emitterFactory({});
+        const result = await emitter.determineCurrentVersion({
+            name: 'the-name',
+            registrySettings,
+            versioning: { automatic: false, version: 'manual-version' }
+        });
 
-    const result = await emitter.determineCurrentVersion({
-        name: 'the-name',
-        registrySettings,
-        versioning: { automatic: false, version: 'manual-version' }
+        assert.deepStrictEqual(result, Maybe.just('manual-version'));
     });
 
-    assert.deepStrictEqual(result, Maybe.just('manual-version'));
-});
+    test('checkBundleAlreadyPublished() fetches the latest version', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.nothing());
+        const emitter = emitterFactory({ fetchLatestVersion });
 
-test('checkBundleAlreadyPublished() fetches the latest version', async () => {
-    const fetchLatestVersion = fake.resolves(Maybe.nothing());
-    const emitter = emitterFactory({ fetchLatestVersion });
+        await emitter.checkBundleAlreadyPublished({
+            registrySettings,
+            bundle: namedBundle()
+        });
 
-    await emitter.checkBundleAlreadyPublished({
-        registrySettings,
-        bundle: namedBundle()
+        assert.strictEqual(fetchLatestVersion.callCount, 1);
+        assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
     });
 
-    assert.strictEqual(fetchLatestVersion.callCount, 1);
-    assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
-});
+    test('checkBundleAlreadyPublished() returns false when there is no latest version in the registry', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.nothing());
+        const collectContents = fake.returns([]);
+        const emitter = emitterFactory({ fetchLatestVersion, collectContents });
 
-test('checkBundleAlreadyPublished() returns false when there is no latest version in the registry', async () => {
-    const fetchLatestVersion = fake.resolves(Maybe.nothing());
-    const collectContents = fake.returns([]);
-    const emitter = emitterFactory({ fetchLatestVersion, collectContents });
+        const result = await emitter.checkBundleAlreadyPublished({
+            registrySettings,
+            bundle: namedBundle()
+        });
 
-    const result = await emitter.checkBundleAlreadyPublished({
-        registrySettings,
-        bundle: namedBundle()
+        assert.deepStrictEqual(result, { alreadyPublishedAsLatest: false });
+        assert.strictEqual(collectContents.callCount, 0);
     });
 
-    assert.deepStrictEqual(result, { alreadyPublishedAsLatest: false });
-    assert.strictEqual(collectContents.callCount, 0);
-});
+    test('checkBundleAlreadyPublished() returns false when the latest version contents doesn’t match the given bundle', async function () {
+        const fetchLatestVersion = fake.resolves(
+            Maybe.just({ version: '1.2.3', tarballUrl: 'https://registry.example.test/package.tgz' })
+        );
+        const fetchTarball = fake.resolves(tarballWithOneFile);
+        const collectContents = fake.returns([]);
+        const emitter = emitterFactory({ fetchLatestVersion, fetchTarball, collectContents });
 
-test('checkBundleAlreadyPublished() returns false when the latest version contents doesn’t match the given bundle', async () => {
-    const fetchLatestVersion = fake.resolves(
-        Maybe.just({ version: '1.2.3', tarballUrl: 'https://registry.example.test/package.tgz' })
-    );
-    const fetchTarball = fake.resolves(tarballWithOneFile);
-    const collectContents = fake.returns([]);
-    const emitter = emitterFactory({ fetchLatestVersion, fetchTarball, collectContents });
+        const bundle = namedBundle();
+        const result = await emitter.checkBundleAlreadyPublished({
+            registrySettings,
+            bundle
+        });
 
-    const bundle = namedBundle();
-    const result = await emitter.checkBundleAlreadyPublished({
-        registrySettings,
-        bundle
+        assert.deepStrictEqual(result, { alreadyPublishedAsLatest: false });
+        assert.deepStrictEqual(collectContents.firstCall.args, [bundle, 'package', undefined]);
+        assert.deepStrictEqual(fetchTarball.firstCall.args, [
+            'https://registry.example.test/package.tgz',
+            registrySettings
+        ]);
     });
 
-    assert.deepStrictEqual(result, { alreadyPublishedAsLatest: false });
-    assert.deepStrictEqual(collectContents.firstCall.args, [bundle, 'package', undefined]);
-    assert.deepStrictEqual(fetchTarball.firstCall.args, [
-        'https://registry.example.test/package.tgz',
-        registrySettings
-    ]);
-});
+    test('checkBundleAlreadyPublished() forwards extra files to collectContents', async function () {
+        const checkScenario = createPublishedBundleScenario();
+        const bundle = namedBundle();
+        const extraFile = { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false };
+        await checkScenario.emitter.checkBundleAlreadyPublished({
+            registrySettings,
+            bundle,
+            extraFiles: [extraFile]
+        });
 
-test('checkBundleAlreadyPublished() forwards extra files to collectContents', async () => {
-    const checkScenario = createPublishedBundleScenario();
-    const bundle = namedBundle();
-    const extraFile = { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false };
-    await checkScenario.emitter.checkBundleAlreadyPublished({
-        registrySettings,
-        bundle,
-        extraFiles: [extraFile]
+        assert.deepStrictEqual(checkScenario.collectContents.firstCall.args, [bundle, 'package', [extraFile]]);
     });
 
-    assert.deepStrictEqual(checkScenario.collectContents.firstCall.args, [bundle, 'package', [extraFile]]);
-});
+    test('checkBundleAlreadyPublished() returns true when the latest version contents match the given bundle contents', async function () {
+        const fetchLatestVersion = fake.resolves(
+            Maybe.just({ version: '1.2.3', tarballUrl: 'https://registry.example.test/package.tgz' })
+        );
+        const fetchTarball = fake.resolves(emptyTarball);
+        const collectContents = fake.returns([]);
+        const emitter = emitterFactory({ fetchLatestVersion, fetchTarball, collectContents });
 
-test('checkBundleAlreadyPublished() returns true when the latest version contents match the given bundle contents', async () => {
-    const fetchLatestVersion = fake.resolves(
-        Maybe.just({ version: '1.2.3', tarballUrl: 'https://registry.example.test/package.tgz' })
-    );
-    const fetchTarball = fake.resolves(emptyTarball);
-    const collectContents = fake.returns([]);
-    const emitter = emitterFactory({ fetchLatestVersion, fetchTarball, collectContents });
+        const result = await emitter.checkBundleAlreadyPublished({
+            registrySettings,
+            bundle: namedBundle()
+        });
 
-    const result = await emitter.checkBundleAlreadyPublished({
-        registrySettings,
-        bundle: namedBundle()
+        assert.deepStrictEqual(result, { alreadyPublishedAsLatest: true });
+        assert.deepStrictEqual(collectContents.firstCall.args[1], 'package');
+        assert.deepStrictEqual(fetchTarball.firstCall.args, [
+            'https://registry.example.test/package.tgz',
+            registrySettings
+        ]);
     });
 
-    assert.deepStrictEqual(result, { alreadyPublishedAsLatest: true });
-    assert.deepStrictEqual(collectContents.firstCall.args[1], 'package');
-    assert.deepStrictEqual(fetchTarball.firstCall.args, [
-        'https://registry.example.test/package.tgz',
-        registrySettings
-    ]);
-});
+    test('publish() publishes the given bundle', async function () {
+        const buildTarball = fake.resolves({ tarData: emptyTarball });
+        const publishPackage = fake.resolves(undefined);
+        const emitter = emitterFactory({ buildTarball, publishPackage });
+        const publishSettings = { access: 'public' } as const;
 
-test('publish() publishes the given bundle', async () => {
-    const buildTarball = fake.resolves({ tarData: emptyTarball });
-    const publishPackage = fake.resolves(undefined);
-    const emitter = emitterFactory({ buildTarball, publishPackage });
-    const publishSettings = { access: 'public' } as const;
+        await emitter.publish({
+            registrySettings,
+            bundle: namedBundle(),
+            publishSettings
+        });
 
-    await emitter.publish({
-        registrySettings,
-        bundle: namedBundle(),
-        publishSettings
+        assert.strictEqual(publishPackage.callCount, 1);
+        assert.deepStrictEqual(publishPackage.firstCall.args, [
+            { name: '', version: '' },
+            emptyTarball,
+            registrySettings,
+            publishSettings
+        ]);
     });
 
-    assert.strictEqual(publishPackage.callCount, 1);
-    assert.deepStrictEqual(publishPackage.firstCall.args, [
-        { name: '', version: '' },
-        emptyTarball,
-        registrySettings,
-        publishSettings
-    ]);
-});
+    test('publish() forwards extra files to buildTarball', async function () {
+        const buildTarball = fake.resolves({ tarData: emptyTarball });
+        const emitter = emitterFactory({ buildTarball });
+        const bundle = namedBundle();
+        const extraFile = { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false };
 
-test('publish() forwards extra files to buildTarball', async () => {
-    const buildTarball = fake.resolves({ tarData: emptyTarball });
-    const emitter = emitterFactory({ buildTarball });
-    const bundle = namedBundle();
-    const extraFile = { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false };
+        await emitter.publish({
+            registrySettings,
+            bundle,
+            publishSettings: { access: 'public' },
+            extraFiles: [extraFile]
+        });
 
-    await emitter.publish({
-        registrySettings,
-        bundle,
-        publishSettings: { access: 'public' },
-        extraFiles: [extraFile]
+        assert.deepStrictEqual(buildTarball.firstCall.args, [bundle, [extraFile]]);
     });
 
-    assert.deepStrictEqual(buildTarball.firstCall.args, [bundle, [extraFile]]);
-});
+    function bundleWithRepository(repository: string | undefined): ReturnType<typeof versionedBundleWithManifest> {
+        const packageJson = repository === undefined ? { name: 'the-name' } : { name: 'the-name', repository };
+        return versionedBundleWithManifest({ packageJson });
+    }
 
-function bundleWithRepository(repository: string | undefined): ReturnType<typeof versionedBundleWithManifest> {
-    const packageJson = repository === undefined ? { name: 'the-name' } : { name: 'the-name', repository };
-    return versionedBundleWithManifest({ packageJson });
-}
+    test('publish() rejects under provenance auto mode when the manifest repository differs from the CI repository', async function () {
+        const buildTarball = fake.resolves({ tarData: emptyTarball });
+        const publishPackage = fake.resolves(undefined);
+        const emitter = emitterFactory({
+            buildTarball,
+            publishPackage,
+            ciRepositoryUrl: 'https://github.com/upstream/package'
+        });
 
-test('publish() rejects under provenance auto mode when the manifest repository differs from the CI repository', async () => {
-    const buildTarball = fake.resolves({ tarData: emptyTarball });
-    const publishPackage = fake.resolves(undefined);
-    const emitter = emitterFactory({
-        buildTarball,
-        publishPackage,
-        ciRepositoryUrl: 'https://github.com/upstream/package'
+        try {
+            await emitter.publish({
+                registrySettings,
+                bundle: bundleWithRepository('https://github.com/foo/forked-package'),
+                publishSettings: { access: 'public', provenance: { type: 'auto' } }
+            });
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /repository URL does not match/u);
+            assert.strictEqual(buildTarball.callCount, 0);
+            assert.strictEqual(publishPackage.callCount, 0);
+            return;
+        }
+        assert.fail('Expected publish() to throw');
     });
 
-    try {
+    test('publish() does not run the coherence check under provenance file mode', async function () {
+        const buildTarball = fake.resolves({ tarData: emptyTarball });
+        const publishPackage = fake.resolves(undefined);
+        const emitter = emitterFactory({
+            buildTarball,
+            publishPackage,
+            ciRepositoryUrl: 'https://github.com/upstream/package'
+        });
+
         await emitter.publish({
             registrySettings,
             bundle: bundleWithRepository('https://github.com/foo/forked-package'),
-            publishSettings: { access: 'public', provenance: { type: 'auto' } }
+            publishSettings: { access: 'public', provenance: { type: 'file', path: '/build/bundle.sigstore' } }
         });
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.match(error.message, /repository URL does not match/u);
-        assert.strictEqual(buildTarball.callCount, 0);
-        assert.strictEqual(publishPackage.callCount, 0);
-        return;
-    }
-    assert.fail('Expected publish() to throw');
-});
 
-test('publish() does not run the coherence check under provenance file mode', async () => {
-    const buildTarball = fake.resolves({ tarData: emptyTarball });
-    const publishPackage = fake.resolves(undefined);
-    const emitter = emitterFactory({
-        buildTarball,
-        publishPackage,
-        ciRepositoryUrl: 'https://github.com/upstream/package'
+        assert.strictEqual(buildTarball.callCount, 1);
+        assert.strictEqual(publishPackage.callCount, 1);
     });
 
-    await emitter.publish({
-        registrySettings,
-        bundle: bundleWithRepository('https://github.com/foo/forked-package'),
-        publishSettings: { access: 'public', provenance: { type: 'file', path: '/build/bundle.sigstore' } }
+    test('publish() does not run the coherence check when provenance is unset', async function () {
+        const buildTarball = fake.resolves({ tarData: emptyTarball });
+        const publishPackage = fake.resolves(undefined);
+        const emitter = emitterFactory({
+            buildTarball,
+            publishPackage,
+            ciRepositoryUrl: undefined
+        });
+
+        await emitter.publish({
+            registrySettings,
+            bundle: bundleWithRepository(undefined),
+            publishSettings: { access: 'public' }
+        });
+
+        assert.strictEqual(buildTarball.callCount, 1);
+        assert.strictEqual(publishPackage.callCount, 1);
     });
 
-    assert.strictEqual(buildTarball.callCount, 1);
-    assert.strictEqual(publishPackage.callCount, 1);
-});
+    test('publish() does not run the coherence check when access is restricted even if provenance is set to auto', async function () {
+        const buildTarball = fake.resolves({ tarData: emptyTarball });
+        const publishPackage = fake.resolves(undefined);
+        const emitter = emitterFactory({
+            buildTarball,
+            publishPackage,
+            ciRepositoryUrl: 'https://github.com/upstream/package'
+        });
 
-test('publish() does not run the coherence check when provenance is unset', async () => {
-    const buildTarball = fake.resolves({ tarData: emptyTarball });
-    const publishPackage = fake.resolves(undefined);
-    const emitter = emitterFactory({
-        buildTarball,
-        publishPackage,
-        ciRepositoryUrl: undefined
+        await emitter.publish({
+            registrySettings,
+            bundle: bundleWithRepository('https://github.com/foo/forked-package'),
+            publishSettings: { access: 'restricted', provenance: { type: 'auto' } } as unknown as PublishSettings
+        });
+
+        assert.strictEqual(buildTarball.callCount, 1);
+        assert.strictEqual(publishPackage.callCount, 1);
     });
-
-    await emitter.publish({
-        registrySettings,
-        bundle: bundleWithRepository(undefined),
-        publishSettings: { access: 'public' }
-    });
-
-    assert.strictEqual(buildTarball.callCount, 1);
-    assert.strictEqual(publishPackage.callCount, 1);
-});
-
-test('publish() does not run the coherence check when access is restricted even if provenance is set to auto', async () => {
-    const buildTarball = fake.resolves({ tarData: emptyTarball });
-    const publishPackage = fake.resolves(undefined);
-    const emitter = emitterFactory({
-        buildTarball,
-        publishPackage,
-        ciRepositoryUrl: 'https://github.com/upstream/package'
-    });
-
-    await emitter.publish({
-        registrySettings,
-        bundle: bundleWithRepository('https://github.com/foo/forked-package'),
-        publishSettings: { access: 'restricted', provenance: { type: 'auto' } } as unknown as PublishSettings
-    });
-
-    assert.strictEqual(buildTarball.callCount, 1);
-    assert.strictEqual(publishPackage.callCount, 1);
 });

--- a/source/bundle-emitter/extract-package-tarball.test.ts
+++ b/source/bundle-emitter/extract-package-tarball.test.ts
@@ -1,28 +1,30 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createTarballBuilder } from '../tar/tarball-builder.ts';
 import { extractPackageTarball } from './extract-package-tarball.ts';
 
-test('returns an empty array when the given tarball is empty', async () => {
-    const tarballBuilder = createTarballBuilder();
-    const tarball = await tarballBuilder.build([]);
-    const files = await extractPackageTarball(tarball);
+suite('extract-package-tarball', function () {
+    test('returns an empty array when the given tarball is empty', async function () {
+        const tarballBuilder = createTarballBuilder();
+        const tarball = await tarballBuilder.build([]);
+        const files = await extractPackageTarball(tarball);
 
-    assert.deepStrictEqual(files, []);
-});
+        assert.deepStrictEqual(files, []);
+    });
 
-test('returns the extracted file descriptions when the given tarball is not empty', async () => {
-    const tarballBuilder = createTarballBuilder();
-    const tarball = await tarballBuilder.build([{ filePath: 'foo', content: 'bar', isExecutable: true }]);
-    const files = await extractPackageTarball(tarball);
+    test('returns the extracted file descriptions when the given tarball is not empty', async function () {
+        const tarballBuilder = createTarballBuilder();
+        const tarball = await tarballBuilder.build([{ filePath: 'foo', content: 'bar', isExecutable: true }]);
+        const files = await extractPackageTarball(tarball);
 
-    assert.deepStrictEqual(files, [{ filePath: 'foo', content: 'bar', isExecutable: true }]);
-});
+        assert.deepStrictEqual(files, [{ filePath: 'foo', content: 'bar', isExecutable: true }]);
+    });
 
-test('marks extracted files as non-executable when the tar header has no executable mode', async () => {
-    const tarballBuilder = createTarballBuilder();
-    const tarball = await tarballBuilder.build([{ filePath: 'foo', content: 'bar', isExecutable: false }]);
-    const files = await extractPackageTarball(tarball);
+    test('marks extracted files as non-executable when the tar header has no executable mode', async function () {
+        const tarballBuilder = createTarballBuilder();
+        const tarball = await tarballBuilder.build([{ filePath: 'foo', content: 'bar', isExecutable: false }]);
+        const files = await extractPackageTarball(tarball);
 
-    assert.deepStrictEqual(files, [{ filePath: 'foo', content: 'bar', isExecutable: false }]);
+        assert.deepStrictEqual(files, [{ filePath: 'foo', content: 'bar', isExecutable: false }]);
+    });
 });

--- a/source/bundle-emitter/publish-error/auto-mode-error-matching.test.ts
+++ b/source/bundle-emitter/publish-error/auto-mode-error-matching.test.ts
@@ -1,54 +1,56 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { matchAutoModeError } from './auto-mode-error-matching.ts';
 
-test('matchAutoModeError returns undefined when given a non-error-like value', () => {
-    assert.strictEqual(matchAutoModeError(undefined), undefined);
-    assert.strictEqual(matchAutoModeError('not an error'), undefined);
-});
-
-test('matchAutoModeError returns undefined when the message has no recognized marker', () => {
-    assert.strictEqual(matchAutoModeError({ message: 'unrelated failure' }), undefined);
-});
-
-test('matchAutoModeError maps the unsupported-provider marker and embeds the CI name', () => {
-    const result = matchAutoModeError({
-        message: 'provenance is not supported for provider: CircleCI please use file mode'
+suite('auto-mode-error-matching', function () {
+    test('matchAutoModeError returns undefined when given a non-error-like value', function () {
+        assert.strictEqual(matchAutoModeError(undefined), undefined);
+        assert.strictEqual(matchAutoModeError('not an error'), undefined);
     });
 
-    assert.ok(result instanceof Error);
-    assert.ok(result.message.includes('Detected CI: CircleCI.'));
-});
-
-test('matchAutoModeError falls back to "unknown" when no CI name follows the unsupported-provider marker', () => {
-    const result = matchAutoModeError({ message: 'not supported for provider:' });
-
-    assert.ok(result?.message.includes('Detected CI: unknown.'));
-});
-
-test('matchAutoModeError preserves the CI name when it is the last token without trailing whitespace', () => {
-    const result = matchAutoModeError({ message: 'not supported for provider: CircleCI' });
-
-    assert.ok(result?.message.includes('Detected CI: CircleCI.'));
-});
-
-test('matchAutoModeError maps the GitHub Actions id-token error to a workflow-permissions hint', () => {
-    const result = matchAutoModeError({
-        message: 'token does not have "write" access to the "id-token" permission'
+    test('matchAutoModeError returns undefined when the message has no recognized marker', function () {
+        assert.strictEqual(matchAutoModeError({ message: 'unrelated failure' }), undefined);
     });
 
-    assert.ok(result?.message.includes('permissions: id-token: write'));
-});
+    test('matchAutoModeError maps the unsupported-provider marker and embeds the CI name', function () {
+        const result = matchAutoModeError({
+            message: 'provenance is not supported for provider: CircleCI please use file mode'
+        });
 
-test('matchAutoModeError maps the GitLab sigstore id-token error to a sigstore-audience hint', () => {
-    const result = matchAutoModeError({ message: 'SIGSTORE_ID_TOKEN environment variable is missing' });
+        assert.ok(result instanceof Error);
+        assert.ok(result.message.includes('Detected CI: CircleCI.'));
+    });
 
-    assert.ok(result?.message.includes('sigstore'));
-});
+    test('matchAutoModeError falls back to "unknown" when no CI name follows the unsupported-provider marker', function () {
+        const result = matchAutoModeError({ message: 'not supported for provider:' });
 
-test('matchAutoModeError attaches the original error as the cause of the rewritten error', () => {
-    const original = { message: 'token does not have "write" access to the "id-token" permission' };
-    const result = matchAutoModeError(original);
+        assert.ok(result?.message.includes('Detected CI: unknown.'));
+    });
 
-    assert.strictEqual(result?.cause, original);
+    test('matchAutoModeError preserves the CI name when it is the last token without trailing whitespace', function () {
+        const result = matchAutoModeError({ message: 'not supported for provider: CircleCI' });
+
+        assert.ok(result?.message.includes('Detected CI: CircleCI.'));
+    });
+
+    test('matchAutoModeError maps the GitHub Actions id-token error to a workflow-permissions hint', function () {
+        const result = matchAutoModeError({
+            message: 'token does not have "write" access to the "id-token" permission'
+        });
+
+        assert.ok(result?.message.includes('permissions: id-token: write'));
+    });
+
+    test('matchAutoModeError maps the GitLab sigstore id-token error to a sigstore-audience hint', function () {
+        const result = matchAutoModeError({ message: 'SIGSTORE_ID_TOKEN environment variable is missing' });
+
+        assert.ok(result?.message.includes('sigstore'));
+    });
+
+    test('matchAutoModeError attaches the original error as the cause of the rewritten error', function () {
+        const original = { message: 'token does not have "write" access to the "id-token" permission' };
+        const result = matchAutoModeError(original);
+
+        assert.strictEqual(result?.cause, original);
+    });
 });

--- a/source/bundle-emitter/publish-error/error-shape-helpers.test.ts
+++ b/source/bundle-emitter/publish-error/error-shape-helpers.test.ts
@@ -1,36 +1,38 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { ensureError, isErrorLike, isRecord } from './error-shape-helpers.ts';
 
-test('isRecord returns true for object values', () => {
-    assert.strictEqual(isRecord({}), true);
-    assert.strictEqual(isRecord({ a: 1 }), true);
-});
+suite('error-shape-helpers', function () {
+    test('isRecord returns true for object values', function () {
+        assert.strictEqual(isRecord({}), true);
+        assert.strictEqual(isRecord({ a: 1 }), true);
+    });
 
-test('isRecord returns false for null, primitives, and undefined', () => {
-    assert.strictEqual(isRecord(null), false);
-    assert.strictEqual(isRecord(undefined), false);
-    assert.strictEqual(isRecord('s'), false);
-    assert.strictEqual(isRecord(42), false);
-});
+    test('isRecord returns false for null, primitives, and undefined', function () {
+        assert.strictEqual(isRecord(null), false);
+        assert.strictEqual(isRecord(undefined), false);
+        assert.strictEqual(isRecord('s'), false);
+        assert.strictEqual(isRecord(42), false);
+    });
 
-test('isErrorLike returns true when the value has a string message property', () => {
-    assert.strictEqual(isErrorLike({ message: 'boom' }), true);
-});
+    test('isErrorLike returns true when the value has a string message property', function () {
+        assert.strictEqual(isErrorLike({ message: 'boom' }), true);
+    });
 
-test('isErrorLike returns false when message is missing or not a string', () => {
-    assert.strictEqual(isErrorLike({}), false);
-    assert.strictEqual(isErrorLike({ message: 42 }), false);
-    assert.strictEqual(isErrorLike(null), false);
-});
+    test('isErrorLike returns false when message is missing or not a string', function () {
+        assert.strictEqual(isErrorLike({}), false);
+        assert.strictEqual(isErrorLike({ message: 42 }), false);
+        assert.strictEqual(isErrorLike(null), false);
+    });
 
-test('ensureError returns the value unchanged when it is already an Error instance', () => {
-    const original = new Error('boom');
-    assert.strictEqual(ensureError(original), original);
-});
+    test('ensureError returns the value unchanged when it is already an Error instance', function () {
+        const original = new Error('boom');
+        assert.strictEqual(ensureError(original), original);
+    });
 
-test('ensureError wraps non-Error values via String coercion', () => {
-    const wrapped = ensureError('plain string');
-    assert.ok(wrapped instanceof Error);
-    assert.strictEqual(wrapped.message, 'plain string');
+    test('ensureError wraps non-Error values via String coercion', function () {
+        const wrapped = ensureError('plain string');
+        assert.ok(wrapped instanceof Error);
+        assert.strictEqual(wrapped.message, 'plain string');
+    });
 });

--- a/source/bundle-emitter/publish-error/file-mode-error-matching.test.ts
+++ b/source/bundle-emitter/publish-error/file-mode-error-matching.test.ts
@@ -1,43 +1,45 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { matchFileModeError } from './file-mode-error-matching.ts';
 
-test('matchFileModeError maps ENOENT to a missing-provenance-file message', () => {
-    const result = matchFileModeError({ code: 'ENOENT' }, '/p/bundle.json');
+suite('file-mode-error-matching', function () {
+    test('matchFileModeError maps ENOENT to a missing-provenance-file message', function () {
+        const result = matchFileModeError({ code: 'ENOENT' }, '/p/bundle.json');
 
-    assert.ok(result?.message.includes('does not exist'));
-    assert.ok(result?.message.includes('"/p/bundle.json"'));
-});
+        assert.ok(result?.message.includes('does not exist'));
+        assert.ok(result?.message.includes('"/p/bundle.json"'));
+    });
 
-test('matchFileModeError returns undefined for a non-error-like value with no ENOENT code', () => {
-    assert.strictEqual(matchFileModeError('plain string', '/p/bundle.json'), undefined);
-});
+    test('matchFileModeError returns undefined for a non-error-like value with no ENOENT code', function () {
+        assert.strictEqual(matchFileModeError('plain string', '/p/bundle.json'), undefined);
+    });
 
-test('matchFileModeError returns undefined when the message does not match any provenance error pattern', () => {
-    assert.strictEqual(matchFileModeError({ message: 'unrelated' }, '/p/bundle.json'), undefined);
-});
+    test('matchFileModeError returns undefined when the message does not match any provenance error pattern', function () {
+        assert.strictEqual(matchFileModeError({ message: 'unrelated' }, '/p/bundle.json'), undefined);
+    });
 
-test('matchFileModeError maps "Bundle is invalid" without "subject"/"digest" to an invalid-bundle message', () => {
-    const result = matchFileModeError({ message: 'Bundle is invalid' }, '/p/bundle.json');
+    test('matchFileModeError maps "Bundle is invalid" without "subject"/"digest" to an invalid-bundle message', function () {
+        const result = matchFileModeError({ message: 'Bundle is invalid' }, '/p/bundle.json');
 
-    assert.ok(result?.message.includes('not a valid sigstore bundle'));
-});
+        assert.ok(result?.message.includes('not a valid sigstore bundle'));
+    });
 
-test('matchFileModeError maps a bundle error containing "digest" to a digest-mismatch message', () => {
-    const result = matchFileModeError({ message: 'Bundle is invalid: digest mismatch' }, '/p/bundle.json');
+    test('matchFileModeError maps a bundle error containing "digest" to a digest-mismatch message', function () {
+        const result = matchFileModeError({ message: 'Bundle is invalid: digest mismatch' }, '/p/bundle.json');
 
-    assert.ok(result?.message.includes('signed against a different tarball'));
-});
+        assert.ok(result?.message.includes('signed against a different tarball'));
+    });
 
-test('matchFileModeError maps a bundle error containing "subject" to a digest-mismatch message', () => {
-    const result = matchFileModeError({ message: 'subject does not match' }, '/p/bundle.json');
+    test('matchFileModeError maps a bundle error containing "subject" to a digest-mismatch message', function () {
+        const result = matchFileModeError({ message: 'subject does not match' }, '/p/bundle.json');
 
-    assert.ok(result?.message.includes('signed against a different tarball'));
-});
+        assert.ok(result?.message.includes('signed against a different tarball'));
+    });
 
-test('matchFileModeError attaches the original error as the cause of the rewritten error', () => {
-    const original = { message: 'Bundle is invalid' };
-    const result = matchFileModeError(original, '/p/bundle.json');
+    test('matchFileModeError attaches the original error as the cause of the rewritten error', function () {
+        const original = { message: 'Bundle is invalid' };
+        const result = matchFileModeError(original, '/p/bundle.json');
 
-    assert.strictEqual(result?.cause, original);
+        assert.strictEqual(result?.cause, original);
+    });
 });

--- a/source/bundle-emitter/publish-error/publish-error-messages.test.ts
+++ b/source/bundle-emitter/publish-error/publish-error-messages.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     buildInvalidProvenanceFileMessage,
     buildMissingProvenanceFileMessage,
@@ -10,34 +10,36 @@ import {
     unsupportedProviderMarker
 } from './publish-error-messages.ts';
 
-test('unsupportedProviderMarker exposes the canonical marker substring', () => {
-    assert.strictEqual(unsupportedProviderMarker, 'not supported for provider:');
-});
+suite('publish-error-messages', function () {
+    test('unsupportedProviderMarker exposes the canonical marker substring', function () {
+        assert.strictEqual(unsupportedProviderMarker, 'not supported for provider:');
+    });
 
-test('githubActionsIdTokenMessage references the id-token write permission', () => {
-    assert.ok(githubActionsIdTokenMessage.includes('permissions: id-token: write'));
-});
+    test('githubActionsIdTokenMessage references the id-token write permission', function () {
+        assert.ok(githubActionsIdTokenMessage.includes('permissions: id-token: write'));
+    });
 
-test('gitlabSigstoreIdTokenMessage references the sigstore audience', () => {
-    assert.ok(gitlabSigstoreIdTokenMessage.includes('sigstore'));
-});
+    test('gitlabSigstoreIdTokenMessage references the sigstore audience', function () {
+        assert.ok(gitlabSigstoreIdTokenMessage.includes('sigstore'));
+    });
 
-test('buildUnsupportedProviderMessage embeds the detected CI name in the message', () => {
-    assert.ok(buildUnsupportedProviderMessage('CircleCI').includes('Detected CI: CircleCI.'));
-});
+    test('buildUnsupportedProviderMessage embeds the detected CI name in the message', function () {
+        assert.ok(buildUnsupportedProviderMessage('CircleCI').includes('Detected CI: CircleCI.'));
+    });
 
-test('buildMissingProvenanceFileMessage embeds the file path in the message', () => {
-    assert.ok(buildMissingProvenanceFileMessage('/p/bundle.json').includes('"/p/bundle.json"'));
-});
+    test('buildMissingProvenanceFileMessage embeds the file path in the message', function () {
+        assert.ok(buildMissingProvenanceFileMessage('/p/bundle.json').includes('"/p/bundle.json"'));
+    });
 
-test('buildInvalidProvenanceFileMessage embeds the file path and mentions sigstore', () => {
-    const message = buildInvalidProvenanceFileMessage('/p/bundle.json');
-    assert.ok(message.includes('"/p/bundle.json"'));
-    assert.ok(message.includes('sigstore'));
-});
+    test('buildInvalidProvenanceFileMessage embeds the file path and mentions sigstore', function () {
+        const message = buildInvalidProvenanceFileMessage('/p/bundle.json');
+        assert.ok(message.includes('"/p/bundle.json"'));
+        assert.ok(message.includes('sigstore'));
+    });
 
-test('buildProvenanceDigestMismatchMessage embeds the file path and warns about defeating provenance', () => {
-    const message = buildProvenanceDigestMismatchMessage('/p/bundle.json');
-    assert.ok(message.includes('/p/bundle.json'));
-    assert.ok(message.includes('defeat'));
+    test('buildProvenanceDigestMismatchMessage embeds the file path and warns about defeating provenance', function () {
+        const message = buildProvenanceDigestMismatchMessage('/p/bundle.json');
+        assert.ok(message.includes('/p/bundle.json'));
+        assert.ok(message.includes('defeat'));
+    });
 });

--- a/source/bundle-emitter/registry/metadata-auth-retry.test.ts
+++ b/source/bundle-emitter/registry/metadata-auth-retry.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { RegistrySettings } from '../../config/registry-settings.ts';
 import type { AuthResolution, NpmFetchOptions } from './registry-auth-config.ts';
 import { retryWithFallbackAuth } from './metadata-auth-retry.ts';
@@ -34,49 +34,51 @@ async function expectRethrown(
     }
 }
 
-test('retryWithFallbackAuth returns the run() result when it succeeds on the first attempt', async () => {
-    const callOptions: NpmFetchOptions[] = [];
+suite('metadata-auth-retry', function () {
+    test('retryWithFallbackAuth returns the run() result when it succeeds on the first attempt', async function () {
+        const callOptions: NpmFetchOptions[] = [];
 
-    const result = await retryWithFallbackAuth({ auth: tokenAuth }, authResolution(), async (options) => {
-        callOptions.push(options);
-        return 'ok' as const;
+        const result = await retryWithFallbackAuth({ auth: tokenAuth }, authResolution(), async (options) => {
+            callOptions.push(options);
+            return 'ok' as const;
+        });
+
+        assert.strictEqual(result, 'ok');
+        assert.strictEqual(callOptions.length, 1);
     });
 
-    assert.strictEqual(result, 'ok');
-    assert.strictEqual(callOptions.length, 1);
-});
+    test('retryWithFallbackAuth rethrows the error when retry is not allowed', async function () {
+        await expectRethrown({ auth: tokenAuth }, authResolution(), 401);
+    });
 
-test('retryWithFallbackAuth rethrows the error when retry is not allowed', async () => {
-    await expectRethrown({ auth: tokenAuth }, authResolution(), 401);
-});
+    test('retryWithFallbackAuth rethrows non-auth failures even when retry is allowed', async function () {
+        await expectRethrown({ auth: tokenAuth }, authResolution({ allowsAutomaticRetry: true }), 500);
+    });
 
-test('retryWithFallbackAuth rethrows non-auth failures even when retry is allowed', async () => {
-    await expectRethrown({ auth: tokenAuth }, authResolution({ allowsAutomaticRetry: true }), 500);
-});
+    test('retryWithFallbackAuth retries with publish auth options on auth failure when retry is allowed', async function () {
+        const settings: RegistrySettings = { auth: tokenAuth };
+        let attempts = 0;
+        const callOptions: NpmFetchOptions[] = [];
 
-test('retryWithFallbackAuth retries with publish auth options on auth failure when retry is allowed', async () => {
-    const settings: RegistrySettings = { auth: tokenAuth };
-    let attempts = 0;
-    const callOptions: NpmFetchOptions[] = [];
-
-    const result = await retryWithFallbackAuth(
-        settings,
-        authResolution({ allowsAutomaticRetry: true }),
-        async (options) => {
-            callOptions.push(options);
-            attempts += 1;
-            if (attempts === 1) {
-                throw authFailure(403);
+        const result = await retryWithFallbackAuth(
+            settings,
+            authResolution({ allowsAutomaticRetry: true }),
+            async (options) => {
+                callOptions.push(options);
+                attempts += 1;
+                if (attempts === 1) {
+                    throw authFailure(403);
+                }
+                return 'fallback' as const;
             }
-            return 'fallback' as const;
-        }
-    );
+        );
 
-    assert.strictEqual(result, 'fallback');
-    assert.strictEqual(attempts, 2);
-    assert.deepStrictEqual((callOptions[1] as { forceAuth?: { token?: string } }).forceAuth, { token: 'abc' });
-});
+        assert.strictEqual(result, 'fallback');
+        assert.strictEqual(attempts, 2);
+        assert.deepStrictEqual((callOptions[1] as { forceAuth?: { token?: string } }).forceAuth, { token: 'abc' });
+    });
 
-test('retryWithFallbackAuth rethrows when retry is allowed but publish auth is npm-oidc', async () => {
-    await expectRethrown({ auth: { type: 'npm-oidc' } }, authResolution({ allowsAutomaticRetry: true }), 401);
+    test('retryWithFallbackAuth rethrows when retry is allowed but publish auth is npm-oidc', async function () {
+        await expectRethrown({ auth: { type: 'npm-oidc' } }, authResolution({ allowsAutomaticRetry: true }), 401);
+    });
 });

--- a/source/bundle-emitter/registry/oidc-token-exchange.test.ts
+++ b/source/bundle-emitter/registry/oidc-token-exchange.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import type { PublishAuthStrategy } from '../../config/registry-settings.ts';
 import { createFakeClock } from '../../test-libraries/fake-clock.ts';
@@ -57,97 +57,99 @@ async function expectExchangeError(
     }
 }
 
-test('exchangeToken returns the registry token when the OIDC exchange succeeds', async () => {
-    const token = await exchangerFactory().exchangeToken('pkg-a', npmSettings, oidcAuth);
+suite('oidc-token-exchange', function () {
+    test('exchangeToken returns the registry token when the OIDC exchange succeeds', async function () {
+        const token = await exchangerFactory().exchangeToken('pkg-a', npmSettings, oidcAuth);
 
-    assert.strictEqual(token, 'exchanged-token');
-});
-
-test('exchangeToken caches the token for repeated calls within the refresh threshold', async () => {
-    const idTokenSpy = fake.resolves('upstream-id-token');
-    const exchanger = exchangerFactory({ resolveIdToken: idTokenSpy });
-
-    await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
-    await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
-
-    assert.strictEqual(idTokenSpy.callCount, 1);
-});
-
-test('exchangeToken refreshes the token after the cached entry is within the refresh threshold', async () => {
-    const idTokenSpy = fake.resolves('upstream-id-token');
-    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
-    const exchanger = exchangerFactory({ clock, resolveIdToken: idTokenSpy });
-
-    await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
-    clock.tick(Date.parse('2026-05-06T11:00:00.000Z') - Date.parse('2026-05-06T10:00:00.000Z'));
-    await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
-
-    assert.strictEqual(idTokenSpy.callCount, 2);
-});
-
-test('exchangeToken throws when configured for a non-npm registry', async () => {
-    try {
-        await exchangerFactory().exchangeToken(
-            'pkg-a',
-            { registryUrl: 'https://internal.example.com/', auth: oidcAuth },
-            oidcAuth
-        );
-        assert.fail('Expected exchangeToken() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'npm-oidc auth is only supported with the npmjs.org registry');
-    }
-});
-
-test('exchangeToken throws when the OIDC exchange response status is not ok', async () => {
-    await expectExchangeError(
-        exchangerFactory({
-            fetch: fake.resolves(
-                fakeFetchResponse({ ok: false, status: 500, json: {} })
-            ) as unknown as typeof globalThis.fetch
-        }),
-        'OIDC token exchange failed with status 500'
-    );
-});
-
-test('exchangeToken throws when the OIDC response does not match the expected shape', async () => {
-    await expectExchangeError(
-        exchangerFactory({
-            fetch: fake.resolves(
-                fakeFetchResponse({ json: { token_type: 'oidc' } })
-            ) as unknown as typeof globalThis.fetch
-        }),
-        'OIDC token exchange returned an invalid response'
-    );
-});
-
-test('exchangeToken throws when the OIDC response expiry is not parseable', async () => {
-    await expectExchangeError(
-        exchangerFactory({
-            fetch: fake.resolves(
-                fakeFetchResponse({
-                    json: {
-                        token_type: 'oidc',
-                        token: 'exchanged-token',
-                        created: '2026-05-06T10:00:00.000Z',
-                        expires: 'not-a-date'
-                    }
-                })
-            ) as unknown as typeof globalThis.fetch
-        }),
-        'OIDC token exchange returned an invalid expiry timestamp'
-    );
-});
-
-test('resolveWriteAuthOptions returns bearer auth options when publish strategy is bearer-token', async () => {
-    const options = await exchangerFactory().resolveWriteAuthOptions('pkg-a', {
-        auth: { type: 'bearer-token', token: 'static-token' }
+        assert.strictEqual(token, 'exchanged-token');
     });
 
-    assert.deepStrictEqual((options as { forceAuth: { token: string } }).forceAuth, { token: 'static-token' });
-});
+    test('exchangeToken caches the token for repeated calls within the refresh threshold', async function () {
+        const idTokenSpy = fake.resolves('upstream-id-token');
+        const exchanger = exchangerFactory({ resolveIdToken: idTokenSpy });
 
-test('resolveWriteAuthOptions exchanges and returns the OIDC token when publish strategy is npm-oidc', async () => {
-    const options = await exchangerFactory().resolveWriteAuthOptions('pkg-a', npmSettings);
+        await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
+        await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
 
-    assert.deepStrictEqual((options as { forceAuth: { token: string } }).forceAuth, { token: 'exchanged-token' });
+        assert.strictEqual(idTokenSpy.callCount, 1);
+    });
+
+    test('exchangeToken refreshes the token after the cached entry is within the refresh threshold', async function () {
+        const idTokenSpy = fake.resolves('upstream-id-token');
+        const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+        const exchanger = exchangerFactory({ clock, resolveIdToken: idTokenSpy });
+
+        await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
+        clock.tick(Date.parse('2026-05-06T11:00:00.000Z') - Date.parse('2026-05-06T10:00:00.000Z'));
+        await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth);
+
+        assert.strictEqual(idTokenSpy.callCount, 2);
+    });
+
+    test('exchangeToken throws when configured for a non-npm registry', async function () {
+        try {
+            await exchangerFactory().exchangeToken(
+                'pkg-a',
+                { registryUrl: 'https://internal.example.com/', auth: oidcAuth },
+                oidcAuth
+            );
+            assert.fail('Expected exchangeToken() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'npm-oidc auth is only supported with the npmjs.org registry');
+        }
+    });
+
+    test('exchangeToken throws when the OIDC exchange response status is not ok', async function () {
+        await expectExchangeError(
+            exchangerFactory({
+                fetch: fake.resolves(
+                    fakeFetchResponse({ ok: false, status: 500, json: {} })
+                ) as unknown as typeof globalThis.fetch
+            }),
+            'OIDC token exchange failed with status 500'
+        );
+    });
+
+    test('exchangeToken throws when the OIDC response does not match the expected shape', async function () {
+        await expectExchangeError(
+            exchangerFactory({
+                fetch: fake.resolves(
+                    fakeFetchResponse({ json: { token_type: 'oidc' } })
+                ) as unknown as typeof globalThis.fetch
+            }),
+            'OIDC token exchange returned an invalid response'
+        );
+    });
+
+    test('exchangeToken throws when the OIDC response expiry is not parseable', async function () {
+        await expectExchangeError(
+            exchangerFactory({
+                fetch: fake.resolves(
+                    fakeFetchResponse({
+                        json: {
+                            token_type: 'oidc',
+                            token: 'exchanged-token',
+                            created: '2026-05-06T10:00:00.000Z',
+                            expires: 'not-a-date'
+                        }
+                    })
+                ) as unknown as typeof globalThis.fetch
+            }),
+            'OIDC token exchange returned an invalid expiry timestamp'
+        );
+    });
+
+    test('resolveWriteAuthOptions returns bearer auth options when publish strategy is bearer-token', async function () {
+        const options = await exchangerFactory().resolveWriteAuthOptions('pkg-a', {
+            auth: { type: 'bearer-token', token: 'static-token' }
+        });
+
+        assert.deepStrictEqual((options as { forceAuth: { token: string } }).forceAuth, { token: 'static-token' });
+    });
+
+    test('resolveWriteAuthOptions exchanges and returns the OIDC token when publish strategy is npm-oidc', async function () {
+        const options = await exchangerFactory().resolveWriteAuthOptions('pkg-a', npmSettings);
+
+        assert.deepStrictEqual((options as { forceAuth: { token: string } }).forceAuth, { token: 'exchanged-token' });
+    });
 });

--- a/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type _npmFetch from 'npm-registry-fetch';
 import type { RegistrySettings } from '../../config/registry-settings.ts';
@@ -24,65 +24,67 @@ async function expectError(npmFetch: typeof _npmFetch, expectedMessage: string):
     }
 }
 
-test('fetchLatestPackageVersion returns the latest version details when the registry response is valid', async () => {
-    const result = await fetchLatestPackageVersion(
-        fakeNpmFetch(
-            fake.resolves({
-                name: 'pkg-a',
-                'dist-tags': { latest: '1.2.3' },
-                versions: { '1.2.3': { dist: { tarball: 'https://example.com/pkg-a-1.2.3.tgz' } } }
-            })
-        ),
-        'pkg-a',
-        settings
-    );
-
-    assert.deepStrictEqual(result.unwrapOr({ version: '', tarballUrl: '' }), {
-        version: '1.2.3',
-        tarballUrl: 'https://example.com/pkg-a-1.2.3.tgz'
-    });
-});
-
-test('fetchLatestPackageVersion returns Nothing when the registry has no latest dist-tag', async () => {
-    const result = await fetchLatestPackageVersion(
-        fakeNpmFetch(fake.resolves({ name: 'pkg-a', 'dist-tags': {}, versions: {} })),
-        'pkg-a',
-        settings
-    );
-
-    assert.strictEqual(result.isNothing, true);
-});
-
-test('fetchLatestPackageVersion returns Nothing when the registry responds with a missing-package status', async () => {
-    for (const statusCode of [404, 403] as const) {
+suite('package-metadata-fetcher', function () {
+    test('fetchLatestPackageVersion returns the latest version details when the registry response is valid', async function () {
         const result = await fetchLatestPackageVersion(
-            fakeNpmFetch(fake.rejects(Object.assign(new Error(`status ${statusCode}`), { statusCode }))),
+            fakeNpmFetch(
+                fake.resolves({
+                    name: 'pkg-a',
+                    'dist-tags': { latest: '1.2.3' },
+                    versions: { '1.2.3': { dist: { tarball: 'https://example.com/pkg-a-1.2.3.tgz' } } }
+                })
+            ),
             'pkg-a',
             settings
         );
+
+        assert.deepStrictEqual(result.unwrapOr({ version: '', tarballUrl: '' }), {
+            version: '1.2.3',
+            tarballUrl: 'https://example.com/pkg-a-1.2.3.tgz'
+        });
+    });
+
+    test('fetchLatestPackageVersion returns Nothing when the registry has no latest dist-tag', async function () {
+        const result = await fetchLatestPackageVersion(
+            fakeNpmFetch(fake.resolves({ name: 'pkg-a', 'dist-tags': {}, versions: {} })),
+            'pkg-a',
+            settings
+        );
+
         assert.strictEqual(result.isNothing, true);
-    }
-});
+    });
 
-test('fetchLatestPackageVersion throws when the registry response shape is invalid', async () => {
-    await expectError(fakeNpmFetch(fake.resolves({ name: 'pkg-a' })), 'Got an invalid response from registry API');
-});
+    test('fetchLatestPackageVersion returns Nothing when the registry responds with a missing-package status', async function () {
+        for (const statusCode of [404, 403] as const) {
+            const result = await fetchLatestPackageVersion(
+                fakeNpmFetch(fake.rejects(Object.assign(new Error(`status ${statusCode}`), { statusCode }))),
+                'pkg-a',
+                settings
+            );
+            assert.strictEqual(result.isNothing, true);
+        }
+    });
 
-test('fetchLatestPackageVersion throws when the version listed under dist-tags.latest has no entry', async () => {
-    await expectError(
-        fakeNpmFetch(fake.resolves({ name: 'pkg-a', 'dist-tags': { latest: '1.2.3' }, versions: {} })),
-        'Version "1.2.3" for package "pkg-a" has no entry in the registry response'
-    );
-});
+    test('fetchLatestPackageVersion throws when the registry response shape is invalid', async function () {
+        await expectError(fakeNpmFetch(fake.resolves({ name: 'pkg-a' })), 'Got an invalid response from registry API');
+    });
 
-test('fetchPackageTarball returns the buffered tarball contents', async () => {
-    const buffer = fake.resolves(Buffer.from('tarball-bytes'));
+    test('fetchLatestPackageVersion throws when the version listed under dist-tags.latest has no entry', async function () {
+        await expectError(
+            fakeNpmFetch(fake.resolves({ name: 'pkg-a', 'dist-tags': { latest: '1.2.3' }, versions: {} })),
+            'Version "1.2.3" for package "pkg-a" has no entry in the registry response'
+        );
+    });
 
-    const result = await fetchPackageTarball(
-        fakeNpmFetch(fake(), buffer),
-        'https://example.com/pkg-a-1.2.3.tgz',
-        settings
-    );
+    test('fetchPackageTarball returns the buffered tarball contents', async function () {
+        const buffer = fake.resolves(Buffer.from('tarball-bytes'));
 
-    assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+        const result = await fetchPackageTarball(
+            fakeNpmFetch(fake(), buffer),
+            'https://example.com/pkg-a-1.2.3.tgz',
+            settings
+        );
+
+        assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+    });
 });

--- a/source/bundle-emitter/registry/publish-settings-bridge.test.ts
+++ b/source/bundle-emitter/registry/publish-settings-bridge.test.ts
@@ -1,264 +1,271 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PublishSettings } from '../../config/publish-settings.ts';
 import { buildPublishOptionsForPublishSettings, remapPublishError } from './publish-settings-bridge.ts';
 
-test('buildPublishOptionsForPublishSettings() emits access "restricted" only', () => {
-    const result = buildPublishOptionsForPublishSettings({ access: 'restricted' });
+suite('publish-settings-bridge', function () {
+    test('buildPublishOptionsForPublishSettings() emits access "restricted" only', function () {
+        const result = buildPublishOptionsForPublishSettings({ access: 'restricted' });
 
-    assert.deepStrictEqual(result, { access: 'restricted' });
-});
-
-test('buildPublishOptionsForPublishSettings() emits access "public" without provenance keys when provenance is omitted', () => {
-    const result = buildPublishOptionsForPublishSettings({ access: 'public' });
-
-    assert.deepStrictEqual(result, { access: 'public' });
-});
-
-test('buildPublishOptionsForPublishSettings() maps auto-mode provenance to provenance: true', () => {
-    const result = buildPublishOptionsForPublishSettings({
-        access: 'public',
-        provenance: { type: 'auto' }
+        assert.deepStrictEqual(result, { access: 'restricted' });
     });
 
-    assert.deepStrictEqual(result, { access: 'public', provenance: true });
-});
+    test('buildPublishOptionsForPublishSettings() emits access "public" without provenance keys when provenance is omitted', function () {
+        const result = buildPublishOptionsForPublishSettings({ access: 'public' });
 
-test('buildPublishOptionsForPublishSettings() maps file-mode provenance to provenanceFile', () => {
-    const result = buildPublishOptionsForPublishSettings({
-        access: 'public',
-        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        assert.deepStrictEqual(result, { access: 'public' });
     });
 
-    assert.deepStrictEqual(result, { access: 'public', provenanceFile: '/build/pkg.sigstore' });
-});
+    test('buildPublishOptionsForPublishSettings() maps auto-mode provenance to provenance: true', function () {
+        const result = buildPublishOptionsForPublishSettings({
+            access: 'public',
+            provenance: { type: 'auto' }
+        });
 
-function expectRemapped(
-    originalError: unknown,
-    publishSettings: Readonly<PublishSettings>,
-    expectedMessage: string
-): void {
-    const remapped = remapPublishError(originalError, publishSettings);
-
-    assert.ok(remapped instanceof Error, 'Expected remapped value to be an Error');
-    assert.strictEqual(remapped.message, expectedMessage);
-    assert.strictEqual(remapped.cause, originalError, 'Expected the original error to be preserved as cause');
-}
-
-function buildUnsupportedProviderExpectedMessage(ciName: string): string {
-    return [
-        'Provenance auto mode requires GitHub Actions or GitLab CI.',
-        `Detected CI: ${ciName}.`,
-        "Use provenance: { type: 'file' } for other environments."
-    ].join(' ');
-}
-
-const unsupportedProviderMessage = buildUnsupportedProviderExpectedMessage('jenkins');
-
-const githubActionsIdTokenExpectedMessage =
-    'GitHub Actions provenance needs "permissions: id-token: write" on the workflow job.' +
-    ' See the packtory readme for the workflow snippet.';
-
-const gitlabSigstoreIdTokenExpectedMessage =
-    'GitLab CI provenance needs an "id_tokens" entry with audience "sigstore"' +
-    ' exposed as SIGSTORE_ID_TOKEN. See the packtory readme for the workflow snippet.';
-
-const missingFileExpectedMessage =
-    'Provenance bundle file "/build/pkg.sigstore" does not exist.' +
-    " Generate it with your CI's attestation tool (e.g. actions/attest-build-provenance) before running packtory.";
-
-const invalidBundleExpectedMessage =
-    'Provenance bundle file "/build/pkg.sigstore" is not a valid sigstore bundle. Re-generate it from the current build.';
-
-const digestMismatchExpectedMessage =
-    'Provenance bundle at "/build/pkg.sigstore" was signed against a different tarball' +
-    ' than the one packtory built. Re-generate the bundle from the current source —' +
-    ' shipping a mismatched attestation would defeat the purpose of provenance.';
-
-test('remapPublishError() rewrites the "unsupported provider" libnpmpublish error with the detected CI name', () => {
-    expectRemapped(
-        Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins'), {
-            code: 'EUSAGE'
-        }),
-        { access: 'public', provenance: { type: 'auto' } },
-        unsupportedProviderMessage
-    );
-});
-
-test('remapPublishError() handles libnpmpublish messages where the provider follows the colon directly', () => {
-    expectRemapped(
-        Object.assign(new Error('Automatic provenance generation not supported for provider:circleci'), {
-            code: 'EUSAGE'
-        }),
-        { access: 'public', provenance: { type: 'auto' } },
-        buildUnsupportedProviderExpectedMessage('circleci')
-    );
-});
-
-test('remapPublishError() falls back to "unknown" CI name when the libnpmpublish message lacks a provider', () => {
-    expectRemapped(
-        Object.assign(new Error('Automatic provenance generation not supported for provider:'), {
-            code: 'EUSAGE'
-        }),
-        { access: 'public', provenance: { type: 'auto' } },
-        buildUnsupportedProviderExpectedMessage('unknown')
-    );
-});
-
-test('remapPublishError() extracts only the first whitespace-delimited token after the "provider:" marker', () => {
-    expectRemapped(
-        Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins extra trailing'), {
-            code: 'EUSAGE'
-        }),
-        { access: 'public', provenance: { type: 'auto' } },
-        buildUnsupportedProviderExpectedMessage('jenkins')
-    );
-});
-
-test('remapPublishError() rewrites the missing GitHub Actions id-token permission error', () => {
-    expectRemapped(
-        Object.assign(
-            new Error('Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'),
-            { code: 'EUSAGE' }
-        ),
-        { access: 'public', provenance: { type: 'auto' } },
-        githubActionsIdTokenExpectedMessage
-    );
-});
-
-test('remapPublishError() rewrites the missing GitLab SIGSTORE_ID_TOKEN error', () => {
-    expectRemapped(
-        Object.assign(
-            new Error('Provenance generation in GitLab CI requires "SIGSTORE_ID_TOKEN" with "sigstore" audience'),
-            { code: 'EUSAGE' }
-        ),
-        { access: 'public', provenance: { type: 'auto' } },
-        gitlabSigstoreIdTokenExpectedMessage
-    );
-});
-
-test('remapPublishError() rewrites a missing provenance bundle file (ENOENT) error', () => {
-    expectRemapped(
-        Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' }),
-        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
-        missingFileExpectedMessage
-    );
-});
-
-test('remapPublishError() rewrites an invalid sigstore bundle parse error', () => {
-    expectRemapped(
-        new Error('Bundle is invalid: malformed protobuf'),
-        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
-        invalidBundleExpectedMessage
-    );
-});
-
-test('remapPublishError() rewrites a sigstore subject-digest mismatch error', () => {
-    expectRemapped(
-        new Error('Provenance subject does not match published package digest'),
-        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
-        digestMismatchExpectedMessage
-    );
-});
-
-test('remapPublishError() classifies a "subject does not match" error as a digest mismatch even without the word "digest"', () => {
-    expectRemapped(
-        new Error('Provenance subject does not match'),
-        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
-        digestMismatchExpectedMessage
-    );
-});
-
-test('remapPublishError() classifies a "Bundle is invalid" digest error as a digest mismatch even without the word "subject"', () => {
-    expectRemapped(
-        new Error('Bundle is invalid: digest verification failed'),
-        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
-        digestMismatchExpectedMessage
-    );
-});
-
-test('remapPublishError() rewrites a generic invalid-bundle parse error without a digest hint', () => {
-    expectRemapped(
-        new Error('Unsupported bundle format'),
-        { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
-        invalidBundleExpectedMessage
-    );
-});
-
-test('remapPublishError() returns the original error when no remap rule matches', () => {
-    const original = new Error('Network failure: ECONNRESET');
-
-    const result = remapPublishError(original, { access: 'public' });
-
-    assert.strictEqual(result, original);
-});
-
-test('remapPublishError() ignores file-mode patterns when publishSettings does not configure file provenance', () => {
-    const original = new Error('Bundle is invalid: malformed protobuf');
-
-    const result = remapPublishError(original, { access: 'public', provenance: { type: 'auto' } });
-
-    assert.strictEqual(result, original);
-});
-
-test('remapPublishError() returns the original error in file mode when the failure is neither ENOENT nor a bundle error', () => {
-    const original = new Error('Network failure: ECONNRESET');
-
-    const result = remapPublishError(original, {
-        access: 'public',
-        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        assert.deepStrictEqual(result, { access: 'public', provenance: true });
     });
 
-    assert.strictEqual(result, original);
-});
+    test('buildPublishOptionsForPublishSettings() maps file-mode provenance to provenanceFile', function () {
+        const result = buildPublishOptionsForPublishSettings({
+            access: 'public',
+            provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        });
 
-test('remapPublishError() wraps a non-Error rejection value into an Error when no remap rule matches', () => {
-    const result = remapPublishError('plain-string-failure', { access: 'public' });
-
-    assert.ok(result instanceof Error);
-    assert.strictEqual(result.message, 'plain-string-failure');
-});
-
-test('remapPublishError() wraps a null rejection value without dereferencing its non-existent message', () => {
-    const result = remapPublishError(null, { access: 'public' });
-
-    assert.ok(result instanceof Error);
-    assert.strictEqual(result.message, 'null');
-});
-
-test('remapPublishError() wraps a null rejection value when publishSettings configures file provenance', () => {
-    const result = remapPublishError(null, {
-        access: 'public',
-        provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        assert.deepStrictEqual(result, { access: 'public', provenanceFile: '/build/pkg.sigstore' });
     });
 
-    assert.ok(result instanceof Error);
-    assert.strictEqual(result.message, 'null');
-});
+    function expectRemapped(
+        originalError: unknown,
+        publishSettings: Readonly<PublishSettings>,
+        expectedMessage: string
+    ): void {
+        const remapped = remapPublishError(originalError, publishSettings);
 
-test('remapPublishError() does not enter file-mode remapping when publishSettings has restricted access', () => {
-    const original = new Error('Bundle is invalid: malformed protobuf');
+        assert.ok(remapped instanceof Error, 'Expected remapped value to be an Error');
+        assert.strictEqual(remapped.message, expectedMessage);
+        assert.strictEqual(remapped.cause, originalError, 'Expected the original error to be preserved as cause');
+    }
 
-    const result = remapPublishError(original, { access: 'restricted' });
+    function buildUnsupportedProviderExpectedMessage(ciName: string): string {
+        return [
+            'Provenance auto mode requires GitHub Actions or GitLab CI.',
+            `Detected CI: ${ciName}.`,
+            "Use provenance: { type: 'file' } for other environments."
+        ].join(' ');
+    }
 
-    assert.strictEqual(result, original);
-});
+    const unsupportedProviderMessage = buildUnsupportedProviderExpectedMessage('jenkins');
 
-test('remapPublishError() guards against a runtime-only restricted+provenance combination that bypasses the type system', () => {
-    const restrictedWithProvenance = {
-        access: 'restricted',
-        provenance: { type: 'file', path: '/build/pkg.sigstore' }
-    } as unknown as PublishSettings;
-    const original = new Error('Bundle is invalid: malformed protobuf');
+    const githubActionsIdTokenExpectedMessage =
+        'GitHub Actions provenance needs "permissions: id-token: write" on the workflow job.' +
+        ' See the packtory readme for the workflow snippet.';
 
-    const result = remapPublishError(original, restrictedWithProvenance);
+    const gitlabSigstoreIdTokenExpectedMessage =
+        'GitLab CI provenance needs an "id_tokens" entry with audience "sigstore"' +
+        ' exposed as SIGSTORE_ID_TOKEN. See the packtory readme for the workflow snippet.';
 
-    assert.strictEqual(result, original);
-});
+    const missingFileExpectedMessage =
+        'Provenance bundle file "/build/pkg.sigstore" does not exist.' +
+        " Generate it with your CI's attestation tool (e.g. actions/attest-build-provenance) before running packtory.";
 
-test('remapPublishError() ignores a non-string message field on an object-like rejection value', () => {
-    const result = remapPublishError({ message: 12_345 }, { access: 'public' });
+    const invalidBundleExpectedMessage =
+        'Provenance bundle file "/build/pkg.sigstore" is not a valid sigstore bundle. Re-generate it from the current build.';
 
-    assert.ok(result instanceof Error);
-    assert.strictEqual(result.message, '[object Object]');
+    const digestMismatchExpectedMessage =
+        'Provenance bundle at "/build/pkg.sigstore" was signed against a different tarball' +
+        ' than the one packtory built. Re-generate the bundle from the current source —' +
+        ' shipping a mismatched attestation would defeat the purpose of provenance.';
+
+    test('remapPublishError() rewrites the "unsupported provider" libnpmpublish error with the detected CI name', function () {
+        expectRemapped(
+            Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins'), {
+                code: 'EUSAGE'
+            }),
+            { access: 'public', provenance: { type: 'auto' } },
+            unsupportedProviderMessage
+        );
+    });
+
+    test('remapPublishError() handles libnpmpublish messages where the provider follows the colon directly', function () {
+        expectRemapped(
+            Object.assign(new Error('Automatic provenance generation not supported for provider:circleci'), {
+                code: 'EUSAGE'
+            }),
+            { access: 'public', provenance: { type: 'auto' } },
+            buildUnsupportedProviderExpectedMessage('circleci')
+        );
+    });
+
+    test('remapPublishError() falls back to "unknown" CI name when the libnpmpublish message lacks a provider', function () {
+        expectRemapped(
+            Object.assign(new Error('Automatic provenance generation not supported for provider:'), {
+                code: 'EUSAGE'
+            }),
+            { access: 'public', provenance: { type: 'auto' } },
+            buildUnsupportedProviderExpectedMessage('unknown')
+        );
+    });
+
+    test('remapPublishError() extracts only the first whitespace-delimited token after the "provider:" marker', function () {
+        expectRemapped(
+            Object.assign(
+                new Error('Automatic provenance generation not supported for provider: jenkins extra trailing'),
+                {
+                    code: 'EUSAGE'
+                }
+            ),
+            { access: 'public', provenance: { type: 'auto' } },
+            buildUnsupportedProviderExpectedMessage('jenkins')
+        );
+    });
+
+    test('remapPublishError() rewrites the missing GitHub Actions id-token permission error', function () {
+        expectRemapped(
+            Object.assign(
+                new Error(
+                    'Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'
+                ),
+                { code: 'EUSAGE' }
+            ),
+            { access: 'public', provenance: { type: 'auto' } },
+            githubActionsIdTokenExpectedMessage
+        );
+    });
+
+    test('remapPublishError() rewrites the missing GitLab SIGSTORE_ID_TOKEN error', function () {
+        expectRemapped(
+            Object.assign(
+                new Error('Provenance generation in GitLab CI requires "SIGSTORE_ID_TOKEN" with "sigstore" audience'),
+                { code: 'EUSAGE' }
+            ),
+            { access: 'public', provenance: { type: 'auto' } },
+            gitlabSigstoreIdTokenExpectedMessage
+        );
+    });
+
+    test('remapPublishError() rewrites a missing provenance bundle file (ENOENT) error', function () {
+        expectRemapped(
+            Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' }),
+            { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+            missingFileExpectedMessage
+        );
+    });
+
+    test('remapPublishError() rewrites an invalid sigstore bundle parse error', function () {
+        expectRemapped(
+            new Error('Bundle is invalid: malformed protobuf'),
+            { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+            invalidBundleExpectedMessage
+        );
+    });
+
+    test('remapPublishError() rewrites a sigstore subject-digest mismatch error', function () {
+        expectRemapped(
+            new Error('Provenance subject does not match published package digest'),
+            { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+            digestMismatchExpectedMessage
+        );
+    });
+
+    test('remapPublishError() classifies a "subject does not match" error as a digest mismatch even without the word "digest"', function () {
+        expectRemapped(
+            new Error('Provenance subject does not match'),
+            { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+            digestMismatchExpectedMessage
+        );
+    });
+
+    test('remapPublishError() classifies a "Bundle is invalid" digest error as a digest mismatch even without the word "subject"', function () {
+        expectRemapped(
+            new Error('Bundle is invalid: digest verification failed'),
+            { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+            digestMismatchExpectedMessage
+        );
+    });
+
+    test('remapPublishError() rewrites a generic invalid-bundle parse error without a digest hint', function () {
+        expectRemapped(
+            new Error('Unsupported bundle format'),
+            { access: 'public', provenance: { type: 'file', path: '/build/pkg.sigstore' } },
+            invalidBundleExpectedMessage
+        );
+    });
+
+    test('remapPublishError() returns the original error when no remap rule matches', function () {
+        const original = new Error('Network failure: ECONNRESET');
+
+        const result = remapPublishError(original, { access: 'public' });
+
+        assert.strictEqual(result, original);
+    });
+
+    test('remapPublishError() ignores file-mode patterns when publishSettings does not configure file provenance', function () {
+        const original = new Error('Bundle is invalid: malformed protobuf');
+
+        const result = remapPublishError(original, { access: 'public', provenance: { type: 'auto' } });
+
+        assert.strictEqual(result, original);
+    });
+
+    test('remapPublishError() returns the original error in file mode when the failure is neither ENOENT nor a bundle error', function () {
+        const original = new Error('Network failure: ECONNRESET');
+
+        const result = remapPublishError(original, {
+            access: 'public',
+            provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        });
+
+        assert.strictEqual(result, original);
+    });
+
+    test('remapPublishError() wraps a non-Error rejection value into an Error when no remap rule matches', function () {
+        const result = remapPublishError('plain-string-failure', { access: 'public' });
+
+        assert.ok(result instanceof Error);
+        assert.strictEqual(result.message, 'plain-string-failure');
+    });
+
+    test('remapPublishError() wraps a null rejection value without dereferencing its non-existent message', function () {
+        const result = remapPublishError(null, { access: 'public' });
+
+        assert.ok(result instanceof Error);
+        assert.strictEqual(result.message, 'null');
+    });
+
+    test('remapPublishError() wraps a null rejection value when publishSettings configures file provenance', function () {
+        const result = remapPublishError(null, {
+            access: 'public',
+            provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        });
+
+        assert.ok(result instanceof Error);
+        assert.strictEqual(result.message, 'null');
+    });
+
+    test('remapPublishError() does not enter file-mode remapping when publishSettings has restricted access', function () {
+        const original = new Error('Bundle is invalid: malformed protobuf');
+
+        const result = remapPublishError(original, { access: 'restricted' });
+
+        assert.strictEqual(result, original);
+    });
+
+    test('remapPublishError() guards against a runtime-only restricted+provenance combination that bypasses the type system', function () {
+        const restrictedWithProvenance = {
+            access: 'restricted',
+            provenance: { type: 'file', path: '/build/pkg.sigstore' }
+        } as unknown as PublishSettings;
+        const original = new Error('Bundle is invalid: malformed protobuf');
+
+        const result = remapPublishError(original, restrictedWithProvenance);
+
+        assert.strictEqual(result, original);
+    });
+
+    test('remapPublishError() ignores a non-string message field on an object-like rejection value', function () {
+        const result = remapPublishError({ message: 12_345 }, { access: 'public' });
+
+        assert.ok(result instanceof Error);
+        assert.strictEqual(result.message, '[object Object]');
+    });
 });

--- a/source/bundle-emitter/registry/registry-auth-config.test.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { RegistrySettings } from '../../config/registry-settings.ts';
 import {
     buildAuthOptions,
@@ -24,110 +24,112 @@ function settings(overrides: Partial<RegistrySettings> = {}): RegistrySettings {
 
 const basicEncoded = Buffer.from('user:pass').toString('base64');
 
-test('resolveRegistryUrl returns the configured registry URL', () => {
-    assert.strictEqual(
-        resolveRegistryUrl(settings({ registryUrl: 'https://internal.example.com/' })),
-        'https://internal.example.com/'
-    );
-});
-
-test('resolveRegistryUrl returns undefined when no registry URL is configured', () => {
-    assert.strictEqual(resolveRegistryUrl(settings()), undefined);
-});
-
-test('isNpmRegistry returns true for the canonical npm registry URL', () => {
-    assert.strictEqual(isNpmRegistry('https://registry.npmjs.org/'), true);
-});
-
-test('isNpmRegistry returns true when no URL is provided (defaults to npm)', () => {
-    assert.strictEqual(isNpmRegistry(undefined), true);
-});
-
-test('isNpmRegistry returns false for a non-npm registry URL', () => {
-    assert.strictEqual(isNpmRegistry('https://internal.example.com/'), false);
-});
-
-test('createBaseOptions always sets alwaysAuth and the configured registry', () => {
-    assert.deepStrictEqual(createBaseOptions(settings({ registryUrl: 'https://internal.example.com/' })), {
-        alwaysAuth: true,
-        registry: 'https://internal.example.com/'
+suite('registry-auth-config', function () {
+    test('resolveRegistryUrl returns the configured registry URL', function () {
+        assert.strictEqual(
+            resolveRegistryUrl(settings({ registryUrl: 'https://internal.example.com/' })),
+            'https://internal.example.com/'
+        );
     });
-});
 
-test('buildAuthOptions forces a bearer token when the strategy is bearer-token', () => {
-    assert.deepStrictEqual(buildAuthOptions(tokenAuth, settings()), {
-        allowsAutomaticRetry: false,
-        registry: undefined,
-        options: { alwaysAuth: true, registry: undefined, forceAuth: { token: 'abc' } }
+    test('resolveRegistryUrl returns undefined when no registry URL is configured', function () {
+        assert.strictEqual(resolveRegistryUrl(settings()), undefined);
     });
-});
 
-test('buildAuthOptions encodes user:password as base64 when the strategy is basic', () => {
-    assert.deepStrictEqual(buildAuthOptions(basicAuth, settings({ auth: basicAuth })), {
-        allowsAutomaticRetry: false,
-        registry: undefined,
-        options: {
+    test('isNpmRegistry returns true for the canonical npm registry URL', function () {
+        assert.strictEqual(isNpmRegistry('https://registry.npmjs.org/'), true);
+    });
+
+    test('isNpmRegistry returns true when no URL is provided (defaults to npm)', function () {
+        assert.strictEqual(isNpmRegistry(undefined), true);
+    });
+
+    test('isNpmRegistry returns false for a non-npm registry URL', function () {
+        assert.strictEqual(isNpmRegistry('https://internal.example.com/'), false);
+    });
+
+    test('createBaseOptions always sets alwaysAuth and the configured registry', function () {
+        assert.deepStrictEqual(createBaseOptions(settings({ registryUrl: 'https://internal.example.com/' })), {
             alwaysAuth: true,
+            registry: 'https://internal.example.com/'
+        });
+    });
+
+    test('buildAuthOptions forces a bearer token when the strategy is bearer-token', function () {
+        assert.deepStrictEqual(buildAuthOptions(tokenAuth, settings()), {
+            allowsAutomaticRetry: false,
             registry: undefined,
-            forceAuth: { _auth: basicEncoded },
-            email: 'user@example.com'
-        }
+            options: { alwaysAuth: true, registry: undefined, forceAuth: { token: 'abc' } }
+        });
     });
-});
 
-test('buildAuthOptions omits the email field when the basic auth strategy has no email', () => {
-    assert.deepStrictEqual(buildAuthOptions({ type: 'basic', username: 'u', password: 'p' }, settings()), {
-        allowsAutomaticRetry: false,
-        registry: undefined,
-        options: {
-            alwaysAuth: true,
+    test('buildAuthOptions encodes user:password as base64 when the strategy is basic', function () {
+        assert.deepStrictEqual(buildAuthOptions(basicAuth, settings({ auth: basicAuth })), {
+            allowsAutomaticRetry: false,
             registry: undefined,
-            forceAuth: { _auth: Buffer.from('u:p').toString('base64') }
-        }
+            options: {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { _auth: basicEncoded },
+                email: 'user@example.com'
+            }
+        });
     });
-});
 
-test('resolvePublishAuth returns the flat auth strategy directly', () => {
-    assert.deepStrictEqual(resolvePublishAuth(settings()), tokenAuth);
-});
-
-test('resolvePublishAuth returns the publish branch of a split metadata/publish auth', () => {
-    assert.deepStrictEqual(resolvePublishAuth({ auth: { publish: tokenAuth, metadata: 'auto' } }), tokenAuth);
-});
-
-test('resolveMetadataAuthOptions falls back to publish auth when no metadata mode is configured', () => {
-    assert.deepStrictEqual(resolveMetadataAuthOptions(settings()), {
-        allowsAutomaticRetry: false,
-        registry: undefined,
-        options: { alwaysAuth: true, registry: undefined, forceAuth: { token: 'abc' } }
-    });
-});
-
-test('resolveMetadataAuthOptions returns anonymous options with retry enabled when metadata mode is auto', () => {
-    assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { publish: tokenAuth, metadata: 'auto' } }), {
-        allowsAutomaticRetry: true,
-        registry: undefined,
-        options: { alwaysAuth: true, registry: undefined }
-    });
-});
-
-test('resolveMetadataAuthOptions returns anonymous options when publish auth is npm-oidc', () => {
-    assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { type: 'npm-oidc' } }), {
-        allowsAutomaticRetry: false,
-        registry: undefined,
-        options: { alwaysAuth: true, registry: undefined }
-    });
-});
-
-test('resolveMetadataAuthOptions uses a custom metadata auth strategy when one is provided', () => {
-    assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { publish: tokenAuth, metadata: basicAuth } }), {
-        allowsAutomaticRetry: false,
-        registry: undefined,
-        options: {
-            alwaysAuth: true,
+    test('buildAuthOptions omits the email field when the basic auth strategy has no email', function () {
+        assert.deepStrictEqual(buildAuthOptions({ type: 'basic', username: 'u', password: 'p' }, settings()), {
+            allowsAutomaticRetry: false,
             registry: undefined,
-            forceAuth: { _auth: basicEncoded },
-            email: 'user@example.com'
-        }
+            options: {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { _auth: Buffer.from('u:p').toString('base64') }
+            }
+        });
+    });
+
+    test('resolvePublishAuth returns the flat auth strategy directly', function () {
+        assert.deepStrictEqual(resolvePublishAuth(settings()), tokenAuth);
+    });
+
+    test('resolvePublishAuth returns the publish branch of a split metadata/publish auth', function () {
+        assert.deepStrictEqual(resolvePublishAuth({ auth: { publish: tokenAuth, metadata: 'auto' } }), tokenAuth);
+    });
+
+    test('resolveMetadataAuthOptions falls back to publish auth when no metadata mode is configured', function () {
+        assert.deepStrictEqual(resolveMetadataAuthOptions(settings()), {
+            allowsAutomaticRetry: false,
+            registry: undefined,
+            options: { alwaysAuth: true, registry: undefined, forceAuth: { token: 'abc' } }
+        });
+    });
+
+    test('resolveMetadataAuthOptions returns anonymous options with retry enabled when metadata mode is auto', function () {
+        assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { publish: tokenAuth, metadata: 'auto' } }), {
+            allowsAutomaticRetry: true,
+            registry: undefined,
+            options: { alwaysAuth: true, registry: undefined }
+        });
+    });
+
+    test('resolveMetadataAuthOptions returns anonymous options when publish auth is npm-oidc', function () {
+        assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { type: 'npm-oidc' } }), {
+            allowsAutomaticRetry: false,
+            registry: undefined,
+            options: { alwaysAuth: true, registry: undefined }
+        });
+    });
+
+    test('resolveMetadataAuthOptions uses a custom metadata auth strategy when one is provided', function () {
+        assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { publish: tokenAuth, metadata: basicAuth } }), {
+            allowsAutomaticRetry: false,
+            registry: undefined,
+            options: {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { _auth: basicEncoded },
+                email: 'user@example.com'
+            }
+        });
     });
 });

--- a/source/bundle-emitter/registry/registry-client.test.ts
+++ b/source/bundle-emitter/registry/registry-client.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
 import type { PublishAuthStrategy } from '../../config/registry-settings.ts';
@@ -80,1068 +80,911 @@ function buildLatestVersionFetchJson(): SinonSpy {
     });
 }
 
-test('publishPackage() uses shorthand bearer auth and one-time-password prompt when provided', async () => {
-    const publish = fake.resolves(undefined);
-    const promptForOneTimePassword = fake.resolves('123456');
-    const registryClient = registryClientFactory({ publish, promptForOneTimePassword });
-    const tarData = Buffer.from([1, 2, 3, 4]);
+suite('registry-client', function () {
+    test('publishPackage() uses shorthand bearer auth and one-time-password prompt when provided', async function () {
+        const publish = fake.resolves(undefined);
+        const promptForOneTimePassword = fake.resolves('123456');
+        const registryClient = registryClientFactory({ publish, promptForOneTimePassword });
+        const tarData = Buffer.from([1, 2, 3, 4]);
 
-    await registryClient.publishPackage(
-        { name: 'the-name', version: 'the-version' },
-        tarData,
-        {
-            auth: { type: 'bearer-token', token: 'the-token' }
-        },
-        { access: 'public' }
-    );
+        await registryClient.publishPackage(
+            { name: 'the-name', version: 'the-version' },
+            tarData,
+            {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            },
+            { access: 'public' }
+        );
 
-    assert.deepStrictEqual(publish.firstCall.args, [
-        { name: 'the-name', version: 'the-version' },
-        tarData,
-        {
+        assert.deepStrictEqual(publish.firstCall.args, [
+            { name: 'the-name', version: 'the-version' },
+            tarData,
+            {
+                defaultTag: 'latest',
+                alwaysAuth: true,
+                registry: undefined,
+                access: 'public',
+                forceAuth: { token: 'the-token' },
+                otpPrompt: promptForOneTimePassword
+            }
+        ]);
+    });
+
+    test('publishPackage() uses explicit basic auth when configured', async function () {
+        const publish = fake.resolves(undefined);
+        const registryClient = registryClientFactory({ publish });
+
+        await registryClient.publishPackage(
+            { name: 'the-name', version: 'the-version' },
+            Buffer.from([]),
+            {
+                registryUrl: 'https://registry.example.test',
+                auth: {
+                    type: 'basic',
+                    username: 'user',
+                    password: 'secret'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.deepStrictEqual(publish.firstCall.args.at(-1), {
             defaultTag: 'latest',
             alwaysAuth: true,
-            registry: undefined,
+            registry: 'https://registry.example.test',
             access: 'public',
-            forceAuth: { token: 'the-token' },
-            otpPrompt: promptForOneTimePassword
-        }
-    ]);
-});
-
-test('publishPackage() uses explicit basic auth when configured', async () => {
-    const publish = fake.resolves(undefined);
-    const registryClient = registryClientFactory({ publish });
-
-    await registryClient.publishPackage(
-        { name: 'the-name', version: 'the-version' },
-        Buffer.from([]),
-        {
-            registryUrl: 'https://registry.example.test',
-            auth: {
-                type: 'basic',
-                username: 'user',
-                password: 'secret'
-            }
-        },
-        { access: 'public' }
-    );
-
-    assert.deepStrictEqual(publish.firstCall.args.at(-1), {
-        defaultTag: 'latest',
-        alwaysAuth: true,
-        registry: 'https://registry.example.test',
-        access: 'public',
-        forceAuth: {
-            _auth: Buffer.from('user:secret', 'utf8').toString('base64')
-        }
-    });
-});
-
-test('fetchLatestVersion() uses shorthand auth for metadata by default', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: { type: 'bearer-token', token: 'the-token' }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            forceAuth: { token: 'the-token' },
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() uses explicit metadata auth when configured', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'bearer-token', token: 'writer-token' },
-            metadata: { type: 'basic', username: 'reader', password: 'reader-secret' }
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
             forceAuth: {
-                _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
-            },
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() uses explicit bearer metadata auth when configured', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'basic', username: 'writer', password: 'writer-secret' },
-            metadata: { type: 'bearer-token', token: 'reader-token' }
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            forceAuth: { token: 'reader-token' },
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() inherits publish auth for metadata by default when expanded auth omits metadata', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'bearer-token', token: 'writer-token' }
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            forceAuth: { token: 'writer-token' },
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() uses anonymous metadata access by default for explicit npm oidc auth', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'npm-oidc' }
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() uses shorthand npm oidc auth without attaching metadata credentials', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: { type: 'npm-oidc', provider: 'env' }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() uses anonymous metadata access by default for shorthand npm oidc auth', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: { type: 'npm-oidc' }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() uses anonymous metadata access when explicitly configured', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'bearer-token', token: 'writer-token' },
-            metadata: 'anonymous'
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() inherits publish auth for metadata when explicit metadata mode requests it', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'basic', username: 'reader', password: 'reader-secret', email: 'reader@example.test' },
-            metadata: 'inherit-publish-auth'
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            forceAuth: {
-                _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
-            },
-            email: 'reader@example.test',
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() treats inherit-publish-auth as anonymous when publish auth uses npm oidc', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'npm-oidc', provider: 'env' },
-            metadata: 'inherit-publish-auth'
-        }
-    });
-
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('metadata auto retries with publish auth on a 401 challenge', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 401;
-    let callCount = 0;
-    const npmFetchJson = fake(async () => {
-        callCount += 1;
-        if (callCount === 1) {
-            throw error;
-        }
-        return {
-            name: '',
-            'dist-tags': { latest: '1' },
-            versions: { 1: { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
-        };
-    });
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    const result = await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'bearer-token', token: 'writer-token' },
-            metadata: 'auto'
-        }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        Maybe.just({
-            version: '1',
-            tarballUrl: 'https://registry.example.test/pkg.tgz'
-        })
-    );
-    assert.strictEqual(npmFetchJson.callCount, 2);
-    assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-    assert.deepStrictEqual(npmFetchJson.secondCall.args, [
-        '/the-name',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            forceAuth: { token: 'writer-token' },
-            headers: { accept: 'application/vnd.npm.install-v1+json' }
-        }
-    ]);
-});
-
-test('metadata auto retries with publish auth on a 403 challenge', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 403;
-    let callCount = 0;
-    const npmFetchJson = fake(async () => {
-        callCount += 1;
-        if (callCount === 1) {
-            throw error;
-        }
-
-        return {
-            name: '',
-            'dist-tags': { latest: '1' },
-            versions: { 1: { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
-        };
-    });
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    const result = await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'bearer-token', token: 'writer-token' },
-            metadata: 'auto'
-        }
-    });
-
-    assert.deepStrictEqual(
-        result,
-        Maybe.just({
-            version: '1',
-            tarballUrl: 'https://registry.example.test/pkg.tgz'
-        })
-    );
-    assert.strictEqual(npmFetchJson.callCount, 2);
-});
-
-test('metadata auto does not retry when the registry returns 404', async () => {
-    const error = new Error('not found');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 404;
-    const npmFetchJson = fake.rejects(error);
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    const result = await registryClient.fetchLatestVersion('the-name', {
-        auth: {
-            publish: { type: 'bearer-token', token: 'writer-token' },
-            metadata: 'auto'
-        }
-    });
-
-    assert.deepStrictEqual(result, Maybe.nothing());
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('metadata auto does not retry when publish auth uses npm oidc', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 401;
-    const npmFetchJson = fake.rejects(error);
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'auto'
+                _auth: Buffer.from('user:secret', 'utf8').toString('base64')
             }
         });
-    }, /^Error: auth required$/u);
-
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('metadata auto does not retry when the registry returns a non-auth error', async () => {
-    const error = new Error('server error');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 500;
-    const npmFetchJson = fake.rejects(error);
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: {
-                publish: { type: 'bearer-token', token: 'writer-token' },
-                metadata: 'auto'
-            }
-        });
-    }, /^Error: server error$/u);
-
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('metadata auto rethrows non-object errors without retrying', async () => {
-    const npmFetchJson = fake(async () => {
-        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
-        throw 'server-error';
     });
-    const registryClient = registryClientFactory({ npmFetchJson });
 
-    await expectFailure(async () => {
+    test('fetchLatestVersion() uses shorthand auth for metadata by default', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
         await registryClient.fetchLatestVersion('the-name', {
-            auth: {
-                publish: { type: 'bearer-token', token: 'writer-token' },
-                metadata: 'auto'
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { token: 'the-token' },
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
             }
-        });
-    }, /^server-error$/u);
+        ]);
+    });
 
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
+    test('fetchLatestVersion() uses explicit metadata auth when configured', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-test('metadata auto rethrows object errors without statusCode without retrying', async () => {
-    const npmFetchJson = fake.rejects(new Error('server-error'));
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: {
-                publish: { type: 'bearer-token', token: 'writer-token' },
-                metadata: 'auto'
-            }
-        });
-    }, /^Error: server-error$/u);
-
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('metadata using inherited publish auth does not retry on a 401 challenge', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 401;
-    const npmFetchJson = fake.rejects(error);
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'writer-token' }
-        });
-    }, /^Error: auth required$/u);
-
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('anonymous metadata access does not retry on a 401 challenge', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 401;
-    const npmFetchJson = fake.rejects(error);
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: {
-                publish: { type: 'bearer-token', token: 'writer-token' },
-                metadata: 'anonymous'
-            }
-        });
-    }, /^Error: auth required$/u);
-
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('basic metadata auth does not retry on a 401 challenge', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 401;
-    const npmFetchJson = fake.rejects(error);
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await expectFailure(async () => {
         await registryClient.fetchLatestVersion('the-name', {
             auth: {
                 publish: { type: 'bearer-token', token: 'writer-token' },
                 metadata: { type: 'basic', username: 'reader', password: 'reader-secret' }
             }
         });
-    }, /^Error: auth required$/u);
 
-    assert.strictEqual(npmFetchJson.callCount, 1);
-});
-
-test('fetchTarball() also retries metadata auto with publish auth on a 401 challenge', async () => {
-    const error = new Error('auth required');
-    // @ts-expect-error intentional test shape
-    error.statusCode = 401;
-    let callCount = 0;
-    const npmFetch = fake(async () => {
-        callCount += 1;
-        if (callCount === 1) {
-            throw error;
-        }
-
-        return {
-            buffer: fake.resolves(Buffer.from([1, 2, 3]))
-        };
-    }) as unknown as FakeNpmFetch;
-    npmFetch.json = fake();
-    const registryClient = registryClientFactory({ npmFetch });
-
-    const result = await registryClient.fetchTarball('https://registry.example.test/pkg.tgz', {
-        auth: {
-            publish: { type: 'basic', username: 'reader', password: 'reader-secret' },
-            metadata: 'auto'
-        }
-    });
-
-    assert.deepStrictEqual(result, Buffer.from([1, 2, 3]));
-    assert.strictEqual(npmFetch.callCount, 2);
-    assert.deepStrictEqual(npmFetch.secondCall.args, [
-        'https://registry.example.test/pkg.tgz',
-        {
-            alwaysAuth: true,
-            registry: undefined,
-            forceAuth: {
-                _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: {
+                    _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+                },
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
             }
-        }
-    ]);
-});
-
-test('fetchLatestVersion() escapes scoped package names', async () => {
-    const npmFetchJson = buildLatestVersionFetchJson();
-    const registryClient = registryClientFactory({ npmFetchJson });
-
-    await registryClient.fetchLatestVersion('@the/name', {
-        auth: { type: 'bearer-token', token: 'the-token' }
+        ]);
     });
 
-    assert.strictEqual(npmFetchJson.firstCall.firstArg, '/@the%2Fname');
-});
+    test('fetchLatestVersion() uses explicit bearer metadata auth when configured', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-test('publishPackage() resolves and exchanges npm oidc id tokens', async () => {
-    const publish = fake.resolves(undefined);
-    const resolveIdToken = fake.resolves('upstream-id-token');
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T11:00:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        resolveIdToken
-    });
-
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.0' },
-        Buffer.from([]),
-        {
+        await registryClient.fetchLatestVersion('the-name', {
             auth: {
-                publish: { type: 'npm-oidc', provider: 'github-actions' },
-                metadata: 'anonymous'
+                publish: { type: 'basic', username: 'writer', password: 'writer-secret' },
+                metadata: { type: 'bearer-token', token: 'reader-token' }
             }
-        },
-        { access: 'public' }
-    );
+        });
 
-    assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc', provider: 'github-actions' }]);
-    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
-        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fthe-name',
-        {
-            method: 'POST',
-            headers: { Authorization: 'Bearer upstream-id-token' }
-        }
-    ]);
-    assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
-});
-
-test('publishPackage() exchanges npm oidc tokens and caches the exchange token per package', async () => {
-    const publish = fake.resolves(undefined);
-    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T11:00:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        clock,
-        resolveIdToken: fake.resolves('upstream-id-token')
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { token: 'reader-token' },
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
     });
 
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.0' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.1' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
+    test('fetchLatestVersion() inherits publish auth for metadata by default when expanded auth omits metadata', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
-    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
-        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fthe-name',
-        {
-            method: 'POST',
-            headers: { Authorization: 'Bearer upstream-id-token' }
-        }
-    ]);
-    assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
-    assert.strictEqual(getPublishedToken(publish, 1), 'oidc-exchange-token');
-});
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' }
+            }
+        });
 
-test('publishPackage() passes shorthand npm oidc auth through to the id token resolver', async () => {
-    const publish = fake.resolves(undefined);
-    const resolveIdToken = fake.resolves('upstream-id-token');
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T11:00:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        resolveIdToken
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { token: 'writer-token' },
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
     });
 
-    await registryClient.publishPackage(
-        { name: 'the-name', version: '1.0.0' },
-        Buffer.from([]),
-        {
+    test('fetchLatestVersion() uses anonymous metadata access by default for explicit npm oidc auth', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'npm-oidc' }
+            }
+        });
+
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('fetchLatestVersion() uses shorthand npm oidc auth without attaching metadata credentials', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: { type: 'npm-oidc', provider: 'env' }
+        });
+
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('fetchLatestVersion() uses anonymous metadata access by default for shorthand npm oidc auth', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('the-name', {
             auth: { type: 'npm-oidc' }
-        },
-        { access: 'public' }
-    );
+        });
 
-    assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc' }]);
-    assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
-});
-
-test('publishPackage() refreshes the exchanged npm oidc token after expiry', async () => {
-    const publish = fake.resolves(undefined);
-    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T10:01:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        clock,
-        resolveIdToken: fake.resolves('upstream-id-token')
-    });
-
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.0' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-
-    clock.tick(61_000);
-
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.1' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
-});
-
-test('publishPackage() refreshes the exchanged npm oidc token when exactly 60 seconds remain', async () => {
-    const publish = fake.resolves(undefined);
-    const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T10:01:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        clock,
-        resolveIdToken: fake.resolves('upstream-id-token')
-    });
-
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.0' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.1' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
-});
-
-test('publishPackage() caches exchanged npm oidc tokens per package name', async () => {
-    const publish = fake.resolves(undefined);
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T11:00:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
-    });
-
-    await registryClient.publishPackage(
-        { name: '@scope/first-package', version: '1.0.0' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-    await registryClient.publishPackage(
-        { name: '@scope/second-package', version: '1.0.0' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
-    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
-        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Ffirst-package',
-        {
-            method: 'POST',
-            headers: { Authorization: 'Bearer upstream-id-token' }
-        }
-    ]);
-    assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).secondCall.args, [
-        'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fsecond-package',
-        {
-            method: 'POST',
-            headers: { Authorization: 'Bearer upstream-id-token' }
-        }
-    ]);
-});
-
-test('publishPackage() reuses exchanged npm oidc tokens between implicit and explicit npm registry URLs', async () => {
-    const publish = fake.resolves(undefined);
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T11:00:00.000Z'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        publish,
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
-    });
-
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.0' },
-        Buffer.from([]),
-        {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-    await registryClient.publishPackage(
-        { name: '@scope/the-name', version: '1.0.1' },
-        Buffer.from([]),
-        {
-            registryUrl: 'https://registry.npmjs.org/',
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env' },
-                metadata: 'anonymous'
-            }
-        },
-        { access: 'public' }
-    );
-
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
-});
-
-test('publishPackage() rejects npm oidc auth for non-npm registries', async () => {
-    const registryClient = registryClientFactory({
-        resolveIdToken: fake.resolves('upstream-id-token')
-    });
-
-    await expectFailure(async () => {
-        await registryClient.publishPackage(
-            { name: 'the-name', version: '1.0.0' },
-            Buffer.from([]),
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
             {
-                registryUrl: 'https://registry.example.test',
+                alwaysAuth: true,
+                registry: undefined,
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('fetchLatestVersion() uses anonymous metadata access when explicitly configured', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'anonymous'
+            }
+        });
+
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('fetchLatestVersion() inherits publish auth for metadata when explicit metadata mode requests it', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'basic', username: 'reader', password: 'reader-secret', email: 'reader@example.test' },
+                metadata: 'inherit-publish-auth'
+            }
+        });
+
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: {
+                    _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+                },
+                email: 'reader@example.test',
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('fetchLatestVersion() treats inherit-publish-auth as anonymous when publish auth uses npm oidc', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'npm-oidc', provider: 'env' },
+                metadata: 'inherit-publish-auth'
+            }
+        });
+
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('metadata auto retries with publish auth on a 401 challenge', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 401;
+        let callCount = 0;
+        const npmFetchJson = fake(async () => {
+            callCount += 1;
+            if (callCount === 1) {
+                throw error;
+            }
+            return {
+                name: '',
+                'dist-tags': { latest: '1' },
+                versions: { 1: { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
+            };
+        });
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'auto'
+            }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            Maybe.just({
+                version: '1',
+                tarballUrl: 'https://registry.example.test/pkg.tgz'
+            })
+        );
+        assert.strictEqual(npmFetchJson.callCount, 2);
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+        assert.deepStrictEqual(npmFetchJson.secondCall.args, [
+            '/the-name',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { token: 'writer-token' },
+                headers: { accept: 'application/vnd.npm.install-v1+json' }
+            }
+        ]);
+    });
+
+    test('metadata auto retries with publish auth on a 403 challenge', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 403;
+        let callCount = 0;
+        const npmFetchJson = fake(async () => {
+            callCount += 1;
+            if (callCount === 1) {
+                throw error;
+            }
+
+            return {
+                name: '',
+                'dist-tags': { latest: '1' },
+                versions: { 1: { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
+            };
+        });
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'auto'
+            }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            Maybe.just({
+                version: '1',
+                tarballUrl: 'https://registry.example.test/pkg.tgz'
+            })
+        );
+        assert.strictEqual(npmFetchJson.callCount, 2);
+    });
+
+    test('metadata auto does not retry when the registry returns 404', async function () {
+        const error = new Error('not found');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 404;
+        const npmFetchJson = fake.rejects(error);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchLatestVersion('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'auto'
+            }
+        });
+
+        assert.deepStrictEqual(result, Maybe.nothing());
+        assert.strictEqual(npmFetchJson.callCount, 1);
+    });
+
+    test('metadata auto does not retry when publish auth uses npm oidc', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 401;
+        const npmFetchJson = fake.rejects(error);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
                 auth: {
                     publish: { type: 'npm-oidc', provider: 'env' },
-                    metadata: 'anonymous'
+                    metadata: 'auto'
                 }
-            },
-            { access: 'public' }
-        );
-    }, /^Error: npm-oidc auth is only supported with the npmjs.org registry$/u);
-});
+            });
+        }, /^Error: auth required$/u);
 
-test('publishPackage() rejects an invalid OIDC exchange response body', async () => {
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({ token: 'missing-fields' })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
+        assert.strictEqual(npmFetchJson.callCount, 1);
     });
 
-    await expectFailure(async () => {
-        await registryClient.publishPackage(
-            { name: 'the-name', version: '1.0.0' },
-            Buffer.from([]),
-            {
-                auth: {
-                    publish: { type: 'npm-oidc', provider: 'env' },
-                    metadata: 'anonymous'
-                }
-            },
-            { access: 'public' }
-        );
-    }, /^TypeError: OIDC token exchange returned an invalid response$/u);
-});
+    test('metadata auto does not retry when the registry returns a non-auth error', async function () {
+        const error = new Error('server error');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 500;
+        const npmFetchJson = fake.rejects(error);
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-test('publishPackage() rejects a non-object OIDC exchange response body', async () => {
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves('invalid-response')
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: {
+                    publish: { type: 'bearer-token', token: 'writer-token' },
+                    metadata: 'auto'
+                }
+            });
+        }, /^Error: server error$/u);
+
+        assert.strictEqual(npmFetchJson.callCount, 1);
     });
 
-    await expectFailure(async () => {
-        await registryClient.publishPackage(
-            { name: 'the-name', version: '1.0.0' },
-            Buffer.from([]),
-            {
-                auth: {
-                    publish: { type: 'npm-oidc', provider: 'env' },
-                    metadata: 'anonymous'
-                }
-            },
-            { access: 'public' }
-        );
-    }, /^TypeError: OIDC token exchange returned an invalid response$/u);
-});
+    test('metadata auto rethrows non-object errors without retrying', async function () {
+        const npmFetchJson = fake(async () => {
+            // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
+            throw 'server-error';
+        });
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-test('publishPackage() rejects a null OIDC exchange response body', async () => {
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves(null)
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: {
+                    publish: { type: 'bearer-token', token: 'writer-token' },
+                    metadata: 'auto'
+                }
+            });
+        }, /^server-error$/u);
+
+        assert.strictEqual(npmFetchJson.callCount, 1);
     });
 
-    await expectFailure(async () => {
-        await registryClient.publishPackage(
-            { name: 'the-name', version: '1.0.0' },
-            Buffer.from([]),
-            {
-                auth: {
-                    publish: { type: 'npm-oidc', provider: 'env' },
-                    metadata: 'anonymous'
-                }
-            },
-            { access: 'public' }
-        );
-    }, /^TypeError: OIDC token exchange returned an invalid response$/u);
-});
+    test('metadata auto rethrows object errors without statusCode without retrying', async function () {
+        const npmFetchJson = fake.rejects(new Error('server-error'));
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-test('publishPackage() rejects a failing OIDC exchange request', async () => {
-    const fetchSpy = fake.resolves({
-        ok: false,
-        status: 502,
-        json: fake.resolves({})
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: {
+                    publish: { type: 'bearer-token', token: 'writer-token' },
+                    metadata: 'auto'
+                }
+            });
+        }, /^Error: server-error$/u);
+
+        assert.strictEqual(npmFetchJson.callCount, 1);
     });
 
-    await expectFailure(async () => {
-        await registryClient.publishPackage(
-            { name: 'the-name', version: '1.0.0' },
-            Buffer.from([]),
-            {
-                auth: {
-                    publish: { type: 'npm-oidc', provider: 'env' },
-                    metadata: 'anonymous'
-                }
-            },
-            { access: 'public' }
-        );
-    }, /^Error: OIDC token exchange failed with status 502$/u);
-});
+    test('metadata using inherited publish auth does not retry on a 401 challenge', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 401;
+        const npmFetchJson = fake.rejects(error);
+        const registryClient = registryClientFactory({ npmFetchJson });
 
-test('publishPackage() rejects an invalid OIDC exchange expiry timestamp', async () => {
-    const fetchSpy = fake.resolves({
-        ok: true,
-        status: 201,
-        json: fake.resolves({
-            token_type: 'oidc',
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: 'not-a-date'
-        })
-    }) as unknown as typeof globalThis.fetch;
-    const registryClient = registryClientFactory({
-        fetch: fetchSpy,
-        resolveIdToken: fake.resolves('upstream-id-token')
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'writer-token' }
+            });
+        }, /^Error: auth required$/u);
+
+        assert.strictEqual(npmFetchJson.callCount, 1);
     });
 
-    await expectFailure(async () => {
-        await registryClient.publishPackage(
-            { name: 'the-name', version: '1.0.0' },
-            Buffer.from([]),
-            {
+    test('anonymous metadata access does not retry on a 401 challenge', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 401;
+        const npmFetchJson = fake.rejects(error);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
                 auth: {
-                    publish: { type: 'npm-oidc', provider: 'env' },
+                    publish: { type: 'bearer-token', token: 'writer-token' },
                     metadata: 'anonymous'
                 }
-            },
-            { access: 'public' }
-        );
-    }, /^TypeError: OIDC token exchange returned an invalid expiry timestamp$/u);
-});
+            });
+        }, /^Error: auth required$/u);
 
-for (const [testName, response] of [
-    [
-        'token_type is invalid',
-        {
-            token_type: 123,
-            token: 'oidc-exchange-token',
-            created: '2026-05-06T10:00:00.000Z',
-            expires: '2026-05-06T11:00:00.000Z'
-        }
-    ],
-    [
-        'token is invalid',
-        { token_type: 'oidc', token: 123, created: '2026-05-06T10:00:00.000Z', expires: '2026-05-06T11:00:00.000Z' }
-    ],
-    [
-        'created is invalid',
-        { token_type: 'oidc', token: 'oidc-exchange-token', created: 123, expires: '2026-05-06T11:00:00.000Z' }
-    ],
-    [
-        'expires is invalid',
-        { token_type: 'oidc', token: 'oidc-exchange-token', created: '2026-05-06T10:00:00.000Z', expires: 123 }
-    ]
-] as const) {
-    test(`publishPackage() rejects an OIDC exchange response when ${testName}`, async () => {
+        assert.strictEqual(npmFetchJson.callCount, 1);
+    });
+
+    test('basic metadata auth does not retry on a 401 challenge', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 401;
+        const npmFetchJson = fake.rejects(error);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: {
+                    publish: { type: 'bearer-token', token: 'writer-token' },
+                    metadata: { type: 'basic', username: 'reader', password: 'reader-secret' }
+                }
+            });
+        }, /^Error: auth required$/u);
+
+        assert.strictEqual(npmFetchJson.callCount, 1);
+    });
+
+    test('fetchTarball() also retries metadata auto with publish auth on a 401 challenge', async function () {
+        const error = new Error('auth required');
+        // @ts-expect-error intentional test shape
+        error.statusCode = 401;
+        let callCount = 0;
+        const npmFetch = fake(async () => {
+            callCount += 1;
+            if (callCount === 1) {
+                throw error;
+            }
+
+            return {
+                buffer: fake.resolves(Buffer.from([1, 2, 3]))
+            };
+        }) as unknown as FakeNpmFetch;
+        npmFetch.json = fake();
+        const registryClient = registryClientFactory({ npmFetch });
+
+        const result = await registryClient.fetchTarball('https://registry.example.test/pkg.tgz', {
+            auth: {
+                publish: { type: 'basic', username: 'reader', password: 'reader-secret' },
+                metadata: 'auto'
+            }
+        });
+
+        assert.deepStrictEqual(result, Buffer.from([1, 2, 3]));
+        assert.strictEqual(npmFetch.callCount, 2);
+        assert.deepStrictEqual(npmFetch.secondCall.args, [
+            'https://registry.example.test/pkg.tgz',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: {
+                    _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+                }
+            }
+        ]);
+    });
+
+    test('fetchLatestVersion() escapes scoped package names', async function () {
+        const npmFetchJson = buildLatestVersionFetchJson();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await registryClient.fetchLatestVersion('@the/name', {
+            auth: { type: 'bearer-token', token: 'the-token' }
+        });
+
+        assert.strictEqual(npmFetchJson.firstCall.firstArg, '/@the%2Fname');
+    });
+
+    test('publishPackage() resolves and exchanges npm oidc id tokens', async function () {
+        const publish = fake.resolves(undefined);
+        const resolveIdToken = fake.resolves('upstream-id-token');
         const fetchSpy = fake.resolves({
             ok: true,
             status: 201,
-            json: fake.resolves(response)
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T11:00:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            resolveIdToken
+        });
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'github-actions' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc', provider: 'github-actions' }]);
+        assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
+            'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fthe-name',
+            {
+                method: 'POST',
+                headers: { Authorization: 'Bearer upstream-id-token' }
+            }
+        ]);
+        assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
+    });
+
+    test('publishPackage() exchanges npm oidc tokens and caches the exchange token per package', async function () {
+        const publish = fake.resolves(undefined);
+        const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T11:00:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            clock,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.1' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
+        assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
+            'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fthe-name',
+            {
+                method: 'POST',
+                headers: { Authorization: 'Bearer upstream-id-token' }
+            }
+        ]);
+        assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
+        assert.strictEqual(getPublishedToken(publish, 1), 'oidc-exchange-token');
+    });
+
+    test('publishPackage() passes shorthand npm oidc auth through to the id token resolver', async function () {
+        const publish = fake.resolves(undefined);
+        const resolveIdToken = fake.resolves('upstream-id-token');
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T11:00:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            resolveIdToken
+        });
+
+        await registryClient.publishPackage(
+            { name: 'the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: { type: 'npm-oidc' }
+            },
+            { access: 'public' }
+        );
+
+        assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc' }]);
+        assert.strictEqual(getPublishedToken(publish), 'oidc-exchange-token');
+    });
+
+    test('publishPackage() refreshes the exchanged npm oidc token after expiry', async function () {
+        const publish = fake.resolves(undefined);
+        const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T10:01:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            clock,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        clock.tick(61_000);
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.1' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
+    });
+
+    test('publishPackage() refreshes the exchanged npm oidc token when exactly 60 seconds remain', async function () {
+        const publish = fake.resolves(undefined);
+        const clock = createFakeClock({ initialTimestamp: Date.parse('2026-05-06T10:00:00.000Z') });
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T10:01:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            clock,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.1' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
+    });
+
+    test('publishPackage() caches exchanged npm oidc tokens per package name', async function () {
+        const publish = fake.resolves(undefined);
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T11:00:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await registryClient.publishPackage(
+            { name: '@scope/first-package', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+        await registryClient.publishPackage(
+            { name: '@scope/second-package', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
+        assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).firstCall.args, [
+            'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Ffirst-package',
+            {
+                method: 'POST',
+                headers: { Authorization: 'Bearer upstream-id-token' }
+            }
+        ]);
+        assert.deepStrictEqual((fetchSpy as unknown as SinonSpy).secondCall.args, [
+            'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@scope%2Fsecond-package',
+            {
+                method: 'POST',
+                headers: { Authorization: 'Bearer upstream-id-token' }
+            }
+        ]);
+    });
+
+    test('publishPackage() reuses exchanged npm oidc tokens between implicit and explicit npm registry URLs', async function () {
+        const publish = fake.resolves(undefined);
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: '2026-05-06T11:00:00.000Z'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            publish,
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.0' },
+            Buffer.from([]),
+            {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+        await registryClient.publishPackage(
+            { name: '@scope/the-name', version: '1.0.1' },
+            Buffer.from([]),
+            {
+                registryUrl: 'https://registry.npmjs.org/',
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'anonymous'
+                }
+            },
+            { access: 'public' }
+        );
+
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
+    });
+
+    test('publishPackage() rejects npm oidc auth for non-npm registries', async function () {
+        const registryClient = registryClientFactory({
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                {
+                    registryUrl: 'https://registry.example.test',
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                },
+                { access: 'public' }
+            );
+        }, /^Error: npm-oidc auth is only supported with the npmjs.org registry$/u);
+    });
+
+    test('publishPackage() rejects an invalid OIDC exchange response body', async function () {
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({ token: 'missing-fields' })
         }) as unknown as typeof globalThis.fetch;
         const registryClient = registryClientFactory({
             fetch: fetchSpy,
@@ -1162,97 +1005,191 @@ for (const [testName, response] of [
             );
         }, /^TypeError: OIDC token exchange returned an invalid response$/u);
     });
-}
 
-test('fetchLatestVersion() returns nothing for 404 and 403 responses', async () => {
-    for (const statusCode of [404, 403]) {
-        const error = new Error('fetch-error');
-        // @ts-expect-error -- intentional shape for npm fetch errors
-        error.statusCode = statusCode;
-        const registryClient = registryClientFactory({ npmFetchJson: fake.rejects(error) });
-
-        const result = await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'the-token' }
-        });
-
-        assert.deepStrictEqual(result, Maybe.nothing());
-    }
-});
-
-test('fetchLatestVersion() throws on invalid registry payloads', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake.resolves({ invalid: 'response-data' })
-    });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'the-token' }
-        });
-    }, /^Error: Got an invalid response from registry API$/u);
-});
-
-test('fetchLatestVersion() throws on invalid non-object registry payloads', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake.resolves('invalid-response')
-    });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'the-token' }
-        });
-    }, /^Error: Got an invalid response from registry API$/u);
-});
-
-test('fetchLatestVersion() returns nothing when the registry response has no latest tag', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake.resolves({
-            name: 'the-name',
-            'dist-tags': {},
-            versions: { '1.0.0': { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
-        })
-    });
-
-    const result = await registryClient.fetchLatestVersion('the-name', {
-        auth: { type: 'bearer-token', token: 'the-token' }
-    });
-
-    assert.deepStrictEqual(result, Maybe.nothing());
-});
-
-test('fetchLatestVersion() throws when the latest tag points to a missing version entry', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake.resolves({
-            name: 'the-name',
-            'dist-tags': { latest: '1.0.0' },
-            versions: {}
-        })
-    });
-
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'the-token' }
-        });
-    }, /^Error: Version "1.0.0" for package "the-name" has no entry in the registry response$/u);
-});
-
-for (const [testName, response] of [
-    ['response is not an object', 'invalid-response'],
-    ['dist-tags is not an object', { name: 'the-name', 'dist-tags': 'invalid', versions: {} }],
-    ['dist-tags latest is not a string', { name: 'the-name', 'dist-tags': { latest: 1 }, versions: {} }],
-    ['versions is not an object', { name: 'the-name', 'dist-tags': {}, versions: 'invalid' }],
-    ['version dist is missing', { name: 'the-name', 'dist-tags': { latest: '1.0.0' }, versions: { '1.0.0': {} } }],
-    [
-        'version tarball is not a string',
-        {
-            name: 'the-name',
-            'dist-tags': { latest: '1.0.0' },
-            versions: { '1.0.0': { dist: { tarball: false } } }
-        }
-    ]
-] as const) {
-    test(`fetchLatestVersion() rejects invalid registry payloads when ${testName}`, async () => {
+    test('publishPackage() rejects a non-object OIDC exchange response body', async function () {
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves('invalid-response')
+        }) as unknown as typeof globalThis.fetch;
         const registryClient = registryClientFactory({
-            npmFetchJson: fake.resolves(response)
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                {
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                },
+                { access: 'public' }
+            );
+        }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+    });
+
+    test('publishPackage() rejects a null OIDC exchange response body', async function () {
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves(null)
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                {
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                },
+                { access: 'public' }
+            );
+        }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+    });
+
+    test('publishPackage() rejects a failing OIDC exchange request', async function () {
+        const fetchSpy = fake.resolves({
+            ok: false,
+            status: 502,
+            json: fake.resolves({})
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                {
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                },
+                { access: 'public' }
+            );
+        }, /^Error: OIDC token exchange failed with status 502$/u);
+    });
+
+    test('publishPackage() rejects an invalid OIDC exchange expiry timestamp', async function () {
+        const fetchSpy = fake.resolves({
+            ok: true,
+            status: 201,
+            json: fake.resolves({
+                token_type: 'oidc',
+                token: 'oidc-exchange-token',
+                created: '2026-05-06T10:00:00.000Z',
+                expires: 'not-a-date'
+            })
+        }) as unknown as typeof globalThis.fetch;
+        const registryClient = registryClientFactory({
+            fetch: fetchSpy,
+            resolveIdToken: fake.resolves('upstream-id-token')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                {
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                },
+                { access: 'public' }
+            );
+        }, /^TypeError: OIDC token exchange returned an invalid expiry timestamp$/u);
+    });
+
+    suite('OIDC exchange invalid responses', function () {
+        for (const [testName, response] of [
+            [
+                'token_type is invalid',
+                {
+                    token_type: 123,
+                    token: 'oidc-exchange-token',
+                    created: '2026-05-06T10:00:00.000Z',
+                    expires: '2026-05-06T11:00:00.000Z'
+                }
+            ],
+            [
+                'token is invalid',
+                {
+                    token_type: 'oidc',
+                    token: 123,
+                    created: '2026-05-06T10:00:00.000Z',
+                    expires: '2026-05-06T11:00:00.000Z'
+                }
+            ],
+            [
+                'created is invalid',
+                { token_type: 'oidc', token: 'oidc-exchange-token', created: 123, expires: '2026-05-06T11:00:00.000Z' }
+            ],
+            [
+                'expires is invalid',
+                { token_type: 'oidc', token: 'oidc-exchange-token', created: '2026-05-06T10:00:00.000Z', expires: 123 }
+            ]
+        ] as const) {
+            test(`publishPackage() rejects an OIDC exchange response when ${testName}`, async function () {
+                const fetchSpy = fake.resolves({
+                    ok: true,
+                    status: 201,
+                    json: fake.resolves(response)
+                }) as unknown as typeof globalThis.fetch;
+                const registryClient = registryClientFactory({
+                    fetch: fetchSpy,
+                    resolveIdToken: fake.resolves('upstream-id-token')
+                });
+
+                await expectFailure(async () => {
+                    await registryClient.publishPackage(
+                        { name: 'the-name', version: '1.0.0' },
+                        Buffer.from([]),
+                        {
+                            auth: {
+                                publish: { type: 'npm-oidc', provider: 'env' },
+                                metadata: 'anonymous'
+                            }
+                        },
+                        { access: 'public' }
+                    );
+                }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+            });
+        }
+    });
+
+    test('fetchLatestVersion() returns nothing for 404 and 403 responses', async function () {
+        for (const statusCode of [404, 403]) {
+            const error = new Error('fetch-error');
+            // @ts-expect-error -- intentional shape for npm fetch errors
+            error.statusCode = statusCode;
+            const registryClient = registryClientFactory({ npmFetchJson: fake.rejects(error) });
+
+            const result = await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+
+            assert.deepStrictEqual(result, Maybe.nothing());
+        }
+    });
+
+    test('fetchLatestVersion() throws on invalid registry payloads', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({ invalid: 'response-data' })
         });
 
         await expectFailure(async () => {
@@ -1261,85 +1198,165 @@ for (const [testName, response] of [
             });
         }, /^Error: Got an invalid response from registry API$/u);
     });
-}
 
-test('fetchLatestVersion() rejects null versions payloads', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake.resolves({
-            name: 'the-name',
-            'dist-tags': { latest: '1.0.0' },
-            versions: null
-        })
+    test('fetchLatestVersion() throws on invalid non-object registry payloads', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves('invalid-response')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+        }, /^Error: Got an invalid response from registry API$/u);
     });
 
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
+    test('fetchLatestVersion() returns nothing when the registry response has no latest tag', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({
+                name: 'the-name',
+                'dist-tags': {},
+                versions: { '1.0.0': { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
+            })
+        });
+
+        const result = await registryClient.fetchLatestVersion('the-name', {
             auth: { type: 'bearer-token', token: 'the-token' }
         });
-    }, /^Error: Got an invalid response from registry API$/u);
-});
 
-test('fetchLatestVersion() rethrows non-object unexpected errors', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake(async () => {
-            // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
-            throw 'unexpected-failure';
-        })
+        assert.deepStrictEqual(result, Maybe.nothing());
     });
 
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'the-token' }
+    test('fetchLatestVersion() throws when the latest tag points to a missing version entry', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({
+                name: 'the-name',
+                'dist-tags': { latest: '1.0.0' },
+                versions: {}
+            })
         });
-    }, /^unexpected-failure$/u);
-});
 
-test('fetchLatestVersion() rethrows object unexpected errors without statusCode', async () => {
-    const registryClient = registryClientFactory({
-        npmFetchJson: fake.rejects(new Error('unexpected-failure'))
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+        }, /^Error: Version "1.0.0" for package "the-name" has no entry in the registry response$/u);
     });
 
-    await expectFailure(async () => {
-        await registryClient.fetchLatestVersion('the-name', {
-            auth: { type: 'bearer-token', token: 'the-token' }
+    suite('fetchLatestVersion invalid registry payloads', function () {
+        for (const [testName, response] of [
+            ['response is not an object', 'invalid-response'],
+            ['dist-tags is not an object', { name: 'the-name', 'dist-tags': 'invalid', versions: {} }],
+            ['dist-tags latest is not a string', { name: 'the-name', 'dist-tags': { latest: 1 }, versions: {} }],
+            ['versions is not an object', { name: 'the-name', 'dist-tags': {}, versions: 'invalid' }],
+            [
+                'version dist is missing',
+                { name: 'the-name', 'dist-tags': { latest: '1.0.0' }, versions: { '1.0.0': {} } }
+            ],
+            [
+                'version tarball is not a string',
+                {
+                    name: 'the-name',
+                    'dist-tags': { latest: '1.0.0' },
+                    versions: { '1.0.0': { dist: { tarball: false } } }
+                }
+            ]
+        ] as const) {
+            test(`fetchLatestVersion() rejects invalid registry payloads when ${testName}`, async function () {
+                const registryClient = registryClientFactory({
+                    npmFetchJson: fake.resolves(response)
+                });
+
+                await expectFailure(async () => {
+                    await registryClient.fetchLatestVersion('the-name', {
+                        auth: { type: 'bearer-token', token: 'the-token' }
+                    });
+                }, /^Error: Got an invalid response from registry API$/u);
+            });
+        }
+    });
+
+    test('fetchLatestVersion() rejects null versions payloads', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({
+                name: 'the-name',
+                'dist-tags': { latest: '1.0.0' },
+                versions: null
+            })
         });
-    }, /^Error: unexpected-failure$/u);
-});
 
-test('publishPackage() forwards the access and provenance options resolved from publishSettings to libnpmpublish', async () => {
-    const publish = fake.resolves(undefined);
-    const registryClient = registryClientFactory({ publish });
-
-    await registryClient.publishPackage(
-        { name: 'the-name', version: '1.0.0' },
-        Buffer.from([]),
-        { auth: { type: 'bearer-token', token: 'the-token' } },
-        { access: 'public', provenance: { type: 'auto' } }
-    );
-
-    const publishOptions = publish.firstCall.args.at(-1) as Record<string, unknown>;
-    assert.strictEqual(publishOptions.access, 'public');
-    assert.strictEqual(publishOptions.provenance, true);
-});
-
-test('publishPackage() rewrites a libnpmpublish error through the publish-settings bridge', async () => {
-    const original = Object.assign(new Error('Automatic provenance generation not supported for provider: jenkins'), {
-        code: 'EUSAGE'
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+        }, /^Error: Got an invalid response from registry API$/u);
     });
-    const publish = fake.rejects(original);
-    const registryClient = registryClientFactory({ publish });
 
-    try {
+    test('fetchLatestVersion() rethrows non-object unexpected errors', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake(async () => {
+                // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
+                throw 'unexpected-failure';
+            })
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+        }, /^unexpected-failure$/u);
+    });
+
+    test('fetchLatestVersion() rethrows object unexpected errors without statusCode', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.rejects(new Error('unexpected-failure'))
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchLatestVersion('the-name', {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            });
+        }, /^Error: unexpected-failure$/u);
+    });
+
+    test('publishPackage() forwards the access and provenance options resolved from publishSettings to libnpmpublish', async function () {
+        const publish = fake.resolves(undefined);
+        const registryClient = registryClientFactory({ publish });
+
         await registryClient.publishPackage(
             { name: 'the-name', version: '1.0.0' },
             Buffer.from([]),
             { auth: { type: 'bearer-token', token: 'the-token' } },
             { access: 'public', provenance: { type: 'auto' } }
         );
-        assert.fail('Expected publishPackage() to throw');
-    } catch (error: unknown) {
-        assert.ok(error instanceof Error, 'Expected the thrown value to be an Error');
-        assert.match(error.message, /^Provenance auto mode requires GitHub Actions or GitLab CI/u);
-        assert.strictEqual(error.cause, original);
-    }
+
+        const publishOptions = publish.firstCall.args.at(-1) as Record<string, unknown>;
+        assert.strictEqual(publishOptions.access, 'public');
+        assert.strictEqual(publishOptions.provenance, true);
+    });
+
+    test('publishPackage() rewrites a libnpmpublish error through the publish-settings bridge', async function () {
+        const original = Object.assign(
+            new Error('Automatic provenance generation not supported for provider: jenkins'),
+            {
+                code: 'EUSAGE'
+            }
+        );
+        const publish = fake.rejects(original);
+        const registryClient = registryClientFactory({ publish });
+
+        try {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                { auth: { type: 'bearer-token', token: 'the-token' } },
+                { access: 'public', provenance: { type: 'auto' } }
+            );
+            assert.fail('Expected publishPackage() to throw');
+        } catch (error: unknown) {
+            assert.ok(error instanceof Error, 'Expected the thrown value to be an Error');
+            assert.match(error.message, /^Provenance auto mode requires GitHub Actions or GitLab CI/u);
+            assert.strictEqual(error.cause, original);
+        }
+    });
 });

--- a/source/bundle-emitter/registry/registry-response-schemas.test.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.test.ts
@@ -1,62 +1,64 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { parseAbbreviatedPackageResponse, parseOidcExchangeResponse } from './registry-response-schemas.ts';
 
-test('parseAbbreviatedPackageResponse returns the data when the response matches the schema', () => {
-    assert.deepStrictEqual(
-        parseAbbreviatedPackageResponse({
-            name: 'pkg-a',
-            'dist-tags': { latest: '1.0.0' },
-            versions: { '1.0.0': { dist: { tarball: 'https://example.com/pkg-a-1.0.0.tgz' } } }
-        }),
-        {
-            name: 'pkg-a',
-            'dist-tags': { latest: '1.0.0' },
-            versions: { '1.0.0': { dist: { tarball: 'https://example.com/pkg-a-1.0.0.tgz' } } }
-        }
-    );
-});
-
-test('parseAbbreviatedPackageResponse returns undefined when the response is missing required fields', () => {
-    assert.strictEqual(parseAbbreviatedPackageResponse({ name: 'pkg-a' }), undefined);
-});
-
-test('parseAbbreviatedPackageResponse returns undefined when a version entry has no tarball', () => {
-    assert.strictEqual(
-        parseAbbreviatedPackageResponse({
-            name: 'pkg-a',
-            'dist-tags': { latest: '1.0.0' },
-            versions: { '1.0.0': { dist: {} } }
-        }),
-        undefined
-    );
-});
-
-test('parseAbbreviatedPackageResponse accepts a response without dist-tags.latest', () => {
-    assert.deepStrictEqual(parseAbbreviatedPackageResponse({ name: 'pkg-a', 'dist-tags': {}, versions: {} }), {
-        name: 'pkg-a',
-        'dist-tags': {},
-        versions: {}
+suite('registry-response-schemas', function () {
+    test('parseAbbreviatedPackageResponse returns the data when the response matches the schema', function () {
+        assert.deepStrictEqual(
+            parseAbbreviatedPackageResponse({
+                name: 'pkg-a',
+                'dist-tags': { latest: '1.0.0' },
+                versions: { '1.0.0': { dist: { tarball: 'https://example.com/pkg-a-1.0.0.tgz' } } }
+            }),
+            {
+                name: 'pkg-a',
+                'dist-tags': { latest: '1.0.0' },
+                versions: { '1.0.0': { dist: { tarball: 'https://example.com/pkg-a-1.0.0.tgz' } } }
+            }
+        );
     });
-});
 
-test('parseOidcExchangeResponse returns the data when all token fields are present', () => {
-    assert.deepStrictEqual(
-        parseOidcExchangeResponse({
-            token_type: 'Bearer',
-            token: 'abc',
-            created: '2026-01-01T00:00:00Z',
-            expires: '2026-01-01T01:00:00Z'
-        }),
-        {
-            token_type: 'Bearer',
-            token: 'abc',
-            created: '2026-01-01T00:00:00Z',
-            expires: '2026-01-01T01:00:00Z'
-        }
-    );
-});
+    test('parseAbbreviatedPackageResponse returns undefined when the response is missing required fields', function () {
+        assert.strictEqual(parseAbbreviatedPackageResponse({ name: 'pkg-a' }), undefined);
+    });
 
-test('parseOidcExchangeResponse returns undefined when a required field is missing', () => {
-    assert.strictEqual(parseOidcExchangeResponse({ token: 'abc' }), undefined);
+    test('parseAbbreviatedPackageResponse returns undefined when a version entry has no tarball', function () {
+        assert.strictEqual(
+            parseAbbreviatedPackageResponse({
+                name: 'pkg-a',
+                'dist-tags': { latest: '1.0.0' },
+                versions: { '1.0.0': { dist: {} } }
+            }),
+            undefined
+        );
+    });
+
+    test('parseAbbreviatedPackageResponse accepts a response without dist-tags.latest', function () {
+        assert.deepStrictEqual(parseAbbreviatedPackageResponse({ name: 'pkg-a', 'dist-tags': {}, versions: {} }), {
+            name: 'pkg-a',
+            'dist-tags': {},
+            versions: {}
+        });
+    });
+
+    test('parseOidcExchangeResponse returns the data when all token fields are present', function () {
+        assert.deepStrictEqual(
+            parseOidcExchangeResponse({
+                token_type: 'Bearer',
+                token: 'abc',
+                created: '2026-01-01T00:00:00Z',
+                expires: '2026-01-01T01:00:00Z'
+            }),
+            {
+                token_type: 'Bearer',
+                token: 'abc',
+                created: '2026-01-01T00:00:00Z',
+                expires: '2026-01-01T01:00:00Z'
+            }
+        );
+    });
+
+    test('parseOidcExchangeResponse returns undefined when a required field is missing', function () {
+        assert.strictEqual(parseOidcExchangeResponse({ token: 'abc' }), undefined);
+    });
 });

--- a/source/bundle-emitter/repository-coherence.test.ts
+++ b/source/bundle-emitter/repository-coherence.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     assertRepositoryCoherence,
     getCiRepositoryUrl,
@@ -29,293 +29,298 @@ function buildExpectedMismatchMessage(configuredUrl: string, ciUrl: string): str
     );
 }
 
-test('normalizeRepositoryUrl() returns undefined for undefined input', () => {
-    assert.strictEqual(normalizeRepositoryUrl(undefined), undefined);
-});
+suite('repository-coherence', function () {
+    test('normalizeRepositoryUrl() returns undefined for undefined input', function () {
+        assert.strictEqual(normalizeRepositoryUrl(undefined), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for an empty string', () => {
-    assert.strictEqual(normalizeRepositoryUrl(''), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for an empty string', function () {
+        assert.strictEqual(normalizeRepositoryUrl(''), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for null input', () => {
-    assert.strictEqual(normalizeRepositoryUrl(null), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for null input', function () {
+        assert.strictEqual(normalizeRepositoryUrl(null), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for numeric input', () => {
-    assert.strictEqual(normalizeRepositoryUrl(42), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for numeric input', function () {
+        assert.strictEqual(normalizeRepositoryUrl(42), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for an array input', () => {
-    assert.strictEqual(normalizeRepositoryUrl(['https://github.com/foo/bar']), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for an array input', function () {
+        assert.strictEqual(normalizeRepositoryUrl(['https://github.com/foo/bar']), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for object input missing the url property', () => {
-    assert.strictEqual(normalizeRepositoryUrl({ type: 'git' }), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for object input missing the url property', function () {
+        assert.strictEqual(normalizeRepositoryUrl({ type: 'git' }), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for object input with an empty url property', () => {
-    assert.strictEqual(normalizeRepositoryUrl({ url: '' }), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for object input with an empty url property', function () {
+        assert.strictEqual(normalizeRepositoryUrl({ url: '' }), undefined);
+    });
 
-test('normalizeRepositoryUrl() returns undefined for object input with a non-string url property', () => {
-    assert.strictEqual(normalizeRepositoryUrl({ url: 42 }), undefined);
-});
+    test('normalizeRepositoryUrl() returns undefined for object input with a non-string url property', function () {
+        assert.strictEqual(normalizeRepositoryUrl({ url: 42 }), undefined);
+    });
 
-test('normalizeRepositoryUrl() canonicalizes a plain https GitHub url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar'), 'https://github.com/foo/bar');
-});
+    test('normalizeRepositoryUrl() canonicalizes a plain https GitHub url', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar'), 'https://github.com/foo/bar');
+    });
 
-test('normalizeRepositoryUrl() canonicalizes a https GitHub url with a .git suffix', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar.git'), 'https://github.com/foo/bar');
-});
+    test('normalizeRepositoryUrl() canonicalizes a https GitHub url with a .git suffix', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar.git'), 'https://github.com/foo/bar');
+    });
 
-test('normalizeRepositoryUrl() canonicalizes a https GitHub url with a trailing slash', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar/'), 'https://github.com/foo/bar');
-});
+    test('normalizeRepositoryUrl() canonicalizes a https GitHub url with a trailing slash', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar/'), 'https://github.com/foo/bar');
+    });
 
-test('normalizeRepositoryUrl() canonicalizes a git+https GitHub url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('git+https://github.com/foo/bar.git'), 'https://github.com/foo/bar');
-});
+    test('normalizeRepositoryUrl() canonicalizes a git+https GitHub url', function () {
+        assert.strictEqual(normalizeRepositoryUrl('git+https://github.com/foo/bar.git'), 'https://github.com/foo/bar');
+    });
 
-test('normalizeRepositoryUrl() canonicalizes a git+ssh GitHub url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('git+ssh://git@github.com/foo/bar.git'), 'https://github.com/foo/bar');
-});
-
-test('normalizeRepositoryUrl() canonicalizes an SCP-style GitHub url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('git@github.com:foo/bar.git'), 'https://github.com/foo/bar');
-});
-
-test('normalizeRepositoryUrl() canonicalizes an npm shorthand GitHub url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('github:foo/bar'), 'https://github.com/foo/bar');
-});
-
-test('normalizeRepositoryUrl() canonicalizes a https GitLab url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://gitlab.com/foo/bar'), 'https://gitlab.com/foo/bar');
-});
-
-test('normalizeRepositoryUrl() canonicalizes the object form with a url property', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl({ type: 'git', url: 'git+ssh://git@github.com/foo/bar.git' }),
-        'https://github.com/foo/bar'
-    );
-});
-
-test('normalizeRepositoryUrl() lowercases mixed-case host and path', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://Github.com/Foo/Bar'), 'https://github.com/foo/bar');
-});
-
-test('normalizeRepositoryUrl() drops a committish from a hosted GitHub url', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar#main'), 'https://github.com/foo/bar');
-});
-
-test('normalizeRepositoryUrl() ignores the directory field on the object form', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl({
-            type: 'git',
-            url: 'https://github.com/foo/bar',
-            directory: 'packages/inner'
-        }),
-        'https://github.com/foo/bar'
-    );
-});
-
-test('normalizeRepositoryUrl() falls back to manual normalization for self-hosted https urls', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl('https://gitea.example.com/foo/bar.git'),
-        'https://gitea.example.com/foo/bar'
-    );
-});
-
-test('normalizeRepositoryUrl() strips a trailing slash for self-hosted urls', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl('https://gitea.example.com/foo/bar/'),
-        'https://gitea.example.com/foo/bar'
-    );
-});
-
-test('normalizeRepositoryUrl() strips a git+ prefix for self-hosted urls', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl('git+https://gitea.example.com/foo/bar.git'),
-        'https://gitea.example.com/foo/bar'
-    );
-});
-
-test('normalizeRepositoryUrl() lowercases self-hosted urls', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl('https://Gitea.Example.com/Foo/Bar'),
-        'https://gitea.example.com/foo/bar'
-    );
-});
-
-test('getCiRepositoryUrl() returns undefined when no env vars are set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: undefined,
-        githubRepository: undefined,
-        gitlabProjectUrl: undefined
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), undefined);
-});
-
-test('getCiRepositoryUrl() returns the GitHub Actions repository url when both GHA env vars are set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: 'https://github.com',
-        githubRepository: 'enormora/packtory',
-        gitlabProjectUrl: undefined
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), 'https://github.com/enormora/packtory');
-});
-
-test('getCiRepositoryUrl() returns the GitLab CI repository url when only the GitLab var is set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: undefined,
-        githubRepository: undefined,
-        gitlabProjectUrl: 'https://gitlab.com/enormora/packtory'
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), 'https://gitlab.com/enormora/packtory');
-});
-
-test('getCiRepositoryUrl() prefers GitHub Actions over GitLab when both are set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: 'https://github.com',
-        githubRepository: 'enormora/packtory',
-        gitlabProjectUrl: 'https://gitlab.com/some/other'
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), 'https://github.com/enormora/packtory');
-});
-
-test('getCiRepositoryUrl() returns undefined when only GITHUB_SERVER_URL is set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: 'https://github.com',
-        githubRepository: undefined,
-        gitlabProjectUrl: undefined
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), undefined);
-});
-
-test('getCiRepositoryUrl() returns undefined when only GITHUB_REPOSITORY is set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: undefined,
-        githubRepository: 'enormora/packtory',
-        gitlabProjectUrl: undefined
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), undefined);
-});
-
-test('getCiRepositoryUrl() treats empty env values as not set', () => {
-    const env: CiEnvironment = {
-        githubServerUrl: '',
-        githubRepository: '',
-        gitlabProjectUrl: ''
-    };
-
-    assert.strictEqual(getCiRepositoryUrl(env), undefined);
-});
-
-test('assertRepositoryCoherence() does not throw when the manifest matches the CI repository', () => {
-    assert.doesNotThrow(() => {
-        assertRepositoryCoherence(
-            { repository: 'git+ssh://git@github.com/enormora/packtory.git' },
-            'https://github.com/enormora/packtory'
+    test('normalizeRepositoryUrl() canonicalizes a git+ssh GitHub url', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('git+ssh://git@github.com/foo/bar.git'),
+            'https://github.com/foo/bar'
         );
     });
-});
 
-test('assertRepositoryCoherence() does not throw when the object form matches the CI repository', () => {
-    assert.doesNotThrow(() => {
-        assertRepositoryCoherence(
-            { repository: { type: 'git', url: 'git+ssh://git@github.com/enormora/packtory.git' } },
-            'https://github.com/enormora/packtory'
+    test('normalizeRepositoryUrl() canonicalizes an SCP-style GitHub url', function () {
+        assert.strictEqual(normalizeRepositoryUrl('git@github.com:foo/bar.git'), 'https://github.com/foo/bar');
+    });
+
+    test('normalizeRepositoryUrl() canonicalizes an npm shorthand GitHub url', function () {
+        assert.strictEqual(normalizeRepositoryUrl('github:foo/bar'), 'https://github.com/foo/bar');
+    });
+
+    test('normalizeRepositoryUrl() canonicalizes a https GitLab url', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://gitlab.com/foo/bar'), 'https://gitlab.com/foo/bar');
+    });
+
+    test('normalizeRepositoryUrl() canonicalizes the object form with a url property', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl({ type: 'git', url: 'git+ssh://git@github.com/foo/bar.git' }),
+            'https://github.com/foo/bar'
         );
     });
-});
 
-test('assertRepositoryCoherence() throws when the manifest repository differs from the CI repository', () => {
-    assert.throws(
-        () => {
+    test('normalizeRepositoryUrl() lowercases mixed-case host and path', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://Github.com/Foo/Bar'), 'https://github.com/foo/bar');
+    });
+
+    test('normalizeRepositoryUrl() drops a committish from a hosted GitHub url', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://github.com/foo/bar#main'), 'https://github.com/foo/bar');
+    });
+
+    test('normalizeRepositoryUrl() ignores the directory field on the object form', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl({
+                type: 'git',
+                url: 'https://github.com/foo/bar',
+                directory: 'packages/inner'
+            }),
+            'https://github.com/foo/bar'
+        );
+    });
+
+    test('normalizeRepositoryUrl() falls back to manual normalization for self-hosted https urls', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('https://gitea.example.com/foo/bar.git'),
+            'https://gitea.example.com/foo/bar'
+        );
+    });
+
+    test('normalizeRepositoryUrl() strips a trailing slash for self-hosted urls', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('https://gitea.example.com/foo/bar/'),
+            'https://gitea.example.com/foo/bar'
+        );
+    });
+
+    test('normalizeRepositoryUrl() strips a git+ prefix for self-hosted urls', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('git+https://gitea.example.com/foo/bar.git'),
+            'https://gitea.example.com/foo/bar'
+        );
+    });
+
+    test('normalizeRepositoryUrl() lowercases self-hosted urls', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('https://Gitea.Example.com/Foo/Bar'),
+            'https://gitea.example.com/foo/bar'
+        );
+    });
+
+    test('getCiRepositoryUrl() returns undefined when no env vars are set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: undefined,
+            githubRepository: undefined,
+            gitlabProjectUrl: undefined
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), undefined);
+    });
+
+    test('getCiRepositoryUrl() returns the GitHub Actions repository url when both GHA env vars are set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: 'https://github.com',
+            githubRepository: 'enormora/packtory',
+            gitlabProjectUrl: undefined
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), 'https://github.com/enormora/packtory');
+    });
+
+    test('getCiRepositoryUrl() returns the GitLab CI repository url when only the GitLab var is set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: undefined,
+            githubRepository: undefined,
+            gitlabProjectUrl: 'https://gitlab.com/enormora/packtory'
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), 'https://gitlab.com/enormora/packtory');
+    });
+
+    test('getCiRepositoryUrl() prefers GitHub Actions over GitLab when both are set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: 'https://github.com',
+            githubRepository: 'enormora/packtory',
+            gitlabProjectUrl: 'https://gitlab.com/some/other'
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), 'https://github.com/enormora/packtory');
+    });
+
+    test('getCiRepositoryUrl() returns undefined when only GITHUB_SERVER_URL is set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: 'https://github.com',
+            githubRepository: undefined,
+            gitlabProjectUrl: undefined
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), undefined);
+    });
+
+    test('getCiRepositoryUrl() returns undefined when only GITHUB_REPOSITORY is set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: undefined,
+            githubRepository: 'enormora/packtory',
+            gitlabProjectUrl: undefined
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), undefined);
+    });
+
+    test('getCiRepositoryUrl() treats empty env values as not set', function () {
+        const env: CiEnvironment = {
+            githubServerUrl: '',
+            githubRepository: '',
+            gitlabProjectUrl: ''
+        };
+
+        assert.strictEqual(getCiRepositoryUrl(env), undefined);
+    });
+
+    test('assertRepositoryCoherence() does not throw when the manifest matches the CI repository', function () {
+        assert.doesNotThrow(() => {
             assertRepositoryCoherence(
-                { repository: 'https://github.com/foo/forked-package' },
-                'https://github.com/upstream/package'
+                { repository: 'git+ssh://git@github.com/enormora/packtory.git' },
+                'https://github.com/enormora/packtory'
             );
-        },
-        (error: unknown) => {
-            assert.ok(error instanceof Error);
-            assert.strictEqual(
-                error.message,
-                buildExpectedMismatchMessage(
-                    'https://github.com/foo/forked-package',
+        });
+    });
+
+    test('assertRepositoryCoherence() does not throw when the object form matches the CI repository', function () {
+        assert.doesNotThrow(() => {
+            assertRepositoryCoherence(
+                { repository: { type: 'git', url: 'git+ssh://git@github.com/enormora/packtory.git' } },
+                'https://github.com/enormora/packtory'
+            );
+        });
+    });
+
+    test('assertRepositoryCoherence() throws when the manifest repository differs from the CI repository', function () {
+        assert.throws(
+            () => {
+                assertRepositoryCoherence(
+                    { repository: 'https://github.com/foo/forked-package' },
                     'https://github.com/upstream/package'
-                )
-            );
-            return true;
-        }
-    );
-});
-
-test('assertRepositoryCoherence() throws the missing-repository error when the manifest has no repository', () => {
-    assert.throws(
-        () => {
-            assertRepositoryCoherence({}, 'https://github.com/enormora/packtory');
-        },
-        (error: unknown) => {
-            assert.ok(error instanceof Error);
-            assert.strictEqual(error.message, expectedNoRepositoryDeclaredMessage);
-            return true;
-        }
-    );
-});
-
-test('assertRepositoryCoherence() throws the missing-repository error when the repository is an unsupported value', () => {
-    assert.throws(
-        () => {
-            assertRepositoryCoherence({ repository: 42 }, 'https://github.com/enormora/packtory');
-        },
-        (error: unknown) => {
-            assert.ok(error instanceof Error);
-            assert.strictEqual(error.message, expectedNoRepositoryDeclaredMessage);
-            return true;
-        }
-    );
-});
-
-test('assertRepositoryCoherence() throws the missing-CI error when no CI repository url is provided', () => {
-    assert.throws(
-        () => {
-            assertRepositoryCoherence({ repository: 'https://github.com/enormora/packtory' }, undefined);
-        },
-        (error: unknown) => {
-            assert.ok(error instanceof Error);
-            assert.strictEqual(error.message, expectedNoCiDetectedMessage);
-            return true;
-        }
-    );
-});
-
-test('readCiEnvironment() reads GitHub Actions, GitLab CI, and missing env vars from the given env', () => {
-    const env: CiEnvironment = readCiEnvironment({
-        GITHUB_SERVER_URL: 'https://github.com',
-        GITHUB_REPOSITORY: 'enormora/packtory',
-        CI_PROJECT_URL: 'https://gitlab.com/some/other'
+                );
+            },
+            (error: unknown) => {
+                assert.ok(error instanceof Error);
+                assert.strictEqual(
+                    error.message,
+                    buildExpectedMismatchMessage(
+                        'https://github.com/foo/forked-package',
+                        'https://github.com/upstream/package'
+                    )
+                );
+                return true;
+            }
+        );
     });
 
-    assert.deepStrictEqual(env, {
-        githubServerUrl: 'https://github.com',
-        githubRepository: 'enormora/packtory',
-        gitlabProjectUrl: 'https://gitlab.com/some/other'
+    test('assertRepositoryCoherence() throws the missing-repository error when the manifest has no repository', function () {
+        assert.throws(
+            () => {
+                assertRepositoryCoherence({}, 'https://github.com/enormora/packtory');
+            },
+            (error: unknown) => {
+                assert.ok(error instanceof Error);
+                assert.strictEqual(error.message, expectedNoRepositoryDeclaredMessage);
+                return true;
+            }
+        );
     });
-});
 
-test('readCiEnvironment() returns undefined values when env vars are absent', () => {
-    const env: CiEnvironment = readCiEnvironment({});
+    test('assertRepositoryCoherence() throws the missing-repository error when the repository is an unsupported value', function () {
+        assert.throws(
+            () => {
+                assertRepositoryCoherence({ repository: 42 }, 'https://github.com/enormora/packtory');
+            },
+            (error: unknown) => {
+                assert.ok(error instanceof Error);
+                assert.strictEqual(error.message, expectedNoRepositoryDeclaredMessage);
+                return true;
+            }
+        );
+    });
 
-    assert.deepStrictEqual(env, {
-        githubServerUrl: undefined,
-        githubRepository: undefined,
-        gitlabProjectUrl: undefined
+    test('assertRepositoryCoherence() throws the missing-CI error when no CI repository url is provided', function () {
+        assert.throws(
+            () => {
+                assertRepositoryCoherence({ repository: 'https://github.com/enormora/packtory' }, undefined);
+            },
+            (error: unknown) => {
+                assert.ok(error instanceof Error);
+                assert.strictEqual(error.message, expectedNoCiDetectedMessage);
+                return true;
+            }
+        );
+    });
+
+    test('readCiEnvironment() reads GitHub Actions, GitLab CI, and missing env vars from the given env', function () {
+        const env: CiEnvironment = readCiEnvironment({
+            GITHUB_SERVER_URL: 'https://github.com',
+            GITHUB_REPOSITORY: 'enormora/packtory',
+            CI_PROJECT_URL: 'https://gitlab.com/some/other'
+        });
+
+        assert.deepStrictEqual(env, {
+            githubServerUrl: 'https://github.com',
+            githubRepository: 'enormora/packtory',
+            gitlabProjectUrl: 'https://gitlab.com/some/other'
+        });
+    });
+
+    test('readCiEnvironment() returns undefined values when env vars are absent', function () {
+        const env: CiEnvironment = readCiEnvironment({});
+
+        assert.deepStrictEqual(env, {
+            githubServerUrl: undefined,
+            githubRepository: undefined,
+            gitlabProjectUrl: undefined
+        });
     });
 });

--- a/source/bundle-emitter/repository-url-normalizer.test.ts
+++ b/source/bundle-emitter/repository-url-normalizer.test.ts
@@ -1,50 +1,55 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { normalizeRepositoryUrl } from './repository-url-normalizer.ts';
 
-test('normalizeRepositoryUrl returns undefined for an empty string', () => {
-    assert.strictEqual(normalizeRepositoryUrl(''), undefined);
-});
+suite('repository-url-normalizer', function () {
+    test('normalizeRepositoryUrl returns undefined for an empty string', function () {
+        assert.strictEqual(normalizeRepositoryUrl(''), undefined);
+    });
 
-test('normalizeRepositoryUrl returns undefined for null and undefined', () => {
-    assert.strictEqual(normalizeRepositoryUrl(undefined), undefined);
-    assert.strictEqual(normalizeRepositoryUrl(null), undefined);
-});
+    test('normalizeRepositoryUrl returns undefined for null and undefined', function () {
+        assert.strictEqual(normalizeRepositoryUrl(undefined), undefined);
+        assert.strictEqual(normalizeRepositoryUrl(null), undefined);
+    });
 
-test('normalizeRepositoryUrl returns undefined for a record with no url field', () => {
-    assert.strictEqual(normalizeRepositoryUrl({ type: 'git' }), undefined);
-});
+    test('normalizeRepositoryUrl returns undefined for a record with no url field', function () {
+        assert.strictEqual(normalizeRepositoryUrl({ type: 'git' }), undefined);
+    });
 
-test('normalizeRepositoryUrl reads the url field from a record input', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl({ url: 'https://github.com/owner/repo' }),
-        'https://github.com/owner/repo'
-    );
-});
+    test('normalizeRepositoryUrl reads the url field from a record input', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl({ url: 'https://github.com/owner/repo' }),
+            'https://github.com/owner/repo'
+        );
+    });
 
-test('normalizeRepositoryUrl strips a leading git+ prefix from non-hosted URLs', () => {
-    assert.strictEqual(normalizeRepositoryUrl('git+ssh://example.com/owner/repo'), 'ssh://example.com/owner/repo');
-});
+    test('normalizeRepositoryUrl strips a leading git+ prefix from non-hosted URLs', function () {
+        assert.strictEqual(normalizeRepositoryUrl('git+ssh://example.com/owner/repo'), 'ssh://example.com/owner/repo');
+    });
 
-test('normalizeRepositoryUrl strips a trailing .git suffix from non-hosted URLs', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://example.com/owner/repo.git'), 'https://example.com/owner/repo');
-});
+    test('normalizeRepositoryUrl strips a trailing .git suffix from non-hosted URLs', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('https://example.com/owner/repo.git'),
+            'https://example.com/owner/repo'
+        );
+    });
 
-test('normalizeRepositoryUrl strips a trailing slash from non-hosted URLs', () => {
-    assert.strictEqual(normalizeRepositoryUrl('https://example.com/owner/repo/'), 'https://example.com/owner/repo');
-});
+    test('normalizeRepositoryUrl strips a trailing slash from non-hosted URLs', function () {
+        assert.strictEqual(normalizeRepositoryUrl('https://example.com/owner/repo/'), 'https://example.com/owner/repo');
+    });
 
-test('normalizeRepositoryUrl lowercases the resulting URL', () => {
-    assert.strictEqual(normalizeRepositoryUrl('HTTPS://Example.COM/OWNER/REPO'), 'https://example.com/owner/repo');
-});
+    test('normalizeRepositoryUrl lowercases the resulting URL', function () {
+        assert.strictEqual(normalizeRepositoryUrl('HTTPS://Example.COM/OWNER/REPO'), 'https://example.com/owner/repo');
+    });
 
-test('normalizeRepositoryUrl resolves a hosted git URL to its https form', () => {
-    assert.strictEqual(
-        normalizeRepositoryUrl('git+https://github.com/Owner/Repo.git'),
-        'https://github.com/owner/repo'
-    );
-});
+    test('normalizeRepositoryUrl resolves a hosted git URL to its https form', function () {
+        assert.strictEqual(
+            normalizeRepositoryUrl('git+https://github.com/Owner/Repo.git'),
+            'https://github.com/owner/repo'
+        );
+    });
 
-test('normalizeRepositoryUrl resolves a github shorthand to the canonical https URL', () => {
-    assert.strictEqual(normalizeRepositoryUrl('github:owner/repo'), 'https://github.com/owner/repo');
+    test('normalizeRepositoryUrl resolves a github shorthand to the canonical https URL', function () {
+        assert.strictEqual(normalizeRepositoryUrl('github:owner/repo'), 'https://github.com/owner/repo');
+    });
 });

--- a/source/checks/check-runner.test.ts
+++ b/source/checks/check-runner.test.ts
@@ -1,41 +1,43 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
 import { runChecks } from './check-runner.ts';
 
-test('does not invoke any rule when settings are empty', () => {
-    const issues = runChecks({
-        settings: {},
-        perPackageSettings: new Map(),
-        packageConfigs: {},
-        bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
+suite('check-runner', function () {
+    test('does not invoke any rule when settings are empty', function () {
+        const issues = runChecks({
+            settings: {},
+            perPackageSettings: new Map(),
+            packageConfigs: {},
+            bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
+        });
+
+        assert.deepStrictEqual(issues, []);
     });
 
-    assert.deepStrictEqual(issues, []);
-});
+    test('dispatches an enabled rule with the provided bundles and aggregates its issues', function () {
+        const issues = runChecks({
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map(),
+            packageConfigs: {},
+            bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
+        });
 
-test('dispatches an enabled rule with the provided bundles and aggregates its issues', () => {
-    const issues = runChecks({
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map(),
-        packageConfigs: {},
-        bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
+        assert.deepStrictEqual(issues, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    assert.deepStrictEqual(issues, ['File "shared.ts" is included in multiple packages: a, b']);
-});
+    test('threads per-package settings through to the rule for cross-package consent decisions', function () {
+        const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
+        const issues = runChecks({
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map([
+                ['a', consent],
+                ['b', consent]
+            ]),
+            packageConfigs: {},
+            bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
+        });
 
-test('threads per-package settings through to the rule for cross-package consent decisions', () => {
-    const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
-    const issues = runChecks({
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map([
-            ['a', consent],
-            ['b', consent]
-        ]),
-        packageConfigs: {},
-        bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
+        assert.deepStrictEqual(issues, []);
     });
-
-    assert.deepStrictEqual(issues, []);
 });

--- a/source/checks/rule.test.ts
+++ b/source/checks/rule.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     emptyPerPackageSchema,
     enabledOnlyGlobalSchema,
@@ -15,37 +15,39 @@ function parseOrFail<T>(schema: { safeParse: (input: unknown) => { success: bool
     return result.data!;
 }
 
-test('enabledOnlyGlobalSchema accepts an object with just an enabled flag', () => {
-    assert.deepStrictEqual(parseOrFail(enabledOnlyGlobalSchema, { enabled: true }), { enabled: true });
-});
-
-test('enabledOnlyGlobalSchema rejects unknown fields in strict mode', () => {
-    assert.strictEqual(enabledOnlyGlobalSchema.safeParse({ enabled: true, extra: 1 }).success, false);
-});
-
-test('emptyPerPackageSchema accepts an empty object', () => {
-    assert.deepStrictEqual(parseOrFail(emptyPerPackageSchema, {}), {});
-});
-
-test('emptyPerPackageSchema rejects any field in strict mode', () => {
-    assert.strictEqual(emptyPerPackageSchema.safeParse({ extra: 1 }).success, false);
-});
-
-test('pathAllowListGlobalSchema accepts enabled with an allow list of non-empty strings', () => {
-    assert.deepStrictEqual(parseOrFail(pathAllowListGlobalSchema, { enabled: true, allowList: ['a', 'b'] }), {
-        enabled: true,
-        allowList: ['a', 'b']
+suite('rule', function () {
+    test('enabledOnlyGlobalSchema accepts an object with just an enabled flag', function () {
+        assert.deepStrictEqual(parseOrFail(enabledOnlyGlobalSchema, { enabled: true }), { enabled: true });
     });
-});
 
-test('pathAllowListGlobalSchema rejects an allow list with empty strings', () => {
-    assert.strictEqual(pathAllowListGlobalSchema.safeParse({ enabled: true, allowList: [''] }).success, false);
-});
+    test('enabledOnlyGlobalSchema rejects unknown fields in strict mode', function () {
+        assert.strictEqual(enabledOnlyGlobalSchema.safeParse({ enabled: true, extra: 1 }).success, false);
+    });
 
-test('pathAllowListPerPackageSchema accepts an empty object', () => {
-    assert.deepStrictEqual(parseOrFail(pathAllowListPerPackageSchema, {}), {});
-});
+    test('emptyPerPackageSchema accepts an empty object', function () {
+        assert.deepStrictEqual(parseOrFail(emptyPerPackageSchema, {}), {});
+    });
 
-test('pathAllowListPerPackageSchema accepts a per-package allow list of non-empty strings', () => {
-    assert.deepStrictEqual(parseOrFail(pathAllowListPerPackageSchema, { allowList: ['a'] }), { allowList: ['a'] });
+    test('emptyPerPackageSchema rejects any field in strict mode', function () {
+        assert.strictEqual(emptyPerPackageSchema.safeParse({ extra: 1 }).success, false);
+    });
+
+    test('pathAllowListGlobalSchema accepts enabled with an allow list of non-empty strings', function () {
+        assert.deepStrictEqual(parseOrFail(pathAllowListGlobalSchema, { enabled: true, allowList: ['a', 'b'] }), {
+            enabled: true,
+            allowList: ['a', 'b']
+        });
+    });
+
+    test('pathAllowListGlobalSchema rejects an allow list with empty strings', function () {
+        assert.strictEqual(pathAllowListGlobalSchema.safeParse({ enabled: true, allowList: [''] }).success, false);
+    });
+
+    test('pathAllowListPerPackageSchema accepts an empty object', function () {
+        assert.deepStrictEqual(parseOrFail(pathAllowListPerPackageSchema, {}), {});
+    });
+
+    test('pathAllowListPerPackageSchema accepts a per-package allow list of non-empty strings', function () {
+        assert.deepStrictEqual(parseOrFail(pathAllowListPerPackageSchema, { allowList: ['a'] }), { allowList: ['a'] });
+    });
 });

--- a/source/checks/rules/duplicate-detection.test.ts
+++ b/source/checks/rules/duplicate-detection.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { duplicateMessage, hasMultipleOwners } from './duplicate-detection.ts';
 import type { OwnerInfo } from './file-ownership.ts';
 
@@ -7,30 +7,35 @@ function owner(bundleName: string, survivingBindings: readonly string[] = []): O
     return { bundleName, survivingBindings: new Set(survivingBindings) };
 }
 
-test('hasMultipleOwners returns false for fewer than two owners', () => {
-    assert.strictEqual(hasMultipleOwners([]), false);
-    assert.strictEqual(hasMultipleOwners([owner('pkg-a')]), false);
-});
+suite('duplicate-detection', function () {
+    test('hasMultipleOwners returns false for fewer than two owners', function () {
+        assert.strictEqual(hasMultipleOwners([]), false);
+        assert.strictEqual(hasMultipleOwners([owner('pkg-a')]), false);
+    });
 
-test('hasMultipleOwners returns true once two or more owners are present', () => {
-    assert.strictEqual(hasMultipleOwners([owner('pkg-a'), owner('pkg-b')]), true);
-});
+    test('hasMultipleOwners returns true once two or more owners are present', function () {
+        assert.strictEqual(hasMultipleOwners([owner('pkg-a'), owner('pkg-b')]), true);
+    });
 
-test('duplicateMessage falls back to the path-level message when no owner has surviving bindings', () => {
-    const message = duplicateMessage('/src/dup.ts', [owner('pkg-a'), owner('pkg-b')]);
+    test('duplicateMessage falls back to the path-level message when no owner has surviving bindings', function () {
+        const message = duplicateMessage('/src/dup.ts', [owner('pkg-a'), owner('pkg-b')]);
 
-    assert.ok(message?.startsWith('File "/src/dup.ts" is included in multiple packages:'));
-});
+        assert.ok(message?.startsWith('File "/src/dup.ts" is included in multiple packages:'));
+    });
 
-test('duplicateMessage returns undefined when owners have bindings but none overlap', () => {
-    const message = duplicateMessage('/src/dup.ts', [owner('pkg-a', ['x']), owner('pkg-b', ['y'])]);
+    test('duplicateMessage returns undefined when owners have bindings but none overlap', function () {
+        const message = duplicateMessage('/src/dup.ts', [owner('pkg-a', ['x']), owner('pkg-b', ['y'])]);
 
-    assert.strictEqual(message, undefined);
-});
+        assert.strictEqual(message, undefined);
+    });
 
-test('duplicateMessage emits a shared-declarations message when owners share at least one binding', () => {
-    const message = duplicateMessage('/src/dup.ts', [owner('pkg-a', ['shared']), owner('pkg-b', ['shared', 'other'])]);
+    test('duplicateMessage emits a shared-declarations message when owners share at least one binding', function () {
+        const message = duplicateMessage('/src/dup.ts', [
+            owner('pkg-a', ['shared']),
+            owner('pkg-b', ['shared', 'other'])
+        ]);
 
-    assert.ok(message?.includes('shared declarations across multiple packages'));
-    assert.ok(message?.includes('"shared"'));
+        assert.ok(message?.includes('shared declarations across multiple packages'));
+        assert.ok(message?.includes('"shared"'));
+    });
 });

--- a/source/checks/rules/duplicate-messages.test.ts
+++ b/source/checks/rules/duplicate-messages.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { OwnerInfo } from './file-ownership.ts';
 import { formatPathLevelMessage, formatSharedDeclarationsMessage } from './duplicate-messages.ts';
 
@@ -7,25 +7,27 @@ function owner(bundleName: string, survivingBindings: readonly string[] = []): O
     return { bundleName, survivingBindings: new Set(survivingBindings) };
 }
 
-test('formatPathLevelMessage lists the owners alphabetically after the path', () => {
-    assert.strictEqual(
-        formatPathLevelMessage('/src/dup.ts', [owner('pkg-c'), owner('pkg-a'), owner('pkg-b')]),
-        'File "/src/dup.ts" is included in multiple packages: pkg-a, pkg-b, pkg-c'
-    );
-});
+suite('duplicate-messages', function () {
+    test('formatPathLevelMessage lists the owners alphabetically after the path', function () {
+        assert.strictEqual(
+            formatPathLevelMessage('/src/dup.ts', [owner('pkg-c'), owner('pkg-a'), owner('pkg-b')]),
+            'File "/src/dup.ts" is included in multiple packages: pkg-a, pkg-b, pkg-c'
+        );
+    });
 
-test('formatSharedDeclarationsMessage sorts the shared declarations and owners alphabetically', () => {
-    const message = formatSharedDeclarationsMessage('/src/dup.ts', new Set(['z', 'a']), [
-        owner('pkg-b'),
-        owner('pkg-a')
-    ]);
+    test('formatSharedDeclarationsMessage sorts the shared declarations and owners alphabetically', function () {
+        const message = formatSharedDeclarationsMessage('/src/dup.ts', new Set(['z', 'a']), [
+            owner('pkg-b'),
+            owner('pkg-a')
+        ]);
 
-    assert.strictEqual(
-        message,
-        [
-            'File "/src/dup.ts" has shared declarations across multiple packages:',
-            '  - "a" → pkg-a, pkg-b',
-            '  - "z" → pkg-a, pkg-b'
-        ].join('\n')
-    );
+        assert.strictEqual(
+            message,
+            [
+                'File "/src/dup.ts" has shared declarations across multiple packages:',
+                '  - "a" → pkg-a, pkg-b',
+                '  - "z" → pkg-a, pkg-b'
+            ].join('\n')
+        );
+    });
 });

--- a/source/checks/rules/file-ownership.test.ts
+++ b/source/checks/rules/file-ownership.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import { collectFileOwnership } from './file-ownership.ts';
 
@@ -17,29 +17,31 @@ function bundle(
     } as unknown as Pick<AnalyzedBundle, 'contents' | 'name'>;
 }
 
-test('collectFileOwnership returns an empty map when given no bundles', () => {
-    const ownership = collectFileOwnership([]);
-    assert.strictEqual(ownership.size, 0);
-});
+suite('file-ownership', function () {
+    test('collectFileOwnership returns an empty map when given no bundles', function () {
+        const ownership = collectFileOwnership([]);
+        assert.strictEqual(ownership.size, 0);
+    });
 
-test('collectFileOwnership keys ownership entries by source file path', () => {
-    const ownership = collectFileOwnership([
-        bundle('pkg-a', [{ sourceFilePath: '/src/a.ts', survivingBindings: ['x'] }])
-    ]);
-    assert.deepStrictEqual(Array.from(ownership.keys()), ['/src/a.ts']);
-});
+    test('collectFileOwnership keys ownership entries by source file path', function () {
+        const ownership = collectFileOwnership([
+            bundle('pkg-a', [{ sourceFilePath: '/src/a.ts', survivingBindings: ['x'] }])
+        ]);
+        assert.deepStrictEqual(Array.from(ownership.keys()), ['/src/a.ts']);
+    });
 
-test('collectFileOwnership accumulates one owner per bundle that contains the file', () => {
-    const ownership = collectFileOwnership([
-        bundle('pkg-a', [{ sourceFilePath: '/src/shared.ts', survivingBindings: ['x'] }]),
-        bundle('pkg-b', [{ sourceFilePath: '/src/shared.ts', survivingBindings: ['y'] }])
-    ]);
+    test('collectFileOwnership accumulates one owner per bundle that contains the file', function () {
+        const ownership = collectFileOwnership([
+            bundle('pkg-a', [{ sourceFilePath: '/src/shared.ts', survivingBindings: ['x'] }]),
+            bundle('pkg-b', [{ sourceFilePath: '/src/shared.ts', survivingBindings: ['y'] }])
+        ]);
 
-    const owners = ownership.get('/src/shared.ts');
-    assert.deepStrictEqual(
-        owners?.map((owner) => owner.bundleName),
-        ['pkg-a', 'pkg-b']
-    );
-    assert.deepStrictEqual(Array.from(owners?.[0]?.survivingBindings ?? []), ['x']);
-    assert.deepStrictEqual(Array.from(owners?.[1]?.survivingBindings ?? []), ['y']);
+        const owners = ownership.get('/src/shared.ts');
+        assert.deepStrictEqual(
+            owners?.map((owner) => owner.bundleName),
+            ['pkg-a', 'pkg-b']
+        );
+        assert.deepStrictEqual(Array.from(owners?.[0]?.survivingBindings ?? []), ['x']);
+        assert.deepStrictEqual(Array.from(owners?.[1]?.survivingBindings ?? []), ['y']);
+    });
 });

--- a/source/checks/rules/max-bundle-size.test.ts
+++ b/source/checks/rules/max-bundle-size.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
 import { maxBundleSizeRule } from './max-bundle-size.ts';
@@ -11,113 +11,115 @@ function bundleWithBytes(name: string, bytes: number): AnalyzedBundle {
     });
 }
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(maxBundleSizeRule.name, 'maxBundleSize');
-    assert.strictEqual(typeof maxBundleSizeRule.run, 'function');
-});
-
-test('returns no issues when settings are missing', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: undefined,
-        perPackageSettings: new Map()
+suite('max-bundle-size', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(maxBundleSizeRule.name, 'maxBundleSize');
+        assert.strictEqual(typeof maxBundleSizeRule.run, 'function');
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: undefined,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when the rule is disabled', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: false, bytes: 10 } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: { maxBundleSize: { enabled: false, bytes: 10 } },
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when neither global nor per-package threshold is set', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when neither global nor per-package threshold is set', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: { maxBundleSize: { enabled: true } },
+            perPackageSettings: new Map()
+        });
 
-test('reports a bundle exceeding the global threshold', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true, bytes: 50 } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
-});
+    test('reports a bundle exceeding the global threshold', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: { maxBundleSize: { enabled: true, bytes: 50 } },
+            perPackageSettings: new Map()
+        });
 
-test('passes a bundle exactly at the threshold', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true, bytes: 100 } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('passes a bundle exactly at the threshold', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: { maxBundleSize: { enabled: true, bytes: 100 } },
+            perPackageSettings: new Map()
+        });
 
-function runWithGlobalAndOverride(globalBytes: number, override: number): readonly string[] {
-    return maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true, bytes: globalBytes } },
-        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: override } }]])
-    });
-}
-
-test('per-package bytes overrides the global default upward', () => {
-    assert.deepStrictEqual(runWithGlobalAndOverride(50, 1000), []);
-});
-
-test('per-package bytes overrides the global default downward', () => {
-    assert.deepStrictEqual(runWithGlobalAndOverride(1000, 50), [
-        'Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)'
-    ]);
-});
-
-test('per-package bytes acts as the threshold when no global default is set', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100), bundleWithBytes('b', 100)],
-        settings: { maxBundleSize: { enabled: true } },
-        perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
-});
+    function runWithGlobalAndOverride(globalBytes: number, override: number): readonly string[] {
+        return maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: { maxBundleSize: { enabled: true, bytes: globalBytes } },
+            perPackageSettings: new Map([['a', { maxBundleSize: { bytes: override } }]])
+        });
+    }
 
-test('falls back to the global default when the per-package entry has no maxBundleSize key', () => {
-    const result = maxBundleSizeRule.run({
-        bundles: [bundleWithBytes('a', 100)],
-        settings: { maxBundleSize: { enabled: true, bytes: 50 } },
-        perPackageSettings: new Map([['a', {}]])
+    test('per-package bytes overrides the global default upward', function () {
+        assert.deepStrictEqual(runWithGlobalAndOverride(50, 1000), []);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
-});
-
-test('measures bundle size as the UTF-8 byte length of every resource’s content', () => {
-    const bundle = analyzedBundle({
-        name: 'multi',
-        contents: [
-            analyzedBundleResource('/multi/a.js', { content: 'ä' }),
-            analyzedBundleResource('/multi/b.js', { content: 'ab' })
-        ]
+    test('per-package bytes overrides the global default downward', function () {
+        assert.deepStrictEqual(runWithGlobalAndOverride(1000, 50), [
+            'Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)'
+        ]);
     });
 
-    const result = maxBundleSizeRule.run({
-        bundles: [bundle],
-        settings: { maxBundleSize: { enabled: true, bytes: 3 } },
-        perPackageSettings: new Map()
+    test('per-package bytes acts as the threshold when no global default is set', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100), bundleWithBytes('b', 100)],
+            settings: { maxBundleSize: { enabled: true } },
+            perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
+        });
+
+        assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
     });
 
-    assert.deepStrictEqual(result, ['Package "multi" exceeds the maximum bundle size: 4 bytes (limit: 3 bytes)']);
+    test('falls back to the global default when the per-package entry has no maxBundleSize key', function () {
+        const result = maxBundleSizeRule.run({
+            bundles: [bundleWithBytes('a', 100)],
+            settings: { maxBundleSize: { enabled: true, bytes: 50 } },
+            perPackageSettings: new Map([['a', {}]])
+        });
+
+        assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
+    });
+
+    test('measures bundle size as the UTF-8 byte length of every resource’s content', function () {
+        const bundle = analyzedBundle({
+            name: 'multi',
+            contents: [
+                analyzedBundleResource('/multi/a.js', { content: 'ä' }),
+                analyzedBundleResource('/multi/b.js', { content: 'ab' })
+            ]
+        });
+
+        const result = maxBundleSizeRule.run({
+            bundles: [bundle],
+            settings: { maxBundleSize: { enabled: true, bytes: 3 } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, ['Package "multi" exceeds the maximum bundle size: 4 bytes (limit: 3 bytes)']);
+    });
 });

--- a/source/checks/rules/no-dev-dependency-imports.test.ts
+++ b/source/checks/rules/no-dev-dependency-imports.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
 import { analyzedBundle } from '../../test-libraries/bundle-fixtures.ts';
@@ -18,137 +18,139 @@ function bundleWithExternals(name: string, externals: readonly string[]): Analyz
 
 const enabled = { noDevDependencyImports: { enabled: true } };
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(noDevDependencyImportsRule.name, 'noDevDependencyImports');
-    assert.strictEqual(typeof noDevDependencyImportsRule.run, 'function');
-});
-
-test('returns no issues when settings are missing', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leaked'])],
-        settings: undefined,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+suite('no-dev-dependency-imports', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(noDevDependencyImportsRule.name, 'noDevDependencyImports');
+        assert.strictEqual(typeof noDevDependencyImportsRule.run, 'function');
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leaked'])],
+            settings: undefined,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+        });
 
-test('returns no issues when the rule is disabled', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leaked'])],
-        settings: { noDevDependencyImports: { enabled: false } },
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leaked'])],
+            settings: { noDevDependencyImports: { enabled: false } },
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+        });
 
-test('returns no issues when packageConfigs is omitted entirely', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leaked'])],
-        settings: enabled,
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when packageConfigs is omitted entirely', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leaked'])],
+            settings: enabled,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when packageConfigs has no entry for the bundle', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leaked'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {}
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when packageConfigs has no entry for the bundle', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leaked'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {}
+        });
 
-test('returns no issues when the package has no main package.json', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leaked'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: {} }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the package has no main package.json', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leaked'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: {} }
+        });
 
-test('reports an external dependency that is only declared in devDependencies', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leaked'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, [
-        'Package "a" imports "leaked" which is only declared in devDependencies of the main package.json'
-    ]);
-});
+    test('reports an external dependency that is only declared in devDependencies', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leaked'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { mainPackageJson: { devDependencies: { leaked: '1.0.0' } } } }
+        });
 
-test('does not report when the dependency is also declared in dependencies', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['shared'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {
-            a: {
-                mainPackageJson: {
-                    dependencies: { shared: '1.0.0' },
-                    devDependencies: { shared: '1.0.0' }
+        assert.deepStrictEqual(result, [
+            'Package "a" imports "leaked" which is only declared in devDependencies of the main package.json'
+        ]);
+    });
+
+    test('does not report when the dependency is also declared in dependencies', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['shared'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {
+                a: {
+                    mainPackageJson: {
+                        dependencies: { shared: '1.0.0' },
+                        devDependencies: { shared: '1.0.0' }
+                    }
                 }
             }
-        }
+        });
+
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
-
-test('does not report when the dependency is declared in peerDependencies', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['peer'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {
-            a: {
-                mainPackageJson: {
-                    peerDependencies: { peer: '1.0.0' },
-                    devDependencies: { peer: '1.0.0' }
+    test('does not report when the dependency is declared in peerDependencies', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['peer'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {
+                a: {
+                    mainPackageJson: {
+                        peerDependencies: { peer: '1.0.0' },
+                        devDependencies: { peer: '1.0.0' }
+                    }
                 }
             }
-        }
+        });
+
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('does not report when the dependency is not in any list', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['unknown'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { mainPackageJson: {} } }
+        });
 
-test('does not report when the dependency is not in any list', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['unknown'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { mainPackageJson: {} } }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('reports independently per bundle', function () {
+        const result = noDevDependencyImportsRule.run({
+            bundles: [bundleWithExternals('a', ['leak-a']), bundleWithExternals('b', ['fine'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {
+                a: { mainPackageJson: { devDependencies: { 'leak-a': '1.0.0' } } },
+                b: { mainPackageJson: { dependencies: { fine: '1.0.0' } } }
+            }
+        });
 
-test('reports independently per bundle', () => {
-    const result = noDevDependencyImportsRule.run({
-        bundles: [bundleWithExternals('a', ['leak-a']), bundleWithExternals('b', ['fine'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {
-            a: { mainPackageJson: { devDependencies: { 'leak-a': '1.0.0' } } },
-            b: { mainPackageJson: { dependencies: { fine: '1.0.0' } } }
-        }
+        assert.deepStrictEqual(result, [
+            'Package "a" imports "leak-a" which is only declared in devDependencies of the main package.json'
+        ]);
     });
-
-    assert.deepStrictEqual(result, [
-        'Package "a" imports "leak-a" which is only declared in devDependencies of the main package.json'
-    ]);
 });

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
@@ -49,221 +49,225 @@ function runWithConsent(
     });
 }
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(noDuplicatedFilesRule.name, 'noDuplicatedFiles');
-    assert.strictEqual(typeof noDuplicatedFilesRule.run, 'function');
-    assert.notStrictEqual(noDuplicatedFilesRule.globalSchema, undefined);
-    assert.notStrictEqual(noDuplicatedFilesRule.perPackageSchema, undefined);
-});
-
-test('returns no issues when settings are missing entirely', () => {
-    const result = noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        settings: undefined,
-        perPackageSettings: new Map()
+suite('no-duplicated-files', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(noDuplicatedFilesRule.name, 'noDuplicatedFiles');
+        assert.strictEqual(typeof noDuplicatedFilesRule.run, 'function');
+        assert.notStrictEqual(noDuplicatedFilesRule.globalSchema, undefined);
+        assert.notStrictEqual(noDuplicatedFilesRule.perPackageSchema, undefined);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing entirely', function () {
+        const result = noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            settings: undefined,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when the rule is disabled at the top level', () => {
-    const result = noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        settings: { noDuplicatedFiles: { enabled: false } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled at the top level', function () {
+        const result = noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            settings: { noDuplicatedFiles: { enabled: false } },
+            perPackageSettings: new Map()
+        });
 
-test('reports every duplicate when no per-package consent is configured', () => {
-    const result = runWithConsent([bundle('b', 'shared.ts'), bundle('a', 'shared.ts')], []);
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('ignores duplicates when every owning package consents via its allowList', () => {
-    const result = runWithConsent(
-        [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        [
-            ['a', ['shared.ts']],
-            ['b', ['shared.ts']]
-        ]
-    );
-
-    assert.deepStrictEqual(result, []);
-});
-
-test('reports a duplicate when only one owner consents', () => {
-    const result = runWithConsent([bundle('a', 'shared.ts'), bundle('b', 'shared.ts')], [['a', ['shared.ts']]]);
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('reports a duplicate when a third owner did not consent', () => {
-    const result = runWithConsent(
-        [bundle('a', 'shared.ts'), bundle('b', 'shared.ts'), bundle('c', 'shared.ts')],
-        [
-            ['a', ['shared.ts']],
-            ['b', ['shared.ts']]
-        ]
-    );
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b, c']);
-});
-
-test('does not match consent for a different file path', () => {
-    const result = runWithConsent(
-        [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        [
-            ['a', ['other.ts']],
-            ['b', ['other.ts']]
-        ]
-    );
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('returns no issues when there are no duplicates', () => {
-    const result = runWithConsent([bundle('a', 'a.ts'), bundle('b', 'b.ts')], []);
-
-    assert.deepStrictEqual(result, []);
-});
-
-function runWithMixedConsent(secondOwnerSettings: PackageChecksSettings): readonly string[] {
-    return noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map([
-            ['a', { noDuplicatedFiles: { allowList: ['shared.ts'] } }],
-            ['b', secondOwnerSettings]
-        ])
-    });
-}
-
-test('reports a duplicate when an owner has per-package settings without a noDuplicatedFiles key', () => {
-    const result = runWithMixedConsent({});
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('reports a duplicate when an owner has noDuplicatedFiles without an allowList', () => {
-    const result = runWithMixedConsent({ noDuplicatedFiles: {} });
-
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
-
-test('ignores duplicates when the global allowList contains the file path even without per-package consent', () => {
-    const result = noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        settings: { noDuplicatedFiles: { enabled: true, allowList: ['shared.ts'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('reports every duplicate when no per-package consent is configured', function () {
+        const result = runWithConsent([bundle('b', 'shared.ts'), bundle('a', 'shared.ts')], []);
 
-test('reports a duplicate that is not present in the global allowList', () => {
-    const result = noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        settings: { noDuplicatedFiles: { enabled: true, allowList: ['other.ts'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
+    test('ignores duplicates when every owning package consents via its allowList', function () {
+        const result = runWithConsent(
+            [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            [
+                ['a', ['shared.ts']],
+                ['b', ['shared.ts']]
+            ]
+        );
 
-test('reports shared declarations when surviving bindings overlap', () => {
-    const project = createSymbolAwareProject();
-    const result = noDuplicatedFilesRule.run({
-        bundles: [
-            project.bundle('pkg1', '/helpers.ts', new Set(['format', 'validate'])),
-            project.bundle('pkg2', '/helpers.ts', new Set(['format', 'parse']))
-        ],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, [
-        ['File "/helpers.ts" has shared declarations across multiple packages:', '  - "format" → pkg1, pkg2'].join('\n')
-    ]);
-});
+    test('reports a duplicate when only one owner consents', function () {
+        const result = runWithConsent([bundle('a', 'shared.ts'), bundle('b', 'shared.ts')], [['a', ['shared.ts']]]);
 
-test('does not report when surviving binding sets are fully disjoint', () => {
-    const project = createSymbolAwareProject();
-    const result = noDuplicatedFilesRule.run({
-        bundles: [
-            project.bundle('pkg1', '/helpers.ts', new Set(['validate'])),
-            project.bundle('pkg2', '/helpers.ts', new Set(['parse']))
-        ],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('reports a duplicate when a third owner did not consent', function () {
+        const result = runWithConsent(
+            [bundle('a', 'shared.ts'), bundle('b', 'shared.ts'), bundle('c', 'shared.ts')],
+            [
+                ['a', ['shared.ts']],
+                ['b', ['shared.ts']]
+            ]
+        );
 
-test('lists every shared declaration in alphabetical order', () => {
-    const project = createSymbolAwareProject();
-    const result = noDuplicatedFilesRule.run({
-        bundles: [
-            project.bundle('pkg1', '/util.ts', new Set(['zeta', 'alpha', 'parse'])),
-            project.bundle('pkg2', '/util.ts', new Set(['zeta', 'alpha', 'validate']))
-        ],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b, c']);
     });
 
-    assert.deepStrictEqual(result, [
-        [
-            'File "/util.ts" has shared declarations across multiple packages:',
-            '  - "alpha" → pkg1, pkg2',
-            '  - "zeta" → pkg1, pkg2'
-        ].join('\n')
-    ]);
-});
+    test('does not match consent for a different file path', function () {
+        const result = runWithConsent(
+            [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            [
+                ['a', ['other.ts']],
+                ['b', ['other.ts']]
+            ]
+        );
 
-test('does not report when only a single bundle owns the file', () => {
-    const result = noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts')],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when there are no duplicates', function () {
+        const result = runWithConsent([bundle('a', 'a.ts'), bundle('b', 'b.ts')], []);
 
-test('does not report when one owner has no surviving bindings and the other has bindings that do not match', () => {
-    const project = createSymbolAwareProject();
-    const result = noDuplicatedFilesRule.run({
-        bundles: [project.bundle('pkg1', '/helpers.ts', new Set(['format'])), bundle('pkg2', '/helpers.ts')],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    function runWithMixedConsent(secondOwnerSettings: PackageChecksSettings): readonly string[] {
+        return noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map([
+                ['a', { noDuplicatedFiles: { allowList: ['shared.ts'] } }],
+                ['b', secondOwnerSettings]
+            ])
+        });
+    }
 
-test('falls back to path-level message when surviving bindings are unavailable for every owner', () => {
-    const result = noDuplicatedFilesRule.run({
-        bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
-        settings: { noDuplicatedFiles: { enabled: true } },
-        perPackageSettings: new Map()
+    test('reports a duplicate when an owner has per-package settings without a noDuplicatedFiles key', function () {
+        const result = runWithMixedConsent({});
+
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
-});
+    test('reports a duplicate when an owner has noDuplicatedFiles without an allowList', function () {
+        const result = runWithMixedConsent({ noDuplicatedFiles: {} });
 
-test('global allowList suppresses the symbol-level message', () => {
-    const project = createSymbolAwareProject();
-    const result = noDuplicatedFilesRule.run({
-        bundles: [
-            project.bundle('pkg1', '/helpers.ts', new Set(['format'])),
-            project.bundle('pkg2', '/helpers.ts', new Set(['format']))
-        ],
-        settings: { noDuplicatedFiles: { enabled: true, allowList: ['/helpers.ts'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    assert.deepStrictEqual(result, []);
+    test('ignores duplicates when the global allowList contains the file path even without per-package consent', function () {
+        const result = noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            settings: { noDuplicatedFiles: { enabled: true, allowList: ['shared.ts'] } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('reports a duplicate that is not present in the global allowList', function () {
+        const result = noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            settings: { noDuplicatedFiles: { enabled: true, allowList: ['other.ts'] } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
+    });
+
+    test('reports shared declarations when surviving bindings overlap', function () {
+        const project = createSymbolAwareProject();
+        const result = noDuplicatedFilesRule.run({
+            bundles: [
+                project.bundle('pkg1', '/helpers.ts', new Set(['format', 'validate'])),
+                project.bundle('pkg2', '/helpers.ts', new Set(['format', 'parse']))
+            ],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, [
+            ['File "/helpers.ts" has shared declarations across multiple packages:', '  - "format" → pkg1, pkg2'].join(
+                '\n'
+            )
+        ]);
+    });
+
+    test('does not report when surviving binding sets are fully disjoint', function () {
+        const project = createSymbolAwareProject();
+        const result = noDuplicatedFilesRule.run({
+            bundles: [
+                project.bundle('pkg1', '/helpers.ts', new Set(['validate'])),
+                project.bundle('pkg2', '/helpers.ts', new Set(['parse']))
+            ],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('lists every shared declaration in alphabetical order', function () {
+        const project = createSymbolAwareProject();
+        const result = noDuplicatedFilesRule.run({
+            bundles: [
+                project.bundle('pkg1', '/util.ts', new Set(['zeta', 'alpha', 'parse'])),
+                project.bundle('pkg2', '/util.ts', new Set(['zeta', 'alpha', 'validate']))
+            ],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, [
+            [
+                'File "/util.ts" has shared declarations across multiple packages:',
+                '  - "alpha" → pkg1, pkg2',
+                '  - "zeta" → pkg1, pkg2'
+            ].join('\n')
+        ]);
+    });
+
+    test('does not report when only a single bundle owns the file', function () {
+        const result = noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts')],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('does not report when one owner has no surviving bindings and the other has bindings that do not match', function () {
+        const project = createSymbolAwareProject();
+        const result = noDuplicatedFilesRule.run({
+            bundles: [project.bundle('pkg1', '/helpers.ts', new Set(['format'])), bundle('pkg2', '/helpers.ts')],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('falls back to path-level message when surviving bindings are unavailable for every owner', function () {
+        const result = noDuplicatedFilesRule.run({
+            bundles: [bundle('a', 'shared.ts'), bundle('b', 'shared.ts')],
+            settings: { noDuplicatedFiles: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, ['File "shared.ts" is included in multiple packages: a, b']);
+    });
+
+    test('global allowList suppresses the symbol-level message', function () {
+        const project = createSymbolAwareProject();
+        const result = noDuplicatedFilesRule.run({
+            bundles: [
+                project.bundle('pkg1', '/helpers.ts', new Set(['format'])),
+                project.bundle('pkg2', '/helpers.ts', new Set(['format']))
+            ],
+            settings: { noDuplicatedFiles: { enabled: true, allowList: ['/helpers.ts'] } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, []);
+    });
 });

--- a/source/checks/rules/no-side-effects.test.ts
+++ b/source/checks/rules/no-side-effects.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
@@ -44,155 +44,161 @@ function runWithInitSideEffect(
     });
 }
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(noSideEffectsRule.name, 'noSideEffects');
-    assert.strictEqual(typeof noSideEffectsRule.run, 'function');
-    assert.notStrictEqual(noSideEffectsRule.globalSchema, undefined);
-    assert.notStrictEqual(noSideEffectsRule.perPackageSchema, undefined);
-});
-
-test('returns no issues when settings are missing entirely', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [
-            bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])])
-        ],
-        settings: undefined,
-        perPackageSettings: new Map()
+suite('no-side-effects', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(noSideEffectsRule.name, 'noSideEffects');
+        assert.strictEqual(typeof noSideEffectsRule.run, 'function');
+        assert.notStrictEqual(noSideEffectsRule.globalSchema, undefined);
+        assert.notStrictEqual(noSideEffectsRule.perPackageSchema, undefined);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing entirely', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [
+                bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])])
+            ],
+            settings: undefined,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when the rule is disabled at the top level', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [
-            bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])])
-        ],
-        settings: { noSideEffects: { enabled: false } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled at the top level', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [
+                bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])])
+            ],
+            settings: { noSideEffects: { enabled: false } },
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when no resource has side effects', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [bundleWithImpureResources('a', [analyzedBundleResource('/a.ts')])],
-        settings: { noSideEffects: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when no resource has side effects', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [bundleWithImpureResources('a', [analyzedBundleResource('/a.ts')])],
+            settings: { noSideEffects: { enabled: true } },
+            perPackageSettings: new Map()
+        });
 
-test('reports a resource with side effects, including line numbers and statement kinds', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [
-            bundleWithImpureResources('a', [
-                impureResource('/init.ts', [
-                    { line: 5, kind: 'expression statement' },
-                    { line: 12, kind: 'if statement' }
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('reports a resource with side effects, including line numbers and statement kinds', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [
+                bundleWithImpureResources('a', [
+                    impureResource('/init.ts', [
+                        { line: 5, kind: 'expression statement' },
+                        { line: 12, kind: 'if statement' }
+                    ])
                 ])
-            ])
-        ],
-        settings: { noSideEffects: { enabled: true } },
-        perPackageSettings: new Map()
+            ],
+            settings: { noSideEffects: { enabled: true } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, [
+            [
+                'File "/init.ts" in package "a" has top-level side effects:',
+                '  - line 5: expression statement',
+                '  - line 12: if statement',
+                'Side effects prevent downstream tree-shaking.'
+            ].join('\n')
+        ]);
     });
 
-    assert.deepStrictEqual(result, [
-        [
-            'File "/init.ts" in package "a" has top-level side effects:',
-            '  - line 5: expression statement',
-            '  - line 12: if statement',
-            'Side effects prevent downstream tree-shaking.'
-        ].join('\n')
-    ]);
-});
+    test('skips a resource that is on the global allowList', function () {
+        const result = runWithInitSideEffect({ noSideEffects: { enabled: true, allowList: ['/init.ts'] } }, new Map());
 
-test('skips a resource that is on the global allowList', () => {
-    const result = runWithInitSideEffect({ noSideEffects: { enabled: true, allowList: ['/init.ts'] } }, new Map());
-
-    assert.deepStrictEqual(result, []);
-});
-
-test('skips a resource that is on the per-package allowList', () => {
-    const result = runWithInitSideEffect({ noSideEffects: { enabled: true } }, consentMap([['a', ['/init.ts']]]));
-
-    assert.deepStrictEqual(result, []);
-});
-
-test('iterates resources independently and reports only the impure ones', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [
-            bundleWithImpureResources('a', [
-                analyzedBundleResource('/pure.ts'),
-                impureResource('/impure.ts', [{ line: 1, kind: 'expression statement' }])
-            ])
-        ],
-        settings: { noSideEffects: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.strictEqual(result.length, 1);
-    const [issue] = result;
-    assert.ok(issue?.includes('/impure.ts'));
-});
+    test('skips a resource that is on the per-package allowList', function () {
+        const result = runWithInitSideEffect({ noSideEffects: { enabled: true } }, consentMap([['a', ['/init.ts']]]));
 
-test('iterates bundles independently', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [
-            bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])]),
-            bundleWithImpureResources('b', [impureResource('/b.ts', [{ line: 1, kind: 'if statement' }])])
-        ],
-        settings: { noSideEffects: { enabled: true } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.strictEqual(result.length, 2);
-    assert.ok(result.some((issue) => issue.includes('package "a"')));
-    assert.ok(result.some((issue) => issue.includes('package "b"')));
-});
+    test('iterates resources independently and reports only the impure ones', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [
+                bundleWithImpureResources('a', [
+                    analyzedBundleResource('/pure.ts'),
+                    impureResource('/impure.ts', [{ line: 1, kind: 'expression statement' }])
+                ])
+            ],
+            settings: { noSideEffects: { enabled: true } },
+            perPackageSettings: new Map()
+        });
 
-test('per-package allowList only suppresses for the listed package', () => {
-    const result = noSideEffectsRule.run({
-        bundles: [
-            bundleWithImpureResources('a', [impureResource('/shared.ts', [{ line: 1, kind: 'expression statement' }])]),
-            bundleWithImpureResources('b', [impureResource('/shared.ts', [{ line: 1, kind: 'expression statement' }])])
-        ],
-        settings: { noSideEffects: { enabled: true } },
-        perPackageSettings: consentMap([['a', ['/shared.ts']]])
+        assert.strictEqual(result.length, 1);
+        const [issue] = result;
+        assert.ok(issue?.includes('/impure.ts'));
     });
 
-    assert.strictEqual(result.length, 1);
-    const [issue] = result;
-    assert.ok(issue?.includes('package "b"'));
-});
+    test('iterates bundles independently', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [
+                bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])]),
+                bundleWithImpureResources('b', [impureResource('/b.ts', [{ line: 1, kind: 'if statement' }])])
+            ],
+            settings: { noSideEffects: { enabled: true } },
+            perPackageSettings: new Map()
+        });
 
-test('reports a side effect when the per-package settings entry exists for the bundle but does not include noSideEffects', () => {
-    const result = runWithInitSideEffect(
-        { noSideEffects: { enabled: true } },
-        new Map<string, PackageChecksSettings>([['a', {}]])
-    );
+        assert.strictEqual(result.length, 2);
+        assert.ok(result.some((issue) => issue.includes('package "a"')));
+        assert.ok(result.some((issue) => issue.includes('package "b"')));
+    });
 
-    assert.strictEqual(result.length, 1);
-});
+    test('per-package allowList only suppresses for the listed package', function () {
+        const result = noSideEffectsRule.run({
+            bundles: [
+                bundleWithImpureResources('a', [
+                    impureResource('/shared.ts', [{ line: 1, kind: 'expression statement' }])
+                ]),
+                bundleWithImpureResources('b', [
+                    impureResource('/shared.ts', [{ line: 1, kind: 'expression statement' }])
+                ])
+            ],
+            settings: { noSideEffects: { enabled: true } },
+            perPackageSettings: consentMap([['a', ['/shared.ts']]])
+        });
 
-test('global schema accepts a configuration with enabled and an allowList', () => {
-    const result = safeParse(noSideEffectsRule.globalSchema, { enabled: true, allowList: ['/init.ts'] });
-    assert.strictEqual(result.success, true);
-});
+        assert.strictEqual(result.length, 1);
+        const [issue] = result;
+        assert.ok(issue?.includes('package "b"'));
+    });
 
-test('global schema rejects a configuration without the enabled flag', () => {
-    const result = safeParse(noSideEffectsRule.globalSchema, { allowList: ['/init.ts'] });
-    assert.strictEqual(result.success, false);
-});
+    test('reports a side effect when the per-package settings entry exists for the bundle but does not include noSideEffects', function () {
+        const result = runWithInitSideEffect(
+            { noSideEffects: { enabled: true } },
+            new Map<string, PackageChecksSettings>([['a', {}]])
+        );
 
-test('per-package schema accepts a configuration with an allowList', () => {
-    const result = safeParse(noSideEffectsRule.perPackageSchema, { allowList: ['/init.ts'] });
-    assert.strictEqual(result.success, true);
-});
+        assert.strictEqual(result.length, 1);
+    });
 
-test('per-package schema rejects unknown keys', () => {
-    const result = safeParse(noSideEffectsRule.perPackageSchema, { unknown: 1 });
-    assert.strictEqual(result.success, false);
+    test('global schema accepts a configuration with enabled and an allowList', function () {
+        const result = safeParse(noSideEffectsRule.globalSchema, { enabled: true, allowList: ['/init.ts'] });
+        assert.strictEqual(result.success, true);
+    });
+
+    test('global schema rejects a configuration without the enabled flag', function () {
+        const result = safeParse(noSideEffectsRule.globalSchema, { allowList: ['/init.ts'] });
+        assert.strictEqual(result.success, false);
+    });
+
+    test('per-package schema accepts a configuration with an allowList', function () {
+        const result = safeParse(noSideEffectsRule.perPackageSchema, { allowList: ['/init.ts'] });
+        assert.strictEqual(result.success, true);
+    });
+
+    test('per-package schema rejects unknown keys', function () {
+        const result = safeParse(noSideEffectsRule.perPackageSchema, { unknown: 1 });
+        assert.strictEqual(result.success, false);
+    });
 });

--- a/source/checks/rules/no-unused-bundle-dependencies.test.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
 import { analyzedBundle } from '../../test-libraries/bundle-fixtures.ts';
@@ -18,124 +18,126 @@ function bundleWithLinkedDeps(name: string, linked: readonly string[]): Analyzed
 
 const enabled = { noUnusedBundleDependencies: { enabled: true } };
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(noUnusedBundleDependenciesRule.name, 'noUnusedBundleDependencies');
-    assert.strictEqual(typeof noUnusedBundleDependenciesRule.run, 'function');
-});
-
-test('returns no issues when settings are missing', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: undefined,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { bundleDependencies: ['unused'] } }
+suite('no-unused-bundle-dependencies', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(noUnusedBundleDependenciesRule.name, 'noUnusedBundleDependencies');
+        assert.strictEqual(typeof noUnusedBundleDependenciesRule.run, 'function');
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: undefined,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { bundleDependencies: ['unused'] } }
+        });
 
-test('returns no issues when the rule is disabled', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: { noUnusedBundleDependencies: { enabled: false } },
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { bundleDependencies: ['unused'] } }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: { noUnusedBundleDependencies: { enabled: false } },
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { bundleDependencies: ['unused'] } }
+        });
 
-test('returns no issues when packageConfigs is omitted entirely', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: enabled,
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when packageConfigs is omitted entirely', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: enabled,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when no entry exists in packageConfigs for the bundle', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {}
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when no entry exists in packageConfigs for the bundle', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {}
+        });
 
-test('returns no issues when the package declares no bundle dependencies', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: {} }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the package declares no bundle dependencies', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: {} }
+        });
 
-test('reports a declared bundleDependency that is never substituted', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { bundleDependencies: ['unused'] } }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, ['Unused bundle dependency "unused" declared by package "a"']);
-});
+    test('reports a declared bundleDependency that is never substituted', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { bundleDependencies: ['unused'] } }
+        });
 
-test('reports a declared bundlePeerDependency that is never substituted', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', [])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { bundlePeerDependencies: ['unused-peer'] } }
+        assert.deepStrictEqual(result, ['Unused bundle dependency "unused" declared by package "a"']);
     });
 
-    assert.deepStrictEqual(result, ['Unused bundle peer dependency "unused-peer" declared by package "a"']);
-});
+    test('reports a declared bundlePeerDependency that is never substituted', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', [])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { bundlePeerDependencies: ['unused-peer'] } }
+        });
 
-test('does not report a declared bundleDependency that was substituted', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', ['used'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: { a: { bundleDependencies: ['used'] } }
+        assert.deepStrictEqual(result, ['Unused bundle peer dependency "unused-peer" declared by package "a"']);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('does not report a declared bundleDependency that was substituted', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', ['used'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: { a: { bundleDependencies: ['used'] } }
+        });
 
-test('reports a mix of unused regular and peer dependencies for the same package', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', ['used'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {
-            a: { bundleDependencies: ['used', 'orphan'], bundlePeerDependencies: ['orphan-peer'] }
-        }
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, [
-        'Unused bundle dependency "orphan" declared by package "a"',
-        'Unused bundle peer dependency "orphan-peer" declared by package "a"'
-    ]);
-});
+    test('reports a mix of unused regular and peer dependencies for the same package', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', ['used'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {
+                a: { bundleDependencies: ['used', 'orphan'], bundlePeerDependencies: ['orphan-peer'] }
+            }
+        });
 
-test('iterates every bundle independently', () => {
-    const result = noUnusedBundleDependenciesRule.run({
-        bundles: [bundleWithLinkedDeps('a', []), bundleWithLinkedDeps('b', ['used'])],
-        settings: enabled,
-        perPackageSettings: new Map(),
-        packageConfigs: {
-            a: { bundleDependencies: ['unused-a'] },
-            b: { bundleDependencies: ['used'] }
-        }
+        assert.deepStrictEqual(result, [
+            'Unused bundle dependency "orphan" declared by package "a"',
+            'Unused bundle peer dependency "orphan-peer" declared by package "a"'
+        ]);
     });
 
-    assert.deepStrictEqual(result, ['Unused bundle dependency "unused-a" declared by package "a"']);
+    test('iterates every bundle independently', function () {
+        const result = noUnusedBundleDependenciesRule.run({
+            bundles: [bundleWithLinkedDeps('a', []), bundleWithLinkedDeps('b', ['used'])],
+            settings: enabled,
+            perPackageSettings: new Map(),
+            packageConfigs: {
+                a: { bundleDependencies: ['unused-a'] },
+                b: { bundleDependencies: ['used'] }
+            }
+        });
+
+        assert.deepStrictEqual(result, ['Unused bundle dependency "unused-a" declared by package "a"']);
+    });
 });

--- a/source/checks/rules/registry.test.ts
+++ b/source/checks/rules/registry.test.ts
@@ -1,31 +1,33 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { allRules } from './registry.ts';
 
-test('allRules exposes the seven well-known check rules by name', () => {
-    const names = allRules.map((rule) => rule.name).toSorted();
-    assert.deepStrictEqual(names, [
-        'maxBundleSize',
-        'noDevDependencyImports',
-        'noDuplicatedFiles',
-        'noSideEffects',
-        'noUnusedBundleDependencies',
-        'requiredFiles',
-        'uniqueTargetPaths'
-    ]);
-});
+suite('registry', function () {
+    test('allRules exposes the seven well-known check rules by name', function () {
+        const names = allRules.map((rule) => rule.name).toSorted();
+        assert.deepStrictEqual(names, [
+            'maxBundleSize',
+            'noDevDependencyImports',
+            'noDuplicatedFiles',
+            'noSideEffects',
+            'noUnusedBundleDependencies',
+            'requiredFiles',
+            'uniqueTargetPaths'
+        ]);
+    });
 
-test('allRules contains no duplicate rule names', () => {
-    const names = allRules.map((rule) => rule.name);
-    assert.strictEqual(new Set(names).size, names.length);
-});
+    test('allRules contains no duplicate rule names', function () {
+        const names = allRules.map((rule) => rule.name);
+        assert.strictEqual(new Set(names).size, names.length);
+    });
 
-test('every entry in allRules exposes the rule contract (name, schemas, run)', () => {
-    for (const rule of allRules) {
-        assert.strictEqual(typeof rule.name, 'string', `name should be a string for ${rule.name}`);
-        assert.ok(typeof rule.run === 'function', `run should be a function for ${rule.name}`);
-        assert.ok(rule.globalSchema !== undefined, `globalSchema should be defined for ${rule.name}`);
-        assert.ok(rule.perPackageSchema !== undefined, `perPackageSchema should be defined for ${rule.name}`);
-    }
+    test('every entry in allRules exposes the rule contract (name, schemas, run)', function () {
+        for (const rule of allRules) {
+            assert.strictEqual(typeof rule.name, 'string', `name should be a string for ${rule.name}`);
+            assert.ok(typeof rule.run === 'function', `run should be a function for ${rule.name}`);
+            assert.ok(rule.globalSchema !== undefined, `globalSchema should be defined for ${rule.name}`);
+            assert.ok(rule.perPackageSchema !== undefined, `perPackageSchema should be defined for ${rule.name}`);
+        }
+    });
 });

--- a/source/checks/rules/required-files.test.ts
+++ b/source/checks/rules/required-files.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import { checkBundle as bundle } from '../../test-libraries/check-bundle-fixture.ts';
 import { requiredFilesRule } from './required-files.ts';
@@ -8,90 +8,92 @@ function packageRequiring(files: readonly string[]): PackageChecksSettings {
     return { requiredFiles: { files } };
 }
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(requiredFilesRule.name, 'requiredFiles');
-    assert.strictEqual(typeof requiredFilesRule.run, 'function');
-});
-
-test('returns no issues when settings are missing', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', [])],
-        settings: undefined,
-        perPackageSettings: new Map()
+suite('required-files', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(requiredFilesRule.name, 'requiredFiles');
+        assert.strictEqual(typeof requiredFilesRule.run, 'function');
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', [])],
+            settings: undefined,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when the rule is disabled', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', [])],
-        settings: { requiredFiles: { enabled: false, files: ['LICENSE'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', [])],
+            settings: { requiredFiles: { enabled: false, files: ['LICENSE'] } },
+            perPackageSettings: new Map()
+        });
 
-test('reports a missing global required file for every bundle that lacks it', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', ['LICENSE']), bundle('b', [])],
-        settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, ['Package "b" is missing required file "LICENSE"']);
-});
+    test('reports a missing global required file for every bundle that lacks it', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', ['LICENSE']), bundle('b', [])],
+            settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when all bundles contain every globally required file', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', ['LICENSE', 'readme.md']), bundle('b', ['LICENSE', 'readme.md'])],
-        settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['Package "b" is missing required file "LICENSE"']);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when all bundles contain every globally required file', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', ['LICENSE', 'readme.md']), bundle('b', ['LICENSE', 'readme.md'])],
+            settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
+            perPackageSettings: new Map()
+        });
 
-test('extends global required files with per-package required files', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', ['LICENSE'])],
-        settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
-        perPackageSettings: new Map([['a', packageRequiring(['CHANGELOG.md'])]])
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" is missing required file "CHANGELOG.md"']);
-});
+    test('extends global required files with per-package required files', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', ['LICENSE'])],
+            settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
+            perPackageSettings: new Map([['a', packageRequiring(['CHANGELOG.md'])]])
+        });
 
-test('deduplicates required files when per-package config repeats a global entry', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', [])],
-        settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
-        perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
+        assert.deepStrictEqual(result, ['Package "a" is missing required file "CHANGELOG.md"']);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
-});
+    test('deduplicates required files when per-package config repeats a global entry', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', [])],
+            settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
+            perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
+        });
 
-test('uses per-package required files even when the global list is empty', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', [])],
-        settings: { requiredFiles: { enabled: true } },
-        perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
+        assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
-});
+    test('uses per-package required files even when the global list is empty', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', [])],
+            settings: { requiredFiles: { enabled: true } },
+            perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
+        });
 
-test('reports multiple missing files for a single bundle', () => {
-    const result = requiredFilesRule.run({
-        bundles: [bundle('a', [])],
-        settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
     });
 
-    assert.deepStrictEqual(result, [
-        'Package "a" is missing required file "LICENSE"',
-        'Package "a" is missing required file "readme.md"'
-    ]);
+    test('reports multiple missing files for a single bundle', function () {
+        const result = requiredFilesRule.run({
+            bundles: [bundle('a', [])],
+            settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, [
+            'Package "a" is missing required file "LICENSE"',
+            'Package "a" is missing required file "readme.md"'
+        ]);
+    });
 });

--- a/source/checks/rules/set-intersection.test.ts
+++ b/source/checks/rules/set-intersection.test.ts
@@ -1,25 +1,27 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { intersectAll } from './set-intersection.ts';
 
-test('intersectAll returns a copy of the single set when only one is given', () => {
-    const original = new Set(['a', 'b']);
-    const result = intersectAll([original]);
-    assert.deepStrictEqual(Array.from(result), ['a', 'b']);
-    assert.notStrictEqual(result, original);
-});
+suite('set-intersection', function () {
+    test('intersectAll returns a copy of the single set when only one is given', function () {
+        const original = new Set(['a', 'b']);
+        const result = intersectAll([original]);
+        assert.deepStrictEqual(Array.from(result), ['a', 'b']);
+        assert.notStrictEqual(result, original);
+    });
 
-test('intersectAll returns elements present in every set', () => {
-    const result = intersectAll([new Set(['a', 'b', 'c']), new Set(['b', 'c', 'd']), new Set(['c', 'b'])]);
-    assert.deepStrictEqual(Array.from(result).sort(), ['b', 'c']);
-});
+    test('intersectAll returns elements present in every set', function () {
+        const result = intersectAll([new Set(['a', 'b', 'c']), new Set(['b', 'c', 'd']), new Set(['c', 'b'])]);
+        assert.deepStrictEqual(Array.from(result).sort(), ['b', 'c']);
+    });
 
-test('intersectAll returns an empty set when no element is present in every set', () => {
-    const result = intersectAll([new Set(['a']), new Set(['b'])]);
-    assert.deepStrictEqual(Array.from(result), []);
-});
+    test('intersectAll returns an empty set when no element is present in every set', function () {
+        const result = intersectAll([new Set(['a']), new Set(['b'])]);
+        assert.deepStrictEqual(Array.from(result), []);
+    });
 
-test('intersectAll preserves the iteration order of the first set', () => {
-    const result = intersectAll([new Set(['c', 'a', 'b']), new Set(['a', 'b', 'c'])]);
-    assert.deepStrictEqual(Array.from(result), ['c', 'a', 'b']);
+    test('intersectAll preserves the iteration order of the first set', function () {
+        const result = intersectAll([new Set(['c', 'a', 'b']), new Set(['a', 'b', 'c'])]);
+        assert.deepStrictEqual(Array.from(result), ['c', 'a', 'b']);
+    });
 });

--- a/source/checks/rules/unique-target-paths.test.ts
+++ b/source/checks/rules/unique-target-paths.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
 import { uniqueTargetPathsRule } from './unique-target-paths.ts';
@@ -15,106 +15,108 @@ function bundleWithMappings(name: string, mappings: readonly (readonly [string, 
 
 const enabled = { uniqueTargetPaths: { enabled: true } };
 
-test('rule definition exposes name, schemas and a run function', () => {
-    assert.strictEqual(uniqueTargetPathsRule.name, 'uniqueTargetPaths');
-    assert.strictEqual(typeof uniqueTargetPathsRule.run, 'function');
-});
-
-test('returns no issues when settings are missing', () => {
-    const result = uniqueTargetPathsRule.run({
-        bundles: [
-            bundleWithMappings('a', [
-                ['/src/a.js', 'collide.js'],
-                ['/src/b.js', 'collide.js']
-            ])
-        ],
-        settings: undefined,
-        perPackageSettings: new Map()
+suite('unique-target-paths', function () {
+    test('rule definition exposes name, schemas and a run function', function () {
+        assert.strictEqual(uniqueTargetPathsRule.name, 'uniqueTargetPaths');
+        assert.strictEqual(typeof uniqueTargetPathsRule.run, 'function');
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when settings are missing', function () {
+        const result = uniqueTargetPathsRule.run({
+            bundles: [
+                bundleWithMappings('a', [
+                    ['/src/a.js', 'collide.js'],
+                    ['/src/b.js', 'collide.js']
+                ])
+            ],
+            settings: undefined,
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when the rule is disabled', () => {
-    const result = uniqueTargetPathsRule.run({
-        bundles: [
-            bundleWithMappings('a', [
-                ['/src/a.js', 'collide.js'],
-                ['/src/b.js', 'collide.js']
-            ])
-        ],
-        settings: { uniqueTargetPaths: { enabled: false } },
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when the rule is disabled', function () {
+        const result = uniqueTargetPathsRule.run({
+            bundles: [
+                bundleWithMappings('a', [
+                    ['/src/a.js', 'collide.js'],
+                    ['/src/b.js', 'collide.js']
+                ])
+            ],
+            settings: { uniqueTargetPaths: { enabled: false } },
+            perPackageSettings: new Map()
+        });
 
-test('returns no issues when every targetFilePath is unique', () => {
-    const result = uniqueTargetPathsRule.run({
-        bundles: [
-            bundleWithMappings('a', [
-                ['/src/a.js', 'a.js'],
-                ['/src/b.js', 'b.js']
-            ])
-        ],
-        settings: enabled,
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('returns no issues when every targetFilePath is unique', function () {
+        const result = uniqueTargetPathsRule.run({
+            bundles: [
+                bundleWithMappings('a', [
+                    ['/src/a.js', 'a.js'],
+                    ['/src/b.js', 'b.js']
+                ])
+            ],
+            settings: enabled,
+            perPackageSettings: new Map()
+        });
 
-test('reports a collision and lists the colliding source paths sorted', () => {
-    const result = uniqueTargetPathsRule.run({
-        bundles: [
-            bundleWithMappings('a', [
-                ['/src/b.js', 'collide.js'],
-                ['/src/a.js', 'collide.js']
-            ])
-        ],
-        settings: enabled,
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "collide.js": /src/a.js, /src/b.js']);
-});
+    test('reports a collision and lists the colliding source paths sorted', function () {
+        const result = uniqueTargetPathsRule.run({
+            bundles: [
+                bundleWithMappings('a', [
+                    ['/src/b.js', 'collide.js'],
+                    ['/src/a.js', 'collide.js']
+                ])
+            ],
+            settings: enabled,
+            perPackageSettings: new Map()
+        });
 
-test('reports collisions independently per bundle', () => {
-    const result = uniqueTargetPathsRule.run({
-        bundles: [
-            bundleWithMappings('a', [
-                ['/a-src/x.js', 'shared.js'],
-                ['/a-src/y.js', 'shared.js']
-            ]),
-            bundleWithMappings('b', [
-                ['/b-src/p.js', 'p.js'],
-                ['/b-src/q.js', 'q.js']
-            ])
-        ],
-        settings: enabled,
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "collide.js": /src/a.js, /src/b.js']);
     });
 
-    assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "shared.js": /a-src/x.js, /a-src/y.js']);
-});
+    test('reports collisions independently per bundle', function () {
+        const result = uniqueTargetPathsRule.run({
+            bundles: [
+                bundleWithMappings('a', [
+                    ['/a-src/x.js', 'shared.js'],
+                    ['/a-src/y.js', 'shared.js']
+                ]),
+                bundleWithMappings('b', [
+                    ['/b-src/p.js', 'p.js'],
+                    ['/b-src/q.js', 'q.js']
+                ])
+            ],
+            settings: enabled,
+            perPackageSettings: new Map()
+        });
 
-test('reports each colliding target path of a bundle', () => {
-    const result = uniqueTargetPathsRule.run({
-        bundles: [
-            bundleWithMappings('a', [
-                ['/src/x1.js', 'one.js'],
-                ['/src/x2.js', 'one.js'],
-                ['/src/y1.js', 'two.js'],
-                ['/src/y2.js', 'two.js']
-            ])
-        ],
-        settings: enabled,
-        perPackageSettings: new Map()
+        assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "shared.js": /a-src/x.js, /a-src/y.js']);
     });
 
-    assert.deepStrictEqual(result, [
-        'Package "a" maps multiple sources to "one.js": /src/x1.js, /src/x2.js',
-        'Package "a" maps multiple sources to "two.js": /src/y1.js, /src/y2.js'
-    ]);
+    test('reports each colliding target path of a bundle', function () {
+        const result = uniqueTargetPathsRule.run({
+            bundles: [
+                bundleWithMappings('a', [
+                    ['/src/x1.js', 'one.js'],
+                    ['/src/x2.js', 'one.js'],
+                    ['/src/y1.js', 'two.js'],
+                    ['/src/y2.js', 'two.js']
+                ])
+            ],
+            settings: enabled,
+            perPackageSettings: new Map()
+        });
+
+        assert.deepStrictEqual(result, [
+            'Package "a" maps multiple sources to "one.js": /src/x1.js, /src/x2.js',
+            'Package "a" maps multiple sources to "two.js": /src/y1.js, /src/y2.js'
+        ]);
+    });
 });

--- a/source/command-line-interface/config-loader.property.ts
+++ b/source/command-line-interface/config-loader.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createConfigLoader } from './config-loader.ts';
 
 async function expectFailure(action: () => Promise<unknown>): Promise<void> {
@@ -21,51 +21,53 @@ function createLoader(moduleValue: unknown) {
     });
 }
 
-test('load() rejects malformed module export shapes', async () => {
-    await fc.assert(
-        fc.asyncProperty(
-            fc.oneof(
-                fc.boolean(),
-                fc.integer(),
-                fc.string(),
-                fc.constant(null),
-                fc.constant(undefined),
-                fc.array(fc.anything())
-            ),
-            async (moduleValue) => {
+suite('config-loader', function () {
+    test('load() rejects malformed module export shapes', async function () {
+        await fc.assert(
+            fc.asyncProperty(
+                fc.oneof(
+                    fc.boolean(),
+                    fc.integer(),
+                    fc.string(),
+                    fc.constant(null),
+                    fc.constant(undefined),
+                    fc.array(fc.anything())
+                ),
+                async (moduleValue) => {
+                    await expectFailure(async () => {
+                        await createLoader(moduleValue).load();
+                    });
+                }
+            )
+        );
+    });
+
+    test('load() rejects objects without config and buildConfig exports', async function () {
+        await fc.assert(
+            fc.asyncProperty(fc.dictionary(fc.string(), fc.anything(), { maxKeys: 4 }), async (moduleValue) => {
+                if ('config' in moduleValue || 'buildConfig' in moduleValue) {
+                    return;
+                }
+
                 await expectFailure(async () => {
                     await createLoader(moduleValue).load();
                 });
-            }
-        )
-    );
-});
+            })
+        );
+    });
 
-test('load() rejects objects without config and buildConfig exports', async () => {
-    await fc.assert(
-        fc.asyncProperty(fc.dictionary(fc.string(), fc.anything(), { maxKeys: 4 }), async (moduleValue) => {
-            if ('config' in moduleValue || 'buildConfig' in moduleValue) {
-                return;
-            }
-
-            await expectFailure(async () => {
-                await createLoader(moduleValue).load();
-            });
-        })
-    );
-});
-
-test('load() rejects non-function buildConfig exports when config is absent', async () => {
-    await fc.assert(
-        fc.asyncProperty(
-            fc.anything().filter((value) => {
-                return typeof value !== 'function';
-            }),
-            async (buildConfig) => {
-                await expectFailure(async () => {
-                    await createLoader({ buildConfig }).load();
-                });
-            }
-        )
-    );
+    test('load() rejects non-function buildConfig exports when config is absent', async function () {
+        await fc.assert(
+            fc.asyncProperty(
+                fc.anything().filter((value) => {
+                    return typeof value !== 'function';
+                }),
+                async (buildConfig) => {
+                    await expectFailure(async () => {
+                        await createLoader({ buildConfig }).load();
+                    });
+                }
+            )
+        );
+    });
 });

--- a/source/command-line-interface/config-loader.test.ts
+++ b/source/command-line-interface/config-loader.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { createConfigLoader, type ConfigLoader } from './config-loader.ts';
 
@@ -13,95 +13,97 @@ function configLoaderFactory(overrides: Overrides = {}): ConfigLoader {
     return createConfigLoader({ currentWorkingDirectory, importModule });
 }
 
-test('loads the packtory.config.js file relative to the current working directory', async () => {
-    const importModule = fake.resolves({ config: 'foo' });
-    const configLoader = configLoaderFactory({ currentWorkingDirectory: 'the-folder', importModule });
+suite('config-loader', function () {
+    test('loads the packtory.config.js file relative to the current working directory', async function () {
+        const importModule = fake.resolves({ config: 'foo' });
+        const configLoader = configLoaderFactory({ currentWorkingDirectory: 'the-folder', importModule });
 
-    await configLoader.load();
-
-    assert.strictEqual(importModule.callCount, 1);
-    assert.deepStrictEqual(importModule.firstCall.args, ['the-folder/packtory.config.js']);
-});
-
-test('throws when the imported module is not an object', async () => {
-    const importModule = fake.resolves('foo');
-    const configLoader = configLoaderFactory({ importModule });
-
-    try {
         await configLoader.load();
-        assert.fail('Expected load() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Invalid config file');
-    }
-});
 
-test('throws when the imported module is an object but has no config nor buildConfig property', async () => {
-    const importModule = fake.resolves({ something: 'but not config' });
-    const configLoader = configLoaderFactory({ importModule });
+        assert.strictEqual(importModule.callCount, 1);
+        assert.deepStrictEqual(importModule.firstCall.args, ['the-folder/packtory.config.js']);
+    });
 
-    try {
-        await configLoader.load();
-        assert.fail('Expected load() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Config file doesn’t have a named export "config" nor "buildConfig"'
-        );
-    }
-});
+    test('throws when the imported module is not an object', async function () {
+        const importModule = fake.resolves('foo');
+        const configLoader = configLoaderFactory({ importModule });
 
-test('returns the value of the config property when it exists and buildConfig doesn’t exist', async () => {
-    const importModule = fake.resolves({ config: 'the-value' });
-    const configLoader = configLoaderFactory({ importModule });
-
-    const result = await configLoader.load();
-
-    assert.strictEqual(result, 'the-value');
-});
-
-test('returns the value of the config property when it exists and buildConfig exists', async () => {
-    const importModule = fake.resolves({ config: 'the-value', buildConfig: fake() });
-    const configLoader = configLoaderFactory({ importModule });
-
-    const result = await configLoader.load();
-
-    assert.strictEqual(result, 'the-value');
-});
-
-test('throws an error when config doesn’t exist but buildConfig does but it is not a function', async () => {
-    const importModule = fake.resolves({ buildConfig: 'foo' });
-    const configLoader = configLoaderFactory({ importModule });
-
-    try {
-        await configLoader.load();
-        assert.fail('Expected load() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Named export of "buildConfig" config file is not a function');
-    }
-});
-
-test('returns the value returned by the buildConfig function when it exists and config doesn’t', async () => {
-    const importModule = fake.resolves({
-        buildConfig() {
-            return 'the-value-from-function';
+        try {
+            await configLoader.load();
+            assert.fail('Expected load() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Invalid config file');
         }
     });
-    const configLoader = configLoaderFactory({ importModule });
 
-    const result = await configLoader.load();
+    test('throws when the imported module is an object but has no config nor buildConfig property', async function () {
+        const importModule = fake.resolves({ something: 'but not config' });
+        const configLoader = configLoaderFactory({ importModule });
 
-    assert.strictEqual(result, 'the-value-from-function');
-});
-
-test('awaits the buildConfig function when it returns a promise', async () => {
-    const importModule = fake.resolves({
-        async buildConfig() {
-            return 'the-value-from-async-function';
+        try {
+            await configLoader.load();
+            assert.fail('Expected load() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Config file doesn’t have a named export "config" nor "buildConfig"'
+            );
         }
     });
-    const configLoader = configLoaderFactory({ importModule });
 
-    const result = await configLoader.load();
+    test('returns the value of the config property when it exists and buildConfig doesn’t exist', async function () {
+        const importModule = fake.resolves({ config: 'the-value' });
+        const configLoader = configLoaderFactory({ importModule });
 
-    assert.strictEqual(result, 'the-value-from-async-function');
+        const result = await configLoader.load();
+
+        assert.strictEqual(result, 'the-value');
+    });
+
+    test('returns the value of the config property when it exists and buildConfig exists', async function () {
+        const importModule = fake.resolves({ config: 'the-value', buildConfig: fake() });
+        const configLoader = configLoaderFactory({ importModule });
+
+        const result = await configLoader.load();
+
+        assert.strictEqual(result, 'the-value');
+    });
+
+    test('throws an error when config doesn’t exist but buildConfig does but it is not a function', async function () {
+        const importModule = fake.resolves({ buildConfig: 'foo' });
+        const configLoader = configLoaderFactory({ importModule });
+
+        try {
+            await configLoader.load();
+            assert.fail('Expected load() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Named export of "buildConfig" config file is not a function');
+        }
+    });
+
+    test('returns the value returned by the buildConfig function when it exists and config doesn’t', async function () {
+        const importModule = fake.resolves({
+            buildConfig() {
+                return 'the-value-from-function';
+            }
+        });
+        const configLoader = configLoaderFactory({ importModule });
+
+        const result = await configLoader.load();
+
+        assert.strictEqual(result, 'the-value-from-function');
+    });
+
+    test('awaits the buildConfig function when it returns a promise', async function () {
+        const importModule = fake.resolves({
+            async buildConfig() {
+                return 'the-value-from-async-function';
+            }
+        });
+        const configLoader = configLoaderFactory({ importModule });
+
+        const result = await configLoader.load();
+
+        assert.strictEqual(result, 'the-value-from-async-function');
+    });
 });

--- a/source/command-line-interface/one-time-password-prompt.test.ts
+++ b/source/command-line-interface/one-time-password-prompt.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { createFakeClock, type FakeClock } from '../test-libraries/fake-clock.ts';
 import { withPromiseDeadline } from '../test-libraries/promise-with-deadline.ts';
@@ -49,70 +49,72 @@ function createPrompt(overrides: Overrides = {}) {
     };
 }
 
-test('throws when one-time-password prompting is attempted without an interactive terminal', async () => {
-    const { prompt, stopSpinner, question, close } = createPrompt({
-        isInteractiveTerminal: () => false
+suite('one-time-password-prompt', function () {
+    test('throws when one-time-password prompting is attempted without an interactive terminal', async function () {
+        const { prompt, stopSpinner, question, close } = createPrompt({
+            isInteractiveTerminal: () => false
+        });
+
+        await expectFailure(async () => {
+            await prompt();
+        }, /^Error: The registry requested a one-time password, but prompting requires an interactive terminal$/u);
+
+        assert.strictEqual(stopSpinner.callCount, 0);
+        assert.strictEqual(question.callCount, 0);
+        assert.strictEqual(close.callCount, 0);
     });
 
-    await expectFailure(async () => {
-        await prompt();
-    }, /^Error: The registry requested a one-time password, but prompting requires an interactive terminal$/u);
+    test('stops the spinner before prompting and trims the entered one-time password', async function () {
+        const stopSpinner = fake();
+        const question = fake.resolves(' 123456 ');
+        const { prompt } = createPrompt({ stopSpinner, question });
 
-    assert.strictEqual(stopSpinner.callCount, 0);
-    assert.strictEqual(question.callCount, 0);
-    assert.strictEqual(close.callCount, 0);
-});
+        const result = await withPromiseDeadline(prompt(), 'one-time password prompt success');
 
-test('stops the spinner before prompting and trims the entered one-time password', async () => {
-    const stopSpinner = fake();
-    const question = fake.resolves(' 123456 ');
-    const { prompt } = createPrompt({ stopSpinner, question });
-
-    const result = await withPromiseDeadline(prompt(), 'one-time password prompt success');
-
-    assert.strictEqual(result, '123456');
-    assert.strictEqual(stopSpinner.callCount, 1);
-    assert.deepStrictEqual(question.firstCall.args, ['Registry one-time password: ']);
-    assert.ok(stopSpinner.calledBefore(question));
-});
-
-test('closes the prompt interface after a successful prompt', async () => {
-    const close = fake();
-    const { prompt } = createPrompt({ close });
-
-    await withPromiseDeadline(prompt(), 'one-time password prompt close');
-
-    assert.strictEqual(close.callCount, 1);
-});
-
-test('closes the prompt interface when the prompt times out', async () => {
-    const close = fake();
-    const clock = createFakeClock();
-    const { prompt } = createPrompt({
-        clock,
-        close,
-        question: async () => {
-            return new Promise<string>(() => {
-                // Intentionally unresolved to exercise the timeout path.
-            });
-        }
+        assert.strictEqual(result, '123456');
+        assert.strictEqual(stopSpinner.callCount, 1);
+        assert.deepStrictEqual(question.firstCall.args, ['Registry one-time password: ']);
+        assert.ok(stopSpinner.calledBefore(question));
     });
 
-    const promptPromise = prompt();
-    clock.tick(90_000);
-    await expectFailure(async () => {
-        await withPromiseDeadline(promptPromise, 'one-time password prompt timeout');
-    }, /^Error: One-time password input timed out or was empty$/u);
+    test('closes the prompt interface after a successful prompt', async function () {
+        const close = fake();
+        const { prompt } = createPrompt({ close });
 
-    assert.strictEqual(close.callCount, 1);
-});
+        await withPromiseDeadline(prompt(), 'one-time password prompt close');
 
-test('throws when the entered one-time password is empty after trimming', async () => {
-    const { prompt } = createPrompt({
-        question: fake.resolves('   ')
+        assert.strictEqual(close.callCount, 1);
     });
 
-    await expectFailure(async () => {
-        await withPromiseDeadline(prompt(), 'one-time password prompt empty input');
-    }, /^Error: One-time password input timed out or was empty$/u);
+    test('closes the prompt interface when the prompt times out', async function () {
+        const close = fake();
+        const clock = createFakeClock();
+        const { prompt } = createPrompt({
+            clock,
+            close,
+            question: async () => {
+                return new Promise<string>(() => {
+                    // Intentionally unresolved to exercise the timeout path.
+                });
+            }
+        });
+
+        const promptPromise = prompt();
+        clock.tick(90_000);
+        await expectFailure(async () => {
+            await withPromiseDeadline(promptPromise, 'one-time password prompt timeout');
+        }, /^Error: One-time password input timed out or was empty$/u);
+
+        assert.strictEqual(close.callCount, 1);
+    });
+
+    test('throws when the entered one-time password is empty after trimming', async function () {
+        const { prompt } = createPrompt({
+            question: fake.resolves('   ')
+        });
+
+        await expectFailure(async () => {
+            await withPromiseDeadline(prompt(), 'one-time password prompt empty input');
+        }, /^Error: One-time password input timed out or was empty$/u);
+    });
 });

--- a/source/command-line-interface/preview-io/preview-io-shared.test.ts
+++ b/source/command-line-interface/preview-io/preview-io-shared.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax, functional/no-this-expressions, destructuring/in-params, sonarjs/publicly-writable-directories, no-undef -- fake child-process scaffolding is intentionally imperative in these tests */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { withPromiseDeadline } from '../../test-libraries/promise-with-deadline.ts';
 import { createPreviewIo } from './preview-io-shared.ts';
 import type { SpawnedProcess, SpawnOptions } from './preview-spawn.ts';
@@ -110,156 +110,164 @@ function emitProcessError(kind: 'error' | 'stdinError'): NonNullable<PreviewIoFa
     };
 }
 
-test('createTemporaryPreviewHtmlPath uses tmpdir and the generated uuid', () => {
-    const { previewIo: io } = previewIoFactory();
+suite('preview-io-shared', function () {
+    test('createTemporaryPreviewHtmlPath uses tmpdir and the generated uuid', function () {
+        const { previewIo: io } = previewIoFactory();
 
-    assert.strictEqual(io.createTemporaryPreviewHtmlPath(), '/tmp/packtory-preview-uuid-123.html');
-});
-
-test('pagePreviewOutput returns false immediately when stdout is not a TTY', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ stdoutIsTTY: false });
-
-    assert.strictEqual(
-        await withPromiseDeadline(io.pagePreviewOutput('content'), 'non-interactive preview skip'),
-        false
-    );
-    assert.deepStrictEqual(calls, []);
-});
-
-test('pagePreviewOutput uses the configured pager when it succeeds', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ pager: 'bat', spawnHook: closeProcess(0) });
-
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'configured pager success'), true);
-    assert.deepStrictEqual(
-        calls.map((call) => [call.command, call.args]),
-        [['sh', ['-lc', 'bat']]]
-    );
-    const firstCall = requireFirstCall(calls);
-    assert.deepStrictEqual(firstCall.options, { stdio: ['pipe', 'inherit', 'inherit'] });
-    assert.ok(firstCall.child.listeners.close !== undefined);
-    assert.ok(firstCall.child.listeners.error !== undefined);
-    assert.ok(firstCall.child.listeners.stdinError !== undefined);
-    assert.strictEqual(firstCall.child.endedContent, 'content');
-});
-
-test('pagePreviewOutput falls back to less when the configured pager fails', async () => {
-    let invocation = 0;
-    const { previewIo: io, calls } = previewIoFactory({
-        pager: 'bat',
-        shell: '/bin/bash',
-        spawnHook: ({ child }) => {
-            invocation += 1;
-            queueMicrotask(() => {
-                child.listeners.close?.(invocation === 1 ? 1 : 0);
-            });
-        }
+        assert.strictEqual(io.createTemporaryPreviewHtmlPath(), '/tmp/packtory-preview-uuid-123.html');
     });
 
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'pager fallback'), true);
-    assert.deepStrictEqual(
-        calls.map((call) => [call.command, call.args]),
-        [
-            ['/bin/bash', ['-lc', 'bat']],
-            ['/bin/bash', ['-lc', 'less -R']]
-        ]
-    );
-});
+    test('pagePreviewOutput returns false immediately when stdout is not a TTY', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ stdoutIsTTY: false });
 
-test('pagePreviewOutput uses less directly when no pager is configured', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ spawnHook: closeProcess(0) });
+        assert.strictEqual(
+            await withPromiseDeadline(io.pagePreviewOutput('content'), 'non-interactive preview skip'),
+            false
+        );
+        assert.deepStrictEqual(calls, []);
+    });
 
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'default less pager'), true);
-    assert.deepStrictEqual(
-        calls.map((call) => [call.command, call.args]),
-        [['sh', ['-lc', 'less -R']]]
-    );
-});
+    test('pagePreviewOutput uses the configured pager when it succeeds', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ pager: 'bat', spawnHook: closeProcess(0) });
 
-test('pagePreviewOutput falls back to less when the pager is empty', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ pager: '', spawnHook: closeProcess(0) });
+        assert.strictEqual(
+            await withPromiseDeadline(io.pagePreviewOutput('content'), 'configured pager success'),
+            true
+        );
+        assert.deepStrictEqual(
+            calls.map((call) => [call.command, call.args]),
+            [['sh', ['-lc', 'bat']]]
+        );
+        const firstCall = requireFirstCall(calls);
+        assert.deepStrictEqual(firstCall.options, { stdio: ['pipe', 'inherit', 'inherit'] });
+        assert.ok(firstCall.child.listeners.close !== undefined);
+        assert.ok(firstCall.child.listeners.error !== undefined);
+        assert.ok(firstCall.child.listeners.stdinError !== undefined);
+        assert.strictEqual(firstCall.child.endedContent, 'content');
+    });
 
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'empty pager fallback'), true);
-    assert.deepStrictEqual(
-        calls.map((call) => call.args),
-        [['-lc', 'less -R']]
-    );
-});
+    test('pagePreviewOutput falls back to less when the configured pager fails', async function () {
+        let invocation = 0;
+        const { previewIo: io, calls } = previewIoFactory({
+            pager: 'bat',
+            shell: '/bin/bash',
+            spawnHook: ({ child }) => {
+                invocation += 1;
+                queueMicrotask(() => {
+                    child.listeners.close?.(invocation === 1 ? 1 : 0);
+                });
+            }
+        });
 
-test('pagePreviewOutput returns false when spawn errors', async () => {
-    const { previewIo: io } = previewIoFactory({ pager: 'bat', spawnHook: emitProcessError('error') });
+        assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'pager fallback'), true);
+        assert.deepStrictEqual(
+            calls.map((call) => [call.command, call.args]),
+            [
+                ['/bin/bash', ['-lc', 'bat']],
+                ['/bin/bash', ['-lc', 'less -R']]
+            ]
+        );
+    });
 
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview spawn error'), false);
-});
+    test('pagePreviewOutput uses less directly when no pager is configured', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ spawnHook: closeProcess(0) });
 
-test('pagePreviewOutput returns false when stdin errors', async () => {
-    const { previewIo: io } = previewIoFactory({ spawnHook: emitProcessError('stdinError') });
+        assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'default less pager'), true);
+        assert.deepStrictEqual(
+            calls.map((call) => [call.command, call.args]),
+            [['sh', ['-lc', 'less -R']]]
+        );
+    });
 
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview stdin error'), false);
-});
+    test('pagePreviewOutput falls back to less when the pager is empty', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ pager: '', spawnHook: closeProcess(0) });
 
-test('pagePreviewOutput returns false when the spawned pager process exposes a null stdin stream', async () => {
-    const { previewIo: io } = previewIoFactory({ stdinMode: 'null' });
+        assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'empty pager fallback'), true);
+        assert.deepStrictEqual(
+            calls.map((call) => call.args),
+            [['-lc', 'less -R']]
+        );
+    });
 
-    assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview null stdin'), false);
-});
+    test('pagePreviewOutput returns false when spawn errors', async function () {
+        const { previewIo: io } = previewIoFactory({ pager: 'bat', spawnHook: emitProcessError('error') });
 
-test('openPreviewFile uses open on macOS', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ platform: 'darwin' });
+        assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview spawn error'), false);
+    });
 
-    assert.strictEqual(
-        await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview on macOS'),
-        true
-    );
-    assert.deepStrictEqual(
-        calls.map((call) => [call.command, call.args]),
-        [['open', ['/tmp/report.html']]]
-    );
-    const firstCall = requireFirstCall(calls);
-    assert.deepStrictEqual(firstCall.options, { detached: true, stdio: 'ignore' });
-    assert.ok(firstCall.child.listeners.error !== undefined);
-    assert.strictEqual(firstCall.child.wasUnrefCalled, true);
-});
+    test('pagePreviewOutput returns false when stdin errors', async function () {
+        const { previewIo: io } = previewIoFactory({ spawnHook: emitProcessError('stdinError') });
 
-test('openPreviewFile uses start on Windows', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ platform: 'win32' });
+        assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview stdin error'), false);
+    });
 
-    assert.strictEqual(
-        await withPromiseDeadline(io.openPreviewFile('C:\\report.html'), 'open preview on Windows'),
-        true
-    );
-    assert.deepStrictEqual(
-        calls.map((call) => [call.command, call.args]),
-        [['cmd', ['/c', 'start', '', 'C:\\report.html']]]
-    );
-});
+    test('pagePreviewOutput returns false when the spawned pager process exposes a null stdin stream', async function () {
+        const { previewIo: io } = previewIoFactory({ stdinMode: 'null' });
 
-test('openPreviewFile uses xdg-open on other platforms', async () => {
-    const { previewIo: io, calls } = previewIoFactory({ platform: 'linux' });
+        assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview null stdin'), false);
+    });
 
-    assert.strictEqual(
-        await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview on Linux'),
-        true
-    );
-    assert.deepStrictEqual(
-        calls.map((call) => [call.command, call.args]),
-        [['xdg-open', ['/tmp/report.html']]]
-    );
-});
+    test('openPreviewFile uses open on macOS', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ platform: 'darwin' });
 
-test('openPreviewFile returns false when opening emits an error', async () => {
-    const { previewIo: io } = previewIoFactory({ spawnHook: emitProcessError('error') });
+        assert.strictEqual(
+            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview on macOS'),
+            true
+        );
+        assert.deepStrictEqual(
+            calls.map((call) => [call.command, call.args]),
+            [['open', ['/tmp/report.html']]]
+        );
+        const firstCall = requireFirstCall(calls);
+        assert.deepStrictEqual(firstCall.options, { detached: true, stdio: 'ignore' });
+        assert.ok(firstCall.child.listeners.error !== undefined);
+        assert.strictEqual(firstCall.child.wasUnrefCalled, true);
+    });
 
-    assert.strictEqual(await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview error'), false);
-});
+    test('openPreviewFile uses start on Windows', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ platform: 'win32' });
 
-test('openPreviewFile ignores an error emitted after the success path has already settled', async () => {
-    const { previewIo: io, calls } = previewIoFactory();
+        assert.strictEqual(
+            await withPromiseDeadline(io.openPreviewFile('C:\\report.html'), 'open preview on Windows'),
+            true
+        );
+        assert.deepStrictEqual(
+            calls.map((call) => [call.command, call.args]),
+            [['cmd', ['/c', 'start', '', 'C:\\report.html']]]
+        );
+    });
 
-    assert.strictEqual(
-        await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview late error ignore'),
-        true
-    );
-    const firstCall = requireFirstCall(calls);
-    firstCall.child.listeners.error?.();
-    assert.strictEqual(firstCall.child.wasUnrefCalled, true);
+    test('openPreviewFile uses xdg-open on other platforms', async function () {
+        const { previewIo: io, calls } = previewIoFactory({ platform: 'linux' });
+
+        assert.strictEqual(
+            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview on Linux'),
+            true
+        );
+        assert.deepStrictEqual(
+            calls.map((call) => [call.command, call.args]),
+            [['xdg-open', ['/tmp/report.html']]]
+        );
+    });
+
+    test('openPreviewFile returns false when opening emits an error', async function () {
+        const { previewIo: io } = previewIoFactory({ spawnHook: emitProcessError('error') });
+
+        assert.strictEqual(
+            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview error'),
+            false
+        );
+    });
+
+    test('openPreviewFile ignores an error emitted after the success path has already settled', async function () {
+        const { previewIo: io, calls } = previewIoFactory();
+
+        assert.strictEqual(
+            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview late error ignore'),
+            true
+        );
+        const firstCall = requireFirstCall(calls);
+        firstCall.child.listeners.error?.();
+        assert.strictEqual(firstCall.child.wasUnrefCalled, true);
+    });
 });

--- a/source/command-line-interface/preview-io/preview-io.test.ts
+++ b/source/command-line-interface/preview-io/preview-io.test.ts
@@ -1,34 +1,36 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { withPromiseDeadline } from '../../test-libraries/promise-with-deadline.ts';
 import { createDefaultPreviewIo } from './preview-io.ts';
 
-test('createDefaultPreviewIo exposes the default preview helpers', () => {
-    const previewIo = createDefaultPreviewIo({
-        platform: 'linux',
-        shell: 'sh',
-        pager: undefined,
-        stdoutIsTTY: true
+suite('preview-io', function () {
+    test('createDefaultPreviewIo exposes the default preview helpers', function () {
+        const previewIo = createDefaultPreviewIo({
+            platform: 'linux',
+            shell: 'sh',
+            pager: undefined,
+            stdoutIsTTY: true
+        });
+
+        assert.strictEqual(typeof previewIo.createTemporaryPreviewHtmlPath, 'function');
+        assert.strictEqual(typeof previewIo.pagePreviewOutput, 'function');
+        assert.strictEqual(typeof previewIo.openPreviewFile, 'function');
+        assert.ok(previewIo.createTemporaryPreviewHtmlPath().includes('packtory-preview-'));
     });
 
-    assert.strictEqual(typeof previewIo.createTemporaryPreviewHtmlPath, 'function');
-    assert.strictEqual(typeof previewIo.pagePreviewOutput, 'function');
-    assert.strictEqual(typeof previewIo.openPreviewFile, 'function');
-    assert.ok(previewIo.createTemporaryPreviewHtmlPath().includes('packtory-preview-'));
-});
+    test('createDefaultPreviewIo falls back to the default spawn process when no custom spawner is injected', async function () {
+        const previewIo = createDefaultPreviewIo({
+            platform: 'linux',
+            shell: 'sh',
+            pager: 'cat >/dev/null',
+            stdoutIsTTY: true,
+            randomUuid: () => 'uuid-123',
+            tmpdir: () => '/tmp'
+        });
 
-test('createDefaultPreviewIo falls back to the default spawn process when no custom spawner is injected', async () => {
-    const previewIo = createDefaultPreviewIo({
-        platform: 'linux',
-        shell: 'sh',
-        pager: 'cat >/dev/null',
-        stdoutIsTTY: true,
-        randomUuid: () => 'uuid-123',
-        tmpdir: () => '/tmp'
+        assert.strictEqual(
+            await withPromiseDeadline(previewIo.pagePreviewOutput('hello'), 'default preview io fallback spawner'),
+            true
+        );
     });
-
-    assert.strictEqual(
-        await withPromiseDeadline(previewIo.pagePreviewOutput('hello'), 'default preview io fallback spawner'),
-        true
-    );
 });

--- a/source/command-line-interface/preview-io/preview-spawn.test.ts
+++ b/source/command-line-interface/preview-io/preview-spawn.test.ts
@@ -1,34 +1,36 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { defaultSpawnProcess } from './preview-spawn.ts';
 
-test('defaultSpawnProcess delegates to child_process.spawn with array args', async () => {
-    const child = defaultSpawnProcess(process.execPath, ['-e', 'process.exit(0)'], {
-        stdio: ['pipe', 'inherit', 'inherit']
+suite('preview-spawn', function () {
+    test('defaultSpawnProcess delegates to child_process.spawn with array args', async function () {
+        const child = defaultSpawnProcess(process.execPath, ['-e', 'process.exit(0)'], {
+            stdio: ['pipe', 'inherit', 'inherit']
+        });
+
+        if (child.stdin === null) {
+            assert.fail('expected stdin to be available for pipe stdio');
+        }
+        child.stdin.end('');
+        const exitCode = await new Promise<number | undefined>((resolve) => {
+            child.on('close', resolve);
+        });
+
+        assert.strictEqual(exitCode, 0);
     });
 
-    if (child.stdin === null) {
-        assert.fail('expected stdin to be available for pipe stdio');
-    }
-    child.stdin.end('');
-    const exitCode = await new Promise<number | undefined>((resolve) => {
-        child.on('close', resolve);
+    test('defaultSpawnProcess preserves ignored stdio', async function () {
+        const child = defaultSpawnProcess(process.execPath, ['-e', 'process.exit(0)'], {
+            detached: true,
+            stdio: 'ignore'
+        });
+
+        assert.strictEqual(child.stdin, null);
+        child.unref();
+        const exitCode = await new Promise<number | undefined>((resolve) => {
+            child.on('close', resolve);
+        });
+
+        assert.strictEqual(exitCode, 0);
     });
-
-    assert.strictEqual(exitCode, 0);
-});
-
-test('defaultSpawnProcess preserves ignored stdio', async () => {
-    const child = defaultSpawnProcess(process.execPath, ['-e', 'process.exit(0)'], {
-        detached: true,
-        stdio: 'ignore'
-    });
-
-    assert.strictEqual(child.stdin, null);
-    child.unref();
-    const exitCode = await new Promise<number | undefined>((resolve) => {
-        child.on('close', resolve);
-    });
-
-    assert.strictEqual(exitCode, 0);
 });

--- a/source/command-line-interface/runner/command-parsing.test.ts
+++ b/source/command-line-interface/runner/command-parsing.test.ts
@@ -1,27 +1,29 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { getParseExitCode } from './command-parsing.ts';
 
-test('getParseExitCode returns undefined when the parse result has no error key', () => {
-    const calls: string[] = [];
-    const logged = (message: string): void => {
-        calls.push(message);
-    };
+suite('command-parsing', function () {
+    test('getParseExitCode returns undefined when the parse result has no error key', function () {
+        const calls: string[] = [];
+        const logged = (message: string): void => {
+            calls.push(message);
+        };
 
-    assert.strictEqual(getParseExitCode(logged, { command: 'noop' } as never), undefined);
-    assert.deepStrictEqual(calls, []);
-});
+        assert.strictEqual(getParseExitCode(logged, { command: 'noop' } as never), undefined);
+        assert.deepStrictEqual(calls, []);
+    });
 
-test('getParseExitCode logs the error message and returns its exit code when the parse failed', () => {
-    const calls: string[] = [];
-    const logged = (message: string): void => {
-        calls.push(message);
-    };
+    test('getParseExitCode logs the error message and returns its exit code when the parse failed', function () {
+        const calls: string[] = [];
+        const logged = (message: string): void => {
+            calls.push(message);
+        };
 
-    const exitCode = getParseExitCode(logged, {
-        error: { config: { message: 'bad usage', exitCode: 2 } }
-    } as never);
+        const exitCode = getParseExitCode(logged, {
+            error: { config: { message: 'bad usage', exitCode: 2 } }
+        } as never);
 
-    assert.strictEqual(exitCode, 2);
-    assert.deepStrictEqual(calls, ['bad usage']);
+        assert.strictEqual(exitCode, 2);
+        assert.deepStrictEqual(calls, ['bad usage']);
+    });
 });

--- a/source/command-line-interface/runner/failure-printing.test.ts
+++ b/source/command-line-interface/runner/failure-printing.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PublishFailure } from '../../packtory/packtory-results.ts';
 import { printDryRunNote, printPublishFailure, printSuccessSummary } from './failure-printing.ts';
 
@@ -13,63 +13,65 @@ function captureLogger(): { readonly log: (message: string) => void; readonly me
     };
 }
 
-test('printDryRunNote does not log anything when noDryRun is true', () => {
-    const sink = captureLogger();
-    printDryRunNote(sink.log, { noDryRun: true });
+suite('failure-printing', function () {
+    test('printDryRunNote does not log anything when noDryRun is true', function () {
+        const sink = captureLogger();
+        printDryRunNote(sink.log, { noDryRun: true });
 
-    assert.deepStrictEqual(sink.messages, []);
-});
+        assert.deepStrictEqual(sink.messages, []);
+    });
 
-test('printDryRunNote logs a single dry-run reminder when noDryRun is false', () => {
-    const sink = captureLogger();
-    printDryRunNote(sink.log, { noDryRun: false });
+    test('printDryRunNote logs a single dry-run reminder when noDryRun is false', function () {
+        const sink = captureLogger();
+        printDryRunNote(sink.log, { noDryRun: false });
 
-    assert.strictEqual(sink.messages.length, 1);
-    assert.match(sink.messages[0] ?? '', /dry-run mode was enabled/u);
-});
+        assert.strictEqual(sink.messages.length, 1);
+        assert.match(sink.messages[0] ?? '', /dry-run mode was enabled/u);
+    });
 
-test('printPublishFailure formats config issues with bullet list when type is config', () => {
-    const sink = captureLogger();
-    const failure: PublishFailure = { type: 'config', issues: ['issue A', 'issue B'] };
+    test('printPublishFailure formats config issues with bullet list when type is config', function () {
+        const sink = captureLogger();
+        const failure: PublishFailure = { type: 'config', issues: ['issue A', 'issue B'] };
 
-    printPublishFailure(sink.log, failure);
+        printPublishFailure(sink.log, failure);
 
-    assert.strictEqual(sink.messages.length, 1);
-    const message = sink.messages[0] ?? '';
-    assert.match(message, /The provided config is invalid, there are 2 issue\(s\)/u);
-    assert.match(message, /- issue A\n- issue B/u);
-});
+        assert.strictEqual(sink.messages.length, 1);
+        const message = sink.messages[0] ?? '';
+        assert.match(message, /The provided config is invalid, there are 2 issue\(s\)/u);
+        assert.match(message, /- issue A\n- issue B/u);
+    });
 
-test('printPublishFailure formats check issues with bullet list when type is checks', () => {
-    const sink = captureLogger();
-    const failure: PublishFailure = { type: 'checks', issues: ['check X'] };
+    test('printPublishFailure formats check issues with bullet list when type is checks', function () {
+        const sink = captureLogger();
+        const failure: PublishFailure = { type: 'checks', issues: ['check X'] };
 
-    printPublishFailure(sink.log, failure);
+        printPublishFailure(sink.log, failure);
 
-    const message = sink.messages[0] ?? '';
-    assert.match(message, /Checks failed, there are 1 issue\(s\)/u);
-    assert.match(message, /- check X/u);
-});
+        const message = sink.messages[0] ?? '';
+        assert.match(message, /Checks failed, there are 1 issue\(s\)/u);
+        assert.match(message, /- check X/u);
+    });
 
-test('printPublishFailure summarises partial failures when type is partial', () => {
-    const sink = captureLogger();
-    const failure: PublishFailure = {
-        type: 'partial',
-        succeeded: [{ name: 'pkg-a' }, { name: 'pkg-b' }] as never,
-        failures: [{ message: 'pkg-c failed' }] as never
-    };
+    test('printPublishFailure summarises partial failures when type is partial', function () {
+        const sink = captureLogger();
+        const failure: PublishFailure = {
+            type: 'partial',
+            succeeded: [{ name: 'pkg-a' }, { name: 'pkg-b' }] as never,
+            failures: [{ message: 'pkg-c failed' }] as never
+        };
 
-    printPublishFailure(sink.log, failure);
+        printPublishFailure(sink.log, failure);
 
-    const message = sink.messages[0] ?? '';
-    assert.ok(message.includes('package(s) failed'));
-    assert.ok(message.includes('- pkg-c failed'));
-});
+        const message = sink.messages[0] ?? '';
+        assert.ok(message.includes('package(s) failed'));
+        assert.ok(message.includes('- pkg-c failed'));
+    });
 
-test('printSuccessSummary logs the count of published packages', () => {
-    const sink = captureLogger();
+    test('printSuccessSummary logs the count of published packages', function () {
+        const sink = captureLogger();
 
-    printSuccessSummary(sink.log, [{ name: 'a' }, { name: 'b' }] as never);
+        printSuccessSummary(sink.log, [{ name: 'a' }, { name: 'b' }] as never);
 
-    assert.match(sink.messages[0] ?? '', /all 2 package\(s\) have been published/u);
+        assert.match(sink.messages[0] ?? '', /all 2 package\(s\) have been published/u);
+    });
 });

--- a/source/command-line-interface/runner/preview-handler.test.ts
+++ b/source/command-line-interface/runner/preview-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
@@ -29,83 +29,85 @@ function emptyOutcome(overrides: Partial<BuildOutcome> = {}): BuildOutcome {
     } as unknown as BuildOutcome;
 }
 
-test('runPreviewHandler returns 0 on success and pages the inline terminal preview', async () => {
-    const pageSpy: SinonSpy = fake.resolves(undefined);
+suite('preview-handler', function () {
+    test('runPreviewHandler returns 0 on success and pages the inline terminal preview', async function () {
+        const pageSpy: SinonSpy = fake.resolves(undefined);
 
-    const code = await runPreviewHandler({
-        log: () => undefined,
-        pageOutput: pageSpy,
-        openFile: fake.resolves(true),
-        createTemporaryFilePath: () => '/var/folders/preview.html',
-        packtory: packtoryStub(emptyOutcome()),
-        spinnerRenderer: spinnerRendererStub(),
-        configLoader: configLoaderStub(),
-        fileManager: createFakeFileManager(),
-        flags: { open: false }
+        const code = await runPreviewHandler({
+            log: () => undefined,
+            pageOutput: pageSpy,
+            openFile: fake.resolves(true),
+            createTemporaryFilePath: () => '/var/folders/preview.html',
+            packtory: packtoryStub(emptyOutcome()),
+            spinnerRenderer: spinnerRendererStub(),
+            configLoader: configLoaderStub(),
+            fileManager: createFakeFileManager(),
+            flags: { open: false }
+        });
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(pageSpy.callCount, 1);
     });
 
-    assert.strictEqual(code, 0);
-    assert.strictEqual(pageSpy.callCount, 1);
-});
+    test('runPreviewHandler returns 1 when the build fails', async function () {
+        const code = await runPreviewHandler({
+            log: () => undefined,
+            pageOutput: fake.resolves(undefined),
+            openFile: fake.resolves(true),
+            createTemporaryFilePath: () => '/var/folders/preview.html',
+            packtory: packtoryStub(
+                emptyOutcome({
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the preview-handler only inspects isOk/isErr; full Result shape is irrelevant here
+                    result: { isOk: false, isErr: true, error: { type: 'config', issues: [] } } as never
+                })
+            ),
+            spinnerRenderer: spinnerRendererStub(),
+            configLoader: configLoaderStub(),
+            fileManager: createFakeFileManager(),
+            flags: { open: false }
+        });
 
-test('runPreviewHandler returns 1 when the build fails', async () => {
-    const code = await runPreviewHandler({
-        log: () => undefined,
-        pageOutput: fake.resolves(undefined),
-        openFile: fake.resolves(true),
-        createTemporaryFilePath: () => '/var/folders/preview.html',
-        packtory: packtoryStub(
-            emptyOutcome({
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the preview-handler only inspects isOk/isErr; full Result shape is irrelevant here
-                result: { isOk: false, isErr: true, error: { type: 'config', issues: [] } } as never
-            })
-        ),
-        spinnerRenderer: spinnerRendererStub(),
-        configLoader: configLoaderStub(),
-        fileManager: createFakeFileManager(),
-        flags: { open: false }
+        assert.strictEqual(code, 1);
     });
 
-    assert.strictEqual(code, 1);
-});
+    test('runPreviewHandler writes the HTML report to a temporary file when the open flag is set', async function () {
+        const fileManager = createFakeFileManager();
+        const openSpy: SinonSpy = fake.resolves(true);
 
-test('runPreviewHandler writes the HTML report to a temporary file when the open flag is set', async () => {
-    const fileManager = createFakeFileManager();
-    const openSpy: SinonSpy = fake.resolves(true);
+        await runPreviewHandler({
+            log: () => undefined,
+            pageOutput: fake.resolves(undefined),
+            openFile: openSpy,
+            createTemporaryFilePath: () => '/var/folders/preview.html',
+            packtory: packtoryStub(emptyOutcome()),
+            spinnerRenderer: spinnerRendererStub(),
+            configLoader: configLoaderStub(),
+            fileManager,
+            flags: { open: true }
+        });
 
-    await runPreviewHandler({
-        log: () => undefined,
-        pageOutput: fake.resolves(undefined),
-        openFile: openSpy,
-        createTemporaryFilePath: () => '/var/folders/preview.html',
-        packtory: packtoryStub(emptyOutcome()),
-        spinnerRenderer: spinnerRendererStub(),
-        configLoader: configLoaderStub(),
-        fileManager,
-        flags: { open: true }
+        assert.strictEqual(openSpy.callCount, 1);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.strictEqual(fileManager.getWriteFileCall(0).filePath, '/var/folders/preview.html');
     });
 
-    assert.strictEqual(openSpy.callCount, 1);
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, '/var/folders/preview.html');
-});
+    test('runPreviewHandler logs the temporary file path when openFile reports failure', async function () {
+        const messages: string[] = [];
 
-test('runPreviewHandler logs the temporary file path when openFile reports failure', async () => {
-    const messages: string[] = [];
+        await runPreviewHandler({
+            log: (message) => {
+                messages.push(message);
+            },
+            pageOutput: fake.resolves(undefined),
+            openFile: fake.resolves(false),
+            createTemporaryFilePath: () => '/var/folders/preview.html',
+            packtory: packtoryStub(emptyOutcome()),
+            spinnerRenderer: spinnerRendererStub(),
+            configLoader: configLoaderStub(),
+            fileManager: createFakeFileManager(),
+            flags: { open: true }
+        });
 
-    await runPreviewHandler({
-        log: (message) => {
-            messages.push(message);
-        },
-        pageOutput: fake.resolves(undefined),
-        openFile: fake.resolves(false),
-        createTemporaryFilePath: () => '/var/folders/preview.html',
-        packtory: packtoryStub(emptyOutcome()),
-        spinnerRenderer: spinnerRendererStub(),
-        configLoader: configLoaderStub(),
-        fileManager: createFakeFileManager(),
-        flags: { open: true }
+        assert.deepStrictEqual(messages, ['/var/folders/preview.html']);
     });
-
-    assert.deepStrictEqual(messages, ['/var/folders/preview.html']);
 });

--- a/source/command-line-interface/runner/progress-wiring.test.ts
+++ b/source/command-line-interface/runner/progress-wiring.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import { registerProgressListeners } from './progress-wiring.ts';
@@ -32,87 +32,89 @@ function captureSpinner(): { readonly renderer: TerminalSpinnerRenderer; readonl
     return { renderer, calls };
 }
 
-test('registerProgressListeners adds a spinner when a scheduled event arrives', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+suite('progress-wiring', function () {
+    test('registerProgressListeners adds a spinner when a scheduled event arrives', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('scheduled', { packageName: 'pkg-a' });
+        broadcaster.provider.emit('scheduled', { packageName: 'pkg-a' });
 
-    assert.deepStrictEqual(sink.calls, [{ kind: 'add', id: 'pkg-a', label: 'pkg-a', message: 'Scheduled …' }]);
-});
+        assert.deepStrictEqual(sink.calls, [{ kind: 'add', id: 'pkg-a', label: 'pkg-a', message: 'Scheduled …' }]);
+    });
 
-test('registerProgressListeners stops the spinner with a failure on an error event', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+    test('registerProgressListeners stops the spinner with a failure on an error event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('error', { packageName: 'pkg-a', error: new Error('boom') });
+        broadcaster.provider.emit('error', { packageName: 'pkg-a', error: new Error('boom') });
 
-    assert.deepStrictEqual(sink.calls, [{ kind: 'stop', id: 'pkg-a', status: 'failure', message: 'boom' }]);
-});
+        assert.deepStrictEqual(sink.calls, [{ kind: 'stop', id: 'pkg-a', status: 'failure', message: 'boom' }]);
+    });
 
-test('registerProgressListeners reports already-published status on a done event', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+    test('registerProgressListeners reports already-published status on a done event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'already-published', version: '1.0.0' });
+        broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'already-published', version: '1.0.0' });
 
-    assert.deepStrictEqual(sink.calls, [
-        {
-            kind: 'stop',
-            id: 'pkg-a',
-            status: 'success',
-            message: 'Nothing has changed, published version 1.0.0 is already up-to-date'
-        }
-    ]);
-});
+        assert.deepStrictEqual(sink.calls, [
+            {
+                kind: 'stop',
+                id: 'pkg-a',
+                status: 'success',
+                message: 'Nothing has changed, published version 1.0.0 is already up-to-date'
+            }
+        ]);
+    });
 
-test('registerProgressListeners reports initial-version status on a done event', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+    test('registerProgressListeners reports initial-version status on a done event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'initial-version', version: '1.0.0' });
+        broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'initial-version', version: '1.0.0' });
 
-    assert.deepStrictEqual(sink.calls, [
-        { kind: 'stop', id: 'pkg-a', status: 'success', message: 'First version 1.0.0 has been published' }
-    ]);
-});
+        assert.deepStrictEqual(sink.calls, [
+            { kind: 'stop', id: 'pkg-a', status: 'success', message: 'First version 1.0.0 has been published' }
+        ]);
+    });
 
-test('registerProgressListeners falls back to "New version" for an unknown done status', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+    test('registerProgressListeners falls back to "New version" for an unknown done status', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'new-version', version: '2.0.0' });
+        broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'new-version', version: '2.0.0' });
 
-    assert.deepStrictEqual(sink.calls, [
-        { kind: 'stop', id: 'pkg-a', status: 'success', message: 'New version 2.0.0 published' }
-    ]);
-});
+        assert.deepStrictEqual(sink.calls, [
+            { kind: 'stop', id: 'pkg-a', status: 'success', message: 'New version 2.0.0 published' }
+        ]);
+    });
 
-test('registerProgressListeners updates the spinner message on a building event', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+    test('registerProgressListeners updates the spinner message on a building event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('building', { packageName: 'pkg-a', version: '1.2.3' });
+        broadcaster.provider.emit('building', { packageName: 'pkg-a', version: '1.2.3' });
 
-    assert.deepStrictEqual(sink.calls, [
-        { kind: 'updateMessage', id: 'pkg-a', message: 'Building package with version 1.2.3' }
-    ]);
-});
+        assert.deepStrictEqual(sink.calls, [
+            { kind: 'updateMessage', id: 'pkg-a', message: 'Building package with version 1.2.3' }
+        ]);
+    });
 
-test('registerProgressListeners updates the spinner message on a rebuilding event', () => {
-    const broadcaster = createProgressBroadcaster();
-    const sink = captureSpinner();
-    registerProgressListeners(broadcaster.consumer, sink.renderer);
+    test('registerProgressListeners updates the spinner message on a rebuilding event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-    broadcaster.provider.emit('rebuilding', { packageName: 'pkg-a', version: '1.2.4' });
+        broadcaster.provider.emit('rebuilding', { packageName: 'pkg-a', version: '1.2.4' });
 
-    assert.deepStrictEqual(sink.calls, [
-        { kind: 'updateMessage', id: 'pkg-a', message: 'Rebuilding package with version 1.2.4' }
-    ]);
+        assert.deepStrictEqual(sink.calls, [
+            { kind: 'updateMessage', id: 'pkg-a', message: 'Rebuilding package with version 1.2.4' }
+        ]);
+    });
 });

--- a/source/command-line-interface/runner/publish-handler.test.ts
+++ b/source/command-line-interface/runner/publish-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
@@ -32,58 +32,60 @@ async function captureMessages(
     return { code, messages };
 }
 
-test('runPublishHandler returns 0 and logs a success summary when the build succeeds', async () => {
-    const { code, messages } = await captureMessages(
-        { noDryRun: true, reportJson: false, reportHtml: false },
-        buildOutcome({
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/value matter to the handler
-            result: { isOk: true, isErr: false, value: [{ name: 'pkg-a' }] } as never
-        })
-    );
+suite('publish-handler', function () {
+    test('runPublishHandler returns 0 and logs a success summary when the build succeeds', async function () {
+        const { code, messages } = await captureMessages(
+            { noDryRun: true, reportJson: false, reportHtml: false },
+            buildOutcome({
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/value matter to the handler
+                result: { isOk: true, isErr: false, value: [{ name: 'pkg-a' }] } as never
+            })
+        );
 
-    assert.strictEqual(code, 0);
-    assert.ok(messages.some((message) => message.includes('all 1 package(s) have been published')));
-});
+        assert.strictEqual(code, 0);
+        assert.ok(messages.some((message) => message.includes('all 1 package(s) have been published')));
+    });
 
-test('runPublishHandler returns 1 and logs the publish failure when the build fails', async () => {
-    const { code, messages } = await captureMessages(
-        { noDryRun: true, reportJson: false, reportHtml: false },
-        buildOutcome({
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/error.type matter to the handler
-            result: { isOk: false, isErr: true, error: { type: 'config', issues: ['missing field'] } } as never
-        })
-    );
+    test('runPublishHandler returns 1 and logs the publish failure when the build fails', async function () {
+        const { code, messages } = await captureMessages(
+            { noDryRun: true, reportJson: false, reportHtml: false },
+            buildOutcome({
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/error.type matter to the handler
+                result: { isOk: false, isErr: true, error: { type: 'config', issues: ['missing field'] } } as never
+            })
+        );
 
-    assert.strictEqual(code, 1);
-    assert.ok(messages.some((message) => message.includes('The provided config is invalid')));
-});
+        assert.strictEqual(code, 1);
+        assert.ok(messages.some((message) => message.includes('The provided config is invalid')));
+    });
 
-test('runPublishHandler appends the dry-run reminder when noDryRun is false', async () => {
-    const { messages } = await captureMessages(
-        { noDryRun: false, reportJson: false, reportHtml: false },
-        buildOutcome()
-    );
+    test('runPublishHandler appends the dry-run reminder when noDryRun is false', async function () {
+        const { messages } = await captureMessages(
+            { noDryRun: false, reportJson: false, reportHtml: false },
+            buildOutcome()
+        );
 
-    assert.ok(messages.some((message) => message.includes('dry-run mode was enabled')));
-});
+        assert.ok(messages.some((message) => message.includes('dry-run mode was enabled')));
+    });
 
-test('runPublishHandler stops spinners exactly once when the build throws', async () => {
-    const stopAllSpy: SinonSpy = fake();
-    const spinner = { stopAll: stopAllSpy } as unknown as TerminalSpinnerRenderer;
-    const packtory = { buildAndPublishAll: fake.rejects(new Error('boom')) } as unknown as Packtory;
+    test('runPublishHandler stops spinners exactly once when the build throws', async function () {
+        const stopAllSpy: SinonSpy = fake();
+        const spinner = { stopAll: stopAllSpy } as unknown as TerminalSpinnerRenderer;
+        const packtory = { buildAndPublishAll: fake.rejects(new Error('boom')) } as unknown as Packtory;
 
-    try {
-        await runPublishHandler({
-            log: () => undefined,
-            packtory,
-            spinnerRenderer: spinner,
-            configLoader: configLoaderStub(),
-            fileManager: createFakeFileManager(),
-            flags: { noDryRun: true, reportJson: false, reportHtml: false }
-        });
-        assert.fail('Expected runPublishHandler to throw');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'boom');
-    }
-    assert.strictEqual(stopAllSpy.callCount, 1);
+        try {
+            await runPublishHandler({
+                log: () => undefined,
+                packtory,
+                spinnerRenderer: spinner,
+                configLoader: configLoaderStub(),
+                fileManager: createFakeFileManager(),
+                flags: { noDryRun: true, reportJson: false, reportHtml: false }
+            });
+            assert.fail('Expected runPublishHandler to throw');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'boom');
+        }
+        assert.strictEqual(stopAllSpy.callCount, 1);
+    });
 });

--- a/source/command-line-interface/runner/report-persistence.test.ts
+++ b/source/command-line-interface/runner/report-persistence.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { BuildReport, Packtory } from '../../packtory/packtory.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import { createEmptyReport, writeReports } from './report-persistence.ts';
@@ -14,37 +14,39 @@ const emptyReport: BuildReport = {
     aggregate: { crossBundleLinks: [] }
 };
 
-test('createEmptyReport returns a schema-version-1 report with no packages or aggregate links', () => {
-    const report = createEmptyReport();
+suite('report-persistence', function () {
+    test('createEmptyReport returns a schema-version-1 report with no packages or aggregate links', function () {
+        const report = createEmptyReport();
 
-    assert.strictEqual(report.schemaVersion, 1);
-    assert.deepStrictEqual(report.packages, {});
-    assert.deepStrictEqual(report.aggregate, { crossBundleLinks: [] });
-});
+        assert.strictEqual(report.schemaVersion, 1);
+        assert.deepStrictEqual(report.packages, {});
+        assert.deepStrictEqual(report.aggregate, { crossBundleLinks: [] });
+    });
 
-test('writeReports writes nothing when the report is undefined', async () => {
-    const fileManager = createFakeFileManager();
+    test('writeReports writes nothing when the report is undefined', async function () {
+        const fileManager = createFakeFileManager();
 
-    await writeReports(fileManager, undefined, emptyResult, { reportJson: true, reportHtml: true }, false);
+        await writeReports(fileManager, undefined, emptyResult, { reportJson: true, reportHtml: true }, false);
 
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
-});
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
 
-test('writeReports skips both formats when both flags are disabled', async () => {
-    const fileManager = createFakeFileManager();
+    test('writeReports skips both formats when both flags are disabled', async function () {
+        const fileManager = createFakeFileManager();
 
-    await writeReports(fileManager, emptyReport, emptyResult, { reportJson: false, reportHtml: false }, false);
+        await writeReports(fileManager, emptyReport, emptyResult, { reportJson: false, reportHtml: false }, false);
 
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
-});
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
 
-test('writeReports writes a JSON report when reportJson is enabled', async () => {
-    const fileManager = createFakeFileManager();
+    test('writeReports writes a JSON report when reportJson is enabled', async function () {
+        const fileManager = createFakeFileManager();
 
-    await writeReports(fileManager, emptyReport, emptyResult, { reportJson: true, reportHtml: false }, false);
+        await writeReports(fileManager, emptyReport, emptyResult, { reportJson: true, reportHtml: false }, false);
 
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    const call = fileManager.getWriteFileCall(0);
-    assert.strictEqual(call.filePath, 'packtory-report.json');
-    assert.deepStrictEqual(JSON.parse(call.content), emptyReport);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        const call = fileManager.getWriteFileCall(0);
+        assert.strictEqual(call.filePath, 'packtory-report.json');
+        assert.deepStrictEqual(JSON.parse(call.content), emptyReport);
+    });
 });

--- a/source/command-line-interface/runner/runner-symbols.test.ts
+++ b/source/command-line-interface/runner/runner-symbols.test.ts
@@ -1,16 +1,18 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { bold, green, red, yellow } from 'yoctocolors';
 import { getErrorSymbol, getSuccessSymbol, getWarningSymbol } from './runner-symbols.ts';
 
-test('getErrorSymbol returns a bold red mark', () => {
-    assert.strictEqual(getErrorSymbol(), bold(red('✖')));
-});
+suite('runner-symbols', function () {
+    test('getErrorSymbol returns a bold red mark', function () {
+        assert.strictEqual(getErrorSymbol(), bold(red('✖')));
+    });
 
-test('getSuccessSymbol returns a bold green check', () => {
-    assert.strictEqual(getSuccessSymbol(), bold(green('✔')));
-});
+    test('getSuccessSymbol returns a bold green check', function () {
+        assert.strictEqual(getSuccessSymbol(), bold(green('✔')));
+    });
 
-test('getWarningSymbol returns a yellow warning sign', () => {
-    assert.strictEqual(getWarningSymbol(), yellow('⚠'));
+    test('getWarningSymbol returns a yellow warning sign', function () {
+        assert.strictEqual(getWarningSymbol(), yellow('⚠'));
+    });
 });

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/publicly-writable-directories -- temp preview paths are intentional test fixtures */
 import assert from 'node:assert';
 import { stripVTControlCharacters } from 'node:util';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
 import { createProgressBroadcaster, type ProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
@@ -148,436 +148,309 @@ async function runPreview(
     return { exitCode, pageOutput, log };
 }
 
-test('publish command loads the config file and passes it to buildAndPublishAll()', async () => {
-    await expectCommandLoadsConfig('publish');
-});
-
-test('publish command runs in dry-run mode per default', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll });
-
-    await runner.run(['foo', 'bar', 'publish']);
-
-    assert.strictEqual(buildAndPublishAll.callCount, 1);
-    assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: false });
-});
-
-test('publish command runs not in dry-run mode when no-dry-run flag is set', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll });
-
-    await runner.run(['foo', 'bar', 'publish', '--no-dry-run']);
-
-    assert.strictEqual(buildAndPublishAll.callCount, 1);
-    assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: false, collectReport: false });
-});
-
-test('preview command loads the config file and passes it to buildAndPublishAll()', async () => {
-    await expectCommandLoadsConfig('preview');
-});
-
-test('preview command always runs in dry-run mode with collectReport enabled', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll });
-
-    await runner.run(['foo', 'bar', 'preview']);
-
-    assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: true });
-});
-
-test('returns exit code 0 when publish command had no errors', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll });
-
-    const exitCode = await runner.run(['foo', 'bar', 'publish']);
-
-    assert.strictEqual(exitCode, 0);
-});
-
-test('returns exit code 1 when publish command has errors', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'config', issues: [] })));
-    const runner = runnerFactory({ buildAndPublishAll });
-
-    const exitCode = await runner.run(['foo', 'bar', 'publish']);
-
-    assert.strictEqual(exitCode, 1);
-});
-
-test('returns exit code 1 instead of exiting the process when command parsing fails', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const log = fake();
-    const runner = runnerFactory({ buildAndPublishAll, log });
-
-    const exitCode = await runner.run(['foo', 'bar', 'not-a-command']);
-
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(buildAndPublishAll.callCount, 0);
-    assert.strictEqual(log.callCount, 1);
-    assert.match(String(log.firstCall.args[0]), /packtory --help/);
-});
-
-test('returns exit code 1 when the publish command name is misspelled', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll });
-
-    const exitCode = await runner.run(['foo', 'bar', 'publis']);
-
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(buildAndPublishAll.callCount, 0);
-});
-
-test('prints command help that includes the publish command name and description', async () => {
-    const help = await expectHelp(['--help']);
-
-    assert.ok(help.includes('publish'), 'Expected help output to include the publish command name');
-    assert.ok(
-        help.includes('Builds and publishes all packages (dry-run enabled by default).'),
-        'Expected help output to include the publish command description'
-    );
-    assert.ok(help.includes('preview'), 'Expected help output to include the preview command');
-});
-
-test('prints subcommand help that includes the full publish command path', async () => {
-    assert.match(await expectSubcommandHelp('publish'), /packtory publish/);
-});
-
-test('prints subcommand help that includes the full preview command path and --open flag', async () => {
-    const help = await expectSubcommandHelp('preview');
-
-    assert.match(help, /packtory preview/);
-    assert.match(help, /--open/);
-    assert.match(help, /Builds all packages in fresh dry-run mode and opens a human preview\./);
-});
-
-async function expectRunnerToRethrow(overrides: Overrides, expectedMessage: string): Promise<void> {
-    const runner = runnerFactory(overrides);
-    try {
-        await runner.run(['foo', 'bar', 'publish']);
-        assert.fail('Expected run() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, expectedMessage);
-    }
-}
-
-test('rethrows the error when buildAndPublishAll() throws', async () => {
-    await expectRunnerToRethrow({ buildAndPublishAll: fake.rejects(new Error('foo')) }, 'foo');
-});
-
-async function runWithIssues(
-    type: 'checks' | 'config',
-    issues: readonly string[]
-): Promise<{ readonly log: SinonSpy }> {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type, issues })));
-    const log = fake();
-    const runner = runnerFactory({ buildAndPublishAll, log });
-
-    await runner.run(['foo', 'bar', 'publish']);
-    return { log };
-}
-
-test('prints error summary when publish command encounters config errors', async () => {
-    const { log } = await runWithIssues('config', ['foo']);
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.firstCall.args, ['✖ The provided config is invalid, there are 1 issue(s)\n\n- foo']);
-});
-
-test('prints every config issue on its own bullet line', async () => {
-    const { log } = await runWithIssues('config', ['foo', 'bar']);
-    assert.deepStrictEqual(log.firstCall.args, [
-        '✖ The provided config is invalid, there are 2 issue(s)\n\n- foo\n- bar'
-    ]);
-});
-
-test('prints error summary when publish command encounters check errors', async () => {
-    const { log } = await runWithIssues('checks', ['foo']);
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.firstCall.args, ['✖ Checks failed, there are 1 issue(s)\n\n- foo']);
-});
-
-test('prints every check issue on its own bullet line', async () => {
-    const { log } = await runWithIssues('checks', ['foo', 'bar']);
-    assert.deepStrictEqual(log.firstCall.args, ['✖ Checks failed, there are 2 issue(s)\n\n- foo\n- bar']);
-});
-
-const dryRunNote =
-    '⚠  Note: dry-run mode was enabled, so there was nothing really published; add the --no-dry-run flag to disable dry-run mode';
-
-async function runPublishCapturingLog(
-    buildAndPublishAll: SinonSpy,
-    extraArgs: readonly string[] = []
-): Promise<SinonSpy> {
-    const log = fake();
-    const runner = runnerFactory({ buildAndPublishAll, log });
-    await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
-    return log;
-}
-
-const partialResultWithTwoFailures = toOutcome(
-    Result.err({
-        type: 'partial' as const,
-        succeeded: ['foo'],
-        failures: [new Error('first'), new Error('second')]
-    })
-);
-
-test('prints error summary and dry-run note when publish command encounters partial errors', async () => {
-    const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures));
-
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.firstCall.args, ['✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second']);
-    assert.deepStrictEqual(log.secondCall.args, [dryRunNote]);
-});
-
-test('prints error summary without dry-run note when publish command encounters partial errors and dry-run mode is disabled', async () => {
-    const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures), ['--no-dry-run']);
-
-    assert.strictEqual(log.callCount, 1);
-    assert.deepStrictEqual(log.firstCall.args, ['✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second']);
-});
-
-test('prints success summary and dry-run note when publish command had no errors', async () => {
-    const log = await runPublishCapturingLog(fake.resolves(toOutcome(Result.ok(['foo', 'bar']))));
-
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.firstCall.args, ['✔ Success: all 2 package(s) have been published']);
-    assert.deepStrictEqual(log.secondCall.args, [dryRunNote]);
-});
-
-test('prints success summary without dry-run note when publish command had no errors and dry-run mode is disabled', async () => {
-    const log = await runPublishCapturingLog(fake.resolves(toOutcome(Result.ok(['foo', 'bar']))), ['--no-dry-run']);
-
-    assert.strictEqual(log.callCount, 1);
-    assert.deepStrictEqual(log.firstCall.args, ['✔ Success: all 2 package(s) have been published']);
-});
-
-test('stops all spinners when buildAndPublishAll throws', async () => {
-    const stopAll = fake();
-    await expectRunnerToRethrow(
-        { buildAndPublishAll: fake.rejects(new Error('foo')), spinnerRenderer: { stopAll } },
-        'foo'
-    );
-    assert.strictEqual(stopAll.callCount, 1);
-});
-
-test('stops all spinners when buildAndPublishAll finishes without errors', async () => {
-    const stopAll = fake();
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { stopAll } });
-
-    await runner.run(['foo', 'bar', 'publish']);
-    assert.strictEqual(stopAll.callCount, 1);
-});
-
-test('adds a spinner when progressBroadcaster receives a "scheduled" event', async () => {
-    const add = fake();
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const progressBroadcaster = createProgressBroadcaster();
-    const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { add }, progressBroadcaster });
-
-    await runner.run(['foo', 'bar', 'publish']);
-    progressBroadcaster.provider.emit('scheduled', { packageName: 'foo' });
-
-    assert.strictEqual(add.callCount, 1);
-    assert.deepStrictEqual(add.firstCall.args, ['foo', 'foo', 'Scheduled …']);
-});
-
-async function runWithProgressEvent(
-    spinnerRenderer: NonNullable<Overrides['spinnerRenderer']>,
-    eventName: string,
-    eventPayload: unknown
-): Promise<ProgressBroadcaster> {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const progressBroadcaster = createProgressBroadcaster();
-    const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer, progressBroadcaster });
-
-    await runner.run(['foo', 'bar', 'publish']);
-    progressBroadcaster.provider.emit(eventName as never, eventPayload as never);
-    return progressBroadcaster;
-}
-
-test('stops a running spinner with failure status when progressBroadcaster receives an "error" event', async () => {
-    const stop = fake();
-    await runWithProgressEvent({ stop }, 'error', { packageName: 'foo', error: new Error('bar') });
-
-    assert.strictEqual(stop.callCount, 1);
-    assert.deepStrictEqual(stop.firstCall.args, ['foo', 'failure', 'bar']);
-});
-
-test('stops a running spinner with success status when progressBroadcaster receives an "done" event and already-published status', async () => {
-    const stop = fake();
-    await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'already-published' });
-
-    assert.strictEqual(stop.callCount, 1);
-    assert.deepStrictEqual(stop.firstCall.args, [
-        'foo',
-        'success',
-        'Nothing has changed, published version 1 is already up-to-date'
-    ]);
-});
-
-test('stops a running spinner with success status when progressBroadcaster receives an "done" event and initial-version status', async () => {
-    const stop = fake();
-    await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'initial-version' });
-
-    assert.strictEqual(stop.callCount, 1);
-    assert.deepStrictEqual(stop.firstCall.args, ['foo', 'success', 'First version 1 has been published']);
-});
-
-test('stops a running spinner with success status when progressBroadcaster receives an "done" event and new-version status', async () => {
-    const stop = fake();
-    await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'new-version' });
-
-    assert.strictEqual(stop.callCount, 1);
-    assert.deepStrictEqual(stop.firstCall.args, ['foo', 'success', 'New version 1 published']);
-});
-
-test('updates a running spinner message when a "building" event is received', async () => {
-    const updateMessage = fake();
-    await runWithProgressEvent({ updateMessage }, 'building', { packageName: 'foo', version: '1' });
-
-    assert.strictEqual(updateMessage.callCount, 1);
-    assert.deepStrictEqual(updateMessage.firstCall.args, ['foo', 'Building package with version 1']);
-});
-
-test('updates a running spinner message when a "rebuilding" event is received', async () => {
-    const updateMessage = fake();
-    await runWithProgressEvent({ updateMessage }, 'rebuilding', { packageName: 'foo', version: '1' });
-
-    assert.strictEqual(updateMessage.callCount, 1);
-    assert.deepStrictEqual(updateMessage.firstCall.args, ['foo', 'Rebuilding package with version 1']);
-});
-
-const sampleReport = createBuildReportFixture({
-    packages: {
-        'pkg-a': createPackageReportFixture({
-            outputs: {
-                tarball: {
-                    totalBytes: 20,
-                    entries: [
-                        createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
-                        createArtifactEntryFixture({
-                            path: 'index.js',
-                            sizeBytes: 18,
-                            sourcePath: '/workspace/index.js',
-                            badges: ['dead-code-elimination']
-                        })
-                    ]
-                }
-            },
-            timings: {}
-        })
-    }
-});
-
-function outcomeWithReport(result: unknown): {
-    readonly result: unknown;
-    readonly getReport: () => typeof sampleReport;
-} {
-    return {
-        result,
-        getReport: () => {
-            return sampleReport;
-        }
-    };
-}
-
-test('publish with --report-json requests collectReport: true', async () => {
-    await expectCollectReportFlag('--report-json');
-});
-
-test('publish with --report-html requests collectReport: true', async () => {
-    await expectCollectReportFlag('--report-html');
-});
-
-async function runPublishWithReport(extraArgs: readonly string[]): Promise<FakeFileManager> {
-    const fileManager = createFakeFileManager();
-    const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll, fileManager });
-    await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
-    return fileManager;
-}
-
-test('publish writes packtory-report.json when --report-json is set and getReport returns a report', async () => {
-    const fileManager = await runPublishWithReport(['--report-json']);
-
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, 'packtory-report.json');
-    const writtenContent = fileManager.getWriteFileCall(0).content;
-    assert.ok(writtenContent.endsWith('\n'), 'json report must end with a newline');
-    assert.deepStrictEqual(JSON.parse(writtenContent), sampleReport);
-});
-
-test('publish writes packtory-report.html when --report-html is set and getReport returns a report', async () => {
-    const fileManager = await runPublishWithReport(['--report-html']);
-
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, 'packtory-report.html');
-    const writtenContent = fileManager.getWriteFileCall(0).content;
-    assert.ok(writtenContent.startsWith('<!doctype html>'), 'html report must start with doctype');
-    assert.ok(writtenContent.includes('Dry run'));
-});
-
-test('publish writes report html in publish mode when dry-run is disabled', async () => {
-    const fileManager = await runPublishWithReport(['--report-html', '--no-dry-run']);
-
-    const writtenContent = fileManager.getWriteFileCall(0).content;
-    assert.ok(writtenContent.includes('Publish'));
-    assert.ok(!writtenContent.includes('<div class="mode-label">Dry run</div>'));
-});
-
-test('publish writes both report files when --report-json and --report-html are set', async () => {
-    const fileManager = await runPublishWithReport(['--report-json', '--report-html']);
-
-    const writtenPaths = fileManager.getAllWriteFileCalls().map((call): unknown => {
-        return call.filePath;
+suite('runner', function () {
+    test('publish command loads the config file and passes it to buildAndPublishAll()', async function () {
+        await expectCommandLoadsConfig('publish');
     });
-    assert.deepStrictEqual(writtenPaths, ['packtory-report.json', 'packtory-report.html']);
-});
 
-test('publish writes no report files when neither flag is set', async () => {
-    const fileManager = await runPublishWithReport([]);
+    test('publish command runs in dry-run mode per default', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll });
 
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
-});
+        await runner.run(['foo', 'bar', 'publish']);
 
-test('publish writes no report files when getReport returns undefined even with --report-json set', async () => {
-    const fileManager = createFakeFileManager();
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll, fileManager });
+        assert.strictEqual(buildAndPublishAll.callCount, 1);
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: false });
+    });
 
-    await runner.run(['foo', 'bar', 'publish', '--report-json']);
+    test('publish command runs not in dry-run mode when no-dry-run flag is set', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll });
 
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
-});
+        await runner.run(['foo', 'bar', 'publish', '--no-dry-run']);
 
-test('publish writes the report even when the build failed', async () => {
-    const fileManager = createFakeFileManager();
-    const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'config', issues: ['boom'] })));
-    const runner = runnerFactory({ buildAndPublishAll, fileManager });
+        assert.strictEqual(buildAndPublishAll.callCount, 1);
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: false, collectReport: false });
+    });
 
-    const exitCode = await runner.run(['foo', 'bar', 'publish', '--report-json']);
+    test('preview command loads the config file and passes it to buildAndPublishAll()', async function () {
+        await expectCommandLoadsConfig('preview');
+    });
 
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-});
+    test('preview command always runs in dry-run mode with collectReport enabled', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll });
 
-test('preview pages previewable output and does not print it directly to stdout', async () => {
-    const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-    const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
+        await runner.run(['foo', 'bar', 'preview']);
 
-    assert.strictEqual(exitCode, 0);
-    assert.strictEqual(pageOutput.callCount, 1);
-    assert.match(String(pageOutput.firstCall.args[0]), /Packtory preview/);
-    assert.match(String(pageOutput.firstCall.args[0]), /\[Dry run]/);
-    assert.strictEqual(log.callCount, 0);
-});
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: true });
+    });
 
-test('preview pages partial-success output and still exits with code 1', async () => {
-    const report = {
-        ...sampleReport,
+    test('returns exit code 0 when publish command had no errors', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll });
+
+        const exitCode = await runner.run(['foo', 'bar', 'publish']);
+
+        assert.strictEqual(exitCode, 0);
+    });
+
+    test('returns exit code 1 when publish command has errors', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'config', issues: [] })));
+        const runner = runnerFactory({ buildAndPublishAll });
+
+        const exitCode = await runner.run(['foo', 'bar', 'publish']);
+
+        assert.strictEqual(exitCode, 1);
+    });
+
+    test('returns exit code 1 instead of exiting the process when command parsing fails', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const log = fake();
+        const runner = runnerFactory({ buildAndPublishAll, log });
+
+        const exitCode = await runner.run(['foo', 'bar', 'not-a-command']);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(buildAndPublishAll.callCount, 0);
+        assert.strictEqual(log.callCount, 1);
+        assert.match(String(log.firstCall.args[0]), /packtory --help/);
+    });
+
+    test('returns exit code 1 when the publish command name is misspelled', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll });
+
+        const exitCode = await runner.run(['foo', 'bar', 'publis']);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(buildAndPublishAll.callCount, 0);
+    });
+
+    test('prints command help that includes the publish command name and description', async function () {
+        const help = await expectHelp(['--help']);
+
+        assert.ok(help.includes('publish'), 'Expected help output to include the publish command name');
+        assert.ok(
+            help.includes('Builds and publishes all packages (dry-run enabled by default).'),
+            'Expected help output to include the publish command description'
+        );
+        assert.ok(help.includes('preview'), 'Expected help output to include the preview command');
+    });
+
+    test('prints subcommand help that includes the full publish command path', async function () {
+        assert.match(await expectSubcommandHelp('publish'), /packtory publish/);
+    });
+
+    test('prints subcommand help that includes the full preview command path and --open flag', async function () {
+        const help = await expectSubcommandHelp('preview');
+
+        assert.match(help, /packtory preview/);
+        assert.match(help, /--open/);
+        assert.match(help, /Builds all packages in fresh dry-run mode and opens a human preview\./);
+    });
+
+    async function expectRunnerToRethrow(overrides: Overrides, expectedMessage: string): Promise<void> {
+        const runner = runnerFactory(overrides);
+        try {
+            await runner.run(['foo', 'bar', 'publish']);
+            assert.fail('Expected run() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, expectedMessage);
+        }
+    }
+
+    test('rethrows the error when buildAndPublishAll() throws', async function () {
+        await expectRunnerToRethrow({ buildAndPublishAll: fake.rejects(new Error('foo')) }, 'foo');
+    });
+
+    async function runWithIssues(
+        type: 'checks' | 'config',
+        issues: readonly string[]
+    ): Promise<{ readonly log: SinonSpy }> {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type, issues })));
+        const log = fake();
+        const runner = runnerFactory({ buildAndPublishAll, log });
+
+        await runner.run(['foo', 'bar', 'publish']);
+        return { log };
+    }
+
+    test('prints error summary when publish command encounters config errors', async function () {
+        const { log } = await runWithIssues('config', ['foo']);
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.firstCall.args, ['✖ The provided config is invalid, there are 1 issue(s)\n\n- foo']);
+    });
+
+    test('prints every config issue on its own bullet line', async function () {
+        const { log } = await runWithIssues('config', ['foo', 'bar']);
+        assert.deepStrictEqual(log.firstCall.args, [
+            '✖ The provided config is invalid, there are 2 issue(s)\n\n- foo\n- bar'
+        ]);
+    });
+
+    test('prints error summary when publish command encounters check errors', async function () {
+        const { log } = await runWithIssues('checks', ['foo']);
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.firstCall.args, ['✖ Checks failed, there are 1 issue(s)\n\n- foo']);
+    });
+
+    test('prints every check issue on its own bullet line', async function () {
+        const { log } = await runWithIssues('checks', ['foo', 'bar']);
+        assert.deepStrictEqual(log.firstCall.args, ['✖ Checks failed, there are 2 issue(s)\n\n- foo\n- bar']);
+    });
+
+    const dryRunNote =
+        '⚠  Note: dry-run mode was enabled, so there was nothing really published; add the --no-dry-run flag to disable dry-run mode';
+
+    async function runPublishCapturingLog(
+        buildAndPublishAll: SinonSpy,
+        extraArgs: readonly string[] = []
+    ): Promise<SinonSpy> {
+        const log = fake();
+        const runner = runnerFactory({ buildAndPublishAll, log });
+        await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
+        return log;
+    }
+
+    const partialResultWithTwoFailures = toOutcome(
+        Result.err({
+            type: 'partial' as const,
+            succeeded: ['foo'],
+            failures: [new Error('first'), new Error('second')]
+        })
+    );
+
+    test('prints error summary and dry-run note when publish command encounters partial errors', async function () {
+        const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures));
+
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.firstCall.args, ['✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second']);
+        assert.deepStrictEqual(log.secondCall.args, [dryRunNote]);
+    });
+
+    test('prints error summary without dry-run note when publish command encounters partial errors and dry-run mode is disabled', async function () {
+        const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures), ['--no-dry-run']);
+
+        assert.strictEqual(log.callCount, 1);
+        assert.deepStrictEqual(log.firstCall.args, ['✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second']);
+    });
+
+    test('prints success summary and dry-run note when publish command had no errors', async function () {
+        const log = await runPublishCapturingLog(fake.resolves(toOutcome(Result.ok(['foo', 'bar']))));
+
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.firstCall.args, ['✔ Success: all 2 package(s) have been published']);
+        assert.deepStrictEqual(log.secondCall.args, [dryRunNote]);
+    });
+
+    test('prints success summary without dry-run note when publish command had no errors and dry-run mode is disabled', async function () {
+        const log = await runPublishCapturingLog(fake.resolves(toOutcome(Result.ok(['foo', 'bar']))), ['--no-dry-run']);
+
+        assert.strictEqual(log.callCount, 1);
+        assert.deepStrictEqual(log.firstCall.args, ['✔ Success: all 2 package(s) have been published']);
+    });
+
+    test('stops all spinners when buildAndPublishAll throws', async function () {
+        const stopAll = fake();
+        await expectRunnerToRethrow(
+            { buildAndPublishAll: fake.rejects(new Error('foo')), spinnerRenderer: { stopAll } },
+            'foo'
+        );
+        assert.strictEqual(stopAll.callCount, 1);
+    });
+
+    test('stops all spinners when buildAndPublishAll finishes without errors', async function () {
+        const stopAll = fake();
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { stopAll } });
+
+        await runner.run(['foo', 'bar', 'publish']);
+        assert.strictEqual(stopAll.callCount, 1);
+    });
+
+    test('adds a spinner when progressBroadcaster receives a "scheduled" event', async function () {
+        const add = fake();
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const progressBroadcaster = createProgressBroadcaster();
+        const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { add }, progressBroadcaster });
+
+        await runner.run(['foo', 'bar', 'publish']);
+        progressBroadcaster.provider.emit('scheduled', { packageName: 'foo' });
+
+        assert.strictEqual(add.callCount, 1);
+        assert.deepStrictEqual(add.firstCall.args, ['foo', 'foo', 'Scheduled …']);
+    });
+
+    async function runWithProgressEvent(
+        spinnerRenderer: NonNullable<Overrides['spinnerRenderer']>,
+        eventName: string,
+        eventPayload: unknown
+    ): Promise<ProgressBroadcaster> {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const progressBroadcaster = createProgressBroadcaster();
+        const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer, progressBroadcaster });
+
+        await runner.run(['foo', 'bar', 'publish']);
+        progressBroadcaster.provider.emit(eventName as never, eventPayload as never);
+        return progressBroadcaster;
+    }
+
+    test('stops a running spinner with failure status when progressBroadcaster receives an "error" event', async function () {
+        const stop = fake();
+        await runWithProgressEvent({ stop }, 'error', { packageName: 'foo', error: new Error('bar') });
+
+        assert.strictEqual(stop.callCount, 1);
+        assert.deepStrictEqual(stop.firstCall.args, ['foo', 'failure', 'bar']);
+    });
+
+    test('stops a running spinner with success status when progressBroadcaster receives an "done" event and already-published status', async function () {
+        const stop = fake();
+        await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'already-published' });
+
+        assert.strictEqual(stop.callCount, 1);
+        assert.deepStrictEqual(stop.firstCall.args, [
+            'foo',
+            'success',
+            'Nothing has changed, published version 1 is already up-to-date'
+        ]);
+    });
+
+    test('stops a running spinner with success status when progressBroadcaster receives an "done" event and initial-version status', async function () {
+        const stop = fake();
+        await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'initial-version' });
+
+        assert.strictEqual(stop.callCount, 1);
+        assert.deepStrictEqual(stop.firstCall.args, ['foo', 'success', 'First version 1 has been published']);
+    });
+
+    test('stops a running spinner with success status when progressBroadcaster receives an "done" event and new-version status', async function () {
+        const stop = fake();
+        await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'new-version' });
+
+        assert.strictEqual(stop.callCount, 1);
+        assert.deepStrictEqual(stop.firstCall.args, ['foo', 'success', 'New version 1 published']);
+    });
+
+    test('updates a running spinner message when a "building" event is received', async function () {
+        const updateMessage = fake();
+        await runWithProgressEvent({ updateMessage }, 'building', { packageName: 'foo', version: '1' });
+
+        assert.strictEqual(updateMessage.callCount, 1);
+        assert.deepStrictEqual(updateMessage.firstCall.args, ['foo', 'Building package with version 1']);
+    });
+
+    test('updates a running spinner message when a "rebuilding" event is received', async function () {
+        const updateMessage = fake();
+        await runWithProgressEvent({ updateMessage }, 'rebuilding', { packageName: 'foo', version: '1' });
+
+        assert.strictEqual(updateMessage.callCount, 1);
+        assert.deepStrictEqual(updateMessage.firstCall.args, ['foo', 'Rebuilding package with version 1']);
+    });
+
+    const sampleReport = createBuildReportFixture({
         packages: {
-            'pkg-a': {
-                ...sampleReport.packages['pkg-a'],
+            'pkg-a': createPackageReportFixture({
                 outputs: {
                     tarball: {
                         totalBytes: 20,
@@ -587,134 +460,263 @@ test('preview pages partial-success output and still exits with code 1', async (
                                 path: 'index.js',
                                 sizeBytes: 18,
                                 sourcePath: '/workspace/index.js',
-                                status: 'unchanged',
-                                badges: []
+                                badges: ['dead-code-elimination']
                             })
                         ]
                     }
-                }
-            }
+                },
+                timings: {}
+            })
         }
-    };
-    const buildAndPublishAll = fake.resolves({
-        result: Result.err({
-            type: 'partial' as const,
-            succeeded: [createBuildResultFixture({ contents: [] })],
-            failures: [new Error('boom')]
-        }),
-        getReport: () => report
-    });
-    const { exitCode, pageOutput } = await runPreview(buildAndPublishAll);
-
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(pageOutput.callCount, 1);
-});
-
-test('preview prints failure-only output directly to stdout without paging', async () => {
-    const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'checks', issues: ['boom'] })));
-    const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
-
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(pageOutput.callCount, 0);
-    assert.strictEqual(log.callCount, 1);
-    assert.strictEqual(String(log.firstCall.args[0]), 'Packtory preview [Dry run]\nCheck failures\n- boom');
-});
-
-test('preview treats partial failures with no successful packages as failure-only output', async () => {
-    const buildAndPublishAll = fake.resolves(
-        outcomeWithReport(Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }))
-    );
-    const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
-
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(pageOutput.callCount, 0);
-    assert.strictEqual(log.callCount, 1);
-    assert.strictEqual(String(log.firstCall.args[0]), 'Packtory preview [Dry run]\nPackage failures\n- boom');
-});
-
-test('preview --open writes a temporary html report and invokes the opener', async () => {
-    const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-    const fileManager = createFakeFileManager();
-    const openFile = fake.resolves(true);
-    const log = fake();
-    const runner = runnerFactory({
-        buildAndPublishAll,
-        fileManager,
-        openFile,
-        log,
-        createTemporaryFilePath: () => '/tmp/packtory-preview-test.html'
     });
 
-    const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
-
-    assert.strictEqual(exitCode, 0);
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    assert.deepStrictEqual(fileManager.getWriteFileCall(0).filePath, '/tmp/packtory-preview-test.html');
-    assert.match(fileManager.getWriteFileCall(0).content, /^<!doctype html>/);
-    assert.strictEqual(openFile.callCount, 1);
-    assert.deepStrictEqual(openFile.firstCall.args, ['/tmp/packtory-preview-test.html']);
-    assert.strictEqual(log.callCount, 0);
-});
-
-test('preview --open prints the temp path only when opening fails', async () => {
-    const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-    const openFile = fake.resolves(false);
-    const log = fake();
-    const runner = runnerFactory({
-        buildAndPublishAll,
-        openFile,
-        log,
-        createTemporaryFilePath: () => '/tmp/packtory-preview-test.html'
-    });
-
-    const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
-
-    assert.strictEqual(exitCode, 0);
-    assert.strictEqual(log.callCount, 1);
-    assert.deepStrictEqual(log.firstCall.args, ['/tmp/packtory-preview-test.html']);
-});
-
-test('preview builds an empty fallback report when getReport returns undefined', async () => {
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
-    const log = fake();
-    const runner = runnerFactory({ buildAndPublishAll, log });
-
-    await runner.run(['foo', 'bar', 'preview']);
-
-    assert.strictEqual(String(log.firstCall.args[0]), 'Packtory preview [Dry run]\nCheck failures\n- boom');
-});
-
-test('preview --open writes an empty fallback report when getReport returns undefined', async () => {
-    const fileManager = createFakeFileManager();
-    const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
-    const runner = runnerFactory({
-        buildAndPublishAll,
-        fileManager,
-        createTemporaryFilePath: () => '/tmp/packtory-preview-fallback.html'
-    });
-
-    const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
-
-    assert.strictEqual(exitCode, 1);
-    assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
-    assert.strictEqual(fileManager.getWriteFileCall(0).filePath, '/tmp/packtory-preview-fallback.html');
-    assert.match(
-        fileManager.getWriteFileCall(0).content,
-        /&quot;aggregate&quot;: \{\s+&quot;crossBundleLinks&quot;: \[\]/u
-    );
-});
-
-test('preview stops all spinners when config loading fails before the build starts', async () => {
-    const stopAll = fake();
-    const loadConfig = fake.rejects(new Error('config boom'));
-    const runner = runnerFactory({ loadConfig, spinnerRenderer: { stopAll } });
-
-    try {
-        await runner.run(['foo', 'bar', 'preview']);
-        assert.fail('expected preview run to throw');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'config boom');
+    function outcomeWithReport(result: unknown): {
+        readonly result: unknown;
+        readonly getReport: () => typeof sampleReport;
+    } {
+        return {
+            result,
+            getReport: () => {
+                return sampleReport;
+            }
+        };
     }
 
-    assert.strictEqual(stopAll.callCount, 1);
+    test('publish with --report-json requests collectReport: true', async function () {
+        await expectCollectReportFlag('--report-json');
+    });
+
+    test('publish with --report-html requests collectReport: true', async function () {
+        await expectCollectReportFlag('--report-html');
+    });
+
+    async function runPublishWithReport(extraArgs: readonly string[]): Promise<FakeFileManager> {
+        const fileManager = createFakeFileManager();
+        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll, fileManager });
+        await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
+        return fileManager;
+    }
+
+    test('publish writes packtory-report.json when --report-json is set and getReport returns a report', async function () {
+        const fileManager = await runPublishWithReport(['--report-json']);
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.strictEqual(fileManager.getWriteFileCall(0).filePath, 'packtory-report.json');
+        const writtenContent = fileManager.getWriteFileCall(0).content;
+        assert.ok(writtenContent.endsWith('\n'), 'json report must end with a newline');
+        assert.deepStrictEqual(JSON.parse(writtenContent), sampleReport);
+    });
+
+    test('publish writes packtory-report.html when --report-html is set and getReport returns a report', async function () {
+        const fileManager = await runPublishWithReport(['--report-html']);
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.strictEqual(fileManager.getWriteFileCall(0).filePath, 'packtory-report.html');
+        const writtenContent = fileManager.getWriteFileCall(0).content;
+        assert.ok(writtenContent.startsWith('<!doctype html>'), 'html report must start with doctype');
+        assert.ok(writtenContent.includes('Dry run'));
+    });
+
+    test('publish writes report html in publish mode when dry-run is disabled', async function () {
+        const fileManager = await runPublishWithReport(['--report-html', '--no-dry-run']);
+
+        const writtenContent = fileManager.getWriteFileCall(0).content;
+        assert.ok(writtenContent.includes('Publish'));
+        assert.ok(!writtenContent.includes('<div class="mode-label">Dry run</div>'));
+    });
+
+    test('publish writes both report files when --report-json and --report-html are set', async function () {
+        const fileManager = await runPublishWithReport(['--report-json', '--report-html']);
+
+        const writtenPaths = fileManager.getAllWriteFileCalls().map((call): unknown => {
+            return call.filePath;
+        });
+        assert.deepStrictEqual(writtenPaths, ['packtory-report.json', 'packtory-report.html']);
+    });
+
+    test('publish writes no report files when neither flag is set', async function () {
+        const fileManager = await runPublishWithReport([]);
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
+
+    test('publish writes no report files when getReport returns undefined even with --report-json set', async function () {
+        const fileManager = createFakeFileManager();
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll, fileManager });
+
+        await runner.run(['foo', 'bar', 'publish', '--report-json']);
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
+
+    test('publish writes the report even when the build failed', async function () {
+        const fileManager = createFakeFileManager();
+        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'config', issues: ['boom'] })));
+        const runner = runnerFactory({ buildAndPublishAll, fileManager });
+
+        const exitCode = await runner.run(['foo', 'bar', 'publish', '--report-json']);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    });
+
+    test('preview pages previewable output and does not print it directly to stdout', async function () {
+        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(pageOutput.callCount, 1);
+        assert.match(String(pageOutput.firstCall.args[0]), /Packtory preview/);
+        assert.match(String(pageOutput.firstCall.args[0]), /\[Dry run]/);
+        assert.strictEqual(log.callCount, 0);
+    });
+
+    test('preview pages partial-success output and still exits with code 1', async function () {
+        const report = {
+            ...sampleReport,
+            packages: {
+                'pkg-a': {
+                    ...sampleReport.packages['pkg-a'],
+                    outputs: {
+                        tarball: {
+                            totalBytes: 20,
+                            entries: [
+                                createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
+                                createArtifactEntryFixture({
+                                    path: 'index.js',
+                                    sizeBytes: 18,
+                                    sourcePath: '/workspace/index.js',
+                                    status: 'unchanged',
+                                    badges: []
+                                })
+                            ]
+                        }
+                    }
+                }
+            }
+        };
+        const buildAndPublishAll = fake.resolves({
+            result: Result.err({
+                type: 'partial' as const,
+                succeeded: [createBuildResultFixture({ contents: [] })],
+                failures: [new Error('boom')]
+            }),
+            getReport: () => report
+        });
+        const { exitCode, pageOutput } = await runPreview(buildAndPublishAll);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(pageOutput.callCount, 1);
+    });
+
+    test('preview prints failure-only output directly to stdout without paging', async function () {
+        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'checks', issues: ['boom'] })));
+        const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(pageOutput.callCount, 0);
+        assert.strictEqual(log.callCount, 1);
+        assert.strictEqual(String(log.firstCall.args[0]), 'Packtory preview [Dry run]\nCheck failures\n- boom');
+    });
+
+    test('preview treats partial failures with no successful packages as failure-only output', async function () {
+        const buildAndPublishAll = fake.resolves(
+            outcomeWithReport(Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }))
+        );
+        const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(pageOutput.callCount, 0);
+        assert.strictEqual(log.callCount, 1);
+        assert.strictEqual(String(log.firstCall.args[0]), 'Packtory preview [Dry run]\nPackage failures\n- boom');
+    });
+
+    test('preview --open writes a temporary html report and invokes the opener', async function () {
+        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const fileManager = createFakeFileManager();
+        const openFile = fake.resolves(true);
+        const log = fake();
+        const runner = runnerFactory({
+            buildAndPublishAll,
+            fileManager,
+            openFile,
+            log,
+            createTemporaryFilePath: () => '/tmp/packtory-preview-test.html'
+        });
+
+        const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0).filePath, '/tmp/packtory-preview-test.html');
+        assert.match(fileManager.getWriteFileCall(0).content, /^<!doctype html>/);
+        assert.strictEqual(openFile.callCount, 1);
+        assert.deepStrictEqual(openFile.firstCall.args, ['/tmp/packtory-preview-test.html']);
+        assert.strictEqual(log.callCount, 0);
+    });
+
+    test('preview --open prints the temp path only when opening fails', async function () {
+        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const openFile = fake.resolves(false);
+        const log = fake();
+        const runner = runnerFactory({
+            buildAndPublishAll,
+            openFile,
+            log,
+            createTemporaryFilePath: () => '/tmp/packtory-preview-test.html'
+        });
+
+        const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(log.callCount, 1);
+        assert.deepStrictEqual(log.firstCall.args, ['/tmp/packtory-preview-test.html']);
+    });
+
+    test('preview builds an empty fallback report when getReport returns undefined', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
+        const log = fake();
+        const runner = runnerFactory({ buildAndPublishAll, log });
+
+        await runner.run(['foo', 'bar', 'preview']);
+
+        assert.strictEqual(String(log.firstCall.args[0]), 'Packtory preview [Dry run]\nCheck failures\n- boom');
+    });
+
+    test('preview --open writes an empty fallback report when getReport returns undefined', async function () {
+        const fileManager = createFakeFileManager();
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
+        const runner = runnerFactory({
+            buildAndPublishAll,
+            fileManager,
+            createTemporaryFilePath: () => '/tmp/packtory-preview-fallback.html'
+        });
+
+        const exitCode = await runner.run(['foo', 'bar', 'preview', '--open']);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.strictEqual(fileManager.getWriteFileCall(0).filePath, '/tmp/packtory-preview-fallback.html');
+        assert.match(
+            fileManager.getWriteFileCall(0).content,
+            /&quot;aggregate&quot;: \{\s+&quot;crossBundleLinks&quot;: \[\]/u
+        );
+    });
+
+    test('preview stops all spinners when config loading fails before the build starts', async function () {
+        const stopAll = fake();
+        const loadConfig = fake.rejects(new Error('config boom'));
+        const runner = runnerFactory({ loadConfig, spinnerRenderer: { stopAll } });
+
+        try {
+            await runner.run(['foo', 'bar', 'preview']);
+            assert.fail('expected preview run to throw');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'config boom');
+        }
+
+        assert.strictEqual(stopAll.callCount, 1);
+    });
 });

--- a/source/command-line-interface/spinner/line-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/line-spinner-renderer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { stripVTControlCharacters } from 'node:util';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import { createLineSpinnerRenderer } from './line-spinner-renderer.ts';
 
@@ -33,81 +33,83 @@ function expectErrorMessage(callback: () => void, expectedMessage: string): void
     }
 }
 
-test('add() logs the initial spinner message as a plain line', () => {
-    const { log, renderer } = createRendererWithLog();
+suite('line-spinner-renderer', function () {
+    test('add() logs the initial spinner message as a plain line', function () {
+        const { log, renderer } = createRendererWithLog();
 
-    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+        renderer.add('the-id', 'pkg-a', 'Scheduled ...');
 
-    assert.strictEqual(log.callCount, 1);
-    assert.deepStrictEqual(log.firstCall.args, ['pkg-a: Scheduled ...']);
-});
+        assert.strictEqual(log.callCount, 1);
+        assert.deepStrictEqual(log.firstCall.args, ['pkg-a: Scheduled ...']);
+    });
 
-test('updateMessage() logs message updates as plain lines', () => {
-    const { log, renderer } = createRendererWithLog();
+    test('updateMessage() logs message updates as plain lines', function () {
+        const { log, renderer } = createRendererWithLog();
 
-    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
-    renderer.updateMessage('the-id', 'Building package with version 1.2.3');
-
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.secondCall.args, ['pkg-a: Building package with version 1.2.3']);
-});
-
-test('add() throws when adding two spinners with the same id', () => {
-    const renderer = createRendererWithoutLog();
-
-    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
-
-    expectErrorMessage(() => {
-        renderer.add('the-id', 'pkg-a', 'Scheduled again');
-    }, 'Spinner with id the-id already exists');
-});
-
-test('updateMessage() throws when trying to change the message of a non-existing spinner', () => {
-    const renderer = createRendererWithoutLog();
-
-    expectErrorMessage(() => {
+        renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.updateMessage('the-id', 'Building package with version 1.2.3');
-    }, 'Spinner with id the-id does not exist');
-});
 
-test('stop() logs a success line with the final message', () => {
-    const { log, renderer } = createRendererWithLog();
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.secondCall.args, ['pkg-a: Building package with version 1.2.3']);
+    });
 
-    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
-    renderer.stop('the-id', 'success', 'First version 1.2.3 has been published');
+    test('add() throws when adding two spinners with the same id', function () {
+        const renderer = createRendererWithoutLog();
 
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.secondCall.args, ['✔ pkg-a: First version 1.2.3 has been published']);
-});
+        renderer.add('the-id', 'pkg-a', 'Scheduled ...');
 
-test('stop() logs a failure line with the final message', () => {
-    const { log, renderer } = createRendererWithLog();
+        expectErrorMessage(() => {
+            renderer.add('the-id', 'pkg-a', 'Scheduled again');
+        }, 'Spinner with id the-id already exists');
+    });
 
-    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
-    renderer.stop('the-id', 'failure', 'publish failed');
+    test('updateMessage() throws when trying to change the message of a non-existing spinner', function () {
+        const renderer = createRendererWithoutLog();
 
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.secondCall.args, ['✖ pkg-a: publish failed']);
-});
+        expectErrorMessage(() => {
+            renderer.updateMessage('the-id', 'Building package with version 1.2.3');
+        }, 'Spinner with id the-id does not exist');
+    });
 
-test('stop() throws when trying to stop a spinner that does not exist', () => {
-    const renderer = createRendererWithoutLog();
+    test('stop() logs a success line with the final message', function () {
+        const { log, renderer } = createRendererWithLog();
 
-    expectErrorMessage(() => {
+        renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+        renderer.stop('the-id', 'success', 'First version 1.2.3 has been published');
+
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.secondCall.args, ['✔ pkg-a: First version 1.2.3 has been published']);
+    });
+
+    test('stop() logs a failure line with the final message', function () {
+        const { log, renderer } = createRendererWithLog();
+
+        renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.stop('the-id', 'failure', 'publish failed');
-    }, 'Spinner with id the-id does not exist');
-});
 
-test('stopAll() clears tracked spinners without logging cancellation lines', () => {
-    const { log, renderer } = createRendererWithLog();
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.secondCall.args, ['✖ pkg-a: publish failed']);
+    });
 
-    renderer.add('the-id', 'pkg-a', 'Scheduled ...');
-    renderer.stopAll();
+    test('stop() throws when trying to stop a spinner that does not exist', function () {
+        const renderer = createRendererWithoutLog();
 
-    assert.strictEqual(log.callCount, 1);
+        expectErrorMessage(() => {
+            renderer.stop('the-id', 'failure', 'publish failed');
+        }, 'Spinner with id the-id does not exist');
+    });
 
-    renderer.add('the-id', 'pkg-a', 'Scheduled again');
+    test('stopAll() clears tracked spinners without logging cancellation lines', function () {
+        const { log, renderer } = createRendererWithLog();
 
-    assert.strictEqual(log.callCount, 2);
-    assert.deepStrictEqual(log.secondCall.args, ['pkg-a: Scheduled again']);
+        renderer.add('the-id', 'pkg-a', 'Scheduled ...');
+        renderer.stopAll();
+
+        assert.strictEqual(log.callCount, 1);
+
+        renderer.add('the-id', 'pkg-a', 'Scheduled again');
+
+        assert.strictEqual(log.callCount, 2);
+        assert.deepStrictEqual(log.secondCall.args, ['pkg-a: Scheduled again']);
+    });
 });

--- a/source/command-line-interface/spinner/spinner-boot.test.ts
+++ b/source/command-line-interface/spinner/spinner-boot.test.ts
@@ -1,79 +1,81 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import { bootSpinnerRuntime } from './spinner-boot.ts';
 import type { WorkerSpawnRequest } from './spinner-runtime.ts';
 
-test('bootSpinnerRuntime spawns the worker via the supplied spawn function', () => {
-    const spawnWorker = fake();
+suite('spinner-boot', function () {
+    test('bootSpinnerRuntime spawns the worker via the supplied spawn function', function () {
+        const spawnWorker = fake();
 
-    bootSpinnerRuntime({
-        spawnWorker: (request) => {
-            spawnWorker(request);
-        },
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 80,
-        initialLabel: 'lbl',
-        initialMessage: 'msg'
-    });
-
-    assert.strictEqual(spawnWorker.callCount, 1);
-    const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
-    assert.ok(request.buffer instanceof SharedArrayBuffer);
-    assert.strictEqual(typeof request.slotCount, 'number');
-});
-
-test('bootSpinnerRuntime writes the initial label and message to slot zero', () => {
-    const runtime = bootSpinnerRuntime({
-        spawnWorker: () => {
-            // noop
-        },
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 80,
-        initialLabel: 'packtory',
-        initialMessage: 'Starting …'
-    });
-
-    assert.deepStrictEqual(runtime.accessors.readSlot(0), {
-        state: 'running',
-        label: 'packtory',
-        message: 'Starting …'
-    });
-});
-
-test('bootSpinnerRuntime leaves all other slots empty', () => {
-    const runtime = bootSpinnerRuntime({
-        slotCount: 4,
-        spawnWorker: () => {
-            // noop
-        },
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 80,
-        initialLabel: 'lbl',
-        initialMessage: 'msg'
-    });
-
-    for (const slotIndex of [1, 2, 3]) {
-        assert.deepStrictEqual(runtime.accessors.readSlot(slotIndex), {
-            state: 'empty',
-            label: '',
-            message: ''
+        bootSpinnerRuntime({
+            spawnWorker: (request) => {
+                spawnWorker(request);
+            },
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 80,
+            initialLabel: 'lbl',
+            initialMessage: 'msg'
         });
-    }
-});
 
-test('bootSpinnerRuntime forwards runtime options like intervalMs and stdoutColumns', () => {
-    const runtime = bootSpinnerRuntime({
-        intervalMs: 25,
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 132,
-        spawnWorker: () => {
-            // noop
-        },
-        initialLabel: 'lbl',
-        initialMessage: 'msg'
+        assert.strictEqual(spawnWorker.callCount, 1);
+        const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
+        assert.ok(request.buffer instanceof SharedArrayBuffer);
+        assert.strictEqual(typeof request.slotCount, 'number');
     });
 
-    assert.strictEqual(runtime.accessors.getIntervalMs(), 25);
-    assert.strictEqual(runtime.accessors.getColumns(), 132);
+    test('bootSpinnerRuntime writes the initial label and message to slot zero', function () {
+        const runtime = bootSpinnerRuntime({
+            spawnWorker: () => {
+                // noop
+            },
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 80,
+            initialLabel: 'packtory',
+            initialMessage: 'Starting …'
+        });
+
+        assert.deepStrictEqual(runtime.accessors.readSlot(0), {
+            state: 'running',
+            label: 'packtory',
+            message: 'Starting …'
+        });
+    });
+
+    test('bootSpinnerRuntime leaves all other slots empty', function () {
+        const runtime = bootSpinnerRuntime({
+            slotCount: 4,
+            spawnWorker: () => {
+                // noop
+            },
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 80,
+            initialLabel: 'lbl',
+            initialMessage: 'msg'
+        });
+
+        for (const slotIndex of [1, 2, 3]) {
+            assert.deepStrictEqual(runtime.accessors.readSlot(slotIndex), {
+                state: 'empty',
+                label: '',
+                message: ''
+            });
+        }
+    });
+
+    test('bootSpinnerRuntime forwards runtime options like intervalMs and stdoutColumns', function () {
+        const runtime = bootSpinnerRuntime({
+            intervalMs: 25,
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 132,
+            spawnWorker: () => {
+                // noop
+            },
+            initialLabel: 'lbl',
+            initialMessage: 'msg'
+        });
+
+        assert.strictEqual(runtime.accessors.getIntervalMs(), 25);
+        assert.strictEqual(runtime.accessors.getColumns(), 132);
+    });
 });

--- a/source/command-line-interface/spinner/spinner-glyphs.test.ts
+++ b/source/command-line-interface/spinner/spinner-glyphs.test.ts
@@ -1,49 +1,51 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { clearEntireLine, cursorToColumnZero, cursorUp, formatLine } from './spinner-glyphs.ts';
 
 const escapeSequence = String.fromCodePoint(27);
 
-test('cursorToColumnZero is the carriage-return sequence', () => {
-    assert.strictEqual(cursorToColumnZero, '\r');
-});
+suite('spinner-glyphs', function () {
+    test('cursorToColumnZero is the carriage-return sequence', function () {
+        assert.strictEqual(cursorToColumnZero, '\r');
+    });
 
-test('clearEntireLine emits the ANSI clear-line escape sequence', () => {
-    assert.strictEqual(clearEntireLine, `${escapeSequence}[2K`);
-});
+    test('clearEntireLine emits the ANSI clear-line escape sequence', function () {
+        assert.strictEqual(clearEntireLine, `${escapeSequence}[2K`);
+    });
 
-test('cursorUp emits the ANSI cursor-up sequence for the requested number of lines', () => {
-    assert.strictEqual(cursorUp(3), `${escapeSequence}[3A`);
-});
+    test('cursorUp emits the ANSI cursor-up sequence for the requested number of lines', function () {
+        assert.strictEqual(cursorUp(3), `${escapeSequence}[3A`);
+    });
 
-test('formatLine renders a green check for a succeeded slot', () => {
-    const line = formatLine({ state: 'succeeded', label: 'pkg', message: 'done' }, 0, 80);
-    assert.ok(line.includes('✔'));
-    assert.ok(line.endsWith('pkg: done'));
-});
+    test('formatLine renders a green check for a succeeded slot', function () {
+        const line = formatLine({ state: 'succeeded', label: 'pkg', message: 'done' }, 0, 80);
+        assert.ok(line.includes('✔'));
+        assert.ok(line.endsWith('pkg: done'));
+    });
 
-test('formatLine renders a red cross for a failed slot', () => {
-    const line = formatLine({ state: 'failed', label: 'pkg', message: 'boom' }, 0, 80);
-    assert.ok(line.includes('✖'));
-});
+    test('formatLine renders a red cross for a failed slot', function () {
+        const line = formatLine({ state: 'failed', label: 'pkg', message: 'boom' }, 0, 80);
+        assert.ok(line.includes('✖'));
+    });
 
-test('formatLine renders a red cross for a canceled slot', () => {
-    const line = formatLine({ state: 'canceled', label: 'pkg', message: 'aborted' }, 0, 80);
-    assert.ok(line.includes('✖'));
-});
+    test('formatLine renders a red cross for a canceled slot', function () {
+        const line = formatLine({ state: 'canceled', label: 'pkg', message: 'aborted' }, 0, 80);
+        assert.ok(line.includes('✖'));
+    });
 
-test('formatLine cycles through spinner frames based on the frame index for a running slot', () => {
-    const frames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
-    const composed = formatLine({ state: 'running', label: 'pkg', message: 'go' }, 13, 80);
-    assert.ok(composed.startsWith(frames.charAt(13 % frames.length)));
-});
+    test('formatLine cycles through spinner frames based on the frame index for a running slot', function () {
+        const frames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+        const composed = formatLine({ state: 'running', label: 'pkg', message: 'go' }, 13, 80);
+        assert.ok(composed.startsWith(frames.charAt(13 % frames.length)));
+    });
 
-test('formatLine truncates the rendered line to the given column count', () => {
-    const composed = formatLine({ state: 'running', label: 'pkg', message: 'long-message-here' }, 0, 10);
-    assert.strictEqual(composed.length, 10);
-});
+    test('formatLine truncates the rendered line to the given column count', function () {
+        const composed = formatLine({ state: 'running', label: 'pkg', message: 'long-message-here' }, 0, 10);
+        assert.strictEqual(composed.length, 10);
+    });
 
-test('formatLine returns the full composed line when columns is zero or negative', () => {
-    const composed = formatLine({ state: 'running', label: 'pkg', message: 'x' }, 0, 0);
-    assert.ok(composed.endsWith('pkg: x'));
+    test('formatLine returns the full composed line when columns is zero or negative', function () {
+        const composed = formatLine({ state: 'running', label: 'pkg', message: 'x' }, 0, 0);
+        assert.ok(composed.endsWith('pkg: x'));
+    });
 });

--- a/source/command-line-interface/spinner/spinner-render-sequence.test.ts
+++ b/source/command-line-interface/spinner/spinner-render-sequence.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { buildRenderTickOutput } from './spinner-render-sequence.ts';
 import { createSpinnerSharedAccessors, createSpinnerSharedLayout } from './spinner-shared-state.ts';
 
@@ -9,40 +9,42 @@ function createAccessors(slotCount: number) {
     return createSpinnerSharedAccessors(buffer, layout);
 }
 
-test('buildRenderTickOutput returns no sequence when no slot is active and nothing was rendered before', () => {
-    const accessors = createAccessors(3);
-    const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
+suite('spinner-render-sequence', function () {
+    test('buildRenderTickOutput returns no sequence when no slot is active and nothing was rendered before', function () {
+        const accessors = createAccessors(3);
+        const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
 
-    assert.strictEqual(output.sequence, undefined);
-    assert.strictEqual(output.expectedLineCount, 0);
-});
+        assert.strictEqual(output.sequence, undefined);
+        assert.strictEqual(output.expectedLineCount, 0);
+    });
 
-test('buildRenderTickOutput renders one line per active slot and ends each line with a newline', () => {
-    const accessors = createAccessors(3);
-    accessors.writeSlot(0, 'running', 'pkg-a', 'go');
-    accessors.writeSlot(1, 'running', 'pkg-b', 'building');
+    test('buildRenderTickOutput renders one line per active slot and ends each line with a newline', function () {
+        const accessors = createAccessors(3);
+        accessors.writeSlot(0, 'running', 'pkg-a', 'go');
+        accessors.writeSlot(1, 'running', 'pkg-b', 'building');
 
-    const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
+        const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
 
-    assert.strictEqual(output.expectedLineCount, 2);
-    assert.ok(output.sequence?.endsWith('\n'));
-    const lineCount = output.sequence?.split('\n').length;
-    assert.strictEqual(lineCount, 3);
-});
+        assert.strictEqual(output.expectedLineCount, 2);
+        assert.ok(output.sequence?.endsWith('\n'));
+        const lineCount = output.sequence?.split('\n').length;
+        assert.strictEqual(lineCount, 3);
+    });
 
-test('buildRenderTickOutput prepends a cursor-up sequence equal to the previously rendered line count', () => {
-    const accessors = createAccessors(2);
-    accessors.writeSlot(0, 'running', 'pkg-a', 'go');
+    test('buildRenderTickOutput prepends a cursor-up sequence equal to the previously rendered line count', function () {
+        const accessors = createAccessors(2);
+        accessors.writeSlot(0, 'running', 'pkg-a', 'go');
 
-    const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 2, frameIndex: 0 });
+        const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 2, frameIndex: 0 });
 
-    assert.ok(output.sequence?.includes('[2A'));
-});
+        assert.ok(output.sequence?.includes('[2A'));
+    });
 
-test('buildRenderTickOutput surfaces the latest mutation counter from the shared accessors', () => {
-    const accessors = createAccessors(1);
-    accessors.writeSlot(0, 'running', 'pkg-a', 'go');
-    const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
+    test('buildRenderTickOutput surfaces the latest mutation counter from the shared accessors', function () {
+        const accessors = createAccessors(1);
+        accessors.writeSlot(0, 'running', 'pkg-a', 'go');
+        const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
 
-    assert.strictEqual(output.targetMutation, accessors.getLatestMutation());
+        assert.strictEqual(output.targetMutation, accessors.getLatestMutation());
+    });
 });

--- a/source/command-line-interface/spinner/spinner-runtime.test.ts
+++ b/source/command-line-interface/spinner/spinner-runtime.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createSpinnerRuntime, type WorkerSpawnRequest } from './spinner-runtime.ts';
 
 function captureSpawn(): {
@@ -16,57 +16,59 @@ function captureSpawn(): {
     };
 }
 
-test('createSpinnerRuntime applies the configured slot count and stores it on the runtime', () => {
-    const { spawn } = captureSpawn();
-    const runtime = createSpinnerRuntime({
-        slotCount: 5,
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 80,
-        spawnWorker: spawn
+suite('spinner-runtime', function () {
+    test('createSpinnerRuntime applies the configured slot count and stores it on the runtime', function () {
+        const { spawn } = captureSpawn();
+        const runtime = createSpinnerRuntime({
+            slotCount: 5,
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 80,
+            spawnWorker: spawn
+        });
+
+        assert.strictEqual(runtime.slotCount, 5);
+        assert.strictEqual(runtime.accessors.layout.slotCount, 5);
     });
 
-    assert.strictEqual(runtime.slotCount, 5);
-    assert.strictEqual(runtime.accessors.layout.slotCount, 5);
-});
+    test('createSpinnerRuntime defaults the slot count when none is provided', function () {
+        const { spawn } = captureSpawn();
+        const runtime = createSpinnerRuntime({ stdoutFileDescriptor: 1, stdoutColumns: 80, spawnWorker: spawn });
 
-test('createSpinnerRuntime defaults the slot count when none is provided', () => {
-    const { spawn } = captureSpawn();
-    const runtime = createSpinnerRuntime({ stdoutFileDescriptor: 1, stdoutColumns: 80, spawnWorker: spawn });
-
-    assert.strictEqual(runtime.slotCount, 64);
-});
-
-test('createSpinnerRuntime spawns the worker with the buffer, slot count and stdout fd', () => {
-    const { spawn, calls } = captureSpawn();
-    const runtime = createSpinnerRuntime({
-        slotCount: 4,
-        stdoutFileDescriptor: 7,
-        stdoutColumns: 80,
-        spawnWorker: spawn
+        assert.strictEqual(runtime.slotCount, 64);
     });
 
-    assert.strictEqual(calls.length, 1);
-    assert.strictEqual(calls[0]?.buffer, runtime.accessors.buffer);
-    assert.strictEqual(calls[0]?.slotCount, 4);
-    assert.strictEqual(calls[0]?.stdoutFileDescriptor, 7);
-});
+    test('createSpinnerRuntime spawns the worker with the buffer, slot count and stdout fd', function () {
+        const { spawn, calls } = captureSpawn();
+        const runtime = createSpinnerRuntime({
+            slotCount: 4,
+            stdoutFileDescriptor: 7,
+            stdoutColumns: 80,
+            spawnWorker: spawn
+        });
 
-test('createSpinnerRuntime initializes the shared accessors with the requested interval and columns', () => {
-    const { spawn } = captureSpawn();
-    const runtime = createSpinnerRuntime({
-        intervalMs: 120,
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 100,
-        spawnWorker: spawn
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0]?.buffer, runtime.accessors.buffer);
+        assert.strictEqual(calls[0]?.slotCount, 4);
+        assert.strictEqual(calls[0]?.stdoutFileDescriptor, 7);
     });
 
-    assert.strictEqual(runtime.accessors.getIntervalMs(), 120);
-    assert.strictEqual(runtime.accessors.getColumns(), 100);
-});
+    test('createSpinnerRuntime initializes the shared accessors with the requested interval and columns', function () {
+        const { spawn } = captureSpawn();
+        const runtime = createSpinnerRuntime({
+            intervalMs: 120,
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 100,
+            spawnWorker: spawn
+        });
 
-test('createSpinnerRuntime defaults the interval to 80ms when none is provided', () => {
-    const { spawn } = captureSpawn();
-    const runtime = createSpinnerRuntime({ stdoutFileDescriptor: 1, stdoutColumns: 80, spawnWorker: spawn });
+        assert.strictEqual(runtime.accessors.getIntervalMs(), 120);
+        assert.strictEqual(runtime.accessors.getColumns(), 100);
+    });
 
-    assert.strictEqual(runtime.accessors.getIntervalMs(), 80);
+    test('createSpinnerRuntime defaults the interval to 80ms when none is provided', function () {
+        const { spawn } = captureSpawn();
+        const runtime = createSpinnerRuntime({ stdoutFileDescriptor: 1, stdoutColumns: 80, spawnWorker: spawn });
+
+        assert.strictEqual(runtime.accessors.getIntervalMs(), 80);
+    });
 });

--- a/source/command-line-interface/spinner/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner/spinner-shared-state.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { runNodeProbe } from '../../test-libraries/run-node-probe.ts';
 import {
     createSpinnerSharedAccessors,
@@ -127,512 +127,514 @@ function runWaitScenario(scenario: WaitScenario): {
     return { atomics, mutation, result: accessors.waitForRenderedMutation(mutation, 10) };
 }
 
-test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', () => {
-    const layout = createSpinnerSharedLayout(2);
+suite('spinner-shared-state', function () {
+    test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', function () {
+        const layout = createSpinnerSharedLayout(2);
 
-    assert.strictEqual(layout.slotCount, 2);
-    assert.strictEqual(layout.headerByteLength, 24);
-    assert.strictEqual(layout.slotByteLength, 384);
-    assert.strictEqual(layout.bufferByteLength, 24 + 2 * 384);
-});
-
-test('setColumns and getColumns round-trip the value', () => {
-    const accessors = createAccessors();
-
-    accessors.setColumns(120);
-
-    assert.strictEqual(accessors.getColumns(), 120);
-});
-
-test('setIntervalMs and getIntervalMs round-trip the value', () => {
-    const accessors = createAccessors();
-
-    accessors.setIntervalMs(50);
-
-    assert.strictEqual(accessors.getIntervalMs(), 50);
-});
-
-test('markMutation increments and getLatestMutation reads the latest mutation number', () => {
-    const accessors = createAccessors();
-
-    assert.strictEqual(accessors.getLatestMutation(), 0);
-    assert.strictEqual(accessors.markMutation(), 1);
-    assert.strictEqual(accessors.markMutation(), 2);
-    assert.strictEqual(accessors.getLatestMutation(), 2);
-});
-
-test('waitForRenderedMutation returns true once the render was acknowledged', () => {
-    const accessors = createAccessors();
-    const mutation = accessors.markMutation();
-
-    accessors.acknowledgeRender(mutation);
-
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-});
-
-test('waitForRenderedMutation returns immediately without waiting when the render is already caught up', () => {
-    let mutation = 0;
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            return index === 4 ? mutation : realLoad(typedArray, index);
-        }
+        assert.strictEqual(layout.slotCount, 2);
+        assert.strictEqual(layout.headerByteLength, 24);
+        assert.strictEqual(layout.slotByteLength, 384);
+        assert.strictEqual(layout.bufferByteLength, 24 + 2 * 384);
     });
-    const accessors = createAccessors(4, { now: createNow([100, 100]), atomics });
-    mutation = accessors.markMutation();
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-    assert.strictEqual(atomics.waitCallCount, 0);
-});
+    test('setColumns and getColumns round-trip the value', function () {
+        const accessors = createAccessors();
 
-test('waitForRenderedMutation times out when the render was not acknowledged', () => {
-    const accessors = createAccessors();
-    const mutation = accessors.markMutation();
+        accessors.setColumns(120);
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 1), false);
-});
+        assert.strictEqual(accessors.getColumns(), 120);
+    });
 
-test('waitForRenderedMutation returns once the render catches up between loop checks', () => {
-    let renderedMutationLoadCount = 0;
-    let mutation = 0;
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                renderedMutationLoadCount += 1;
-                if (renderedMutationLoadCount === 1) {
+    test('setIntervalMs and getIntervalMs round-trip the value', function () {
+        const accessors = createAccessors();
+
+        accessors.setIntervalMs(50);
+
+        assert.strictEqual(accessors.getIntervalMs(), 50);
+    });
+
+    test('markMutation increments and getLatestMutation reads the latest mutation number', function () {
+        const accessors = createAccessors();
+
+        assert.strictEqual(accessors.getLatestMutation(), 0);
+        assert.strictEqual(accessors.markMutation(), 1);
+        assert.strictEqual(accessors.markMutation(), 2);
+        assert.strictEqual(accessors.getLatestMutation(), 2);
+    });
+
+    test('waitForRenderedMutation returns true once the render was acknowledged', function () {
+        const accessors = createAccessors();
+        const mutation = accessors.markMutation();
+
+        accessors.acknowledgeRender(mutation);
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    });
+
+    test('waitForRenderedMutation returns immediately without waiting when the render is already caught up', function () {
+        let mutation = 0;
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                return index === 4 ? mutation : realLoad(typedArray, index);
+            }
+        });
+        const accessors = createAccessors(4, { now: createNow([100, 100]), atomics });
+        mutation = accessors.markMutation();
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+        assert.strictEqual(atomics.waitCallCount, 0);
+    });
+
+    test('waitForRenderedMutation times out when the render was not acknowledged', function () {
+        const accessors = createAccessors();
+        const mutation = accessors.markMutation();
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 1), false);
+    });
+
+    test('waitForRenderedMutation returns once the render catches up between loop checks', function () {
+        let renderedMutationLoadCount = 0;
+        let mutation = 0;
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                if (index === 4) {
+                    renderedMutationLoadCount += 1;
+                    if (renderedMutationLoadCount === 1) {
+                        return 0;
+                    }
+                    return mutation;
+                }
+                return realLoad(typedArray, index);
+            }
+        });
+        const accessors = createAccessors(4, { atomics });
+        mutation = accessors.markMutation();
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+    });
+
+    test('waitForRenderedMutation waits with the current rendered mutation and the remaining timeout', function () {
+        let renderedMutationLoadCount = 0;
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                if (index === 4) {
+                    renderedMutationLoadCount += 1;
                     return 0;
                 }
-                return mutation;
+                return realLoad(typedArray, index);
+            },
+            wait() {
+                return 'timed-out';
             }
-            return realLoad(typedArray, index);
-        }
+        });
+        const accessors = createAccessors(4, { now: createNow([100, 105, 110]), atomics });
+        const mutation = accessors.markMutation();
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+        assert.strictEqual(atomics.waitCallCount, 1);
+        assert.strictEqual(renderedMutationLoadCount, 2);
+        assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
     });
-    const accessors = createAccessors(4, { atomics });
-    mutation = accessors.markMutation();
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-});
-
-test('waitForRenderedMutation waits with the current rendered mutation and the remaining timeout', () => {
-    let renderedMutationLoadCount = 0;
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                renderedMutationLoadCount += 1;
-                return 0;
+    test('waitForRenderedMutation returns true after a wait once the rendered mutation reaches the target', function () {
+        let renderedMutationLoadCount = 0;
+        let mutation = 0;
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                if (index === 4) {
+                    renderedMutationLoadCount += 1;
+                    return renderedMutationLoadCount === 1 ? 0 : mutation;
+                }
+                return realLoad(typedArray, index);
+            },
+            wait() {
+                return 'ok';
             }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return 'timed-out';
-        }
+        });
+        const accessors = createAccessors(4, { now: createNow([100, 100, 100]), atomics });
+        mutation = accessors.markMutation();
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+        assert.strictEqual(atomics.waitCallCount, 1);
+        assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
     });
-    const accessors = createAccessors(4, { now: createNow([100, 105, 110]), atomics });
-    const mutation = accessors.markMutation();
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
-    assert.strictEqual(atomics.waitCallCount, 1);
-    assert.strictEqual(renderedMutationLoadCount, 2);
-    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
-});
+    test('waitForRenderedMutation keeps waiting after a timeout when the rendered mutation still makes progress', function () {
+        const { atomics, result } = runWaitScenario({
+            now: [100, 100, 101, 101, 102],
+            renderedMutations: [0, 1, 1],
+            waitResults: ['timed-out', 'ok'],
+            targetOffset: 1
+        });
 
-test('waitForRenderedMutation returns true after a wait once the rendered mutation reaches the target', () => {
-    let renderedMutationLoadCount = 0;
-    let mutation = 0;
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                renderedMutationLoadCount += 1;
-                return renderedMutationLoadCount === 1 ? 0 : mutation;
+        assert.strictEqual(result, true);
+        assert.strictEqual(atomics.waitCallCount, 2);
+        assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+        assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 9]);
+    });
+
+    test('waitForRenderedMutation returns false when the remaining timeout grows without render progress', function () {
+        let renderedMutationLoadCount = 0;
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                if (index === 4) {
+                    renderedMutationLoadCount += 1;
+                    return 0;
+                }
+                return realLoad(typedArray, index);
+            },
+            wait() {
+                return 'ok';
             }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return 'ok';
-        }
-    });
-    const accessors = createAccessors(4, { now: createNow([100, 100, 100]), atomics });
-    mutation = accessors.markMutation();
+        });
+        const accessors = createAccessors(4, { now: createNow([100, 105, 90]), atomics });
+        const mutation = accessors.markMutation();
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-    assert.strictEqual(atomics.waitCallCount, 1);
-    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
-});
-
-test('waitForRenderedMutation keeps waiting after a timeout when the rendered mutation still makes progress', () => {
-    const { atomics, result } = runWaitScenario({
-        now: [100, 100, 101, 101, 102],
-        renderedMutations: [0, 1, 1],
-        waitResults: ['timed-out', 'ok'],
-        targetOffset: 1
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+        assert.strictEqual(atomics.waitCallCount, 1);
+        assert.strictEqual(renderedMutationLoadCount, 2);
     });
 
-    assert.strictEqual(result, true);
-    assert.strictEqual(atomics.waitCallCount, 2);
-    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
-    assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 9]);
-});
+    test('waitForRenderedMutation keeps polling when no progress was made but the remaining timeout still shrank', function () {
+        const { atomics, result } = runWaitScenario({
+            now: [100, 100, 101, 101, 102],
+            renderedMutations: [0, 0, 0],
+            waitResults: ['ok', 'ok']
+        });
 
-test('waitForRenderedMutation returns false when the remaining timeout grows without render progress', () => {
-    let renderedMutationLoadCount = 0;
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                renderedMutationLoadCount += 1;
-                return 0;
+        assert.strictEqual(result, true);
+        assert.strictEqual(atomics.waitCallCount, 2);
+        assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+        assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 9]);
+    });
+
+    test('waitForRenderedMutation keeps polling when no progress was made and the remaining timeout stayed the same', function () {
+        const { atomics, result } = runWaitScenario({
+            now: [100, 100, 100, 100, 101],
+            renderedMutations: [0, 0, 0],
+            waitResults: ['ok', 'ok']
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(atomics.waitCallCount, 2);
+        assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
+        assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 10]);
+    });
+
+    test('waitForRenderedMutation keeps polling when progress was made even if the remaining timeout grows', function () {
+        const { atomics, result } = runWaitScenario({
+            now: [100, 105, 90, 90, 91],
+            renderedMutations: [0, 1, 1],
+            waitResults: ['ok', 'ok'],
+            targetOffset: 1
+        });
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(atomics.waitCallCount, 2);
+        assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
+        assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 10]);
+    });
+
+    test('waitForRenderedMutation returns true when a wait step reaches the target mutation exactly', function () {
+        const renderedMutations = [0];
+        const waitResults: WaitResult[] = ['ok', 'timed-out'];
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                if (index === 4) {
+                    return renderedMutations.shift() ?? 0;
+                }
+                return realLoad(typedArray, index);
+            },
+            wait() {
+                return waitResults.shift() ?? 'timed-out';
             }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return 'ok';
-        }
-    });
-    const accessors = createAccessors(4, { now: createNow([100, 105, 90]), atomics });
-    const mutation = accessors.markMutation();
+        });
+        const accessors = createAccessors(4, { now: createNow([100, 100, 101, 102, 110]), atomics });
+        const mutation = accessors.markMutation();
+        renderedMutations.push(mutation, 0, 0);
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
-    assert.strictEqual(atomics.waitCallCount, 1);
-    assert.strictEqual(renderedMutationLoadCount, 2);
-});
-
-test('waitForRenderedMutation keeps polling when no progress was made but the remaining timeout still shrank', () => {
-    const { atomics, result } = runWaitScenario({
-        now: [100, 100, 101, 101, 102],
-        renderedMutations: [0, 0, 0],
-        waitResults: ['ok', 'ok']
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
+        assert.strictEqual(atomics.waitCallCount, 1);
     });
 
-    assert.strictEqual(result, true);
-    assert.strictEqual(atomics.waitCallCount, 2);
-    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
-    assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 9]);
-});
-
-test('waitForRenderedMutation keeps polling when no progress was made and the remaining timeout stayed the same', () => {
-    const { atomics, result } = runWaitScenario({
-        now: [100, 100, 100, 100, 101],
-        renderedMutations: [0, 0, 0],
-        waitResults: ['ok', 'ok']
-    });
-
-    assert.strictEqual(result, true);
-    assert.strictEqual(atomics.waitCallCount, 2);
-    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 10]);
-    assert.deepStrictEqual(atomics.waitCalls[1], [4, 0, 10]);
-});
-
-test('waitForRenderedMutation keeps polling when progress was made even if the remaining timeout grows', () => {
-    const { atomics, result } = runWaitScenario({
-        now: [100, 105, 90, 90, 91],
-        renderedMutations: [0, 1, 1],
-        waitResults: ['ok', 'ok'],
-        targetOffset: 1
-    });
-
-    assert.strictEqual(result, true);
-    assert.strictEqual(atomics.waitCallCount, 2);
-    assert.deepStrictEqual(atomics.waitCalls[0], [4, 0, 5]);
-    assert.deepStrictEqual(atomics.waitCalls[1], [4, 1, 10]);
-});
-
-test('waitForRenderedMutation returns true when a wait step reaches the target mutation exactly', () => {
-    const renderedMutations = [0];
-    const waitResults: WaitResult[] = ['ok', 'timed-out'];
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            if (index === 4) {
-                return renderedMutations.shift() ?? 0;
+    test('waitForRenderedMutation times out immediately when the timeout has already elapsed', function () {
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                return index === 4 ? 0 : realLoad(typedArray, index);
             }
-            return realLoad(typedArray, index);
-        },
-        wait() {
-            return waitResults.shift() ?? 'timed-out';
-        }
+        });
+        const accessors = createAccessors(4, { now: createNow([100, 110]), atomics });
+        const mutation = accessors.markMutation();
+
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
+        assert.strictEqual(atomics.waitCallCount, 0);
     });
-    const accessors = createAccessors(4, { now: createNow([100, 100, 101, 102, 110]), atomics });
-    const mutation = accessors.markMutation();
-    renderedMutations.push(mutation, 0, 0);
 
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), true);
-    assert.strictEqual(atomics.waitCallCount, 1);
-});
-
-test('waitForRenderedMutation times out immediately when the timeout has already elapsed', () => {
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            return index === 4 ? 0 : realLoad(typedArray, index);
-        }
-    });
-    const accessors = createAccessors(4, { now: createNow([100, 110]), atomics });
-    const mutation = accessors.markMutation();
-
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 10), false);
-    assert.strictEqual(atomics.waitCallCount, 0);
-});
-
-test('waitForRenderedMutation stops after the maximum number of polling attempts', () => {
-    const now = (() => {
-        let current = 0;
-        return () => {
-            current += 1;
-            return current;
-        };
-    })();
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            return index === 4 ? 0 : realLoad(typedArray, index);
-        },
-        wait() {
-            return 'ok';
-        }
-    });
-    const accessors = createAccessors(4, { now, atomics });
-    const mutation = accessors.markMutation();
-
-    assert.strictEqual(accessors.waitForRenderedMutation(mutation, 1000), false);
-    assert.strictEqual(atomics.waitCallCount, 256);
-});
-
-test('isShutdownRequested returns false until requestShutdown is called', () => {
-    const accessors = createAccessors();
-
-    assert.strictEqual(accessors.isShutdownRequested(), false);
-    accessors.requestShutdown();
-    assert.strictEqual(accessors.isShutdownRequested(), true);
-});
-
-test('writeSlot stores state, label and message readable via readSlot', () => {
-    const accessors = createAccessors();
-
-    accessors.writeSlot(1, 'running', 'label-one', 'message-one');
-
-    assert.deepStrictEqual(accessors.readSlot(1), {
-        state: 'running',
-        label: 'label-one',
-        message: 'message-one'
-    });
-});
-
-test('writeSlot handles each declared slot state', () => {
-    const accessors = createAccessors();
-
-    for (const state of ['running', 'succeeded', 'failed', 'canceled', 'empty'] as const) {
-        accessors.writeSlot(0, state, 'label', 'message');
-        assert.strictEqual(accessors.readSlot(0).state, state);
-    }
-});
-
-test('writeSlot replaces previously written content with shorter content', () => {
-    const accessors = createAccessors();
-
-    accessors.writeSlot(0, 'running', 'long-label', 'long-message-that-spans-many-bytes');
-    accessors.writeSlot(0, 'succeeded', 'short', 'tiny');
-
-    assert.deepStrictEqual(accessors.readSlot(0), {
-        state: 'succeeded',
-        label: 'short',
-        message: 'tiny'
-    });
-});
-
-const labelCapacity = 64;
-const messageCapacity = 256;
-
-test('writeSlot truncates labels that exceed the slot label capacity', () => {
-    const accessors = createAccessors();
-
-    accessors.writeSlot(0, 'running', 'a'.repeat(labelCapacity + 10), 'message');
-
-    assert.strictEqual(accessors.readSlot(0).label, 'a'.repeat(labelCapacity));
-});
-
-test('writeSlot truncates messages that exceed the slot message capacity', () => {
-    const accessors = createAccessors();
-
-    accessors.writeSlot(0, 'running', 'label', 'b'.repeat(messageCapacity + 10));
-
-    assert.strictEqual(accessors.readSlot(0).message, 'b'.repeat(messageCapacity));
-});
-
-test('readSlot returns empty strings when no content was written', () => {
-    const accessors = createAccessors();
-
-    assert.deepStrictEqual(accessors.readSlot(2), { state: 'empty', label: '', message: '' });
-});
-
-test('writeSlot and readSlot operate independently per slot', () => {
-    const accessors = createAccessors();
-
-    accessors.writeSlot(0, 'running', 'first-label', 'first-message');
-    accessors.writeSlot(2, 'failed', 'third-label', 'third-message');
-
-    assert.deepStrictEqual(accessors.readSlot(0), {
-        state: 'running',
-        label: 'first-label',
-        message: 'first-message'
-    });
-    assert.deepStrictEqual(accessors.readSlot(1), { state: 'empty', label: '', message: '' });
-    assert.deepStrictEqual(accessors.readSlot(2), {
-        state: 'failed',
-        label: 'third-label',
-        message: 'third-message'
-    });
-});
-
-test('setColumns and setIntervalMs default to zero before being assigned', () => {
-    const accessors = createAccessors();
-
-    assert.strictEqual(accessors.getColumns(), 0);
-    assert.strictEqual(accessors.getIntervalMs(), 0);
-});
-
-test('setColumns does not affect the stored interval', () => {
-    const accessors = createAccessors();
-    accessors.setIntervalMs(50);
-
-    accessors.setColumns(120);
-
-    assert.strictEqual(accessors.getIntervalMs(), 50);
-});
-
-test('setIntervalMs does not affect the stored columns', () => {
-    const accessors = createAccessors();
-    accessors.setColumns(120);
-
-    accessors.setIntervalMs(50);
-
-    assert.strictEqual(accessors.getColumns(), 120);
-});
-
-test('setColumns does not raise the shutdown flag', () => {
-    const accessors = createAccessors();
-
-    accessors.setColumns(120);
-
-    assert.strictEqual(accessors.isShutdownRequested(), false);
-});
-
-test('setIntervalMs does not raise the shutdown flag', () => {
-    const accessors = createAccessors();
-
-    accessors.setIntervalMs(50);
-
-    assert.strictEqual(accessors.isShutdownRequested(), false);
-});
-
-test('requestShutdown does not change the stored columns or interval', () => {
-    const accessors = createAccessors();
-    accessors.setColumns(120);
-    accessors.setIntervalMs(50);
-
-    accessors.requestShutdown();
-
-    assert.strictEqual(accessors.getColumns(), 120);
-    assert.strictEqual(accessors.getIntervalMs(), 50);
-});
-
-test('readSlot retries when the slot generation moves between the bracketing samples', () => {
-    let accessors = createAccessors();
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            const result = realLoad(typedArray, index);
-            if (index === 0 && atomics.loadCallCount === 1) {
-                accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
-                accessors.bumpSlotGeneration(0);
-            }
-            return result;
-        }
-    });
-    accessors = createAccessors(4, { atomics });
-    accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
-    accessors.bumpSlotGeneration(0);
-
-    const slot = accessors.readSlot(0);
-
-    assert.deepStrictEqual(slot, {
-        state: 'succeeded',
-        label: 'final-label',
-        message: 'final-message'
-    });
-    assert.ok(
-        atomics.loadCallCount >= 3,
-        `expected the seqlock retry path to read the generation at least three times, got ${atomics.loadCallCount}`
-    );
-});
-
-test('readSlot throws when the slot generation never stabilizes', () => {
-    let accessors = createAccessors();
-    const atomics = createControlledAtomics({
-        load(typedArray, index, realLoad) {
-            const result = realLoad(typedArray, index);
-            if (typedArray.constructor === Int32Array && index === 0) {
-                accessors.bumpSlotGeneration(0);
-            }
-            return result;
-        }
-    });
-    accessors = createAccessors(4, { atomics });
-    accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
-
-    assert.throws(() => {
-        accessors.readSlot(0);
-    }, /^Error: Failed to read a stable spinner slot snapshot$/u);
-    assert.strictEqual(atomics.loadCallCount, 1025);
-});
-
-test('readSlot completes promptly when a seqlock retry is needed', async () => {
-    const result = await runNodeProbe(
-        `
-            import {
-                createSpinnerSharedAccessors,
-                createSpinnerSharedLayout
-            } from './source/command-line-interface/spinner/spinner-shared-state.ts';
-
-            const layout = createSpinnerSharedLayout(1);
-            const buffer = new SharedArrayBuffer(layout.bufferByteLength);
-            let accessors = createSpinnerSharedAccessors(buffer, layout);
-
-            accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
-            accessors.bumpSlotGeneration(0);
-
-            let callCount = 0;
-            const atomics = {
-                add: Atomics.add,
-                load(...args) {
-                    const value = Atomics.load(...args);
-                    callCount += 1;
-                    if (callCount === 1) {
-                        accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
-                        accessors.bumpSlotGeneration(0);
-                    }
-                    return value;
-                },
-                notify: Atomics.notify,
-                store: Atomics.store,
-                wait: Atomics.wait
+    test('waitForRenderedMutation stops after the maximum number of polling attempts', function () {
+        const now = (() => {
+            let current = 0;
+            return () => {
+                current += 1;
+                return current;
             };
-            accessors = createSpinnerSharedAccessors(buffer, layout, { atomics });
-            accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
-            accessors.bumpSlotGeneration(0);
+        })();
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                return index === 4 ? 0 : realLoad(typedArray, index);
+            },
+            wait() {
+                return 'ok';
+            }
+        });
+        const accessors = createAccessors(4, { now, atomics });
+        const mutation = accessors.markMutation();
 
-            console.log(JSON.stringify(accessors.readSlot(0)));
-        `,
-        { timeoutMs: 3000 }
-    );
+        assert.strictEqual(accessors.waitForRenderedMutation(mutation, 1000), false);
+        assert.strictEqual(atomics.waitCallCount, 256);
+    });
 
-    assert.deepStrictEqual(result, { state: 'succeeded', label: 'final-label', message: 'final-message' });
-}).timeout(probeTestTimeoutMs);
+    test('isShutdownRequested returns false until requestShutdown is called', function () {
+        const accessors = createAccessors();
 
-test('writeSlot then readSlot round-trips strings that contain multi-byte UTF-8 characters', () => {
-    const accessors = createAccessors();
-    const decoder = new TextDecoder();
-    const multibyteLabel = decoder.decode(new Uint8Array([209, 130, 208, 181, 209, 129, 209, 130]));
-    const multibyteMessage = decoder.decode(new Uint8Array([195, 169, 36, 195, 188]));
+        assert.strictEqual(accessors.isShutdownRequested(), false);
+        accessors.requestShutdown();
+        assert.strictEqual(accessors.isShutdownRequested(), true);
+    });
 
-    accessors.writeSlot(0, 'running', multibyteLabel, multibyteMessage);
+    test('writeSlot stores state, label and message readable via readSlot', function () {
+        const accessors = createAccessors();
 
-    assert.deepStrictEqual(accessors.readSlot(0), {
-        state: 'running',
-        label: multibyteLabel,
-        message: multibyteMessage
+        accessors.writeSlot(1, 'running', 'label-one', 'message-one');
+
+        assert.deepStrictEqual(accessors.readSlot(1), {
+            state: 'running',
+            label: 'label-one',
+            message: 'message-one'
+        });
+    });
+
+    test('writeSlot handles each declared slot state', function () {
+        const accessors = createAccessors();
+
+        for (const state of ['running', 'succeeded', 'failed', 'canceled', 'empty'] as const) {
+            accessors.writeSlot(0, state, 'label', 'message');
+            assert.strictEqual(accessors.readSlot(0).state, state);
+        }
+    });
+
+    test('writeSlot replaces previously written content with shorter content', function () {
+        const accessors = createAccessors();
+
+        accessors.writeSlot(0, 'running', 'long-label', 'long-message-that-spans-many-bytes');
+        accessors.writeSlot(0, 'succeeded', 'short', 'tiny');
+
+        assert.deepStrictEqual(accessors.readSlot(0), {
+            state: 'succeeded',
+            label: 'short',
+            message: 'tiny'
+        });
+    });
+
+    const labelCapacity = 64;
+    const messageCapacity = 256;
+
+    test('writeSlot truncates labels that exceed the slot label capacity', function () {
+        const accessors = createAccessors();
+
+        accessors.writeSlot(0, 'running', 'a'.repeat(labelCapacity + 10), 'message');
+
+        assert.strictEqual(accessors.readSlot(0).label, 'a'.repeat(labelCapacity));
+    });
+
+    test('writeSlot truncates messages that exceed the slot message capacity', function () {
+        const accessors = createAccessors();
+
+        accessors.writeSlot(0, 'running', 'label', 'b'.repeat(messageCapacity + 10));
+
+        assert.strictEqual(accessors.readSlot(0).message, 'b'.repeat(messageCapacity));
+    });
+
+    test('readSlot returns empty strings when no content was written', function () {
+        const accessors = createAccessors();
+
+        assert.deepStrictEqual(accessors.readSlot(2), { state: 'empty', label: '', message: '' });
+    });
+
+    test('writeSlot and readSlot operate independently per slot', function () {
+        const accessors = createAccessors();
+
+        accessors.writeSlot(0, 'running', 'first-label', 'first-message');
+        accessors.writeSlot(2, 'failed', 'third-label', 'third-message');
+
+        assert.deepStrictEqual(accessors.readSlot(0), {
+            state: 'running',
+            label: 'first-label',
+            message: 'first-message'
+        });
+        assert.deepStrictEqual(accessors.readSlot(1), { state: 'empty', label: '', message: '' });
+        assert.deepStrictEqual(accessors.readSlot(2), {
+            state: 'failed',
+            label: 'third-label',
+            message: 'third-message'
+        });
+    });
+
+    test('setColumns and setIntervalMs default to zero before being assigned', function () {
+        const accessors = createAccessors();
+
+        assert.strictEqual(accessors.getColumns(), 0);
+        assert.strictEqual(accessors.getIntervalMs(), 0);
+    });
+
+    test('setColumns does not affect the stored interval', function () {
+        const accessors = createAccessors();
+        accessors.setIntervalMs(50);
+
+        accessors.setColumns(120);
+
+        assert.strictEqual(accessors.getIntervalMs(), 50);
+    });
+
+    test('setIntervalMs does not affect the stored columns', function () {
+        const accessors = createAccessors();
+        accessors.setColumns(120);
+
+        accessors.setIntervalMs(50);
+
+        assert.strictEqual(accessors.getColumns(), 120);
+    });
+
+    test('setColumns does not raise the shutdown flag', function () {
+        const accessors = createAccessors();
+
+        accessors.setColumns(120);
+
+        assert.strictEqual(accessors.isShutdownRequested(), false);
+    });
+
+    test('setIntervalMs does not raise the shutdown flag', function () {
+        const accessors = createAccessors();
+
+        accessors.setIntervalMs(50);
+
+        assert.strictEqual(accessors.isShutdownRequested(), false);
+    });
+
+    test('requestShutdown does not change the stored columns or interval', function () {
+        const accessors = createAccessors();
+        accessors.setColumns(120);
+        accessors.setIntervalMs(50);
+
+        accessors.requestShutdown();
+
+        assert.strictEqual(accessors.getColumns(), 120);
+        assert.strictEqual(accessors.getIntervalMs(), 50);
+    });
+
+    test('readSlot retries when the slot generation moves between the bracketing samples', function () {
+        let accessors = createAccessors();
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                const result = realLoad(typedArray, index);
+                if (index === 0 && atomics.loadCallCount === 1) {
+                    accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
+                    accessors.bumpSlotGeneration(0);
+                }
+                return result;
+            }
+        });
+        accessors = createAccessors(4, { atomics });
+        accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
+        accessors.bumpSlotGeneration(0);
+
+        const slot = accessors.readSlot(0);
+
+        assert.deepStrictEqual(slot, {
+            state: 'succeeded',
+            label: 'final-label',
+            message: 'final-message'
+        });
+        assert.ok(
+            atomics.loadCallCount >= 3,
+            `expected the seqlock retry path to read the generation at least three times, got ${atomics.loadCallCount}`
+        );
+    });
+
+    test('readSlot throws when the slot generation never stabilizes', function () {
+        let accessors = createAccessors();
+        const atomics = createControlledAtomics({
+            load(typedArray, index, realLoad) {
+                const result = realLoad(typedArray, index);
+                if (typedArray.constructor === Int32Array && index === 0) {
+                    accessors.bumpSlotGeneration(0);
+                }
+                return result;
+            }
+        });
+        accessors = createAccessors(4, { atomics });
+        accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
+
+        assert.throws(() => {
+            accessors.readSlot(0);
+        }, /^Error: Failed to read a stable spinner slot snapshot$/u);
+        assert.strictEqual(atomics.loadCallCount, 1025);
+    });
+
+    test('readSlot completes promptly when a seqlock retry is needed', async function () {
+        const result = await runNodeProbe(
+            `
+                import {
+                    createSpinnerSharedAccessors,
+                    createSpinnerSharedLayout
+                } from './source/command-line-interface/spinner/spinner-shared-state.ts';
+
+                const layout = createSpinnerSharedLayout(1);
+                const buffer = new SharedArrayBuffer(layout.bufferByteLength);
+                let accessors = createSpinnerSharedAccessors(buffer, layout);
+
+                accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
+                accessors.bumpSlotGeneration(0);
+
+                let callCount = 0;
+                const atomics = {
+                    add: Atomics.add,
+                    load(...args) {
+                        const value = Atomics.load(...args);
+                        callCount += 1;
+                        if (callCount === 1) {
+                            accessors.writeSlot(0, 'succeeded', 'final-label', 'final-message');
+                            accessors.bumpSlotGeneration(0);
+                        }
+                        return value;
+                    },
+                    notify: Atomics.notify,
+                    store: Atomics.store,
+                    wait: Atomics.wait
+                };
+                accessors = createSpinnerSharedAccessors(buffer, layout, { atomics });
+                accessors.writeSlot(0, 'running', 'pending-label', 'pending-message');
+                accessors.bumpSlotGeneration(0);
+
+                console.log(JSON.stringify(accessors.readSlot(0)));
+            `,
+            { timeoutMs: 3000 }
+        );
+
+        assert.deepStrictEqual(result, { state: 'succeeded', label: 'final-label', message: 'final-message' });
+    }).timeout(probeTestTimeoutMs);
+
+    test('writeSlot then readSlot round-trips strings that contain multi-byte UTF-8 characters', function () {
+        const accessors = createAccessors();
+        const decoder = new TextDecoder();
+        const multibyteLabel = decoder.decode(new Uint8Array([209, 130, 208, 181, 209, 129, 209, 130]));
+        const multibyteMessage = decoder.decode(new Uint8Array([195, 169, 36, 195, 188]));
+
+        accessors.writeSlot(0, 'running', multibyteLabel, multibyteMessage);
+
+        assert.deepStrictEqual(accessors.readSlot(0), {
+            state: 'running',
+            label: multibyteLabel,
+            message: multibyteMessage
+        });
     });
 });

--- a/source/command-line-interface/spinner/spinner-snapshots.test.ts
+++ b/source/command-line-interface/spinner/spinner-snapshots.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { findHighestActiveSlotIndex, readAllSnapshots, type SlotSnapshot } from './spinner-snapshots.ts';
 import { createSpinnerSharedAccessors, createSpinnerSharedLayout } from './spinner-shared-state.ts';
 
@@ -9,33 +9,35 @@ function createAccessors(slotCount: number) {
     return createSpinnerSharedAccessors(buffer, layout);
 }
 
-test('readAllSnapshots returns one snapshot per slot in slot order', () => {
-    const accessors = createAccessors(3);
-    accessors.writeSlot(0, 'running', 'pkg-a', 'msg-a');
-    accessors.writeSlot(1, 'succeeded', 'pkg-b', 'msg-b');
-    accessors.writeSlot(2, 'empty', '', '');
+suite('spinner-snapshots', function () {
+    test('readAllSnapshots returns one snapshot per slot in slot order', function () {
+        const accessors = createAccessors(3);
+        accessors.writeSlot(0, 'running', 'pkg-a', 'msg-a');
+        accessors.writeSlot(1, 'succeeded', 'pkg-b', 'msg-b');
+        accessors.writeSlot(2, 'empty', '', '');
 
-    const snapshots = readAllSnapshots(accessors);
+        const snapshots = readAllSnapshots(accessors);
 
-    assert.strictEqual(snapshots.length, 3);
-    assert.strictEqual(snapshots[0]?.label, 'pkg-a');
-    assert.strictEqual(snapshots[1]?.state, 'succeeded');
-});
+        assert.strictEqual(snapshots.length, 3);
+        assert.strictEqual(snapshots[0]?.label, 'pkg-a');
+        assert.strictEqual(snapshots[1]?.state, 'succeeded');
+    });
 
-test('findHighestActiveSlotIndex returns -1 when every slot is empty', () => {
-    const snapshots: readonly SlotSnapshot[] = [
-        { state: 'empty', label: '', message: '' },
-        { state: 'empty', label: '', message: '' }
-    ];
-    assert.strictEqual(findHighestActiveSlotIndex(snapshots), -1);
-});
+    test('findHighestActiveSlotIndex returns -1 when every slot is empty', function () {
+        const snapshots: readonly SlotSnapshot[] = [
+            { state: 'empty', label: '', message: '' },
+            { state: 'empty', label: '', message: '' }
+        ];
+        assert.strictEqual(findHighestActiveSlotIndex(snapshots), -1);
+    });
 
-test('findHighestActiveSlotIndex returns the index of the last non-empty slot', () => {
-    const snapshots: readonly SlotSnapshot[] = [
-        { state: 'running', label: 'a', message: '' },
-        { state: 'empty', label: '', message: '' },
-        { state: 'succeeded', label: 'c', message: '' },
-        { state: 'empty', label: '', message: '' }
-    ];
-    assert.strictEqual(findHighestActiveSlotIndex(snapshots), 2);
+    test('findHighestActiveSlotIndex returns the index of the last non-empty slot', function () {
+        const snapshots: readonly SlotSnapshot[] = [
+            { state: 'running', label: 'a', message: '' },
+            { state: 'empty', label: '', message: '' },
+            { state: 'succeeded', label: 'c', message: '' },
+            { state: 'empty', label: '', message: '' }
+        ];
+        assert.strictEqual(findHighestActiveSlotIndex(snapshots), 2);
+    });
 });

--- a/source/command-line-interface/spinner/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner/spinner-worker-backend.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import {
     createSpinnerSharedAccessors,
@@ -48,135 +48,137 @@ function collectShutdownWaitCalls(intervalMs = 0): readonly (readonly [number, n
     return waitForRenderedMutationCalls;
 }
 
-test('createSpinnerRuntime sets the shared buffer up with the resolved interval and column count', () => {
-    const spawnWorker = fake();
+suite('spinner-worker-backend', function () {
+    test('createSpinnerRuntime sets the shared buffer up with the resolved interval and column count', function () {
+        const spawnWorker = fake();
 
-    const runtime = createSpinnerRuntime({
-        slotCount: 8,
-        intervalMs: 25,
-        stdoutFileDescriptor: 7,
-        stdoutColumns: 132,
-        spawnWorker: (request) => {
-            spawnWorker(request);
-        }
+        const runtime = createSpinnerRuntime({
+            slotCount: 8,
+            intervalMs: 25,
+            stdoutFileDescriptor: 7,
+            stdoutColumns: 132,
+            spawnWorker: (request) => {
+                spawnWorker(request);
+            }
+        });
+
+        assert.strictEqual(runtime.slotCount, 8);
+        assert.strictEqual(runtime.accessors.getIntervalMs(), 25);
+        assert.strictEqual(runtime.accessors.getColumns(), 132);
     });
 
-    assert.strictEqual(runtime.slotCount, 8);
-    assert.strictEqual(runtime.accessors.getIntervalMs(), 25);
-    assert.strictEqual(runtime.accessors.getColumns(), 132);
-});
+    test('createSpinnerRuntime hands the spawn helper the buffer, slot count and stdout file descriptor', function () {
+        const spawnWorker = fake();
 
-test('createSpinnerRuntime hands the spawn helper the buffer, slot count and stdout file descriptor', () => {
-    const spawnWorker = fake();
+        const runtime = createSpinnerRuntime({
+            slotCount: 2,
+            stdoutFileDescriptor: 5,
+            stdoutColumns: 120,
+            spawnWorker: (request) => {
+                spawnWorker(request);
+            }
+        });
 
-    const runtime = createSpinnerRuntime({
-        slotCount: 2,
-        stdoutFileDescriptor: 5,
-        stdoutColumns: 120,
-        spawnWorker: (request) => {
-            spawnWorker(request);
-        }
+        assert.strictEqual(spawnWorker.callCount, 1);
+        const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
+        assert.strictEqual(request.buffer, runtime.accessors.buffer);
+        assert.strictEqual(request.slotCount, 2);
+        assert.strictEqual(request.stdoutFileDescriptor, 5);
     });
 
-    assert.strictEqual(spawnWorker.callCount, 1);
-    const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
-    assert.strictEqual(request.buffer, runtime.accessors.buffer);
-    assert.strictEqual(request.slotCount, 2);
-    assert.strictEqual(request.stdoutFileDescriptor, 5);
-});
+    test('createSpinnerRuntime falls back to default slot and interval settings', function () {
+        const spawnWorker = fake();
 
-test('createSpinnerRuntime falls back to default slot and interval settings', () => {
-    const spawnWorker = fake();
+        const runtime = createSpinnerRuntime({
+            stdoutFileDescriptor: 1,
+            stdoutColumns: 80,
+            spawnWorker: (request) => {
+                spawnWorker(request);
+            }
+        });
 
-    const runtime = createSpinnerRuntime({
-        stdoutFileDescriptor: 1,
-        stdoutColumns: 80,
-        spawnWorker: (request) => {
-            spawnWorker(request);
-        }
+        assert.strictEqual(runtime.slotCount, 64);
+        assert.strictEqual(runtime.accessors.getIntervalMs(), 80);
+        assert.strictEqual(runtime.accessors.getColumns(), 80);
     });
 
-    assert.strictEqual(runtime.slotCount, 64);
-    assert.strictEqual(runtime.accessors.getIntervalMs(), 80);
-    assert.strictEqual(runtime.accessors.getColumns(), 80);
-});
+    test('createWorkerSpinnerBackend.add stores a running slot in the supplied runtime', function () {
+        const { runtime, accessors } = buildRuntime();
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.add stores a running slot in the supplied runtime', () => {
-    const { runtime, accessors } = buildRuntime();
-    const backend = createWorkerSpinnerBackend({ runtime });
+        backend.add(2, 'pkg', 'starting');
 
-    backend.add(2, 'pkg', 'starting');
+        assert.deepStrictEqual(accessors.readSlot(2), { state: 'running', label: 'pkg', message: 'starting' });
+        assert.strictEqual(accessors.getLatestMutation(), 1);
+    });
 
-    assert.deepStrictEqual(accessors.readSlot(2), { state: 'running', label: 'pkg', message: 'starting' });
-    assert.strictEqual(accessors.getLatestMutation(), 1);
-});
+    test('createWorkerSpinnerBackend.update writes a new running slot value', function () {
+        const { runtime, accessors } = buildRuntime();
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.update writes a new running slot value', () => {
-    const { runtime, accessors } = buildRuntime();
-    const backend = createWorkerSpinnerBackend({ runtime });
+        backend.add(0, 'pkg', 'one');
+        backend.update(0, 'pkg', 'two');
 
-    backend.add(0, 'pkg', 'one');
-    backend.update(0, 'pkg', 'two');
+        assert.deepStrictEqual(accessors.readSlot(0), { state: 'running', label: 'pkg', message: 'two' });
+        assert.strictEqual(accessors.getLatestMutation(), 2);
+    });
 
-    assert.deepStrictEqual(accessors.readSlot(0), { state: 'running', label: 'pkg', message: 'two' });
-    assert.strictEqual(accessors.getLatestMutation(), 2);
-});
+    test('createWorkerSpinnerBackend.finish records the finished status', function () {
+        const { runtime, accessors } = buildRuntime();
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.finish records the finished status', () => {
-    const { runtime, accessors } = buildRuntime();
-    const backend = createWorkerSpinnerBackend({ runtime });
+        backend.finish(1, 'succeeded', 'pkg', 'done');
 
-    backend.finish(1, 'succeeded', 'pkg', 'done');
+        assert.deepStrictEqual(accessors.readSlot(1), { state: 'succeeded', label: 'pkg', message: 'done' });
+        assert.strictEqual(accessors.getLatestMutation(), 1);
+    });
 
-    assert.deepStrictEqual(accessors.readSlot(1), { state: 'succeeded', label: 'pkg', message: 'done' });
-    assert.strictEqual(accessors.getLatestMutation(), 1);
-});
+    test('createWorkerSpinnerBackend.add throws when the slot index is at or beyond the runtime capacity', function () {
+        const { runtime } = buildRuntime(2);
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.add throws when the slot index is at or beyond the runtime capacity', () => {
-    const { runtime } = buildRuntime(2);
-    const backend = createWorkerSpinnerBackend({ runtime });
+        assert.throws(() => {
+            backend.add(2, 'pkg', 'msg');
+        }, /Spinner slot index 2 exceeds backend capacity 2; increase slotCount/u);
+    });
 
-    assert.throws(() => {
-        backend.add(2, 'pkg', 'msg');
-    }, /Spinner slot index 2 exceeds backend capacity 2; increase slotCount/u);
-});
+    test('createWorkerSpinnerBackend.update throws when the slot index is beyond the runtime capacity', function () {
+        const { runtime } = buildRuntime(1);
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.update throws when the slot index is beyond the runtime capacity', () => {
-    const { runtime } = buildRuntime(1);
-    const backend = createWorkerSpinnerBackend({ runtime });
+        assert.throws(() => {
+            backend.update(5, 'pkg', 'msg');
+        }, /exceeds backend capacity 1/u);
+    });
 
-    assert.throws(() => {
-        backend.update(5, 'pkg', 'msg');
-    }, /exceeds backend capacity 1/u);
-});
+    test('createWorkerSpinnerBackend.finish throws when the slot index is beyond the runtime capacity', function () {
+        const { runtime } = buildRuntime(1);
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.finish throws when the slot index is beyond the runtime capacity', () => {
-    const { runtime } = buildRuntime(1);
-    const backend = createWorkerSpinnerBackend({ runtime });
+        assert.throws(() => {
+            backend.finish(5, 'failed', 'pkg', 'msg');
+        }, /exceeds backend capacity 1/u);
+    });
 
-    assert.throws(() => {
-        backend.finish(5, 'failed', 'pkg', 'msg');
-    }, /exceeds backend capacity 1/u);
-});
+    test('createWorkerSpinnerBackend.shutdown forwards the shutdown signal to the supplied runtime', function () {
+        const { runtime, accessors } = buildRuntime();
+        const backend = createWorkerSpinnerBackend({ runtime });
 
-test('createWorkerSpinnerBackend.shutdown forwards the shutdown signal to the supplied runtime', () => {
-    const { runtime, accessors } = buildRuntime();
-    const backend = createWorkerSpinnerBackend({ runtime });
+        backend.shutdown();
 
-    backend.shutdown();
+        assert.strictEqual(accessors.isShutdownRequested(), true);
+        assert.strictEqual(accessors.getLatestMutation(), 1);
+    });
 
-    assert.strictEqual(accessors.isShutdownRequested(), true);
-    assert.strictEqual(accessors.getLatestMutation(), 1);
-});
+    test('createWorkerSpinnerBackend.shutdown waits for the render acknowledgement when the worker interval is positive', function () {
+        assert.deepStrictEqual(collectShutdownWaitCalls(25), [[1, 100]]);
+    });
 
-test('createWorkerSpinnerBackend.shutdown waits for the render acknowledgement when the worker interval is positive', () => {
-    assert.deepStrictEqual(collectShutdownWaitCalls(25), [[1, 100]]);
-});
+    test('createWorkerSpinnerBackend.shutdown uses the interval-derived timeout when it exceeds the minimum', function () {
+        assert.deepStrictEqual(collectShutdownWaitCalls(80), [[1, 320]]);
+    });
 
-test('createWorkerSpinnerBackend.shutdown uses the interval-derived timeout when it exceeds the minimum', () => {
-    assert.deepStrictEqual(collectShutdownWaitCalls(80), [[1, 320]]);
-});
-
-test('createWorkerSpinnerBackend.shutdown skips waiting when the worker interval is zero', () => {
-    assert.deepStrictEqual(collectShutdownWaitCalls(), []);
+    test('createWorkerSpinnerBackend.shutdown skips waiting when the worker interval is zero', function () {
+        assert.deepStrictEqual(collectShutdownWaitCalls(), []);
+    });
 });

--- a/source/command-line-interface/spinner/spinner-worker-loop.test.ts
+++ b/source/command-line-interface/spinner/spinner-worker-loop.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     createSpinnerSharedAccessors,
     createSpinnerSharedLayout,
@@ -108,250 +108,252 @@ function createHarness(slotCount: number, stdoutFileDescriptor = 1): Harness {
     };
 }
 
-test('startSpinnerWorker schedules the ticker with the interval stored in the shared buffer', () => {
-    const { input, accessors } = buildInput(1);
-    accessors.setIntervalMs(40);
-    const captured: { ms?: number } = {};
+suite('spinner-worker-loop', function () {
+    test('startSpinnerWorker schedules the ticker with the interval stored in the shared buffer', function () {
+        const { input, accessors } = buildInput(1);
+        accessors.setIntervalMs(40);
+        const captured: { ms?: number } = {};
 
-    startSpinnerWorker(input, {
-        write: () => {
-            // noop
-        },
-        setInterval: (_callback, ms) => {
-            captured.ms = ms;
-            return 'ticker-handle';
-        },
-        clearInterval: () => {
-            // noop
+        startSpinnerWorker(input, {
+            write: () => {
+                // noop
+            },
+            setInterval: (_callback, ms) => {
+                captured.ms = ms;
+                return 'ticker-handle';
+            },
+            clearInterval: () => {
+                // noop
+            }
+        });
+
+        assert.strictEqual(captured.ms, 40);
+    });
+
+    test('startSpinnerWorker writes the running slot label and message to the configured stdout file descriptor', function () {
+        const harness = createHarness(2, 7);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'running', 'pkg', 'starting');
+
+        harness.tick();
+
+        const written = harness.writes().join('');
+        assert.match(written, /pkg: starting/u);
+    });
+
+    test('startSpinnerWorker draws the success symbol for slots that have succeeded', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'succeeded', 'pkg', 'done');
+
+        harness.tick();
+
+        assert.match(harness.writes().join(''), successSymbolPattern);
+    });
+
+    test('startSpinnerWorker draws the failure symbol for failed slots', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'failed', 'pkg', 'oops');
+
+        harness.tick();
+
+        assert.match(harness.writes().join(''), failureSymbolPattern);
+    });
+
+    test('startSpinnerWorker draws the failure symbol for canceled slots', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'canceled', 'pkg', 'aborted');
+
+        harness.tick();
+
+        assert.match(harness.writes().join(''), failureSymbolPattern);
+    });
+
+    const expectedSpinnerFrames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+
+    function extractGlyph(chunk: string): string {
+        const marker = clearLineSequence;
+        const start = chunk.lastIndexOf(marker);
+        if (start === -1) {
+            return '';
+        }
+        return chunk.charAt(start + marker.length);
+    }
+
+    function setupRunningSlotHarnessAndTick(): {
+        readonly harness: ReturnType<typeof createHarness>;
+        readonly written: string;
+    } {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+
+        harness.tick();
+
+        return { harness, written: harness.writes().join('') };
+    }
+
+    test('startSpinnerWorker draws a glyph from the spinner animation set for running slots', function () {
+        const { written } = setupRunningSlotHarnessAndTick();
+        const glyph = extractGlyph(written);
+        assert.ok(expectedSpinnerFrames.includes(glyph), `Expected glyph to be a spinner frame, got "${glyph}"`);
+    });
+
+    test('startSpinnerWorker uses neither the success nor failure symbol while a slot is running', function () {
+        const { written } = setupRunningSlotHarnessAndTick();
+        assert.doesNotMatch(written, successSymbolPattern);
+        assert.doesNotMatch(written, failureSymbolPattern);
+    });
+
+    test('startSpinnerWorker advances to a different spinner frame on the second tick', function () {
+        const { harness } = setupRunningSlotHarnessAndTick();
+        harness.tick();
+
+        const writes = harness.writes();
+        assert.strictEqual(writes.length, 2);
+        const firstGlyph = extractGlyph(writes[0] ?? '');
+        const secondGlyph = extractGlyph(writes[1] ?? '');
+        assert.ok(
+            expectedSpinnerFrames.includes(firstGlyph),
+            `Expected first glyph to be a spinner frame, got "${firstGlyph}"`
+        );
+        assert.ok(
+            expectedSpinnerFrames.includes(secondGlyph),
+            `Expected second glyph to be a spinner frame, got "${secondGlyph}"`
+        );
+        assert.notStrictEqual(firstGlyph, secondGlyph);
+    });
+
+    test('startSpinnerWorker truncates lines that would exceed the configured column width', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(8);
+        harness.accessors.writeSlot(0, 'succeeded', 'long-label', 'long-message');
+
+        harness.tick();
+
+        const lines = harness
+            .writes()
+            .join('')
+            .split('\n')
+            .filter((line) => {
+                return line.length > 0;
+            });
+        for (const line of lines) {
+            const stripped = line.split(clearLineSequence).join('');
+            assert.ok(stripped.length <= 8, `Expected line to be truncated to 8 columns, got ${stripped.length}`);
         }
     });
 
-    assert.strictEqual(captured.ms, 40);
-});
+    test('startSpinnerWorker leaves a line untruncated when columns is configured as zero', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(0);
+        harness.accessors.writeSlot(0, 'succeeded', 'lbl', 'message');
 
-test('startSpinnerWorker writes the running slot label and message to the configured stdout file descriptor', () => {
-    const harness = createHarness(2, 7);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'running', 'pkg', 'starting');
+        harness.tick();
 
-    harness.tick();
+        assert.match(harness.writes().join(''), /lbl: message/u);
+    });
 
-    const written = harness.writes().join('');
-    assert.match(written, /pkg: starting/u);
-});
+    test('startSpinnerWorker draws one line per active slot up to the highest active index', function () {
+        const harness = createHarness(4);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'running', 'a', 'one');
+        harness.accessors.writeSlot(2, 'running', 'c', 'three');
 
-test('startSpinnerWorker draws the success symbol for slots that have succeeded', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'succeeded', 'pkg', 'done');
+        harness.tick();
 
-    harness.tick();
+        const occurrences = countOccurrences(harness.writes().join(''), clearLineSequence);
+        assert.strictEqual(occurrences, 3);
+    });
 
-    assert.match(harness.writes().join(''), successSymbolPattern);
-});
+    test('startSpinnerWorker skips writing to stdout while there is nothing to render', function () {
+        const harness = createHarness(2);
 
-test('startSpinnerWorker draws the failure symbol for failed slots', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'failed', 'pkg', 'oops');
+        harness.tick();
 
-    harness.tick();
+        assert.strictEqual(harness.writes().length, 0);
+    });
 
-    assert.match(harness.writes().join(''), failureSymbolPattern);
-});
+    test('startSpinnerWorker acknowledges a pending mutation even when there is nothing to render', function () {
+        const harness = createHarness(2);
+        const mutation = harness.accessors.markMutation();
 
-test('startSpinnerWorker draws the failure symbol for canceled slots', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'canceled', 'pkg', 'aborted');
+        harness.tick();
 
-    harness.tick();
+        assert.strictEqual(harness.writes().length, 0);
+        assert.strictEqual(harness.accessors.waitForRenderedMutation(mutation, 1), true);
+    });
 
-    assert.match(harness.writes().join(''), failureSymbolPattern);
-});
+    test('startSpinnerWorker rewinds the cursor up by the previously rendered line count before redrawing', function () {
+        const { harness } = setupRunningSlotHarnessAndTick();
+        harness.tick();
 
-const expectedSpinnerFrames = '⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏';
+        const lastChunk = harness.writes().at(-1) ?? '';
+        assert.strictEqual(extractCursorUpLineCount(lastChunk), 1);
+    });
 
-function extractGlyph(chunk: string): string {
-    const marker = clearLineSequence;
-    const start = chunk.lastIndexOf(marker);
-    if (start === -1) {
-        return '';
-    }
-    return chunk.charAt(start + marker.length);
-}
+    test('startSpinnerWorker keeps refreshing the rendered block once a slot was drawn even if it goes empty', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
 
-function setupRunningSlotHarnessAndTick(): {
-    readonly harness: ReturnType<typeof createHarness>;
-    readonly written: string;
-} {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+        harness.tick();
+        harness.accessors.writeSlot(0, 'empty', '', '');
+        harness.tick();
 
-    harness.tick();
+        assert.strictEqual(harness.writes().length, 2);
+    });
 
-    return { harness, written: harness.writes().join('') };
-}
+    test('startSpinnerWorker writes a final tick and clears the interval after a shutdown was requested', function () {
+        const harness = createHarness(1);
+        harness.accessors.setColumns(80);
+        harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
+        harness.accessors.bumpSlotGeneration(0);
+        const runningMutation = harness.accessors.markMutation();
 
-test('startSpinnerWorker draws a glyph from the spinner animation set for running slots', () => {
-    const { written } = setupRunningSlotHarnessAndTick();
-    const glyph = extractGlyph(written);
-    assert.ok(expectedSpinnerFrames.includes(glyph), `Expected glyph to be a spinner frame, got "${glyph}"`);
-});
+        harness.tick();
+        harness.accessors.requestShutdown();
+        const shutdownMutation = harness.accessors.markMutation();
+        harness.tick();
 
-test('startSpinnerWorker uses neither the success nor failure symbol while a slot is running', () => {
-    const { written } = setupRunningSlotHarnessAndTick();
-    assert.doesNotMatch(written, successSymbolPattern);
-    assert.doesNotMatch(written, failureSymbolPattern);
-});
+        assert.strictEqual(harness.clearIntervalCalls().length, 1);
+        assert.strictEqual(harness.clearIntervalCalls()[0], 'ticker-handle');
+        assert.strictEqual(harness.accessors.waitForRenderedMutation(runningMutation, 1), true);
+        assert.strictEqual(harness.accessors.waitForRenderedMutation(shutdownMutation, 1), true);
+    });
 
-test('startSpinnerWorker advances to a different spinner frame on the second tick', () => {
-    const { harness } = setupRunningSlotHarnessAndTick();
-    harness.tick();
+    test('isSpinnerWorkerInput accepts a well-formed payload', function () {
+        const layout = createSpinnerSharedLayout(1);
+        const buffer = new SharedArrayBuffer(layout.bufferByteLength);
 
-    const writes = harness.writes();
-    assert.strictEqual(writes.length, 2);
-    const firstGlyph = extractGlyph(writes[0] ?? '');
-    const secondGlyph = extractGlyph(writes[1] ?? '');
-    assert.ok(
-        expectedSpinnerFrames.includes(firstGlyph),
-        `Expected first glyph to be a spinner frame, got "${firstGlyph}"`
-    );
-    assert.ok(
-        expectedSpinnerFrames.includes(secondGlyph),
-        `Expected second glyph to be a spinner frame, got "${secondGlyph}"`
-    );
-    assert.notStrictEqual(firstGlyph, secondGlyph);
-});
+        assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: 1, stdoutFileDescriptor: 1 }), true);
+    });
 
-test('startSpinnerWorker truncates lines that would exceed the configured column width', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(8);
-    harness.accessors.writeSlot(0, 'succeeded', 'long-label', 'long-message');
+    test('isSpinnerWorkerInput rejects non-objects', function () {
+        assert.strictEqual(isSpinnerWorkerInput(null), false);
+        assert.strictEqual(isSpinnerWorkerInput('not-an-object'), false);
+    });
 
-    harness.tick();
+    test('isSpinnerWorkerInput rejects payloads with a buffer that is not a SharedArrayBuffer', function () {
+        assert.strictEqual(
+            isSpinnerWorkerInput({ buffer: new ArrayBuffer(8), slotCount: 1, stdoutFileDescriptor: 1 }),
+            false
+        );
+    });
 
-    const lines = harness
-        .writes()
-        .join('')
-        .split('\n')
-        .filter((line) => {
-            return line.length > 0;
-        });
-    for (const line of lines) {
-        const stripped = line.split(clearLineSequence).join('');
-        assert.ok(stripped.length <= 8, `Expected line to be truncated to 8 columns, got ${stripped.length}`);
-    }
-});
+    test('isSpinnerWorkerInput rejects payloads with a non-numeric slotCount', function () {
+        const layout = createSpinnerSharedLayout(1);
+        const buffer = new SharedArrayBuffer(layout.bufferByteLength);
 
-test('startSpinnerWorker leaves a line untruncated when columns is configured as zero', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(0);
-    harness.accessors.writeSlot(0, 'succeeded', 'lbl', 'message');
+        assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: '1', stdoutFileDescriptor: 1 }), false);
+    });
 
-    harness.tick();
+    test('isSpinnerWorkerInput rejects payloads with a non-numeric stdoutFileDescriptor', function () {
+        const layout = createSpinnerSharedLayout(1);
+        const buffer = new SharedArrayBuffer(layout.bufferByteLength);
 
-    assert.match(harness.writes().join(''), /lbl: message/u);
-});
-
-test('startSpinnerWorker draws one line per active slot up to the highest active index', () => {
-    const harness = createHarness(4);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'running', 'a', 'one');
-    harness.accessors.writeSlot(2, 'running', 'c', 'three');
-
-    harness.tick();
-
-    const occurrences = countOccurrences(harness.writes().join(''), clearLineSequence);
-    assert.strictEqual(occurrences, 3);
-});
-
-test('startSpinnerWorker skips writing to stdout while there is nothing to render', () => {
-    const harness = createHarness(2);
-
-    harness.tick();
-
-    assert.strictEqual(harness.writes().length, 0);
-});
-
-test('startSpinnerWorker acknowledges a pending mutation even when there is nothing to render', () => {
-    const harness = createHarness(2);
-    const mutation = harness.accessors.markMutation();
-
-    harness.tick();
-
-    assert.strictEqual(harness.writes().length, 0);
-    assert.strictEqual(harness.accessors.waitForRenderedMutation(mutation, 1), true);
-});
-
-test('startSpinnerWorker rewinds the cursor up by the previously rendered line count before redrawing', () => {
-    const { harness } = setupRunningSlotHarnessAndTick();
-    harness.tick();
-
-    const lastChunk = harness.writes().at(-1) ?? '';
-    assert.strictEqual(extractCursorUpLineCount(lastChunk), 1);
-});
-
-test('startSpinnerWorker keeps refreshing the rendered block once a slot was drawn even if it goes empty', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
-
-    harness.tick();
-    harness.accessors.writeSlot(0, 'empty', '', '');
-    harness.tick();
-
-    assert.strictEqual(harness.writes().length, 2);
-});
-
-test('startSpinnerWorker writes a final tick and clears the interval after a shutdown was requested', () => {
-    const harness = createHarness(1);
-    harness.accessors.setColumns(80);
-    harness.accessors.writeSlot(0, 'running', 'pkg', 'msg');
-    harness.accessors.bumpSlotGeneration(0);
-    const runningMutation = harness.accessors.markMutation();
-
-    harness.tick();
-    harness.accessors.requestShutdown();
-    const shutdownMutation = harness.accessors.markMutation();
-    harness.tick();
-
-    assert.strictEqual(harness.clearIntervalCalls().length, 1);
-    assert.strictEqual(harness.clearIntervalCalls()[0], 'ticker-handle');
-    assert.strictEqual(harness.accessors.waitForRenderedMutation(runningMutation, 1), true);
-    assert.strictEqual(harness.accessors.waitForRenderedMutation(shutdownMutation, 1), true);
-});
-
-test('isSpinnerWorkerInput accepts a well-formed payload', () => {
-    const layout = createSpinnerSharedLayout(1);
-    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
-
-    assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: 1, stdoutFileDescriptor: 1 }), true);
-});
-
-test('isSpinnerWorkerInput rejects non-objects', () => {
-    assert.strictEqual(isSpinnerWorkerInput(null), false);
-    assert.strictEqual(isSpinnerWorkerInput('not-an-object'), false);
-});
-
-test('isSpinnerWorkerInput rejects payloads with a buffer that is not a SharedArrayBuffer', () => {
-    assert.strictEqual(
-        isSpinnerWorkerInput({ buffer: new ArrayBuffer(8), slotCount: 1, stdoutFileDescriptor: 1 }),
-        false
-    );
-});
-
-test('isSpinnerWorkerInput rejects payloads with a non-numeric slotCount', () => {
-    const layout = createSpinnerSharedLayout(1);
-    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
-
-    assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: '1', stdoutFileDescriptor: 1 }), false);
-});
-
-test('isSpinnerWorkerInput rejects payloads with a non-numeric stdoutFileDescriptor', () => {
-    const layout = createSpinnerSharedLayout(1);
-    const buffer = new SharedArrayBuffer(layout.bufferByteLength);
-
-    assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: 1, stdoutFileDescriptor: '1' }), false);
+        assert.strictEqual(isSpinnerWorkerInput({ buffer, slotCount: 1, stdoutFileDescriptor: '1' }), false);
+    });
 });

--- a/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import {
     createTerminalSpinnerRenderer,
@@ -38,169 +38,171 @@ function terminalSpinnerRendererFactory(backend: SpinnerBackend = createFakeBack
     return createTerminalSpinnerRenderer({ backend });
 }
 
-test('add() forwards a new spinner to the backend at slot index zero', () => {
-    const add = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ add }));
+suite('terminal-spinner-renderer', function () {
+    test('add() forwards a new spinner to the backend at slot index zero', function () {
+        const add = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ add }));
 
-    renderer.add('the-id', 'the-label', 'the message');
+        renderer.add('the-id', 'the-label', 'the message');
 
-    assert.strictEqual(add.callCount, 1);
-    assert.deepStrictEqual(add.firstCall.args, [0, 'the-label', 'the message']);
-});
+        assert.strictEqual(add.callCount, 1);
+        assert.deepStrictEqual(add.firstCall.args, [0, 'the-label', 'the message']);
+    });
 
-test('add() assigns successive spinners to consecutive slot indices', () => {
-    const add = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ add }));
+    test('add() assigns successive spinners to consecutive slot indices', function () {
+        const add = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ add }));
 
-    renderer.add('first', 'a', '1');
-    renderer.add('second', 'b', '2');
+        renderer.add('first', 'a', '1');
+        renderer.add('second', 'b', '2');
 
-    assert.strictEqual(add.callCount, 2);
-    assert.deepStrictEqual(add.firstCall.args, [0, 'a', '1']);
-    assert.deepStrictEqual(add.secondCall.args, [1, 'b', '2']);
-});
+        assert.strictEqual(add.callCount, 2);
+        assert.deepStrictEqual(add.firstCall.args, [0, 'a', '1']);
+        assert.deepStrictEqual(add.secondCall.args, [1, 'b', '2']);
+    });
 
-test('add() throws when adding two spinners with the same id', () => {
-    const renderer = terminalSpinnerRendererFactory();
+    test('add() throws when adding two spinners with the same id', function () {
+        const renderer = terminalSpinnerRendererFactory();
 
-    renderer.add('the-id', '', '');
-
-    try {
         renderer.add('the-id', '', '');
-        assert.fail('Expected add() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Spinner with id the-id already exists');
-    }
-});
 
-test('updateMessage() forwards the new message to the backend with the spinner slot index', () => {
-    const update = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
+        try {
+            renderer.add('the-id', '', '');
+            assert.fail('Expected add() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Spinner with id the-id already exists');
+        }
+    });
 
-    renderer.add('the-id', 'lbl', 'initial');
-    renderer.updateMessage('the-id', 'foo');
+    test('updateMessage() forwards the new message to the backend with the spinner slot index', function () {
+        const update = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
 
-    assert.strictEqual(update.callCount, 1);
-    assert.deepStrictEqual(update.firstCall.args, [0, 'lbl', 'foo']);
-});
+        renderer.add('the-id', 'lbl', 'initial');
+        renderer.updateMessage('the-id', 'foo');
 
-test('updateMessage() updates the correct spinner when having multiple', () => {
-    const update = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
+        assert.strictEqual(update.callCount, 1);
+        assert.deepStrictEqual(update.firstCall.args, [0, 'lbl', 'foo']);
+    });
 
-    renderer.add('first', 'one', '');
-    renderer.add('second', 'two', '');
-    renderer.updateMessage('first', 'foo');
-    renderer.updateMessage('second', 'bar');
+    test('updateMessage() updates the correct spinner when having multiple', function () {
+        const update = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
 
-    assert.strictEqual(update.callCount, 2);
-    assert.deepStrictEqual(update.firstCall.args, [0, 'one', 'foo']);
-    assert.deepStrictEqual(update.secondCall.args, [1, 'two', 'bar']);
-});
+        renderer.add('first', 'one', '');
+        renderer.add('second', 'two', '');
+        renderer.updateMessage('first', 'foo');
+        renderer.updateMessage('second', 'bar');
 
-test('updateMessage() throws when trying to change the message of a non-existing spinner', () => {
-    const renderer = terminalSpinnerRendererFactory();
+        assert.strictEqual(update.callCount, 2);
+        assert.deepStrictEqual(update.firstCall.args, [0, 'one', 'foo']);
+        assert.deepStrictEqual(update.secondCall.args, [1, 'two', 'bar']);
+    });
 
-    try {
-        renderer.updateMessage('the-id', '');
-        assert.fail('Expected updateMessage() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Spinner with id the-id does not exist');
-    }
-});
+    test('updateMessage() throws when trying to change the message of a non-existing spinner', function () {
+        const renderer = terminalSpinnerRendererFactory();
 
-test('stop() finishes the spinner with succeeded state when the status is success', () => {
-    const finish = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
+        try {
+            renderer.updateMessage('the-id', '');
+            assert.fail('Expected updateMessage() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Spinner with id the-id does not exist');
+        }
+    });
 
-    renderer.add('the-id', 'lbl', '');
-    renderer.stop('the-id', 'success', 'foo');
+    test('stop() finishes the spinner with succeeded state when the status is success', function () {
+        const finish = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    assert.strictEqual(finish.callCount, 1);
-    assert.deepStrictEqual(finish.firstCall.args, [0, 'succeeded', 'lbl', 'foo']);
-});
+        renderer.add('the-id', 'lbl', '');
+        renderer.stop('the-id', 'success', 'foo');
 
-test('stop() finishes the spinner with failed state when the status is failure', () => {
-    const finish = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
+        assert.strictEqual(finish.callCount, 1);
+        assert.deepStrictEqual(finish.firstCall.args, [0, 'succeeded', 'lbl', 'foo']);
+    });
 
-    renderer.add('the-id', 'lbl', '');
-    renderer.stop('the-id', 'failure', 'foo');
+    test('stop() finishes the spinner with failed state when the status is failure', function () {
+        const finish = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    assert.strictEqual(finish.callCount, 1);
-    assert.deepStrictEqual(finish.firstCall.args, [0, 'failed', 'lbl', 'foo']);
-});
+        renderer.add('the-id', 'lbl', '');
+        renderer.stop('the-id', 'failure', 'foo');
 
-test('stop() keeps the stopped spinner addressable for later message updates', () => {
-    const update = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
+        assert.strictEqual(finish.callCount, 1);
+        assert.deepStrictEqual(finish.firstCall.args, [0, 'failed', 'lbl', 'foo']);
+    });
 
-    renderer.add('the-id', 'lbl', '');
-    renderer.stop('the-id', 'success', 'foo');
-    renderer.updateMessage('the-id', 'updated');
+    test('stop() keeps the stopped spinner addressable for later message updates', function () {
+        const update = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ update }));
 
-    assert.strictEqual(update.callCount, 1);
-    assert.deepStrictEqual(update.firstCall.args, [0, 'lbl', 'updated']);
-});
+        renderer.add('the-id', 'lbl', '');
+        renderer.stop('the-id', 'success', 'foo');
+        renderer.updateMessage('the-id', 'updated');
 
-test('stop() finishes only the targeted spinner when having multiple', () => {
-    const finish = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
+        assert.strictEqual(update.callCount, 1);
+        assert.deepStrictEqual(update.firstCall.args, [0, 'lbl', 'updated']);
+    });
 
-    renderer.add('first', 'a', '');
-    renderer.add('second', 'b', '');
-    renderer.stop('first', 'failure', 'foo');
-    renderer.stop('second', 'failure', 'bar');
+    test('stop() finishes only the targeted spinner when having multiple', function () {
+        const finish = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    assert.strictEqual(finish.callCount, 2);
-    assert.deepStrictEqual(finish.firstCall.args, [0, 'failed', 'a', 'foo']);
-    assert.deepStrictEqual(finish.secondCall.args, [1, 'failed', 'b', 'bar']);
-});
+        renderer.add('first', 'a', '');
+        renderer.add('second', 'b', '');
+        renderer.stop('first', 'failure', 'foo');
+        renderer.stop('second', 'failure', 'bar');
 
-test('stop() throws when trying to stop a spinner that does not exist', () => {
-    const renderer = terminalSpinnerRendererFactory();
+        assert.strictEqual(finish.callCount, 2);
+        assert.deepStrictEqual(finish.firstCall.args, [0, 'failed', 'a', 'foo']);
+        assert.deepStrictEqual(finish.secondCall.args, [1, 'failed', 'b', 'bar']);
+    });
 
-    try {
-        renderer.stop('the-id', 'failure', '');
-        assert.fail('Expected stop() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Spinner with id the-id does not exist');
-    }
-});
+    test('stop() throws when trying to stop a spinner that does not exist', function () {
+        const renderer = terminalSpinnerRendererFactory();
 
-test('stopAll() shuts down the backend', () => {
-    const shutdown = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ shutdown }));
+        try {
+            renderer.stop('the-id', 'failure', '');
+            assert.fail('Expected stop() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Spinner with id the-id does not exist');
+        }
+    });
 
-    renderer.add('first', '', '');
-    renderer.stopAll();
+    test('stopAll() shuts down the backend', function () {
+        const shutdown = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ shutdown }));
 
-    assert.strictEqual(shutdown.callCount, 1);
-});
+        renderer.add('first', '', '');
+        renderer.stopAll();
 
-test('stopAll() cancels all spinners that are still running', () => {
-    const finish = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
+        assert.strictEqual(shutdown.callCount, 1);
+    });
 
-    renderer.add('first', 'one', '');
-    renderer.add('second', 'two', '');
-    renderer.stop('first', 'success', 'foo');
-    renderer.stopAll();
+    test('stopAll() cancels all spinners that are still running', function () {
+        const finish = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish }));
 
-    assert.strictEqual(finish.callCount, 2);
-    assert.deepStrictEqual(finish.firstCall.args, [0, 'succeeded', 'one', 'foo']);
-    assert.deepStrictEqual(finish.secondCall.args, [1, 'canceled', 'two', 'Canceled …']);
-});
+        renderer.add('first', 'one', '');
+        renderer.add('second', 'two', '');
+        renderer.stop('first', 'success', 'foo');
+        renderer.stopAll();
 
-test('stopAll() does not re-cancel previously canceled spinners on a second invocation', () => {
-    const finish = fake();
-    const shutdown = fake();
-    const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish, shutdown }));
+        assert.strictEqual(finish.callCount, 2);
+        assert.deepStrictEqual(finish.firstCall.args, [0, 'succeeded', 'one', 'foo']);
+        assert.deepStrictEqual(finish.secondCall.args, [1, 'canceled', 'two', 'Canceled …']);
+    });
 
-    renderer.add('only', 'lbl', '');
-    renderer.stopAll();
-    renderer.stopAll();
+    test('stopAll() does not re-cancel previously canceled spinners on a second invocation', function () {
+        const finish = fake();
+        const shutdown = fake();
+        const renderer = terminalSpinnerRendererFactory(createFakeBackend({ finish, shutdown }));
 
-    assert.strictEqual(finish.callCount, 1);
-    assert.strictEqual(shutdown.callCount, 2);
+        renderer.add('only', 'lbl', '');
+        renderer.stopAll();
+        renderer.stopAll();
+
+        assert.strictEqual(finish.callCount, 1);
+        assert.strictEqual(shutdown.callCount, 2);
+    });
 });

--- a/source/common/clock.test.ts
+++ b/source/common/clock.test.ts
@@ -1,21 +1,23 @@
 import assert from 'node:assert';
 import { clearTimeout as clearTimer, setTimeout as setTimer } from 'node:timers';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createClock } from './clock.ts';
 
-test('createClock() returns the current wall-clock time in milliseconds', () => {
-    const clock = createClock();
-    const before = Date.now();
-    const currentTime = clock.getCurrentTimeInMilliseconds();
-    const after = Date.now();
+suite('clock', function () {
+    test('createClock() returns the current wall-clock time in milliseconds', function () {
+        const clock = createClock();
+        const before = Date.now();
+        const currentTime = clock.getCurrentTimeInMilliseconds();
+        const after = Date.now();
 
-    assert.ok(currentTime >= before);
-    assert.ok(currentTime <= after);
-});
+        assert.ok(currentTime >= before);
+        assert.ok(currentTime <= after);
+    });
 
-test('createClock() exposes the global timeout functions', () => {
-    const clock = createClock();
+    test('createClock() exposes the global timeout functions', function () {
+        const clock = createClock();
 
-    assert.strictEqual(clock.setTimeout, setTimer);
-    assert.strictEqual(clock.clearTimeout, clearTimer);
+        assert.strictEqual(clock.setTimeout, setTimer);
+        assert.strictEqual(clock.clearTimeout, clearTimer);
+    });
 });

--- a/source/common/code-files.test.ts
+++ b/source/common/code-files.test.ts
@@ -1,59 +1,61 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { isCodeFile, isDeclarationCodeFile } from './code-files.ts';
 
-test('isCodeFile recognizes .js as code', () => {
-    assert.strictEqual(isCodeFile('index.js'), true);
-});
+suite('code-files', function () {
+    test('isCodeFile recognizes .js as code', function () {
+        assert.strictEqual(isCodeFile('index.js'), true);
+    });
 
-test('isCodeFile recognizes .ts as code', () => {
-    assert.strictEqual(isCodeFile('index.ts'), true);
-});
+    test('isCodeFile recognizes .ts as code', function () {
+        assert.strictEqual(isCodeFile('index.ts'), true);
+    });
 
-test('isCodeFile recognizes .tsx as code', () => {
-    assert.strictEqual(isCodeFile('index.tsx'), true);
-});
+    test('isCodeFile recognizes .tsx as code', function () {
+        assert.strictEqual(isCodeFile('index.tsx'), true);
+    });
 
-test('isCodeFile recognizes .jsx as code', () => {
-    assert.strictEqual(isCodeFile('index.jsx'), true);
-});
+    test('isCodeFile recognizes .jsx as code', function () {
+        assert.strictEqual(isCodeFile('index.jsx'), true);
+    });
 
-test('isCodeFile recognizes .cjs as code', () => {
-    assert.strictEqual(isCodeFile('index.cjs'), true);
-});
+    test('isCodeFile recognizes .cjs as code', function () {
+        assert.strictEqual(isCodeFile('index.cjs'), true);
+    });
 
-test('isCodeFile recognizes .mjs as code', () => {
-    assert.strictEqual(isCodeFile('index.mjs'), true);
-});
+    test('isCodeFile recognizes .mjs as code', function () {
+        assert.strictEqual(isCodeFile('index.mjs'), true);
+    });
 
-test('isCodeFile recognizes .cts as code', () => {
-    assert.strictEqual(isCodeFile('index.cts'), true);
-});
+    test('isCodeFile recognizes .cts as code', function () {
+        assert.strictEqual(isCodeFile('index.cts'), true);
+    });
 
-test('isCodeFile recognizes .mts as code', () => {
-    assert.strictEqual(isCodeFile('index.mts'), true);
-});
+    test('isCodeFile recognizes .mts as code', function () {
+        assert.strictEqual(isCodeFile('index.mts'), true);
+    });
 
-test('isCodeFile recognizes .d.ts as code', () => {
-    assert.strictEqual(isCodeFile('index.d.ts'), true);
-});
+    test('isCodeFile recognizes .d.ts as code', function () {
+        assert.strictEqual(isCodeFile('index.d.ts'), true);
+    });
 
-test('isDeclarationCodeFile recognizes .d.ts as a declaration code file', () => {
-    assert.strictEqual(isDeclarationCodeFile('index.d.ts'), true);
-});
+    test('isDeclarationCodeFile recognizes .d.ts as a declaration code file', function () {
+        assert.strictEqual(isDeclarationCodeFile('index.d.ts'), true);
+    });
 
-test('isDeclarationCodeFile rejects .js as a declaration code file', () => {
-    assert.strictEqual(isDeclarationCodeFile('index.js'), false);
-});
+    test('isDeclarationCodeFile rejects .js as a declaration code file', function () {
+        assert.strictEqual(isDeclarationCodeFile('index.js'), false);
+    });
 
-test('isCodeFile rejects .json as not code', () => {
-    assert.strictEqual(isCodeFile('data.json'), false);
-});
+    test('isCodeFile rejects .json as not code', function () {
+        assert.strictEqual(isCodeFile('data.json'), false);
+    });
 
-test('isCodeFile rejects LICENSE as not code', () => {
-    assert.strictEqual(isCodeFile('LICENSE'), false);
-});
+    test('isCodeFile rejects LICENSE as not code', function () {
+        assert.strictEqual(isCodeFile('LICENSE'), false);
+    });
 
-test('isCodeFile rejects markdown as not code', () => {
-    assert.strictEqual(isCodeFile('readme.md'), false);
+    test('isCodeFile rejects markdown as not code', function () {
+        assert.strictEqual(isCodeFile('readme.md'), false);
+    });
 });

--- a/source/common/fake-clock.test.ts
+++ b/source/common/fake-clock.test.ts
@@ -1,107 +1,109 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFakeClock } from '../test-libraries/fake-clock.ts';
 
-test('createFakeClock() exposes the initial timestamp and advances with tick()', () => {
-    const clock = createFakeClock({ initialTimestamp: 10 });
+suite('fake-clock', function () {
+    test('createFakeClock() exposes the initial timestamp and advances with tick()', function () {
+        const clock = createFakeClock({ initialTimestamp: 10 });
 
-    assert.strictEqual(clock.getCurrentTimeInMilliseconds(), 10);
-    clock.tick(15);
-    assert.strictEqual(clock.getCurrentTimeInMilliseconds(), 25);
-});
+        assert.strictEqual(clock.getCurrentTimeInMilliseconds(), 10);
+        clock.tick(15);
+        assert.strictEqual(clock.getCurrentTimeInMilliseconds(), 25);
+    });
 
-test('createFakeClock() runs due handlers in order when time advances', () => {
-    const clock = createFakeClock();
-    const calls: string[] = [];
+    test('createFakeClock() runs due handlers in order when time advances', function () {
+        const clock = createFakeClock();
+        const calls: string[] = [];
 
-    clock.setTimeout(() => {
-        calls.push('late');
-    }, 10);
-    clock.setTimeout(() => {
-        calls.push('early');
-    }, 5);
-
-    clock.tick(5);
-    assert.deepStrictEqual(calls, ['early']);
-
-    clock.tick(5);
-    assert.deepStrictEqual(calls, ['early', 'late']);
-});
-
-test('createFakeClock() runs zero-delay handlers immediately', () => {
-    const clock = createFakeClock();
-    const calls: string[] = [];
-
-    clock.setTimeout(
-        (value: string) => {
-            calls.push(value);
-        },
-        0,
-        'now'
-    );
-
-    assert.deepStrictEqual(calls, ['now']);
-});
-
-test('createFakeClock() can clear scheduled handlers', () => {
-    const clock = createFakeClock();
-    const calls: string[] = [];
-    const timeoutId = clock.setTimeout(() => {
-        calls.push('should-not-run');
-    }, 10);
-
-    clock.clearTimeout(timeoutId);
-    clock.tick(10);
-
-    assert.deepStrictEqual(calls, []);
-});
-
-test('createFakeClock() returns sequential timeout identifiers', () => {
-    const clock = createFakeClock();
-
-    const firstTimeoutId = clock.setTimeout(() => {
-        return undefined;
-    }, 10);
-    const secondTimeoutId = clock.setTimeout(() => {
-        return undefined;
-    }, 10);
-
-    assert.strictEqual(firstTimeoutId, 0);
-    assert.strictEqual(secondTimeoutId, 1);
-});
-
-test('createFakeClock() keeps returning increasing timeout identifiers after clearing timers', () => {
-    const clock = createFakeClock();
-    const firstTimeoutId = clock.setTimeout(() => {
-        return undefined;
-    }, 10);
-
-    clock.clearTimeout(firstTimeoutId);
-
-    const secondTimeoutId = clock.setTimeout(() => {
-        return undefined;
-    }, 10);
-
-    assert.strictEqual(firstTimeoutId, 0);
-    assert.strictEqual(secondTimeoutId, 1);
-});
-
-test('createFakeClock() rejects negative delays', () => {
-    const clock = createFakeClock();
-
-    assert.throws(() => {
         clock.setTimeout(() => {
-            return undefined;
-        }, -1);
-    }, /^Error: Invalid delay -1, must be greater than or equal to 0$/u);
-});
-
-test('createFakeClock() rejects non-finite delays', () => {
-    const clock = createFakeClock();
-
-    assert.throws(() => {
+            calls.push('late');
+        }, 10);
         clock.setTimeout(() => {
+            calls.push('early');
+        }, 5);
+
+        clock.tick(5);
+        assert.deepStrictEqual(calls, ['early']);
+
+        clock.tick(5);
+        assert.deepStrictEqual(calls, ['early', 'late']);
+    });
+
+    test('createFakeClock() runs zero-delay handlers immediately', function () {
+        const clock = createFakeClock();
+        const calls: string[] = [];
+
+        clock.setTimeout(
+            (value: string) => {
+                calls.push(value);
+            },
+            0,
+            'now'
+        );
+
+        assert.deepStrictEqual(calls, ['now']);
+    });
+
+    test('createFakeClock() can clear scheduled handlers', function () {
+        const clock = createFakeClock();
+        const calls: string[] = [];
+        const timeoutId = clock.setTimeout(() => {
+            calls.push('should-not-run');
+        }, 10);
+
+        clock.clearTimeout(timeoutId);
+        clock.tick(10);
+
+        assert.deepStrictEqual(calls, []);
+    });
+
+    test('createFakeClock() returns sequential timeout identifiers', function () {
+        const clock = createFakeClock();
+
+        const firstTimeoutId = clock.setTimeout(() => {
             return undefined;
-        }, Number.POSITIVE_INFINITY);
-    }, /^TypeError: Invalid delay, must be a finite number$/u);
+        }, 10);
+        const secondTimeoutId = clock.setTimeout(() => {
+            return undefined;
+        }, 10);
+
+        assert.strictEqual(firstTimeoutId, 0);
+        assert.strictEqual(secondTimeoutId, 1);
+    });
+
+    test('createFakeClock() keeps returning increasing timeout identifiers after clearing timers', function () {
+        const clock = createFakeClock();
+        const firstTimeoutId = clock.setTimeout(() => {
+            return undefined;
+        }, 10);
+
+        clock.clearTimeout(firstTimeoutId);
+
+        const secondTimeoutId = clock.setTimeout(() => {
+            return undefined;
+        }, 10);
+
+        assert.strictEqual(firstTimeoutId, 0);
+        assert.strictEqual(secondTimeoutId, 1);
+    });
+
+    test('createFakeClock() rejects negative delays', function () {
+        const clock = createFakeClock();
+
+        assert.throws(() => {
+            clock.setTimeout(() => {
+                return undefined;
+            }, -1);
+        }, /^Error: Invalid delay -1, must be greater than or equal to 0$/u);
+    });
+
+    test('createFakeClock() rejects non-finite delays', function () {
+        const clock = createFakeClock();
+
+        assert.throws(() => {
+            clock.setTimeout(() => {
+                return undefined;
+            }, Number.POSITIVE_INFINITY);
+        }, /^TypeError: Invalid delay, must be a finite number$/u);
+    });
 });

--- a/source/common/typed-diff.test.ts
+++ b/source/common/typed-diff.test.ts
@@ -1,21 +1,23 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createStructuredPatch } from './typed-diff.ts';
 
-test('createStructuredPatch returns oldFileName and newFileName in the resulting patch', () => {
-    const patch = createStructuredPatch('a.txt', 'b.txt', 'one\n', 'two\n');
-    assert.strictEqual(patch.oldFileName, 'a.txt');
-    assert.strictEqual(patch.newFileName, 'b.txt');
-});
+suite('typed-diff', function () {
+    test('createStructuredPatch returns oldFileName and newFileName in the resulting patch', function () {
+        const patch = createStructuredPatch('a.txt', 'b.txt', 'one\n', 'two\n');
+        assert.strictEqual(patch.oldFileName, 'a.txt');
+        assert.strictEqual(patch.newFileName, 'b.txt');
+    });
 
-test('createStructuredPatch reports an empty hunks array when the inputs are identical', () => {
-    const patch = createStructuredPatch('a.txt', 'a.txt', 'same\n', 'same\n');
-    assert.deepStrictEqual(patch.hunks, []);
-});
+    test('createStructuredPatch reports an empty hunks array when the inputs are identical', function () {
+        const patch = createStructuredPatch('a.txt', 'a.txt', 'same\n', 'same\n');
+        assert.deepStrictEqual(patch.hunks, []);
+    });
 
-test('createStructuredPatch returns one hunk describing the change when the inputs differ', () => {
-    const patch = createStructuredPatch('a.txt', 'a.txt', 'one\n', 'two\n');
-    assert.strictEqual(patch.hunks.length, 1);
-    assert.ok(patch.hunks[0]?.lines.some((line) => line.startsWith('-')));
-    assert.ok(patch.hunks[0]?.lines.some((line) => line.startsWith('+')));
+    test('createStructuredPatch returns one hunk describing the change when the inputs differ', function () {
+        const patch = createStructuredPatch('a.txt', 'a.txt', 'one\n', 'two\n');
+        assert.strictEqual(patch.hunks.length, 1);
+        assert.ok(patch.hunks[0]?.lines.some((line) => line.startsWith('-')));
+        assert.ok(patch.hunks[0]?.lines.some((line) => line.startsWith('+')));
+    });
 });

--- a/source/config/additional-files.test.ts
+++ b/source/config/additional-files.test.ts
@@ -1,154 +1,156 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { additionalFileDescriptionSchema } from './additional-files.ts';
 
-test('schema accepts a valid additional file description', () => {
-    assert.strictEqual(
-        safeParse(additionalFileDescriptionSchema, { sourceFilePath: 'foo', targetFilePath: 'bar' }).success,
-        true
+suite('additional-files', function () {
+    test('schema accepts a valid additional file description', function () {
+        assert.strictEqual(
+            safeParse(additionalFileDescriptionSchema, { sourceFilePath: 'foo', targetFilePath: 'bar' }).success,
+            true
+        );
+    });
+
+    test('schema rejects an additional file description without targetFilePath', function () {
+        assert.strictEqual(safeParse(additionalFileDescriptionSchema, { sourceFilePath: 'foo' }).success, false);
+    });
+
+    test(
+        'validation succeeds when valid data is given',
+        checkValidationSuccess({
+            schema: additionalFileDescriptionSchema,
+            data: {
+                sourceFilePath: 'foo',
+                targetFilePath: 'bar'
+            },
+            expectedData: {
+                sourceFilePath: 'foo',
+                targetFilePath: 'bar'
+            }
+        })
+    );
+
+    test(
+        'validation fails when a non-object is given',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: true,
+            expectedMessages: ['expected object, but got boolean']
+        })
+    );
+
+    test(
+        'validation fails when the an empty object is given',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: {},
+            expectedMessages: ['at sourceFilePath: missing property', 'at targetFilePath: missing property']
+        })
+    );
+
+    test(
+        'validation fails when sourceFilePath is missing',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { targetFilePath: 'foo' },
+            expectedMessages: ['at sourceFilePath: missing property']
+        })
+    );
+
+    test(
+        'validation fails when sourceFilePath is not a string',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { sourceFilePath: [], targetFilePath: 'foo' },
+            expectedMessages: [
+                'at sourceFilePath: expected string, but got array',
+                'at sourceFilePath: array must contain at least 1 element'
+            ]
+        })
+    );
+
+    test(
+        'validation fails when sourceFilePath is undefined',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { sourceFilePath: undefined, targetFilePath: 'foo' },
+            expectedMessages: ['at sourceFilePath: expected string, but got undefined']
+        })
+    );
+
+    test(
+        'validation fails when sourceFilePath is null',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { sourceFilePath: null, targetFilePath: 'foo' },
+            expectedMessages: ['at sourceFilePath: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when sourceFilePath is an empty string',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { sourceFilePath: '', targetFilePath: 'foo' },
+            expectedMessages: ['at sourceFilePath: string must contain at least 1 character']
+        })
+    );
+
+    test(
+        'validation fails when targetFilePath is missing',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { sourceFilePath: 'foo' },
+            expectedMessages: ['at targetFilePath: missing property']
+        })
+    );
+
+    test(
+        'validation fails when targetFilePath is not a string',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { targetFilePath: [], sourceFilePath: 'foo' },
+            expectedMessages: [
+                'at targetFilePath: expected string, but got array',
+                'at targetFilePath: array must contain at least 1 element'
+            ]
+        })
+    );
+
+    test(
+        'validation fails when targetFilePath is undefined',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { targetFilePath: undefined, sourceFilePath: 'foo' },
+            expectedMessages: ['at targetFilePath: expected string, but got undefined']
+        })
+    );
+
+    test(
+        'validation fails when targetFilePath is null',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { targetFilePath: null, sourceFilePath: 'foo' },
+            expectedMessages: ['at targetFilePath: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when targetFilePath is an empty string',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { targetFilePath: '', sourceFilePath: 'foo' },
+            expectedMessages: ['at targetFilePath: string must contain at least 1 character']
+        })
+    );
+
+    test(
+        'validation fails when an additional unknown property is given',
+        checkValidationFailure({
+            schema: additionalFileDescriptionSchema,
+            data: { targetFilePath: 'bar', sourceFilePath: 'foo', something: 'else' },
+            expectedMessages: ['unexpected additional property: "something"']
+        })
     );
 });
-
-test('schema rejects an additional file description without targetFilePath', () => {
-    assert.strictEqual(safeParse(additionalFileDescriptionSchema, { sourceFilePath: 'foo' }).success, false);
-});
-
-test(
-    'validation succeeds when valid data is given',
-    checkValidationSuccess({
-        schema: additionalFileDescriptionSchema,
-        data: {
-            sourceFilePath: 'foo',
-            targetFilePath: 'bar'
-        },
-        expectedData: {
-            sourceFilePath: 'foo',
-            targetFilePath: 'bar'
-        }
-    })
-);
-
-test(
-    'validation fails when a non-object is given',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: true,
-        expectedMessages: ['expected object, but got boolean']
-    })
-);
-
-test(
-    'validation fails when the an empty object is given',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: {},
-        expectedMessages: ['at sourceFilePath: missing property', 'at targetFilePath: missing property']
-    })
-);
-
-test(
-    'validation fails when sourceFilePath is missing',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { targetFilePath: 'foo' },
-        expectedMessages: ['at sourceFilePath: missing property']
-    })
-);
-
-test(
-    'validation fails when sourceFilePath is not a string',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { sourceFilePath: [], targetFilePath: 'foo' },
-        expectedMessages: [
-            'at sourceFilePath: expected string, but got array',
-            'at sourceFilePath: array must contain at least 1 element'
-        ]
-    })
-);
-
-test(
-    'validation fails when sourceFilePath is undefined',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { sourceFilePath: undefined, targetFilePath: 'foo' },
-        expectedMessages: ['at sourceFilePath: expected string, but got undefined']
-    })
-);
-
-test(
-    'validation fails when sourceFilePath is null',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { sourceFilePath: null, targetFilePath: 'foo' },
-        expectedMessages: ['at sourceFilePath: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when sourceFilePath is an empty string',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { sourceFilePath: '', targetFilePath: 'foo' },
-        expectedMessages: ['at sourceFilePath: string must contain at least 1 character']
-    })
-);
-
-test(
-    'validation fails when targetFilePath is missing',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { sourceFilePath: 'foo' },
-        expectedMessages: ['at targetFilePath: missing property']
-    })
-);
-
-test(
-    'validation fails when targetFilePath is not a string',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { targetFilePath: [], sourceFilePath: 'foo' },
-        expectedMessages: [
-            'at targetFilePath: expected string, but got array',
-            'at targetFilePath: array must contain at least 1 element'
-        ]
-    })
-);
-
-test(
-    'validation fails when targetFilePath is undefined',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { targetFilePath: undefined, sourceFilePath: 'foo' },
-        expectedMessages: ['at targetFilePath: expected string, but got undefined']
-    })
-);
-
-test(
-    'validation fails when targetFilePath is null',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { targetFilePath: null, sourceFilePath: 'foo' },
-        expectedMessages: ['at targetFilePath: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when targetFilePath is an empty string',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { targetFilePath: '', sourceFilePath: 'foo' },
-        expectedMessages: ['at targetFilePath: string must contain at least 1 character']
-    })
-);
-
-test(
-    'validation fails when an additional unknown property is given',
-    checkValidationFailure({
-        schema: additionalFileDescriptionSchema,
-        data: { targetFilePath: 'bar', sourceFilePath: 'foo', something: 'else' },
-        expectedMessages: ['unexpected additional property: "something"']
-    })
-);

--- a/source/config/additional-package-json-attributes-schema.test.ts
+++ b/source/config/additional-package-json-attributes-schema.test.ts
@@ -1,27 +1,10 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { additionalPackageJsonAttributesSchema } from './additional-package-json-attributes-schema.ts';
 
-test('additional attributes schema accepts allowed keys', () => {
-    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { license: 'MIT' }).success, true);
-});
-
-test('additional attributes schema rejects forbidden object keys', () => {
-    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { dependencies: {} }).success, false);
-});
-
-test(
-    'additional package json attributes schema: validation succeeds for allowed keys',
-    checkValidationSuccess({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { license: 'MIT', repository: { type: 'git', url: 'https://example.test/repo.git' } },
-        expectedData: { license: 'MIT', repository: { type: 'git', url: 'https://example.test/repo.git' } }
-    })
-);
-
-for (const key of [
+const forbiddenKeys = [
     'bin',
     'dependencies',
     'peerDependencies',
@@ -33,32 +16,55 @@ for (const key of [
     'types',
     'type',
     'version'
-]) {
+] as const;
+
+suite('additional-package-json-attributes-schema', function () {
+    test('additional attributes schema accepts allowed keys', function () {
+        assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { license: 'MIT' }).success, true);
+    });
+
+    test('additional attributes schema rejects forbidden object keys', function () {
+        assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { dependencies: {} }).success, false);
+    });
+
     test(
-        `additional package json attributes schema: validation fails for forbidden key ${key}`,
-        checkValidationFailure({
+        'additional package json attributes schema: validation succeeds for allowed keys',
+        checkValidationSuccess({
             schema: additionalPackageJsonAttributesSchema,
-            data: { [key]: 'value' },
-            expectedMessages: [`at ${key}: invalid key`]
+            data: { license: 'MIT', repository: { type: 'git', url: 'https://example.test/repo.git' } },
+            expectedData: { license: 'MIT', repository: { type: 'git', url: 'https://example.test/repo.git' } }
         })
     );
-}
 
-test('additional package json attributes schema: every forbidden key is rejected', () => {
-    for (const key of [
-        'bin',
-        'dependencies',
-        'peerDependencies',
-        'devDependencies',
-        'exports',
-        'imports',
-        'main',
-        'name',
-        'types',
-        'type',
-        'version'
-    ]) {
-        const result = safeParse(additionalPackageJsonAttributesSchema, { [key]: 'value' });
-        assert.strictEqual(result.success, false);
-    }
+    suite('forbidden keys', function () {
+        for (const key of forbiddenKeys) {
+            test(
+                `additional package json attributes schema: validation fails for forbidden key ${key}`,
+                checkValidationFailure({
+                    schema: additionalPackageJsonAttributesSchema,
+                    data: { [key]: 'value' },
+                    expectedMessages: [`at ${key}: invalid key`]
+                })
+            );
+        }
+    });
+
+    test('additional package json attributes schema: every forbidden key is rejected', function () {
+        for (const key of [
+            'bin',
+            'dependencies',
+            'peerDependencies',
+            'devDependencies',
+            'exports',
+            'imports',
+            'main',
+            'name',
+            'types',
+            'type',
+            'version'
+        ]) {
+            const result = safeParse(additionalPackageJsonAttributesSchema, { [key]: 'value' });
+            assert.strictEqual(result.success, false);
+        }
+    });
 });

--- a/source/config/automatic-versioning-settings.test.ts
+++ b/source/config/automatic-versioning-settings.test.ts
@@ -1,46 +1,48 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { automaticVersioningSettingsSchema } from './automatic-versioning-settings.ts';
 
-test('automatic versioning schema accepts automatic true', () => {
-    assert.strictEqual(
-        safeParse(automaticVersioningSettingsSchema, { automatic: true, minimumVersion: '1.0.0' }).success,
-        true
+suite('automatic-versioning-settings', function () {
+    test('automatic versioning schema accepts automatic true', function () {
+        assert.strictEqual(
+            safeParse(automaticVersioningSettingsSchema, { automatic: true, minimumVersion: '1.0.0' }).success,
+            true
+        );
+    });
+
+    test('automatic versioning schema rejects automatic false', function () {
+        assert.strictEqual(
+            safeParse(automaticVersioningSettingsSchema, { automatic: false, minimumVersion: '1.0.0' }).success,
+            false
+        );
+    });
+
+    test(
+        'automatic versioning: validation succeeds with automatic true',
+        checkValidationSuccess({
+            schema: automaticVersioningSettingsSchema,
+            data: { automatic: true, minimumVersion: '1.0.0' },
+            expectedData: { automatic: true, minimumVersion: '1.0.0' }
+        })
+    );
+
+    test(
+        'automatic versioning: validation fails with automatic false',
+        checkValidationFailure({
+            schema: automaticVersioningSettingsSchema,
+            data: { automatic: false, minimumVersion: '1.0.0' },
+            expectedMessages: ['at automatic: invalid literal: expected true, but got boolean']
+        })
+    );
+
+    test(
+        'automatic versioning: validation fails when version is provided instead of minimumVersion',
+        checkValidationFailure({
+            schema: automaticVersioningSettingsSchema,
+            data: { automatic: true, version: '1.0.0' },
+            expectedMessages: ['unexpected additional property: "version"']
+        })
     );
 });
-
-test('automatic versioning schema rejects automatic false', () => {
-    assert.strictEqual(
-        safeParse(automaticVersioningSettingsSchema, { automatic: false, minimumVersion: '1.0.0' }).success,
-        false
-    );
-});
-
-test(
-    'automatic versioning: validation succeeds with automatic true',
-    checkValidationSuccess({
-        schema: automaticVersioningSettingsSchema,
-        data: { automatic: true, minimumVersion: '1.0.0' },
-        expectedData: { automatic: true, minimumVersion: '1.0.0' }
-    })
-);
-
-test(
-    'automatic versioning: validation fails with automatic false',
-    checkValidationFailure({
-        schema: automaticVersioningSettingsSchema,
-        data: { automatic: false, minimumVersion: '1.0.0' },
-        expectedMessages: ['at automatic: invalid literal: expected true, but got boolean']
-    })
-);
-
-test(
-    'automatic versioning: validation fails when version is provided instead of minimumVersion',
-    checkValidationFailure({
-        schema: automaticVersioningSettingsSchema,
-        data: { automatic: true, version: '1.0.0' },
-        expectedMessages: ['unexpected additional property: "version"']
-    })
-);

--- a/source/config/base-validations.test.ts
+++ b/source/config/base-validations.test.ts
@@ -1,16 +1,18 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { nonEmptyStringSchema } from './base-validations.ts';
 
-test('nonEmptyStringSchema accepts a non-empty string', () => {
-    assert.strictEqual(nonEmptyStringSchema.safeParse('hello').success, true);
-});
+suite('base-validations', function () {
+    test('nonEmptyStringSchema accepts a non-empty string', function () {
+        assert.strictEqual(nonEmptyStringSchema.safeParse('hello').success, true);
+    });
 
-test('nonEmptyStringSchema rejects an empty string', () => {
-    assert.strictEqual(nonEmptyStringSchema.safeParse('').success, false);
-});
+    test('nonEmptyStringSchema rejects an empty string', function () {
+        assert.strictEqual(nonEmptyStringSchema.safeParse('').success, false);
+    });
 
-test('nonEmptyStringSchema rejects non-string inputs', () => {
-    assert.strictEqual(nonEmptyStringSchema.safeParse(null).success, false);
-    assert.strictEqual(nonEmptyStringSchema.safeParse(42).success, false);
+    test('nonEmptyStringSchema rejects non-string inputs', function () {
+        assert.strictEqual(nonEmptyStringSchema.safeParse(null).success, false);
+        assert.strictEqual(nonEmptyStringSchema.safeParse(42).success, false);
+    });
 });

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     checkValidationFailure,
     checkValidationSuccess,
@@ -9,225 +9,236 @@ import {
 } from '../test-libraries/verify-schema-validation.ts';
 import { checksPerPackageSchema, checksSchema } from './checks-schema.ts';
 
-test('schema accepts valid noDuplicatedFiles settings at the top level', () => {
-    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { enabled: true } }).success, true);
-});
+suite('checks-schema', function () {
+    test('schema accepts valid noDuplicatedFiles settings at the top level', function () {
+        assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { enabled: true } }).success, true);
+    });
 
-test('top-level schema accepts a global allowList on noDuplicatedFiles', () => {
-    assert.strictEqual(
-        safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }).success,
-        true
+    test('top-level schema accepts a global allowList on noDuplicatedFiles', function () {
+        assert.strictEqual(
+            safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: ['src/index.ts'] } }).success,
+            true
+        );
+    });
+
+    test('top-level schema rejects an empty path inside the noDuplicatedFiles allowList', function () {
+        assert.strictEqual(
+            safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: [''] } }).success,
+            false
+        );
+    });
+
+    test('schema rejects noDuplicatedFiles settings without enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: {} }).success, false);
+    });
+
+    test('schema accepts empty checks settings', function () {
+        assert.strictEqual(safeParse(checksSchema, {}).success, true);
+    });
+
+    test('schema rejects non-object noDuplicatedFiles settings', function () {
+        assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: true }).success, false);
+    });
+
+    const validNoDuplicatedFilesGlobal = { enabled: true };
+
+    createTestCasesForOptionalField({
+        schema: checksSchema,
+        data: { noDuplicatedFiles: validNoDuplicatedFilesGlobal },
+        path: 'noDuplicatedFiles',
+        expectedFieldType: 'object'
+    });
+
+    createTestCasesForRequiredField({
+        schema: checksSchema,
+        data: { noDuplicatedFiles: validNoDuplicatedFilesGlobal },
+        path: 'noDuplicatedFiles.enabled',
+        expectedFieldType: 'boolean'
+    });
+
+    test(
+        'no duplicated files settings: validation succeeds with enabled at the top level',
+        checkValidationSuccess({
+            schema: checksSchema,
+            data: { noDuplicatedFiles: { enabled: true } },
+            expectedData: { noDuplicatedFiles: { enabled: true } }
+        })
     );
-});
 
-test('top-level schema rejects an empty path inside the noDuplicatedFiles allowList', () => {
-    assert.strictEqual(
-        safeParse(checksSchema, { noDuplicatedFiles: { enabled: true, allowList: [''] } }).success,
-        false
+    test(
+        'no duplicated files settings: validation fails when enabled is missing',
+        checkValidationFailure({
+            schema: checksSchema,
+            data: { noDuplicatedFiles: {} },
+            expectedMessages: ['at noDuplicatedFiles.enabled: missing property']
+        })
     );
-});
 
-test('schema rejects noDuplicatedFiles settings without enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: {} }).success, false);
-});
-
-test('schema accepts empty checks settings', () => {
-    assert.strictEqual(safeParse(checksSchema, {}).success, true);
-});
-
-test('schema rejects non-object noDuplicatedFiles settings', () => {
-    assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: true }).success, false);
-});
-
-const validNoDuplicatedFilesGlobal = { enabled: true };
-
-createTestCasesForOptionalField({
-    schema: checksSchema,
-    data: { noDuplicatedFiles: validNoDuplicatedFilesGlobal },
-    path: 'noDuplicatedFiles',
-    expectedFieldType: 'object'
-});
-
-createTestCasesForRequiredField({
-    schema: checksSchema,
-    data: { noDuplicatedFiles: validNoDuplicatedFilesGlobal },
-    path: 'noDuplicatedFiles.enabled',
-    expectedFieldType: 'boolean'
-});
-
-test(
-    'no duplicated files settings: validation succeeds with enabled at the top level',
-    checkValidationSuccess({
-        schema: checksSchema,
-        data: { noDuplicatedFiles: { enabled: true } },
-        expectedData: { noDuplicatedFiles: { enabled: true } }
-    })
-);
-
-test(
-    'no duplicated files settings: validation fails when enabled is missing',
-    checkValidationFailure({
-        schema: checksSchema,
-        data: { noDuplicatedFiles: {} },
-        expectedMessages: ['at noDuplicatedFiles.enabled: missing property']
-    })
-);
-
-test(
-    'checks settings: validation succeeds when empty',
-    checkValidationSuccess({
-        schema: checksSchema,
-        data: {},
-        expectedData: {}
-    })
-);
-
-test(
-    'checks settings: validation fails when noDuplicatedFiles is not an object',
-    checkValidationFailure({
-        schema: checksSchema,
-        data: { noDuplicatedFiles: true },
-        expectedMessages: ['at noDuplicatedFiles: expected object, but got boolean']
-    })
-);
-
-test(
-    'no duplicated files settings: validation fails when an additional property is given',
-    checkValidationFailure({
-        schema: checksSchema,
-        data: { noDuplicatedFiles: { ...validNoDuplicatedFilesGlobal, extra: true } },
-        expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
-    })
-);
-
-test('per-package schema accepts an empty noDuplicatedFiles object', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: {} }).success, true);
-});
-
-test('per-package schema accepts an allowList of file paths', () => {
-    assert.strictEqual(
-        safeParse(checksPerPackageSchema, { noDuplicatedFiles: { allowList: ['src/shared/util.ts'] } }).success,
-        true
+    test(
+        'checks settings: validation succeeds when empty',
+        checkValidationSuccess({
+            schema: checksSchema,
+            data: {},
+            expectedData: {}
+        })
     );
-});
 
-test('per-package schema rejects an enabled flag', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: { enabled: true } }).success, false);
-});
-
-test('per-package schema rejects an empty string in the allowList', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: { allowList: [''] } }).success, false);
-});
-
-test(
-    'per-package: validation fails when allowList contains an empty path',
-    checkValidationFailure({
-        schema: checksPerPackageSchema,
-        data: { noDuplicatedFiles: { allowList: [''] } },
-        expectedMessages: ['at noDuplicatedFiles.allowList[0]: string must contain at least 1 character']
-    })
-);
-
-test(
-    'per-package: validation fails when an unknown extra property is given',
-    checkValidationFailure({
-        schema: checksPerPackageSchema,
-        data: { noDuplicatedFiles: { allowList: ['LICENSE'], extra: true } },
-        expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
-    })
-);
-
-test('top-level schema accepts requiredFiles with enabled and a files list', () => {
-    assert.strictEqual(safeParse(checksSchema, { requiredFiles: { enabled: true, files: ['LICENSE'] } }).success, true);
-});
-
-test('top-level schema rejects requiredFiles without enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { requiredFiles: { files: ['LICENSE'] } }).success, false);
-});
-
-test('top-level schema rejects an empty path in requiredFiles.files', () => {
-    assert.strictEqual(safeParse(checksSchema, { requiredFiles: { enabled: true, files: [''] } }).success, false);
-});
-
-test('per-package schema accepts requiredFiles with a files list', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { files: ['LICENSE'] } }).success, true);
-});
-
-test('per-package schema rejects an enabled flag on requiredFiles', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { enabled: true } }).success, false);
-});
-
-test('top-level schema accepts maxBundleSize with enabled and a bytes threshold', () => {
-    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: 1024 } }).success, true);
-});
-
-test('top-level schema accepts maxBundleSize without bytes', () => {
-    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true } }).success, true);
-});
-
-test('top-level schema rejects a negative byte threshold', () => {
-    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: -1 } }).success, false);
-});
-
-test('top-level schema rejects a non-integer byte threshold', () => {
-    assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: 1.5 } }).success, false);
-});
-
-test('per-package schema accepts a maxBundleSize override', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { bytes: 2048 } }).success, true);
-});
-
-test('per-package schema rejects an enabled flag on maxBundleSize', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { enabled: true } }).success, false);
-});
-
-test('top-level schema accepts noUnusedBundleDependencies with enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { noUnusedBundleDependencies: { enabled: true } }).success, true);
-});
-
-test('top-level schema rejects noUnusedBundleDependencies without enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { noUnusedBundleDependencies: {} }).success, false);
-});
-
-test('per-package schema accepts an empty noUnusedBundleDependencies object', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { noUnusedBundleDependencies: {} }).success, true);
-});
-
-test('per-package schema rejects any field on noUnusedBundleDependencies', () => {
-    assert.strictEqual(
-        safeParse(checksPerPackageSchema, { noUnusedBundleDependencies: { enabled: true } }).success,
-        false
+    test(
+        'checks settings: validation fails when noDuplicatedFiles is not an object',
+        checkValidationFailure({
+            schema: checksSchema,
+            data: { noDuplicatedFiles: true },
+            expectedMessages: ['at noDuplicatedFiles: expected object, but got boolean']
+        })
     );
-});
 
-test('top-level schema accepts noDevDependencyImports with enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { noDevDependencyImports: { enabled: true } }).success, true);
-});
+    test(
+        'no duplicated files settings: validation fails when an additional property is given',
+        checkValidationFailure({
+            schema: checksSchema,
+            data: { noDuplicatedFiles: { ...validNoDuplicatedFilesGlobal, extra: true } },
+            expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
+        })
+    );
 
-test('top-level schema rejects noDevDependencyImports without enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { noDevDependencyImports: {} }).success, false);
-});
+    test('per-package schema accepts an empty noDuplicatedFiles object', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: {} }).success, true);
+    });
 
-test('per-package schema accepts an empty noDevDependencyImports object', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { noDevDependencyImports: {} }).success, true);
-});
+    test('per-package schema accepts an allowList of file paths', function () {
+        assert.strictEqual(
+            safeParse(checksPerPackageSchema, { noDuplicatedFiles: { allowList: ['src/shared/util.ts'] } }).success,
+            true
+        );
+    });
 
-test('per-package schema rejects any field on noDevDependencyImports', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { noDevDependencyImports: { enabled: true } }).success, false);
-});
+    test('per-package schema rejects an enabled flag', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { noDuplicatedFiles: { enabled: true } }).success, false);
+    });
 
-test('top-level schema accepts uniqueTargetPaths with enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { uniqueTargetPaths: { enabled: true } }).success, true);
-});
+    test('per-package schema rejects an empty string in the allowList', function () {
+        assert.strictEqual(
+            safeParse(checksPerPackageSchema, { noDuplicatedFiles: { allowList: [''] } }).success,
+            false
+        );
+    });
 
-test('top-level schema rejects uniqueTargetPaths without enabled', () => {
-    assert.strictEqual(safeParse(checksSchema, { uniqueTargetPaths: {} }).success, false);
-});
+    test(
+        'per-package: validation fails when allowList contains an empty path',
+        checkValidationFailure({
+            schema: checksPerPackageSchema,
+            data: { noDuplicatedFiles: { allowList: [''] } },
+            expectedMessages: ['at noDuplicatedFiles.allowList[0]: string must contain at least 1 character']
+        })
+    );
 
-test('per-package schema accepts an empty uniqueTargetPaths object', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { uniqueTargetPaths: {} }).success, true);
-});
+    test(
+        'per-package: validation fails when an unknown extra property is given',
+        checkValidationFailure({
+            schema: checksPerPackageSchema,
+            data: { noDuplicatedFiles: { allowList: ['LICENSE'], extra: true } },
+            expectedMessages: ['at noDuplicatedFiles: unexpected additional property: "extra"']
+        })
+    );
 
-test('per-package schema rejects any field on uniqueTargetPaths', () => {
-    assert.strictEqual(safeParse(checksPerPackageSchema, { uniqueTargetPaths: { enabled: true } }).success, false);
+    test('top-level schema accepts requiredFiles with enabled and a files list', function () {
+        assert.strictEqual(
+            safeParse(checksSchema, { requiredFiles: { enabled: true, files: ['LICENSE'] } }).success,
+            true
+        );
+    });
+
+    test('top-level schema rejects requiredFiles without enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { requiredFiles: { files: ['LICENSE'] } }).success, false);
+    });
+
+    test('top-level schema rejects an empty path in requiredFiles.files', function () {
+        assert.strictEqual(safeParse(checksSchema, { requiredFiles: { enabled: true, files: [''] } }).success, false);
+    });
+
+    test('per-package schema accepts requiredFiles with a files list', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { files: ['LICENSE'] } }).success, true);
+    });
+
+    test('per-package schema rejects an enabled flag on requiredFiles', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { requiredFiles: { enabled: true } }).success, false);
+    });
+
+    test('top-level schema accepts maxBundleSize with enabled and a bytes threshold', function () {
+        assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: 1024 } }).success, true);
+    });
+
+    test('top-level schema accepts maxBundleSize without bytes', function () {
+        assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true } }).success, true);
+    });
+
+    test('top-level schema rejects a negative byte threshold', function () {
+        assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: -1 } }).success, false);
+    });
+
+    test('top-level schema rejects a non-integer byte threshold', function () {
+        assert.strictEqual(safeParse(checksSchema, { maxBundleSize: { enabled: true, bytes: 1.5 } }).success, false);
+    });
+
+    test('per-package schema accepts a maxBundleSize override', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { bytes: 2048 } }).success, true);
+    });
+
+    test('per-package schema rejects an enabled flag on maxBundleSize', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { maxBundleSize: { enabled: true } }).success, false);
+    });
+
+    test('top-level schema accepts noUnusedBundleDependencies with enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { noUnusedBundleDependencies: { enabled: true } }).success, true);
+    });
+
+    test('top-level schema rejects noUnusedBundleDependencies without enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { noUnusedBundleDependencies: {} }).success, false);
+    });
+
+    test('per-package schema accepts an empty noUnusedBundleDependencies object', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { noUnusedBundleDependencies: {} }).success, true);
+    });
+
+    test('per-package schema rejects any field on noUnusedBundleDependencies', function () {
+        assert.strictEqual(
+            safeParse(checksPerPackageSchema, { noUnusedBundleDependencies: { enabled: true } }).success,
+            false
+        );
+    });
+
+    test('top-level schema accepts noDevDependencyImports with enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { noDevDependencyImports: { enabled: true } }).success, true);
+    });
+
+    test('top-level schema rejects noDevDependencyImports without enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { noDevDependencyImports: {} }).success, false);
+    });
+
+    test('per-package schema accepts an empty noDevDependencyImports object', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { noDevDependencyImports: {} }).success, true);
+    });
+
+    test('per-package schema rejects any field on noDevDependencyImports', function () {
+        assert.strictEqual(
+            safeParse(checksPerPackageSchema, { noDevDependencyImports: { enabled: true } }).success,
+            false
+        );
+    });
+
+    test('top-level schema accepts uniqueTargetPaths with enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { uniqueTargetPaths: { enabled: true } }).success, true);
+    });
+
+    test('top-level schema rejects uniqueTargetPaths without enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { uniqueTargetPaths: {} }).success, false);
+    });
+
+    test('per-package schema accepts an empty uniqueTargetPaths object', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { uniqueTargetPaths: {} }).success, true);
+    });
+
+    test('per-package schema rejects any field on uniqueTargetPaths', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { uniqueTargetPaths: { enabled: true } }).success, false);
+    });
 });

--- a/source/config/common-package-settings-schemas.test.ts
+++ b/source/config/common-package-settings-schemas.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     checkValidationFailure,
     checkValidationSuccess,
@@ -14,125 +14,128 @@ import {
     requiredCommonPackageSettingsSchema
 } from './common-package-settings-schemas.ts';
 
-test('optional common settings schema accepts an empty object', () => {
-    assert.strictEqual(safeParse(optionalCommonPackageSettingsSchema, {}).success, true);
-});
+suite('common-package-settings-schemas', function () {
+    test('optional common settings schema accepts an empty object', function () {
+        assert.strictEqual(safeParse(optionalCommonPackageSettingsSchema, {}).success, true);
+    });
 
-test('required common settings schema accepts both required properties', () => {
-    assert.strictEqual(
-        safeParse(requiredCommonPackageSettingsSchema, {
-            sourcesFolder: 'src',
-            mainPackageJson: { type: 'module' }
-        }).success,
-        true
-    );
-});
+    test('required common settings schema accepts both required properties', function () {
+        assert.strictEqual(
+            safeParse(requiredCommonPackageSettingsSchema, {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' }
+            }).success,
+            true
+        );
+    });
 
-test('required common settings schema rejects missing sourcesFolder', () => {
-    assert.strictEqual(
-        safeParse(requiredCommonPackageSettingsSchema, { mainPackageJson: { type: 'module' } }).success,
-        false
-    );
-});
+    test('required common settings schema rejects missing sourcesFolder', function () {
+        assert.strictEqual(
+            safeParse(requiredCommonPackageSettingsSchema, { mainPackageJson: { type: 'module' } }).success,
+            false
+        );
+    });
 
-test('required common settings schema rejects missing mainPackageJson', () => {
-    assert.strictEqual(safeParse(requiredCommonPackageSettingsSchema, { sourcesFolder: 'src' }).success, false);
-});
+    test('required common settings schema rejects missing mainPackageJson', function () {
+        assert.strictEqual(safeParse(requiredCommonPackageSettingsSchema, { sourcesFolder: 'src' }).success, false);
+    });
 
-test('sourcesFolder-required common settings schema accepts sourcesFolder only', () => {
-    assert.strictEqual(
-        safeParse(commonPackageSettingsSourcesFolderRequiredSchema, { sourcesFolder: 'src' }).success,
-        true
-    );
-});
+    test('sourcesFolder-required common settings schema accepts sourcesFolder only', function () {
+        assert.strictEqual(
+            safeParse(commonPackageSettingsSourcesFolderRequiredSchema, { sourcesFolder: 'src' }).success,
+            true
+        );
+    });
 
-test('mainPackageJson-required common settings schema accepts mainPackageJson only', () => {
-    assert.strictEqual(
-        safeParse(commonPackageSettingsMainPackageJsonRequiredSchema, { mainPackageJson: { type: 'module' } }).success,
-        true
-    );
-});
+    test('mainPackageJson-required common settings schema accepts mainPackageJson only', function () {
+        assert.strictEqual(
+            safeParse(commonPackageSettingsMainPackageJsonRequiredSchema, { mainPackageJson: { type: 'module' } })
+                .success,
+            true
+        );
+    });
 
-const validRequiredCommonSettings = { sourcesFolder: 'src', mainPackageJson: { type: 'module' } };
+    const validRequiredCommonSettings = { sourcesFolder: 'src', mainPackageJson: { type: 'module' } };
 
-createTestCasesForOptionalField({
-    schema: optionalCommonPackageSettingsSchema,
-    data: validRequiredCommonSettings,
-    path: 'sourcesFolder',
-    expectedFieldType: 'string'
-});
-
-createTestCasesForOptionalField({
-    schema: optionalCommonPackageSettingsSchema,
-    data: validRequiredCommonSettings,
-    path: 'mainPackageJson',
-    expectedFieldType: 'object'
-});
-
-createTestCasesForRequiredField({
-    schema: requiredCommonPackageSettingsSchema,
-    data: validRequiredCommonSettings,
-    path: 'sourcesFolder',
-    expectedFieldType: 'string'
-});
-
-createTestCasesForRequiredField({
-    schema: requiredCommonPackageSettingsSchema,
-    data: validRequiredCommonSettings,
-    path: 'mainPackageJson',
-    expectedFieldType: 'object'
-});
-
-test(
-    'optional common package settings: validation succeeds when empty',
-    checkValidationSuccess({
+    createTestCasesForOptionalField({
         schema: optionalCommonPackageSettingsSchema,
-        data: {},
-        expectedData: {}
-    })
-);
+        data: validRequiredCommonSettings,
+        path: 'sourcesFolder',
+        expectedFieldType: 'string'
+    });
 
-test(
-    'required common package settings: validation fails when sourcesFolder is missing',
-    checkValidationFailure({
+    createTestCasesForOptionalField({
+        schema: optionalCommonPackageSettingsSchema,
+        data: validRequiredCommonSettings,
+        path: 'mainPackageJson',
+        expectedFieldType: 'object'
+    });
+
+    createTestCasesForRequiredField({
         schema: requiredCommonPackageSettingsSchema,
-        data: { mainPackageJson: { type: 'module' } },
-        expectedMessages: ['at sourcesFolder: missing property']
-    })
-);
+        data: validRequiredCommonSettings,
+        path: 'sourcesFolder',
+        expectedFieldType: 'string'
+    });
 
-test(
-    'required common package settings: validation fails when mainPackageJson is missing',
-    checkValidationFailure({
+    createTestCasesForRequiredField({
         schema: requiredCommonPackageSettingsSchema,
-        data: { sourcesFolder: 'src' },
-        expectedMessages: ['at mainPackageJson: missing property']
-    })
-);
+        data: validRequiredCommonSettings,
+        path: 'mainPackageJson',
+        expectedFieldType: 'object'
+    });
 
-test(
-    'sources-folder-required common package settings: validation succeeds without mainPackageJson',
-    checkValidationSuccess({
-        schema: commonPackageSettingsSourcesFolderRequiredSchema,
-        data: { sourcesFolder: 'src' },
-        expectedData: { sourcesFolder: 'src' }
-    })
-);
+    test(
+        'optional common package settings: validation succeeds when empty',
+        checkValidationSuccess({
+            schema: optionalCommonPackageSettingsSchema,
+            data: {},
+            expectedData: {}
+        })
+    );
 
-test(
-    'main-package-json-required common package settings: validation succeeds without sourcesFolder',
-    checkValidationSuccess({
-        schema: commonPackageSettingsMainPackageJsonRequiredSchema,
-        data: { mainPackageJson: { type: 'module' } },
-        expectedData: { mainPackageJson: { type: 'module' } }
-    })
-);
+    test(
+        'required common package settings: validation fails when sourcesFolder is missing',
+        checkValidationFailure({
+            schema: requiredCommonPackageSettingsSchema,
+            data: { mainPackageJson: { type: 'module' } },
+            expectedMessages: ['at sourcesFolder: missing property']
+        })
+    );
 
-test(
-    'required common package settings: validation fails when an additional property is given',
-    checkValidationFailure({
-        schema: requiredCommonPackageSettingsSchema,
-        data: { ...validRequiredCommonSettings, extra: true },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
+    test(
+        'required common package settings: validation fails when mainPackageJson is missing',
+        checkValidationFailure({
+            schema: requiredCommonPackageSettingsSchema,
+            data: { sourcesFolder: 'src' },
+            expectedMessages: ['at mainPackageJson: missing property']
+        })
+    );
+
+    test(
+        'sources-folder-required common package settings: validation succeeds without mainPackageJson',
+        checkValidationSuccess({
+            schema: commonPackageSettingsSourcesFolderRequiredSchema,
+            data: { sourcesFolder: 'src' },
+            expectedData: { sourcesFolder: 'src' }
+        })
+    );
+
+    test(
+        'main-package-json-required common package settings: validation succeeds without sourcesFolder',
+        checkValidationSuccess({
+            schema: commonPackageSettingsMainPackageJsonRequiredSchema,
+            data: { mainPackageJson: { type: 'module' } },
+            expectedData: { mainPackageJson: { type: 'module' } }
+        })
+    );
+
+    test(
+        'required common package settings: validation fails when an additional property is given',
+        checkValidationFailure({
+            schema: requiredCommonPackageSettingsSchema,
+            data: { ...validRequiredCommonSettings, extra: true },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+});

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { configToResolveAndLinkOptions } from '../packtory/map-config.ts';
 import { linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import type { PacktoryConfig } from './config.ts';
@@ -130,97 +130,99 @@ const validConfigArbitrary = fc
         };
     });
 
-test('packtoryConfigSchema accepts generated valid config shapes unchanged', () => {
-    fc.assert(
-        fc.property(validConfigArbitrary, (config) => {
-            const typedConfig = config as unknown as PacktoryConfig;
-            const result = safeParse(packtoryConfigSchema, typedConfig);
+suite('config', function () {
+    test('packtoryConfigSchema accepts generated valid config shapes unchanged', function () {
+        fc.assert(
+            fc.property(validConfigArbitrary, (config) => {
+                const typedConfig = config as unknown as PacktoryConfig;
+                const result = safeParse(packtoryConfigSchema, typedConfig);
 
-            assert.strictEqual(result.success, true);
-            if (result.success) {
-                assert.deepStrictEqual(result.data.registrySettings, typedConfig.registrySettings);
-                assert.strictEqual(result.data.packages.length, config.packages.length);
-                assert.deepStrictEqual(
-                    result.data.packages.map((entry) => {
-                        return entry.name;
-                    }),
-                    typedConfig.packages.map((entry) => {
-                        return entry.name;
-                    })
-                );
-                assert.deepStrictEqual(
-                    result.data.packages.map((entry) => {
-                        return entry.roots;
-                    }),
-                    typedConfig.packages.map((entry) => {
-                        return entry.roots;
-                    })
-                );
-                assert.deepStrictEqual(
-                    result.data.packages.map((entry) => {
-                        return entry.sourcesFolder;
-                    }),
-                    typedConfig.packages.map((entry) => {
-                        return entry.sourcesFolder;
-                    })
-                );
-                assert.deepStrictEqual(
-                    result.data.packages.map((entry) => {
-                        return entry.mainPackageJson;
-                    }),
-                    typedConfig.packages.map((entry) => {
-                        return entry.mainPackageJson;
-                    })
-                );
-                assert.deepStrictEqual(
-                    result.data.commonPackageSettings?.sourcesFolder,
-                    typedConfig.commonPackageSettings?.sourcesFolder
-                );
-                assert.deepStrictEqual(
-                    result.data.commonPackageSettings?.mainPackageJson,
-                    typedConfig.commonPackageSettings?.mainPackageJson
-                );
-            }
-        })
-    );
-});
+                assert.strictEqual(result.success, true);
+                if (result.success) {
+                    assert.deepStrictEqual(result.data.registrySettings, typedConfig.registrySettings);
+                    assert.strictEqual(result.data.packages.length, config.packages.length);
+                    assert.deepStrictEqual(
+                        result.data.packages.map((entry) => {
+                            return entry.name;
+                        }),
+                        typedConfig.packages.map((entry) => {
+                            return entry.name;
+                        })
+                    );
+                    assert.deepStrictEqual(
+                        result.data.packages.map((entry) => {
+                            return entry.roots;
+                        }),
+                        typedConfig.packages.map((entry) => {
+                            return entry.roots;
+                        })
+                    );
+                    assert.deepStrictEqual(
+                        result.data.packages.map((entry) => {
+                            return entry.sourcesFolder;
+                        }),
+                        typedConfig.packages.map((entry) => {
+                            return entry.sourcesFolder;
+                        })
+                    );
+                    assert.deepStrictEqual(
+                        result.data.packages.map((entry) => {
+                            return entry.mainPackageJson;
+                        }),
+                        typedConfig.packages.map((entry) => {
+                            return entry.mainPackageJson;
+                        })
+                    );
+                    assert.deepStrictEqual(
+                        result.data.commonPackageSettings?.sourcesFolder,
+                        typedConfig.commonPackageSettings?.sourcesFolder
+                    );
+                    assert.deepStrictEqual(
+                        result.data.commonPackageSettings?.mainPackageJson,
+                        typedConfig.commonPackageSettings?.mainPackageJson
+                    );
+                }
+            })
+        );
+    });
 
-test('configToResolveAndLinkOptions() keeps package-specific overrides over inherited common settings', () => {
-    fc.assert(
-        fc.property(validConfigArbitrary, (config) => {
-            const typedConfig = config as unknown as PacktoryConfig;
-            const [packageConfig] = typedConfig.packages;
-            if (packageConfig === undefined) {
-                assert.fail('Expected a package configuration');
-            }
-            const existingBundles = (packageConfig.bundleDependencies ?? []).map((dependencyName) => {
-                return linkedBundle({ name: dependencyName, contents: [] });
-            });
+    test('configToResolveAndLinkOptions() keeps package-specific overrides over inherited common settings', function () {
+        fc.assert(
+            fc.property(validConfigArbitrary, (config) => {
+                const typedConfig = config as unknown as PacktoryConfig;
+                const [packageConfig] = typedConfig.packages;
+                if (packageConfig === undefined) {
+                    assert.fail('Expected a package configuration');
+                }
+                const existingBundles = (packageConfig.bundleDependencies ?? []).map((dependencyName) => {
+                    return linkedBundle({ name: dependencyName, contents: [] });
+                });
 
-            const result = configToResolveAndLinkOptions(
-                packageConfig.name,
-                Object.fromEntries(
-                    typedConfig.packages.map((entry) => {
-                        return [entry.name, entry];
-                    })
-                ),
-                typedConfig,
-                existingBundles
-            );
+                const result = configToResolveAndLinkOptions(
+                    packageConfig.name,
+                    Object.fromEntries(
+                        typedConfig.packages.map((entry) => {
+                            return [entry.name, entry];
+                        })
+                    ),
+                    typedConfig,
+                    existingBundles
+                );
 
-            const expectedSourcesFolder =
-                packageConfig.sourcesFolder ?? typedConfig.commonPackageSettings?.sourcesFolder;
-            assert.strictEqual(result.sourcesFolder, expectedSourcesFolder);
+                const expectedSourcesFolder =
+                    packageConfig.sourcesFolder ?? typedConfig.commonPackageSettings?.sourcesFolder;
+                assert.strictEqual(result.sourcesFolder, expectedSourcesFolder);
 
-            if (packageConfig.mainPackageJson === undefined) {
-                assert.deepStrictEqual(result.mainPackageJson, typedConfig.commonPackageSettings?.mainPackageJson);
-            } else {
-                assert.deepStrictEqual(result.mainPackageJson, packageConfig.mainPackageJson);
-            }
+                if (packageConfig.mainPackageJson === undefined) {
+                    assert.deepStrictEqual(result.mainPackageJson, typedConfig.commonPackageSettings?.mainPackageJson);
+                } else {
+                    assert.deepStrictEqual(result.mainPackageJson, packageConfig.mainPackageJson);
+                }
 
-            if (packageConfig.includeSourceMapFiles !== undefined) {
-                assert.strictEqual(result.includeSourceMapFiles, packageConfig.includeSourceMapFiles);
-            }
-        })
-    );
+                if (packageConfig.includeSourceMapFiles !== undefined) {
+                    assert.strictEqual(result.includeSourceMapFiles, packageConfig.includeSourceMapFiles);
+                }
+            })
+        );
+    });
 });

--- a/source/config/config.test.ts
+++ b/source/config/config.test.ts
@@ -1,1158 +1,1149 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { getBundledDependencies } from './config.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
 import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-registry-schema.ts';
 
-test('getBundledDependencies combines direct and peer bundled dependencies', () => {
-    assert.deepStrictEqual(
-        getBundledDependencies({
-            name: 'foo',
-            roots: { main: { js: 'foo.js' } },
-            bundleDependencies: ['bar'],
-            bundlePeerDependencies: ['baz']
-        }),
-        ['bar', 'baz']
+suite('config', function () {
+    test('getBundledDependencies combines direct and peer bundled dependencies', function () {
+        assert.deepStrictEqual(
+            getBundledDependencies({
+                name: 'foo',
+                roots: { main: { js: 'foo.js' } },
+                bundleDependencies: ['bar'],
+                bundlePeerDependencies: ['baz']
+            }),
+            ['bar', 'baz']
+        );
+    });
+
+    test('getBundledDependencies returns an empty list when no bundled dependencies are defined', function () {
+        assert.deepStrictEqual(
+            getBundledDependencies({
+                name: 'foo',
+                roots: { main: { js: 'foo.js' } }
+            }),
+            []
+        );
+    });
+
+    test('config schema accepts a valid config', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigSchema, {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }).success,
+            true
+        );
+    });
+
+    test('config schema rejects configs without registrySettings', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigSchema, {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }).success,
+            false
+        );
+    });
+
+    test('config without registry schema rejects an empty packages tuple', function () {
+        assert.strictEqual(safeParse(packtoryConfigWithoutRegistrySchema, { packages: [] }).success, false);
+    });
+
+    test(
+        'validation succeeds when commonPackageSettings is defined but empty',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {},
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            },
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {},
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
     );
-});
 
-test('getBundledDependencies returns an empty list when no bundled dependencies are defined', () => {
-    assert.deepStrictEqual(
-        getBundledDependencies({
-            name: 'foo',
-            roots: { main: { js: 'foo.js' } }
-        }),
-        []
+    test(
+        'validation fails when registrySettings is missing',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            },
+            expectedMessages: ['at registrySettings: missing property']
+        })
     );
-});
 
-test('config schema accepts a valid config', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigSchema, {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }).success,
-        true
+    test(
+        'validation fails when packages is an empty array',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: []
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
     );
-});
 
-test('config schema rejects configs without registrySettings', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigSchema, {
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }).success,
-        false
+    test(
+        'validation fails when a package supplies entryPoints instead of roots',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        entryPoints: []
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
     );
-});
 
-test('config without registry schema rejects an empty packages tuple', () => {
-    assert.strictEqual(safeParse(packtoryConfigWithoutRegistrySchema, { packages: [] }).success, false);
-});
+    test(
+        'validation fails when checks.noDuplicatedFiles.enabled is missing',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: {}
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation succeeds when commonPackageSettings is defined but empty',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {},
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
+    test(
+        'validation fails when a per-package noDuplicatedFiles.allowList contains an empty path',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: {
+                        enabled: true
+                    }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        checks: { noDuplicatedFiles: { allowList: [''] } }
+                    }
+                ]
+            },
+            expectedMessages: [
+                'at packages[0].checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character'
             ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {},
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
+        })
+    );
 
-test(
-    'validation fails when registrySettings is missing',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['at registrySettings: missing property']
-    })
-);
+    test(
+        'validation succeeds when a package declares a per-package noDuplicatedFiles allowList',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: { enabled: true }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        checks: { noDuplicatedFiles: { allowList: ['foo/bar.ts'] } }
+                    }
+                ]
+            },
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: { enabled: true }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        checks: { noDuplicatedFiles: { allowList: ['foo/bar.ts'] } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation fails when packages is an empty array',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: []
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+    test(
+        'validation succeeds and preserves the checks.noDuplicatedFiles settings',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: { enabled: true }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            },
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: { enabled: true }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation fails when a package supplies entryPoints instead of roots',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    entryPoints: []
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+    test(
+        'validation succeeds when commonPackageSettings is defined with all optional values',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    includeSourceMapFiles: true,
+                    additionalFiles: [],
+                    additionalPackageJsonAttributes: {}
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            },
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    includeSourceMapFiles: true,
+                    additionalFiles: [],
+                    additionalPackageJsonAttributes: {}
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation fails when checks.noDuplicatedFiles.enabled is missing',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: {}
+    test(
+        'validation succeeds when commonPackageSettings is not given and a package contains all required settings',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation fails when a per-package noDuplicatedFiles.allowList contains an empty path',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: {
-                    enabled: true
-                }
-            },
-            packages: [
-                {
+    test(
+        'validation succeeds when commonPackageSettings is given and a package contains no common settings',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    checks: { noDuplicatedFiles: { allowList: [''] } }
-                }
-            ]
-        },
-        expectedMessages: [
-            'at packages[0].checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character'
-        ]
-    })
-);
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            },
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation succeeds when a package declares a per-package noDuplicatedFiles allowList',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: { enabled: true }
-            },
-            packages: [
-                {
+    test(
+        'validation succeeds when commonPackageSettings is given and a package contains common settings as well',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    checks: { noDuplicatedFiles: { allowList: ['foo/bar.ts'] } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: { enabled: true }
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    checks: { noDuplicatedFiles: { allowList: ['foo/bar.ts'] } }
-                }
-            ]
-        }
-    })
-);
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation succeeds and preserves the checks.noDuplicatedFiles settings',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: { enabled: true }
+    test(
+        'validation succeeds when only sourcesFolder is provided in commonPackageSettings',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source'
+                },
+                packages: [
+                    {
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: { enabled: true }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source'
+                },
+                packages: [
+                    {
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation succeeds when commonPackageSettings is defined with all optional values',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                includeSourceMapFiles: true,
-                additionalFiles: [],
-                additionalPackageJsonAttributes: {}
+    test(
+        'validation succeeds when only sourcesFolder is provided in commonPackageSettings and in packages',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source'
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                includeSourceMapFiles: true,
-                additionalFiles: [],
-                additionalPackageJsonAttributes: {}
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
-test(
-    'validation succeeds when commonPackageSettings is not given and a package contains all required settings',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source'
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation succeeds when commonPackageSettings is given and a package contains no common settings',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
+    test(
+        'validation succeeds when only mainPackageJson is provided in commonPackageSettings',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
-            },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation succeeds when commonPackageSettings is given and a package contains common settings as well',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
+    test(
+        'validation succeeds when only mainPackageJson is provided in commonPackageSettings and in packages',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation succeeds when only sourcesFolder is provided in commonPackageSettings',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source'
-            },
-            packages: [
-                {
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source'
-            },
-            packages: [
-                {
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
-
-test(
-    'validation succeeds when only sourcesFolder is provided in commonPackageSettings and in packages',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source'
-            },
-            packages: [
-                {
+    test(
+        'validation succeeds when all optional properties are given',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source'
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
-
-test(
-    'validation succeeds when only mainPackageJson is provided in commonPackageSettings',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module' }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module' }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
-
-test(
-    'validation succeeds when only mainPackageJson is provided in commonPackageSettings and in packages',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module' }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module' }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        }
-    })
-);
-
-test(
-    'validation succeeds when all optional properties are given',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                additionalFiles: [{ sourceFilePath: 'foo', targetFilePath: 'foo' }],
-                includeSourceMapFiles: true,
-                additionalPackageJsonAttributes: { license: 'foo' }
-            },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    versioning: { automatic: true },
-                    bundleDependencies: ['foo'],
-                    bundlePeerDependencies: ['foo'],
                     additionalFiles: [{ sourceFilePath: 'foo', targetFilePath: 'foo' }],
                     includeSourceMapFiles: true,
                     additionalPackageJsonAttributes: { license: 'foo' }
-                }
-            ]
-        },
-        expectedData: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                additionalFiles: [{ sourceFilePath: 'foo', targetFilePath: 'foo' }],
-                includeSourceMapFiles: true,
-                additionalPackageJsonAttributes: { license: 'foo' }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        versioning: { automatic: true },
+                        bundleDependencies: ['foo'],
+                        bundlePeerDependencies: ['foo'],
+                        additionalFiles: [{ sourceFilePath: 'foo', targetFilePath: 'foo' }],
+                        includeSourceMapFiles: true,
+                        additionalPackageJsonAttributes: { license: 'foo' }
+                    }
+                ]
             },
-            packages: [
-                {
+            expectedData: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    versioning: { automatic: true },
-                    bundleDependencies: ['foo'],
-                    bundlePeerDependencies: ['foo'],
                     additionalFiles: [{ sourceFilePath: 'foo', targetFilePath: 'foo' }],
                     includeSourceMapFiles: true,
                     additionalPackageJsonAttributes: { license: 'foo' }
-                }
-            ]
-        }
-    })
-);
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        versioning: { automatic: true },
+                        bundleDependencies: ['foo'],
+                        bundlePeerDependencies: ['foo'],
+                        additionalFiles: [{ sourceFilePath: 'foo', targetFilePath: 'foo' }],
+                        includeSourceMapFiles: true,
+                        additionalPackageJsonAttributes: { license: 'foo' }
+                    }
+                ]
+            }
+        })
+    );
 
-test(
-    'validation fails when a non-object is given',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: true,
-        expectedMessages: ['expected object, but got boolean', 'invalid value: expected object, but got boolean']
-    })
-);
+    test(
+        'validation fails when a non-object is given',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: true,
+            expectedMessages: ['expected object, but got boolean', 'invalid value: expected object, but got boolean']
+        })
+    );
 
-test(
-    'validation fails when an empty object is given',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {},
-        expectedMessages: ['at registrySettings: missing property', 'invalid value doesn’t match expected union']
-    })
-);
+    test(
+        'validation fails when an empty object is given',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {},
+            expectedMessages: ['at registrySettings: missing property', 'invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when commonPackageSettings is not defined and mainPackageJson is missing in a package',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when packages is an empty array',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: []
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when checks.noDuplicatedFiles misses the enabled flag',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: {}
+    test(
+        'validation fails when commonPackageSettings is not defined and mainPackageJson is missing in a package',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when a per-package noDuplicatedFiles.allowList contains an empty path (registry config)',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            checks: {
-                noDuplicatedFiles: { enabled: true }
+    test(
+        'validation fails when checks.noDuplicatedFiles misses the enabled flag',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: {}
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    checks: { noDuplicatedFiles: { allowList: [''] } }
-                }
-            ]
-        },
-        expectedMessages: [
-            'at packages[0].checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character'
-        ]
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when commonPackageSettings is empty and packages don’t define required properties',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {},
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when commonPackageSettings contains only mainPackageJson',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module' }
+    test(
+        'validation fails when a per-package noDuplicatedFiles.allowList contains an empty path (registry config)',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                checks: {
+                    noDuplicatedFiles: { enabled: true }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        checks: { noDuplicatedFiles: { allowList: [''] } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
+            expectedMessages: [
+                'at packages[0].checks.noDuplicatedFiles.allowList[0]: string must contain at least 1 character'
             ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+        })
+    );
 
-test(
-    'validation fails when commonPackageSettings is undefined and sourcesFolder is missing in a package',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: undefined,
-            packages: [
-                {
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when commonPackageSettings contains only sourcesFolder',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'foo'
+    test(
+        'validation fails when commonPackageSettings is empty and packages don’t define required properties',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {},
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when name is missing in a package',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'foo',
-                    mainPackageJson: { type: 'module' },
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when name is not a string',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'foo',
-                    mainPackageJson: { type: 'module' },
-                    name: 42,
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when roots is missing in a package',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'foo',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo'
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when roots is not an object',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'foo',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: 'foo'
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when a root entry is invalid',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            packages: [
-                {
-                    sourcesFolder: 'foo',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { foo: 'bar' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when additionalFiles is not an array',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                additionalFiles: 'foo'
+    test(
+        'validation fails when commonPackageSettings contains only mainPackageJson',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when includeSourceMapFiles is not a boolean',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                includeSourceMapFiles: 'foo'
+    test(
+        'validation fails when commonPackageSettings is undefined and sourcesFolder is missing in a package',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: undefined,
+                packages: [
+                    {
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when additionalPackageJsonAttributes is not an object',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                additionalPackageJsonAttributes: 'foo'
+    test(
+        'validation fails when commonPackageSettings contains only sourcesFolder',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'foo'
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when versioning is not an object',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
+    test(
+        'validation fails when name is missing in a package',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'foo',
+                        mainPackageJson: { type: 'module' },
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    versioning: 'foo'
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when bundleDependencies is not an array',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
+    test(
+        'validation fails when name is not a string',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'foo',
+                        mainPackageJson: { type: 'module' },
+                        name: 42,
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    bundleDependencies: 'foo'
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation fails when bundlePeerDependencies is not an array',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' }
+    test(
+        'validation fails when roots is missing in a package',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'foo',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo'
+                    }
+                ]
             },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    bundlePeerDependencies: 'foo'
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation without registry succeeds for a minimal package config',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            packages: [
-                {
+    test(
+        'validation fails when roots is not an object',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'foo',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: 'foo'
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when a root entry is invalid',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                packages: [
+                    {
+                        sourcesFolder: 'foo',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { foo: 'bar' } }
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when additionalFiles is not an array',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } }
-                }
-            ]
-        },
-        expectedData: {
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } }
-                }
-            ]
-        }
-    })
-);
-
-test(
-    'validation without registry fails when checks is not an object',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            checks: 'foo',
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation without registry fails when commonPackageSettings is not an object',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            commonPackageSettings: 'foo',
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation without registry fails when a package entry is not an object',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            packages: ['foo']
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation prefixes common package.json issues with commonPackageSettings',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { dependencies: true }
+                    additionalFiles: 'foo'
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [{ name: 'foo', roots: { main: { js: 'index.js' } } }]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation prefixes common additional package.json attribute issues with commonPackageSettings',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                additionalPackageJsonAttributes: { dependencies: '1.0.0' }
+    test(
+        'validation fails when includeSourceMapFiles is not a boolean',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { type: 'module' },
+                    includeSourceMapFiles: 'foo'
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [{ name: 'foo', roots: { main: { js: 'index.js' } } }]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'validation prefixes package additionalFiles issues with the array entry path',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            packages: [
-                {
+    test(
+        'validation fails when additionalPackageJsonAttributes is not an object',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } },
-                    additionalFiles: [{ sourceFilePath: 'asset.txt' }]
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation prefixes package additional package.json attribute issues',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } },
-                    additionalPackageJsonAttributes: { version: '1.0.0' }
-                }
-            ]
-        },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation prefixes registry settings issues with registrySettings',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: {
-                auth: { type: 'bearer-token', token: 42 }
+                    additionalPackageJsonAttributes: 'foo'
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
             },
-            packages: [
-                {
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when versioning is not an object',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        versioning: 'foo'
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when bundleDependencies is not an array',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        bundleDependencies: 'foo'
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when bundlePeerDependencies is not an array',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { type: 'module' }
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        bundlePeerDependencies: 'foo'
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation without registry succeeds for a minimal package config',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } }
+                    }
+                ]
+            },
+            expectedData: {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } }
+                    }
+                ]
+            }
+        })
+    );
+
+    test(
+        'validation without registry fails when checks is not an object',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                checks: 'foo',
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } }
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation without registry fails when commonPackageSettings is not an object',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                commonPackageSettings: 'foo',
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } }
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation without registry fails when a package entry is not an object',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                packages: ['foo']
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation prefixes common package.json issues with commonPackageSettings',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { dependencies: true }
+                },
+                packages: [{ name: 'foo', roots: { main: { js: 'index.js' } } }]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation prefixes common additional package.json attribute issues with commonPackageSettings',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                commonPackageSettings: {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } }
-                }
-            ]
-        },
-        expectedMessages: ['at registrySettings.auth: invalid value doesn’t match expected union']
-    })
-);
+                    additionalPackageJsonAttributes: { dependencies: '1.0.0' }
+                },
+                packages: [{ name: 'foo', roots: { main: { js: 'index.js' } } }]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation prefixes package additionalFiles issues with the array entry path',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } },
+                        additionalFiles: [{ sourceFilePath: 'asset.txt' }]
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation prefixes package additional package.json attribute issues',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } },
+                        additionalPackageJsonAttributes: { version: '1.0.0' }
+                    }
+                ]
+            },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation prefixes registry settings issues with registrySettings',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: {
+                    auth: { type: 'bearer-token', token: 42 }
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } }
+                    }
+                ]
+            },
+            expectedMessages: ['at registrySettings.auth: invalid value doesn’t match expected union']
+        })
+    );
+});

--- a/source/config/cross-package-validation.test.ts
+++ b/source/config/cross-package-validation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createDirectedGraph } from '../directed-graph/graph.ts';
 import type { PackageConfig } from './config.ts';
 import { validateCyclicDependencies, validateDuplicatePackages } from './cross-package-validation.ts';
@@ -8,38 +8,42 @@ function packageConfig(name: string): PackageConfig {
     return { name, roots: { main: { js: 'index.js' } }, sourcesFolder: 'src' } as unknown as PackageConfig;
 }
 
-test('validateDuplicatePackages returns no issues when every package has a unique name', () => {
-    assert.deepStrictEqual(validateDuplicatePackages([packageConfig('a'), packageConfig('b')]), []);
-});
+suite('cross-package-validation', function () {
+    test('validateDuplicatePackages returns no issues when every package has a unique name', function () {
+        assert.deepStrictEqual(validateDuplicatePackages([packageConfig('a'), packageConfig('b')]), []);
+    });
 
-test('validateDuplicatePackages reports each duplicated package name once', () => {
-    assert.deepStrictEqual(validateDuplicatePackages([packageConfig('a'), packageConfig('a'), packageConfig('b')]), [
-        'Duplicate package definition with the name "a"'
-    ]);
-});
+    test('validateDuplicatePackages reports each duplicated package name once', function () {
+        assert.deepStrictEqual(
+            validateDuplicatePackages([packageConfig('a'), packageConfig('a'), packageConfig('b')]),
+            ['Duplicate package definition with the name "a"']
+        );
+    });
 
-function graphWithEdges(...edges: readonly { readonly from: string; readonly to: string }[]) {
-    const graph = createDirectedGraph<string, undefined>();
-    const nodes = new Set<string>();
-    for (const edge of edges) {
-        nodes.add(edge.from);
-        nodes.add(edge.to);
+    function graphWithEdges(...edges: readonly { readonly from: string; readonly to: string }[]) {
+        const graph = createDirectedGraph<string, undefined>();
+        const nodes = new Set<string>();
+        for (const edge of edges) {
+            nodes.add(edge.from);
+            nodes.add(edge.to);
+        }
+        for (const id of nodes) {
+            graph.addNode(id, undefined);
+        }
+        for (const edge of edges) {
+            graph.connect(edge);
+        }
+        return graph;
     }
-    for (const id of nodes) {
-        graph.addNode(id, undefined);
-    }
-    for (const edge of edges) {
-        graph.connect(edge);
-    }
-    return graph;
-}
 
-test('validateCyclicDependencies returns no issues for an acyclic graph', () => {
-    assert.deepStrictEqual(validateCyclicDependencies(graphWithEdges({ from: 'a', to: 'b' })), []);
-});
+    test('validateCyclicDependencies returns no issues for an acyclic graph', function () {
+        assert.deepStrictEqual(validateCyclicDependencies(graphWithEdges({ from: 'a', to: 'b' })), []);
+    });
 
-test('validateCyclicDependencies reports the cycle path joined with arrows', () => {
-    assert.deepStrictEqual(validateCyclicDependencies(graphWithEdges({ from: 'a', to: 'b' }, { from: 'b', to: 'a' })), [
-        'Unexpected cyclic dependency path: [a→b→a]'
-    ]);
+    test('validateCyclicDependencies reports the cycle path joined with arrows', function () {
+        assert.deepStrictEqual(
+            validateCyclicDependencies(graphWithEdges({ from: 'a', to: 'b' }, { from: 'b', to: 'a' })),
+            ['Unexpected cyclic dependency path: [a→b→a]']
+        );
+    });
 });

--- a/source/config/dead-code-elimination-settings.test.ts
+++ b/source/config/dead-code-elimination-settings.test.ts
@@ -1,61 +1,63 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     deadCodeEliminationSettingsSchema,
     resolveDeadCodeEliminationSettings
 } from './dead-code-elimination-settings.ts';
 
-test('resolveDeadCodeEliminationSettings() returns undefined when neither package nor common settings are present', () => {
-    assert.strictEqual(resolveDeadCodeEliminationSettings(undefined, undefined), undefined);
-});
-
-test('resolveDeadCodeEliminationSettings() defaults enabled to true when settings exist but do not set it', () => {
-    const packageSettings = {
-        pureImports: [{ from: 'zod/mini' }],
-        pureConstructors: ['Set']
-    } as unknown as Parameters<typeof resolveDeadCodeEliminationSettings>[0];
-
-    assert.deepStrictEqual(resolveDeadCodeEliminationSettings(packageSettings, undefined), {
-        enabled: true,
-        pureImports: [{ from: 'zod/mini' }],
-        pureConstructors: ['Set']
+suite('dead-code-elimination-settings', function () {
+    test('resolveDeadCodeEliminationSettings() returns undefined when neither package nor common settings are present', function () {
+        assert.strictEqual(resolveDeadCodeEliminationSettings(undefined, undefined), undefined);
     });
-});
 
-test('resolveDeadCodeEliminationSettings() prefers package settings over common settings', () => {
-    assert.deepStrictEqual(
-        resolveDeadCodeEliminationSettings(
-            { enabled: false, pureConstructors: ['Map'] },
-            { enabled: true, pureImports: [{ from: 'yoctocolors' }], pureConstructors: ['Set'] }
-        ),
-        {
-            enabled: false,
-            pureImports: [{ from: 'yoctocolors' }],
-            pureConstructors: ['Map']
-        }
-    );
-});
+    test('resolveDeadCodeEliminationSettings() defaults enabled to true when settings exist but do not set it', function () {
+        const packageSettings = {
+            pureImports: [{ from: 'zod/mini' }],
+            pureConstructors: ['Set']
+        } as unknown as Parameters<typeof resolveDeadCodeEliminationSettings>[0];
 
-test('deadCodeEliminationSettingsSchema accepts the documented enabled/pureImports/pureConstructors shape', () => {
-    const result = deadCodeEliminationSettingsSchema.safeParse({
-        enabled: true,
-        pureImports: [{ from: 'zod/mini', imports: ['z'] }],
-        pureConstructors: ['Set']
+        assert.deepStrictEqual(resolveDeadCodeEliminationSettings(packageSettings, undefined), {
+            enabled: true,
+            pureImports: [{ from: 'zod/mini' }],
+            pureConstructors: ['Set']
+        });
     });
-    assert.strictEqual(result.success, true);
-});
 
-test('deadCodeEliminationSettingsSchema rejects an unknown top-level field in strict mode', () => {
-    const result = deadCodeEliminationSettingsSchema.safeParse({ enabled: true, unknown: 1 });
-    assert.strictEqual(result.success, false);
-});
+    test('resolveDeadCodeEliminationSettings() prefers package settings over common settings', function () {
+        assert.deepStrictEqual(
+            resolveDeadCodeEliminationSettings(
+                { enabled: false, pureConstructors: ['Map'] },
+                { enabled: true, pureImports: [{ from: 'yoctocolors' }], pureConstructors: ['Set'] }
+            ),
+            {
+                enabled: false,
+                pureImports: [{ from: 'yoctocolors' }],
+                pureConstructors: ['Map']
+            }
+        );
+    });
 
-test('deadCodeEliminationSettingsSchema rejects a pureImports entry missing the required from field', () => {
-    const result = deadCodeEliminationSettingsSchema.safeParse({ enabled: true, pureImports: [{}] });
-    assert.strictEqual(result.success, false);
-});
+    test('deadCodeEliminationSettingsSchema accepts the documented enabled/pureImports/pureConstructors shape', function () {
+        const result = deadCodeEliminationSettingsSchema.safeParse({
+            enabled: true,
+            pureImports: [{ from: 'zod/mini', imports: ['z'] }],
+            pureConstructors: ['Set']
+        });
+        assert.strictEqual(result.success, true);
+    });
 
-test('deadCodeEliminationSettingsSchema rejects a pureConstructors entry that is an empty string', () => {
-    const result = deadCodeEliminationSettingsSchema.safeParse({ enabled: true, pureConstructors: [''] });
-    assert.strictEqual(result.success, false);
+    test('deadCodeEliminationSettingsSchema rejects an unknown top-level field in strict mode', function () {
+        const result = deadCodeEliminationSettingsSchema.safeParse({ enabled: true, unknown: 1 });
+        assert.strictEqual(result.success, false);
+    });
+
+    test('deadCodeEliminationSettingsSchema rejects a pureImports entry missing the required from field', function () {
+        const result = deadCodeEliminationSettingsSchema.safeParse({ enabled: true, pureImports: [{}] });
+        assert.strictEqual(result.success, false);
+    });
+
+    test('deadCodeEliminationSettingsSchema rejects a pureConstructors entry that is an empty string', function () {
+        const result = deadCodeEliminationSettingsSchema.safeParse({ enabled: true, pureConstructors: [''] });
+        assert.strictEqual(result.success, false);
+    });
 });

--- a/source/config/dependency-existence-validation.test.ts
+++ b/source/config/dependency-existence-validation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { validationPackageConfigFactory } from '../test-libraries/config-fixtures.ts';
 import type { PackageConfig, PackageConfigsByName } from './config.ts';
 import { validateDependenciesExist } from './dependency-existence-validation.ts';
@@ -18,26 +18,28 @@ function configs(...packages: readonly PackageConfig[]): PackageConfigsByName {
     return Object.fromEntries(packages.map((packageConfig) => [packageConfig.name, packageConfig]));
 }
 
-test('validateDependenciesExist returns no issues when every bundle dependency points to a known package', () => {
-    const result = validateDependenciesExist(
-        configs(packageWith('a', { bundleDependencies: ['b'] }), packageWith('b'))
-    );
+suite('dependency-existence-validation', function () {
+    test('validateDependenciesExist returns no issues when every bundle dependency points to a known package', function () {
+        const result = validateDependenciesExist(
+            configs(packageWith('a', { bundleDependencies: ['b'] }), packageWith('b'))
+        );
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('validateDependenciesExist reports bundle dependencies that point to unknown packages', () => {
-    const result = validateDependenciesExist(configs(packageWith('a', { bundleDependencies: ['missing'] })));
+    test('validateDependenciesExist reports bundle dependencies that point to unknown packages', function () {
+        const result = validateDependenciesExist(configs(packageWith('a', { bundleDependencies: ['missing'] })));
 
-    assert.deepStrictEqual(result, ['Bundle dependency "missing" referenced in "a" does not exist']);
-});
+        assert.deepStrictEqual(result, ['Bundle dependency "missing" referenced in "a" does not exist']);
+    });
 
-test('validateDependenciesExist reports bundle peer dependencies that point to unknown packages', () => {
-    const result = validateDependenciesExist(configs(packageWith('a', { bundlePeerDependencies: ['missing'] })));
+    test('validateDependenciesExist reports bundle peer dependencies that point to unknown packages', function () {
+        const result = validateDependenciesExist(configs(packageWith('a', { bundlePeerDependencies: ['missing'] })));
 
-    assert.deepStrictEqual(result, ['Bundle peer dependency "missing" referenced in "a" does not exist']);
-});
+        assert.deepStrictEqual(result, ['Bundle peer dependency "missing" referenced in "a" does not exist']);
+    });
 
-test('validateDependenciesExist returns no issues when a package has no declared dependencies', () => {
-    assert.deepStrictEqual(validateDependenciesExist(configs(packageWith('a'))), []);
+    test('validateDependenciesExist returns no issues when a package has no declared dependencies', function () {
+        assert.deepStrictEqual(validateDependenciesExist(configs(packageWith('a'))), []);
+    });
 });

--- a/source/config/dependency-policy.test.ts
+++ b/source/config/dependency-policy.test.ts
@@ -1,66 +1,68 @@
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { dependencyPolicySchema } from './dependency-policy.ts';
 
-test(
-    'validation succeeds with an empty object',
-    checkValidationSuccess({
-        schema: dependencyPolicySchema,
-        data: {},
-        expectedData: {}
-    })
-);
+suite('dependency-policy', function () {
+    test(
+        'validation succeeds with an empty object',
+        checkValidationSuccess({
+            schema: dependencyPolicySchema,
+            data: {},
+            expectedData: {}
+        })
+    );
 
-test(
-    'validation succeeds with an empty allow-list',
-    checkValidationSuccess({
-        schema: dependencyPolicySchema,
-        data: { allowMutableSpecifiers: [] },
-        expectedData: { allowMutableSpecifiers: [] }
-    })
-);
+    test(
+        'validation succeeds with an empty allow-list',
+        checkValidationSuccess({
+            schema: dependencyPolicySchema,
+            data: { allowMutableSpecifiers: [] },
+            expectedData: { allowMutableSpecifiers: [] }
+        })
+    );
 
-test(
-    'validation succeeds with non-empty allow-list',
-    checkValidationSuccess({
-        schema: dependencyPolicySchema,
-        data: { allowMutableSpecifiers: ['react', 'internal-tool'] },
-        expectedData: { allowMutableSpecifiers: ['react', 'internal-tool'] }
-    })
-);
+    test(
+        'validation succeeds with non-empty allow-list',
+        checkValidationSuccess({
+            schema: dependencyPolicySchema,
+            data: { allowMutableSpecifiers: ['react', 'internal-tool'] },
+            expectedData: { allowMutableSpecifiers: ['react', 'internal-tool'] }
+        })
+    );
 
-test(
-    'validation fails when allowMutableSpecifiers is not an array',
-    checkValidationFailure({
-        schema: dependencyPolicySchema,
-        data: { allowMutableSpecifiers: 'react' },
-        expectedMessages: ['at allowMutableSpecifiers: expected array, but got string']
-    })
-);
+    test(
+        'validation fails when allowMutableSpecifiers is not an array',
+        checkValidationFailure({
+            schema: dependencyPolicySchema,
+            data: { allowMutableSpecifiers: 'react' },
+            expectedMessages: ['at allowMutableSpecifiers: expected array, but got string']
+        })
+    );
 
-test(
-    'validation fails when an entry is not a string',
-    checkValidationFailure({
-        schema: dependencyPolicySchema,
-        data: { allowMutableSpecifiers: [42] },
-        expectedMessages: ['at allowMutableSpecifiers[0]: expected string, but got number']
-    })
-);
+    test(
+        'validation fails when an entry is not a string',
+        checkValidationFailure({
+            schema: dependencyPolicySchema,
+            data: { allowMutableSpecifiers: [42] },
+            expectedMessages: ['at allowMutableSpecifiers[0]: expected string, but got number']
+        })
+    );
 
-test(
-    'validation fails when an entry is an empty string',
-    checkValidationFailure({
-        schema: dependencyPolicySchema,
-        data: { allowMutableSpecifiers: [''] },
-        expectedMessages: ['at allowMutableSpecifiers[0]: string must contain at least 1 character']
-    })
-);
+    test(
+        'validation fails when an entry is an empty string',
+        checkValidationFailure({
+            schema: dependencyPolicySchema,
+            data: { allowMutableSpecifiers: [''] },
+            expectedMessages: ['at allowMutableSpecifiers[0]: string must contain at least 1 character']
+        })
+    );
 
-test(
-    'validation fails when an unknown property is given',
-    checkValidationFailure({
-        schema: dependencyPolicySchema,
-        data: { allowMutableSpecifiers: [], extra: 'no' },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
+    test(
+        'validation fails when an unknown property is given',
+        checkValidationFailure({
+            schema: dependencyPolicySchema,
+            data: { allowMutableSpecifiers: [], extra: 'no' },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+});

--- a/source/config/main-package-json-schema.test.ts
+++ b/source/config/main-package-json-schema.test.ts
@@ -1,67 +1,72 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { mainPackageJsonSchema } from './main-package-json-schema.ts';
 
-test('schema accepts type module', () => {
-    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'module' }).success, true);
+suite('main-package-json-schema', function () {
+    test('schema accepts type module', function () {
+        assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'module' }).success, true);
+    });
+
+    test('schema rejects type commonjs', function () {
+        assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'commonjs' }).success, false);
+    });
+
+    test(
+        'main package json schema: validation succeeds for module type',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module' },
+            expectedData: { type: 'module' }
+        })
+    );
+
+    test(
+        'main package json schema: validation succeeds when imports is an object',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', imports: { '#foo': './src/foo.js', '#bar/*': { default: './src/bar/*.js' } } },
+            expectedData: {
+                type: 'module',
+                imports: { '#foo': './src/foo.js', '#bar/*': { default: './src/bar/*.js' } }
+            }
+        })
+    );
+
+    test(
+        'main package json schema: validation fails when type is missing',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: {},
+            expectedMessages: ['at type: missing property']
+        })
+    );
+
+    test(
+        'main package json schema: validation fails when type is not module',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'commonjs' },
+            expectedMessages: ['at type: invalid literal: expected "module", but got string']
+        })
+    );
+
+    test(
+        'main package json schema: validation fails when dependencies contain non-string values',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', dependencies: { foo: 123 } },
+            expectedMessages: ['at dependencies.foo: expected string, but got number']
+        })
+    );
+
+    test(
+        'main package json schema: validation fails when imports is not an object',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', imports: true },
+            expectedMessages: ['at imports: expected record, but got boolean']
+        })
+    );
 });
-
-test('schema rejects type commonjs', () => {
-    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'commonjs' }).success, false);
-});
-
-test(
-    'main package json schema: validation succeeds for module type',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module' },
-        expectedData: { type: 'module' }
-    })
-);
-
-test(
-    'main package json schema: validation succeeds when imports is an object',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', imports: { '#foo': './src/foo.js', '#bar/*': { default: './src/bar/*.js' } } },
-        expectedData: { type: 'module', imports: { '#foo': './src/foo.js', '#bar/*': { default: './src/bar/*.js' } } }
-    })
-);
-
-test(
-    'main package json schema: validation fails when type is missing',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: {},
-        expectedMessages: ['at type: missing property']
-    })
-);
-
-test(
-    'main package json schema: validation fails when type is not module',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'commonjs' },
-        expectedMessages: ['at type: invalid literal: expected "module", but got string']
-    })
-);
-
-test(
-    'main package json schema: validation fails when dependencies contain non-string values',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', dependencies: { foo: 123 } },
-        expectedMessages: ['at dependencies.foo: expected string, but got number']
-    })
-);
-
-test(
-    'main package json schema: validation fails when imports is not an object',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', imports: true },
-        expectedMessages: ['at imports: expected record, but got boolean']
-    })
-);

--- a/source/config/manual-versioning-settings.test.ts
+++ b/source/config/manual-versioning-settings.test.ts
@@ -1,40 +1,48 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { manualVersioningSettingsSchema } from './manual-versioning-settings.ts';
 
-test('manual versioning schema accepts automatic false', () => {
-    assert.strictEqual(safeParse(manualVersioningSettingsSchema, { automatic: false, version: '1.0.0' }).success, true);
+suite('manual-versioning-settings', function () {
+    test('manual versioning schema accepts automatic false', function () {
+        assert.strictEqual(
+            safeParse(manualVersioningSettingsSchema, { automatic: false, version: '1.0.0' }).success,
+            true
+        );
+    });
+
+    test('manual versioning schema rejects automatic true', function () {
+        assert.strictEqual(
+            safeParse(manualVersioningSettingsSchema, { automatic: true, version: '1.0.0' }).success,
+            false
+        );
+    });
+
+    test(
+        'manual versioning: validation succeeds with automatic false',
+        checkValidationSuccess({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false, version: '1.0.0' },
+            expectedData: { automatic: false, version: '1.0.0' }
+        })
+    );
+
+    test(
+        'manual versioning: validation fails with automatic true',
+        checkValidationFailure({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: true, version: '1.0.0' },
+            expectedMessages: ['at automatic: invalid literal: expected false, but got boolean']
+        })
+    );
+
+    test(
+        'manual versioning: validation fails when minimumVersion is provided instead of version',
+        checkValidationFailure({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false, minimumVersion: '1.0.0' },
+            expectedMessages: ['at version: missing property', 'unexpected additional property: "minimumVersion"']
+        })
+    );
 });
-
-test('manual versioning schema rejects automatic true', () => {
-    assert.strictEqual(safeParse(manualVersioningSettingsSchema, { automatic: true, version: '1.0.0' }).success, false);
-});
-
-test(
-    'manual versioning: validation succeeds with automatic false',
-    checkValidationSuccess({
-        schema: manualVersioningSettingsSchema,
-        data: { automatic: false, version: '1.0.0' },
-        expectedData: { automatic: false, version: '1.0.0' }
-    })
-);
-
-test(
-    'manual versioning: validation fails with automatic true',
-    checkValidationFailure({
-        schema: manualVersioningSettingsSchema,
-        data: { automatic: true, version: '1.0.0' },
-        expectedMessages: ['at automatic: invalid literal: expected false, but got boolean']
-    })
-);
-
-test(
-    'manual versioning: validation fails when minimumVersion is provided instead of version',
-    checkValidationFailure({
-        schema: manualVersioningSettingsSchema,
-        data: { automatic: false, minimumVersion: '1.0.0' },
-        expectedMessages: ['at version: missing property', 'unexpected additional property: "minimumVersion"']
-    })
-);

--- a/source/config/optional-package-settings-schema.test.ts
+++ b/source/config/optional-package-settings-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     checkValidationFailure,
     checkValidationSuccess,
@@ -14,67 +14,69 @@ const validOptionalPackageSettings = {
     additionalPackageJsonAttributes: { license: 'MIT' }
 };
 
-test('optional package settings schema accepts an empty object', () => {
-    assert.strictEqual(safeParse(optionalPackageSettingsSchema, {}).success, true);
-});
+suite('optional-package-settings-schema', function () {
+    test('optional package settings schema accepts an empty object', function () {
+        assert.strictEqual(safeParse(optionalPackageSettingsSchema, {}).success, true);
+    });
 
-test('optional package settings schema rejects an invalid includeSourceMapFiles value', () => {
-    assert.strictEqual(safeParse(optionalPackageSettingsSchema, { includeSourceMapFiles: 'yes' }).success, false);
-});
+    test('optional package settings schema rejects an invalid includeSourceMapFiles value', function () {
+        assert.strictEqual(safeParse(optionalPackageSettingsSchema, { includeSourceMapFiles: 'yes' }).success, false);
+    });
 
-createTestCasesForOptionalField({
-    schema: optionalPackageSettingsSchema,
-    data: validOptionalPackageSettings,
-    path: 'additionalFiles',
-    expectedFieldType: 'array'
-});
-
-createTestCasesForOptionalField({
-    schema: optionalPackageSettingsSchema,
-    data: validOptionalPackageSettings,
-    path: 'includeSourceMapFiles',
-    expectedFieldType: 'boolean'
-});
-
-createTestCasesForOptionalField({
-    schema: optionalPackageSettingsSchema,
-    data: validOptionalPackageSettings,
-    path: 'additionalPackageJsonAttributes',
-    expectedFieldType: 'record'
-});
-
-test(
-    'optional package settings schema: validation succeeds when empty',
-    checkValidationSuccess({
-        schema: optionalPackageSettingsSchema,
-        data: {},
-        expectedData: {}
-    })
-);
-
-test(
-    'optional package settings schema: validation succeeds with all optional values',
-    checkValidationSuccess({
+    createTestCasesForOptionalField({
         schema: optionalPackageSettingsSchema,
         data: validOptionalPackageSettings,
-        expectedData: validOptionalPackageSettings
-    })
-);
+        path: 'additionalFiles',
+        expectedFieldType: 'array'
+    });
 
-test(
-    'optional package settings schema: validation fails when includeSourceMapFiles is not boolean',
-    checkValidationFailure({
+    createTestCasesForOptionalField({
         schema: optionalPackageSettingsSchema,
-        data: { includeSourceMapFiles: 'yes' },
-        expectedMessages: ['at includeSourceMapFiles: expected boolean, but got string']
-    })
-);
+        data: validOptionalPackageSettings,
+        path: 'includeSourceMapFiles',
+        expectedFieldType: 'boolean'
+    });
 
-test(
-    'optional package settings schema: validation fails when an additional property is given',
-    checkValidationFailure({
+    createTestCasesForOptionalField({
         schema: optionalPackageSettingsSchema,
-        data: { extra: true },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
+        data: validOptionalPackageSettings,
+        path: 'additionalPackageJsonAttributes',
+        expectedFieldType: 'record'
+    });
+
+    test(
+        'optional package settings schema: validation succeeds when empty',
+        checkValidationSuccess({
+            schema: optionalPackageSettingsSchema,
+            data: {},
+            expectedData: {}
+        })
+    );
+
+    test(
+        'optional package settings schema: validation succeeds with all optional values',
+        checkValidationSuccess({
+            schema: optionalPackageSettingsSchema,
+            data: validOptionalPackageSettings,
+            expectedData: validOptionalPackageSettings
+        })
+    );
+
+    test(
+        'optional package settings schema: validation fails when includeSourceMapFiles is not boolean',
+        checkValidationFailure({
+            schema: optionalPackageSettingsSchema,
+            data: { includeSourceMapFiles: 'yes' },
+            expectedMessages: ['at includeSourceMapFiles: expected boolean, but got string']
+        })
+    );
+
+    test(
+        'optional package settings schema: validation fails when an additional property is given',
+        checkValidationFailure({
+            schema: optionalPackageSettingsSchema,
+            data: { extra: true },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+});

--- a/source/config/package-config.test.ts
+++ b/source/config/package-config.test.ts
@@ -1,32 +1,34 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { getBundledDependencies, type PackageConfig } from './package-config.ts';
 
 const stubRoots = { main: { js: 'index.js' } } as unknown as PackageConfig['roots'];
 
-test('getBundledDependencies returns an empty list when both fields are absent', () => {
-    const config = { name: 'pkg', roots: stubRoots } as PackageConfig;
-    assert.deepStrictEqual(getBundledDependencies(config), []);
-});
+suite('package-config', function () {
+    test('getBundledDependencies returns an empty list when both fields are absent', function () {
+        const config = { name: 'pkg', roots: stubRoots } as PackageConfig;
+        assert.deepStrictEqual(getBundledDependencies(config), []);
+    });
 
-test('getBundledDependencies returns just the bundleDependencies when only it is present', () => {
-    const config = { name: 'pkg', roots: stubRoots, bundleDependencies: ['dep-a'] } as PackageConfig;
-    assert.deepStrictEqual(getBundledDependencies(config), ['dep-a']);
-});
+    test('getBundledDependencies returns just the bundleDependencies when only it is present', function () {
+        const config = { name: 'pkg', roots: stubRoots, bundleDependencies: ['dep-a'] } as PackageConfig;
+        assert.deepStrictEqual(getBundledDependencies(config), ['dep-a']);
+    });
 
-test('getBundledDependencies returns just the bundlePeerDependencies when only it is present', () => {
-    const config = { name: 'pkg', roots: stubRoots, bundlePeerDependencies: ['peer-a'] } as PackageConfig;
-    assert.deepStrictEqual(getBundledDependencies(config), ['peer-a']);
-});
+    test('getBundledDependencies returns just the bundlePeerDependencies when only it is present', function () {
+        const config = { name: 'pkg', roots: stubRoots, bundlePeerDependencies: ['peer-a'] } as PackageConfig;
+        assert.deepStrictEqual(getBundledDependencies(config), ['peer-a']);
+    });
 
-test('getBundledDependencies concatenates bundleDependencies and bundlePeerDependencies in property order', () => {
-    const config = {
-        name: 'pkg',
-        roots: stubRoots,
-        bundleDependencies: ['a'],
-        bundlePeerDependencies: ['b']
-    } as PackageConfig;
+    test('getBundledDependencies concatenates bundleDependencies and bundlePeerDependencies in property order', function () {
+        const config = {
+            name: 'pkg',
+            roots: stubRoots,
+            bundleDependencies: ['a'],
+            bundlePeerDependencies: ['b']
+        } as PackageConfig;
 
-    assert.deepStrictEqual(getBundledDependencies(config), ['a', 'b']);
+        assert.deepStrictEqual(getBundledDependencies(config), ['a', 'b']);
+    });
 });

--- a/source/config/package-graph-builder.test.ts
+++ b/source/config/package-graph-builder.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { validationPackageConfigFactory } from '../test-libraries/config-fixtures.ts';
 import type { PackageConfig, PackageConfigsByName } from './config.ts';
 import { buildPackageGraph } from './package-graph-builder.ts';
@@ -12,27 +12,29 @@ function configs(...packages: readonly PackageConfig[]): PackageConfigsByName {
     return Object.fromEntries(packages.map((packageConfig) => [packageConfig.name, packageConfig]));
 }
 
-test('buildPackageGraph returns a graph with no nodes when no packages are provided', () => {
-    const graph = buildPackageGraph({});
+suite('package-graph-builder', function () {
+    test('buildPackageGraph returns a graph with no nodes when no packages are provided', function () {
+        const graph = buildPackageGraph({});
 
-    assert.strictEqual(graph.hasNode('any'), false);
-});
+        assert.strictEqual(graph.hasNode('any'), false);
+    });
 
-test('buildPackageGraph adds a node for every package even when there are no dependencies', () => {
-    const graph = buildPackageGraph(configs(packageWith('a'), packageWith('b')));
+    test('buildPackageGraph adds a node for every package even when there are no dependencies', function () {
+        const graph = buildPackageGraph(configs(packageWith('a'), packageWith('b')));
 
-    assert.strictEqual(graph.hasNode('a'), true);
-    assert.strictEqual(graph.hasNode('b'), true);
-});
+        assert.strictEqual(graph.hasNode('a'), true);
+        assert.strictEqual(graph.hasNode('b'), true);
+    });
 
-test('buildPackageGraph connects bundle dependencies between package nodes', () => {
-    const graph = buildPackageGraph(configs(packageWith('a', ['b']), packageWith('b')));
+    test('buildPackageGraph connects bundle dependencies between package nodes', function () {
+        const graph = buildPackageGraph(configs(packageWith('a', ['b']), packageWith('b')));
 
-    assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), true);
-});
+        assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), true);
+    });
 
-test('buildPackageGraph does not connect a bundle dependency that has no incoming edge', () => {
-    const graph = buildPackageGraph(configs(packageWith('a'), packageWith('b')));
+    test('buildPackageGraph does not connect a bundle dependency that has no incoming edge', function () {
+        const graph = buildPackageGraph(configs(packageWith('a'), packageWith('b')));
 
-    assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), false);
+        assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), false);
+    });
 });

--- a/source/config/package-interface.test.ts
+++ b/source/config/package-interface.test.ts
@@ -1,48 +1,50 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { safeParse } from '@schema-hub/zod-error-formatter';
 import { packageInterfaceSchema } from './package-interface.ts';
 
-test('packageInterfaceSchema accepts root exports for "." and subpath exports', () => {
-    assert.strictEqual(
-        safeParse(packageInterfaceSchema, {
-            modules: [
-                { root: 'main', export: '.' },
-                { root: 'feature', export: './feature' }
-            ],
-            privateRoots: ['worker']
-        }).success,
-        true
-    );
-});
+suite('package-interface', function () {
+    test('packageInterfaceSchema accepts root exports for "." and subpath exports', function () {
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                modules: [
+                    { root: 'main', export: '.' },
+                    { root: 'feature', export: './feature' }
+                ],
+                privateRoots: ['worker']
+            }).success,
+            true
+        );
+    });
 
-test('packageInterfaceSchema rejects module export keys without a package-relative prefix', () => {
-    assert.strictEqual(
-        safeParse(packageInterfaceSchema, {
-            modules: [{ root: 'main', export: 'feature' }]
-        }).success,
-        false
-    );
-});
+    test('packageInterfaceSchema rejects module export keys without a package-relative prefix', function () {
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                modules: [{ root: 'main', export: 'feature' }]
+            }).success,
+            false
+        );
+    });
 
-test('packageInterfaceSchema rejects empty module and bin exposure arrays', () => {
-    assert.strictEqual(
-        safeParse(packageInterfaceSchema, {
-            modules: []
-        }).success,
-        false
-    );
-    assert.strictEqual(
-        safeParse(packageInterfaceSchema, {
-            bins: []
-        }).success,
-        false
-    );
-    assert.strictEqual(
-        safeParse(packageInterfaceSchema, {
-            modules: [{ root: 'main', export: '.' }],
-            privateRoots: []
-        }).success,
-        false
-    );
+    test('packageInterfaceSchema rejects empty module and bin exposure arrays', function () {
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                modules: []
+            }).success,
+            false
+        );
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                bins: []
+            }).success,
+            false
+        );
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                modules: [{ root: 'main', export: '.' }],
+                privateRoots: []
+            }).success,
+            false
+        );
+    });
 });

--- a/source/config/package-json.test.ts
+++ b/source/config/package-json.test.ts
@@ -1,354 +1,360 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { isForbiddenAdditionalPackageJsonAttributeName, packageJsonDependencyFieldNames } from './package-json.ts';
 import { additionalPackageJsonAttributesSchema } from './additional-package-json-attributes-schema.ts';
 import { mainPackageJsonSchema } from './main-package-json-schema.ts';
 
-test('package.json dependency field names are exposed as runtime constants', () => {
-    assert.deepStrictEqual(packageJsonDependencyFieldNames, ['dependencies', 'devDependencies', 'peerDependencies']);
+suite('package-json', function () {
+    test('package.json dependency field names are exposed as runtime constants', function () {
+        assert.deepStrictEqual(packageJsonDependencyFieldNames, [
+            'dependencies',
+            'devDependencies',
+            'peerDependencies'
+        ]);
+    });
+
+    test('forbidden additional package.json attribute helper identifies allowed and forbidden keys', function () {
+        assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('dependencies'), true);
+        assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('imports'), true);
+        assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('version'), true);
+        assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('license'), false);
+    });
+
+    test('main package.json schema accepts type module', function () {
+        assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'module' }).success, true);
+    });
+
+    test('main package.json schema rejects type commonjs', function () {
+        assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'commonjs' }).success, false);
+    });
+
+    test('additional package.json attributes schema rejects dependencies', function () {
+        assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { dependencies: {} }).success, false);
+    });
+
+    test('additional package.json attributes schema accepts license', function () {
+        assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { license: 'MIT' }).success, true);
+    });
+
+    test(
+        'main package.json: validation succeeds when type is given',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module' },
+            expectedData: { type: 'module' }
+        })
+    );
+
+    test(
+        'main package.json: validation succeeds when type and dependencies are given',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', dependencies: {} },
+            expectedData: { type: 'module', dependencies: {} }
+        })
+    );
+
+    test(
+        'main package.json: validation succeeds when type and devDependencies are given',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', devDependencies: {} },
+            expectedData: { type: 'module', devDependencies: {} }
+        })
+    );
+
+    test(
+        'main package.json: validation succeeds when type and peerDependencies are given',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', peerDependencies: {} },
+            expectedData: { type: 'module', peerDependencies: {} }
+        })
+    );
+
+    test(
+        'main package.json: validation succeeds when imports are given',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', imports: { '#foo': './src/foo.js' } },
+            expectedData: { type: 'module', imports: { '#foo': './src/foo.js' } }
+        })
+    );
+
+    test(
+        'main package.json: validation succeeds when additional properties are given',
+        checkValidationSuccess({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', foo: 'bar' },
+            expectedData: { type: 'module' }
+        })
+    );
+
+    test(
+        'main package.json: validation fails when imports is not an object',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', imports: true },
+            expectedMessages: ['at imports: expected record, but got boolean']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when a non-object is given',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: 'foo',
+            expectedMessages: ['expected object, but got string']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when type is missing',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: {},
+            expectedMessages: ['at type: missing property']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when type is not "module"',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'foo' },
+            expectedMessages: ['at type: invalid literal: expected "module", but got string']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when type is null',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: null },
+            expectedMessages: ['at type: invalid literal: expected "module", but got null']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when dependencies is not an object',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', dependencies: true },
+            expectedMessages: ['at dependencies: expected record, but got boolean']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when dependencies is null',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', dependencies: null },
+            expectedMessages: ['at dependencies: expected record, but got null']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when dependencies contains non-string values',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', dependencies: { foo: 123 } },
+            expectedMessages: ['at dependencies.foo: expected string, but got number']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when peerDependencies is not an object',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', peerDependencies: true },
+            expectedMessages: ['at peerDependencies: expected record, but got boolean']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when peerDependencies is null',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', peerDependencies: null },
+            expectedMessages: ['at peerDependencies: expected record, but got null']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when peerDependencies contains non-string values',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', peerDependencies: { foo: 123 } },
+            expectedMessages: ['at peerDependencies.foo: expected string, but got number']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when devDependencies is not an object',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', devDependencies: true },
+            expectedMessages: ['at devDependencies: expected record, but got boolean']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when devDependencies is null',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', devDependencies: null },
+            expectedMessages: ['at devDependencies: expected record, but got null']
+        })
+    );
+
+    test(
+        'main package.json: validation fails when devDependencies contains non-string values',
+        checkValidationFailure({
+            schema: mainPackageJsonSchema,
+            data: { type: 'module', devDependencies: { foo: 123 } },
+            expectedMessages: ['at devDependencies.foo: expected string, but got number']
+        })
+    );
+
+    test(
+        'additional attributes: validation succeeds for an empty object',
+        checkValidationSuccess({
+            schema: additionalPackageJsonAttributesSchema,
+            data: {},
+            expectedData: {}
+        })
+    );
+
+    test(
+        'additional attributes: validation succeeds for keys that are not forbidden',
+        checkValidationSuccess({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { license: 123, foo: ['bar'], something: { nested: 'works' } },
+            expectedData: { license: 123, foo: ['bar'], something: { nested: 'works' } }
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when a non-object is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: 'foo',
+            expectedMessages: ['expected record, but got string']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when dependencies key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { dependencies: {} },
+            expectedMessages: ['at dependencies: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when peerDependencies key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { peerDependencies: {} },
+            expectedMessages: ['at peerDependencies: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when devDependencies key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { devDependencies: {} },
+            expectedMessages: ['at devDependencies: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when imports key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { imports: { '#foo': './foo.js' } },
+            expectedMessages: ['at imports: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when main key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { main: 'foo' },
+            expectedMessages: ['at main: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when name key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { name: 'foo' },
+            expectedMessages: ['at name: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when types key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { types: 'foo' },
+            expectedMessages: ['at types: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when type key is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { type: 'module' },
+            expectedMessages: ['at type: invalid key']
+        })
+    );
+
+    test(
+        'additional attributes: validation fails when version is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { version: '999' },
+            expectedMessages: ['at version: invalid key']
+        })
+    );
+
+    test('additional attributes: every forbidden key is rejected by the key schema', async function () {
+        const schema = additionalPackageJsonAttributesSchema;
+
+        for (const key of [
+            'dependencies',
+            'peerDependencies',
+            'devDependencies',
+            'imports',
+            'main',
+            'name',
+            'types',
+            'type',
+            'version'
+        ]) {
+            const result = safeParse(schema, { [key]: 'value' });
+            assert.strictEqual(result.success, false);
+            assert.deepStrictEqual(result.error.issues, [`at ${key}: invalid key`]);
+        }
+    });
+
+    test(
+        'additional attributes: validation fails when forbidden value is given',
+        checkValidationFailure({
+            schema: additionalPackageJsonAttributesSchema,
+            data: { foo: fake() },
+            expectedMessages: [
+                'at foo: invalid value: expected one of string, number, boolean, null, array or record, but got function'
+            ]
+        })
+    );
 });
-
-test('forbidden additional package.json attribute helper identifies allowed and forbidden keys', () => {
-    assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('dependencies'), true);
-    assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('imports'), true);
-    assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('version'), true);
-    assert.strictEqual(isForbiddenAdditionalPackageJsonAttributeName('license'), false);
-});
-
-test('main package.json schema accepts type module', () => {
-    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'module' }).success, true);
-});
-
-test('main package.json schema rejects type commonjs', () => {
-    assert.strictEqual(safeParse(mainPackageJsonSchema, { type: 'commonjs' }).success, false);
-});
-
-test('additional package.json attributes schema rejects dependencies', () => {
-    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { dependencies: {} }).success, false);
-});
-
-test('additional package.json attributes schema accepts license', () => {
-    assert.strictEqual(safeParse(additionalPackageJsonAttributesSchema, { license: 'MIT' }).success, true);
-});
-
-test(
-    'main package.json: validation succeeds when type is given',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module' },
-        expectedData: { type: 'module' }
-    })
-);
-
-test(
-    'main package.json: validation succeeds when type and dependencies are given',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', dependencies: {} },
-        expectedData: { type: 'module', dependencies: {} }
-    })
-);
-
-test(
-    'main package.json: validation succeeds when type and devDependencies are given',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', devDependencies: {} },
-        expectedData: { type: 'module', devDependencies: {} }
-    })
-);
-
-test(
-    'main package.json: validation succeeds when type and peerDependencies are given',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', peerDependencies: {} },
-        expectedData: { type: 'module', peerDependencies: {} }
-    })
-);
-
-test(
-    'main package.json: validation succeeds when imports are given',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', imports: { '#foo': './src/foo.js' } },
-        expectedData: { type: 'module', imports: { '#foo': './src/foo.js' } }
-    })
-);
-
-test(
-    'main package.json: validation succeeds when additional properties are given',
-    checkValidationSuccess({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', foo: 'bar' },
-        expectedData: { type: 'module' }
-    })
-);
-
-test(
-    'main package.json: validation fails when imports is not an object',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', imports: true },
-        expectedMessages: ['at imports: expected record, but got boolean']
-    })
-);
-
-test(
-    'main package.json: validation fails when a non-object is given',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: 'foo',
-        expectedMessages: ['expected object, but got string']
-    })
-);
-
-test(
-    'main package.json: validation fails when type is missing',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: {},
-        expectedMessages: ['at type: missing property']
-    })
-);
-
-test(
-    'main package.json: validation fails when type is not "module"',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'foo' },
-        expectedMessages: ['at type: invalid literal: expected "module", but got string']
-    })
-);
-
-test(
-    'main package.json: validation fails when type is null',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: null },
-        expectedMessages: ['at type: invalid literal: expected "module", but got null']
-    })
-);
-
-test(
-    'main package.json: validation fails when dependencies is not an object',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', dependencies: true },
-        expectedMessages: ['at dependencies: expected record, but got boolean']
-    })
-);
-
-test(
-    'main package.json: validation fails when dependencies is null',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', dependencies: null },
-        expectedMessages: ['at dependencies: expected record, but got null']
-    })
-);
-
-test(
-    'main package.json: validation fails when dependencies contains non-string values',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', dependencies: { foo: 123 } },
-        expectedMessages: ['at dependencies.foo: expected string, but got number']
-    })
-);
-
-test(
-    'main package.json: validation fails when peerDependencies is not an object',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', peerDependencies: true },
-        expectedMessages: ['at peerDependencies: expected record, but got boolean']
-    })
-);
-
-test(
-    'main package.json: validation fails when peerDependencies is null',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', peerDependencies: null },
-        expectedMessages: ['at peerDependencies: expected record, but got null']
-    })
-);
-
-test(
-    'main package.json: validation fails when peerDependencies contains non-string values',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', peerDependencies: { foo: 123 } },
-        expectedMessages: ['at peerDependencies.foo: expected string, but got number']
-    })
-);
-
-test(
-    'main package.json: validation fails when devDependencies is not an object',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', devDependencies: true },
-        expectedMessages: ['at devDependencies: expected record, but got boolean']
-    })
-);
-
-test(
-    'main package.json: validation fails when devDependencies is null',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', devDependencies: null },
-        expectedMessages: ['at devDependencies: expected record, but got null']
-    })
-);
-
-test(
-    'main package.json: validation fails when devDependencies contains non-string values',
-    checkValidationFailure({
-        schema: mainPackageJsonSchema,
-        data: { type: 'module', devDependencies: { foo: 123 } },
-        expectedMessages: ['at devDependencies.foo: expected string, but got number']
-    })
-);
-
-test(
-    'additional attributes: validation succeeds for an empty object',
-    checkValidationSuccess({
-        schema: additionalPackageJsonAttributesSchema,
-        data: {},
-        expectedData: {}
-    })
-);
-
-test(
-    'additional attributes: validation succeeds for keys that are not forbidden',
-    checkValidationSuccess({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { license: 123, foo: ['bar'], something: { nested: 'works' } },
-        expectedData: { license: 123, foo: ['bar'], something: { nested: 'works' } }
-    })
-);
-
-test(
-    'additional attributes: validation fails when a non-object is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: 'foo',
-        expectedMessages: ['expected record, but got string']
-    })
-);
-
-test(
-    'additional attributes: validation fails when dependencies key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { dependencies: {} },
-        expectedMessages: ['at dependencies: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when peerDependencies key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { peerDependencies: {} },
-        expectedMessages: ['at peerDependencies: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when devDependencies key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { devDependencies: {} },
-        expectedMessages: ['at devDependencies: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when imports key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { imports: { '#foo': './foo.js' } },
-        expectedMessages: ['at imports: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when main key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { main: 'foo' },
-        expectedMessages: ['at main: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when name key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { name: 'foo' },
-        expectedMessages: ['at name: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when types key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { types: 'foo' },
-        expectedMessages: ['at types: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when type key is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { type: 'module' },
-        expectedMessages: ['at type: invalid key']
-    })
-);
-
-test(
-    'additional attributes: validation fails when version is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { version: '999' },
-        expectedMessages: ['at version: invalid key']
-    })
-);
-
-test('additional attributes: every forbidden key is rejected by the key schema', async () => {
-    const schema = additionalPackageJsonAttributesSchema;
-
-    for (const key of [
-        'dependencies',
-        'peerDependencies',
-        'devDependencies',
-        'imports',
-        'main',
-        'name',
-        'types',
-        'type',
-        'version'
-    ]) {
-        const result = safeParse(schema, { [key]: 'value' });
-        assert.strictEqual(result.success, false);
-        assert.deepStrictEqual(result.error.issues, [`at ${key}: invalid key`]);
-    }
-});
-
-test(
-    'additional attributes: validation fails when forbidden value is given',
-    checkValidationFailure({
-        schema: additionalPackageJsonAttributesSchema,
-        data: { foo: fake() },
-        expectedMessages: [
-            'at foo: invalid value: expected one of string, number, boolean, null, array or record, but got function'
-        ]
-    })
-);

--- a/source/config/package-schemas.test.ts
+++ b/source/config/package-schemas.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import {
     packageSchemaWithAllCommonSettings,
@@ -9,130 +9,132 @@ import {
     packageSchemaWithPartialCommonSettings
 } from './package-schemas.ts';
 
-test('package schema with all common settings accepts a valid package', () => {
-    assert.strictEqual(
-        safeParse(packageSchemaWithAllCommonSettings, {
-            sourcesFolder: 'src',
-            mainPackageJson: { type: 'module' },
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        }).success,
-        true
+suite('package-schemas', function () {
+    test('package schema with all common settings accepts a valid package', function () {
+        assert.strictEqual(
+            safeParse(packageSchemaWithAllCommonSettings, {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            }).success,
+            true
+        );
+    });
+
+    test('package schema with all common settings rejects missing roots', function () {
+        assert.strictEqual(
+            safeParse(packageSchemaWithAllCommonSettings, {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg'
+            }).success,
+            false
+        );
+    });
+
+    test('package schema with partial common settings accepts package-specific settings only', function () {
+        assert.strictEqual(
+            safeParse(packageSchemaWithPartialCommonSettings, {
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            }).success,
+            true
+        );
+    });
+
+    test('package schema with mandatory sourcesFolder rejects packages without it', function () {
+        assert.strictEqual(
+            safeParse(packageSchemaWithMandatorySourcesFolder, {
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            }).success,
+            false
+        );
+    });
+
+    test('package schema with mandatory mainPackageJson rejects packages without it', function () {
+        assert.strictEqual(
+            safeParse(packageSchemaWithMandatoryMainPackageJson, {
+                sourcesFolder: 'src',
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            }).success,
+            false
+        );
+    });
+
+    test(
+        'package schema with all common settings: validation succeeds with all required fields',
+        checkValidationSuccess({
+            schema: packageSchemaWithAllCommonSettings,
+            data: {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            },
+            expectedData: {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            }
+        })
+    );
+
+    test(
+        'package schema with all common settings: validation fails when roots is missing',
+        checkValidationFailure({
+            schema: packageSchemaWithAllCommonSettings,
+            data: {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg'
+            },
+            expectedMessages: ['at roots: missing property']
+        })
+    );
+
+    test(
+        'package schema with partial common settings: validation succeeds without inherited fields',
+        checkValidationSuccess({
+            schema: packageSchemaWithPartialCommonSettings,
+            data: {
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            },
+            expectedData: {
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            }
+        })
+    );
+
+    test(
+        'package schema with mandatory sourcesFolder: validation fails when sourcesFolder is missing',
+        checkValidationFailure({
+            schema: packageSchemaWithMandatorySourcesFolder,
+            data: {
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            },
+            expectedMessages: ['at sourcesFolder: missing property']
+        })
+    );
+
+    test(
+        'package schema with mandatory mainPackageJson: validation fails when mainPackageJson is missing',
+        checkValidationFailure({
+            schema: packageSchemaWithMandatoryMainPackageJson,
+            data: {
+                sourcesFolder: 'src',
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } }
+            },
+            expectedMessages: ['at mainPackageJson: missing property']
+        })
     );
 });
-
-test('package schema with all common settings rejects missing roots', () => {
-    assert.strictEqual(
-        safeParse(packageSchemaWithAllCommonSettings, {
-            sourcesFolder: 'src',
-            mainPackageJson: { type: 'module' },
-            name: 'pkg'
-        }).success,
-        false
-    );
-});
-
-test('package schema with partial common settings accepts package-specific settings only', () => {
-    assert.strictEqual(
-        safeParse(packageSchemaWithPartialCommonSettings, {
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        }).success,
-        true
-    );
-});
-
-test('package schema with mandatory sourcesFolder rejects packages without it', () => {
-    assert.strictEqual(
-        safeParse(packageSchemaWithMandatorySourcesFolder, {
-            mainPackageJson: { type: 'module' },
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        }).success,
-        false
-    );
-});
-
-test('package schema with mandatory mainPackageJson rejects packages without it', () => {
-    assert.strictEqual(
-        safeParse(packageSchemaWithMandatoryMainPackageJson, {
-            sourcesFolder: 'src',
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        }).success,
-        false
-    );
-});
-
-test(
-    'package schema with all common settings: validation succeeds with all required fields',
-    checkValidationSuccess({
-        schema: packageSchemaWithAllCommonSettings,
-        data: {
-            sourcesFolder: 'src',
-            mainPackageJson: { type: 'module' },
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        },
-        expectedData: {
-            sourcesFolder: 'src',
-            mainPackageJson: { type: 'module' },
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        }
-    })
-);
-
-test(
-    'package schema with all common settings: validation fails when roots is missing',
-    checkValidationFailure({
-        schema: packageSchemaWithAllCommonSettings,
-        data: {
-            sourcesFolder: 'src',
-            mainPackageJson: { type: 'module' },
-            name: 'pkg'
-        },
-        expectedMessages: ['at roots: missing property']
-    })
-);
-
-test(
-    'package schema with partial common settings: validation succeeds without inherited fields',
-    checkValidationSuccess({
-        schema: packageSchemaWithPartialCommonSettings,
-        data: {
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        },
-        expectedData: {
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        }
-    })
-);
-
-test(
-    'package schema with mandatory sourcesFolder: validation fails when sourcesFolder is missing',
-    checkValidationFailure({
-        schema: packageSchemaWithMandatorySourcesFolder,
-        data: {
-            mainPackageJson: { type: 'module' },
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        },
-        expectedMessages: ['at sourcesFolder: missing property']
-    })
-);
-
-test(
-    'package schema with mandatory mainPackageJson: validation fails when mainPackageJson is missing',
-    checkValidationFailure({
-        schema: packageSchemaWithMandatoryMainPackageJson,
-        data: {
-            sourcesFolder: 'src',
-            name: 'pkg',
-            roots: { main: { js: 'index.js' } }
-        },
-        expectedMessages: ['at mainPackageJson: missing property']
-    })
-);

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
 
@@ -17,93 +17,95 @@ const validConfig = {
     ]
 };
 
-test('packtory config schema accepts a valid config', () => {
-    assert.strictEqual(safeParse(packtoryConfigSchema, validConfig).success, true);
-});
+suite('packtory-config-schema', function () {
+    test('packtory config schema accepts a valid config', function () {
+        assert.strictEqual(safeParse(packtoryConfigSchema, validConfig).success, true);
+    });
 
-test('packtory config schema rejects configs without registrySettings', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigSchema, {
-            packages: [
-                {
+    test('packtory config schema rejects configs without registrySettings', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigSchema, {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        publishSettings: { access: 'public' }
+                    }
+                ]
+            }).success,
+            false
+        );
+    });
+
+    test(
+        'packtory config schema: validation succeeds for a minimal valid config',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: validConfig,
+            expectedData: validConfig
+        })
+    );
+
+    test(
+        'packtory config schema: validation fails when registrySettings is missing',
+        checkValidationFailure({
+            schema: packtoryConfigSchema,
+            data: {
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        publishSettings: { access: 'public' }
+                    }
+                ]
+            },
+            expectedMessages: ['at registrySettings: missing property']
+        })
+    );
+
+    test(
+        'packtory config schema: accepts a config with publishSettings declared in commonPackageSettings only',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
                     sourcesFolder: 'source',
                     mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
+                    publishSettings: { access: 'public', provenance: { type: 'auto' } }
+                },
+                packages: [{ name: 'foo', roots: { main: { js: 'foo' } } }]
+            }
+        })
+    );
+
+    test(
+        'packtory config schema: accepts a config with mixed common default and per-package override',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: {
+                    sourcesFolder: 'source',
+                    mainPackageJson: { type: 'module' },
                     publishSettings: { access: 'public' }
-                }
-            ]
-        }).success,
-        false
+                },
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    },
+                    {
+                        name: 'bar',
+                        roots: { main: { js: 'bar' } },
+                        publishSettings: { access: 'restricted' }
+                    }
+                ]
+            }
+        })
     );
 });
-
-test(
-    'packtory config schema: validation succeeds for a minimal valid config',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: validConfig,
-        expectedData: validConfig
-    })
-);
-
-test(
-    'packtory config schema: validation fails when registrySettings is missing',
-    checkValidationFailure({
-        schema: packtoryConfigSchema,
-        data: {
-            packages: [
-                {
-                    sourcesFolder: 'source',
-                    mainPackageJson: { type: 'module' },
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } },
-                    publishSettings: { access: 'public' }
-                }
-            ]
-        },
-        expectedMessages: ['at registrySettings: missing property']
-    })
-);
-
-test(
-    'packtory config schema: accepts a config with publishSettings declared in commonPackageSettings only',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                publishSettings: { access: 'public', provenance: { type: 'auto' } }
-            },
-            packages: [{ name: 'foo', roots: { main: { js: 'foo' } } }]
-        }
-    })
-);
-
-test(
-    'packtory config schema: accepts a config with mixed common default and per-package override',
-    checkValidationSuccess({
-        schema: packtoryConfigSchema,
-        data: {
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                sourcesFolder: 'source',
-                mainPackageJson: { type: 'module' },
-                publishSettings: { access: 'public' }
-            },
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'foo' } }
-                },
-                {
-                    name: 'bar',
-                    roots: { main: { js: 'bar' } },
-                    publishSettings: { access: 'restricted' }
-                }
-            ]
-        }
-    })
-);

--- a/source/config/packtory-config-without-registry-schema.test.ts
+++ b/source/config/packtory-config-without-registry-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-registry-schema.ts';
 
@@ -26,204 +26,206 @@ const configWithPackageSpecificPublishSettings = {
     ]
 } as const;
 
-test('config without registry schema accepts package configs with optional common settings', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            packages: [
-                {
+suite('packtory-config-without-registry-schema', function () {
+    test('config without registry schema accepts package configs with optional common settings', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                packages: [
+                    {
+                        sourcesFolder: 'src',
+                        mainPackageJson: { type: 'module' },
+                        name: 'pkg',
+                        roots: { main: { js: 'index.js' } },
+                        publishSettings: publicPublishSettings
+                    }
+                ]
+            }).success,
+            true
+        );
+    });
+
+    test('config without registry schema accepts required common package settings', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                commonPackageSettings: {
                     sourcesFolder: 'src',
                     mainPackageJson: { type: 'module' },
-                    name: 'pkg',
-                    roots: { main: { js: 'index.js' } },
                     publishSettings: publicPublishSettings
-                }
-            ]
-        }).success,
-        true
-    );
-});
+                },
+                packages: [{ name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            }).success,
+            true
+        );
+    });
 
-test('config without registry schema accepts required common package settings', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: {
-                sourcesFolder: 'src',
-                mainPackageJson: { type: 'module' },
-                publishSettings: publicPublishSettings
-            },
-            packages: [{ name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        }).success,
-        true
-    );
-});
+    test('config without registry schema accepts required mainPackageJson', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
+                packages: [{ sourcesFolder: 'src', name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            }).success,
+            true
+        );
+    });
 
-test('config without registry schema accepts required mainPackageJson', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
-            packages: [{ sourcesFolder: 'src', name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        }).success,
-        true
-    );
-});
+    test('config without registry schema accepts required sourcesFolder', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
+                packages: [{ mainPackageJson: { type: 'module' }, name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            }).success,
+            true
+        );
+    });
 
-test('config without registry schema accepts required sourcesFolder', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
-            packages: [{ mainPackageJson: { type: 'module' }, name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        }).success,
-        true
-    );
-});
+    test('config without registry schema rejects an empty packages tuple', function () {
+        assert.strictEqual(safeParse(packtoryConfigWithoutRegistrySchema, { packages: [] }).success, false);
+    });
 
-test('config without registry schema rejects an empty packages tuple', () => {
-    assert.strictEqual(safeParse(packtoryConfigWithoutRegistrySchema, { packages: [] }).success, false);
-});
-
-test('required common settings branch rejects an empty packages tuple', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: {
-                sourcesFolder: 'src',
-                mainPackageJson: { type: 'module' },
-                publishSettings: publicPublishSettings
-            },
-            packages: []
-        }).success,
-        false
-    );
-});
-
-test('required mainPackageJson branch rejects an empty packages tuple', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
-            packages: []
-        }).success,
-        false
-    );
-});
-
-test('required sourcesFolder branch rejects an empty packages tuple', () => {
-    assert.strictEqual(
-        safeParse(packtoryConfigWithoutRegistrySchema, {
-            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
-            packages: []
-        }).success,
-        false
-    );
-});
-
-test(
-    'config without registry: validation succeeds for the optional-common-settings branch',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            packages: [
-                {
+    test('required common settings branch rejects an empty packages tuple', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                commonPackageSettings: {
                     sourcesFolder: 'src',
                     mainPackageJson: { type: 'module' },
-                    name: 'pkg',
-                    roots: { main: { js: 'index.js' } },
                     publishSettings: publicPublishSettings
-                }
-            ]
-        },
-        expectedData: {
-            packages: [
-                {
+                },
+                packages: []
+            }).success,
+            false
+        );
+    });
+
+    test('required mainPackageJson branch rejects an empty packages tuple', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
+                packages: []
+            }).success,
+            false
+        );
+    });
+
+    test('required sourcesFolder branch rejects an empty packages tuple', function () {
+        assert.strictEqual(
+            safeParse(packtoryConfigWithoutRegistrySchema, {
+                commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
+                packages: []
+            }).success,
+            false
+        );
+    });
+
+    test(
+        'config without registry: validation succeeds for the optional-common-settings branch',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                packages: [
+                    {
+                        sourcesFolder: 'src',
+                        mainPackageJson: { type: 'module' },
+                        name: 'pkg',
+                        roots: { main: { js: 'index.js' } },
+                        publishSettings: publicPublishSettings
+                    }
+                ]
+            },
+            expectedData: {
+                packages: [
+                    {
+                        sourcesFolder: 'src',
+                        mainPackageJson: { type: 'module' },
+                        name: 'pkg',
+                        roots: { main: { js: 'index.js' } },
+                        publishSettings: publicPublishSettings
+                    }
+                ]
+            }
+        })
+    );
+
+    test(
+        'config without registry: validation succeeds for the required-common-settings branch',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                commonPackageSettings: {
                     sourcesFolder: 'src',
                     mainPackageJson: { type: 'module' },
-                    name: 'pkg',
-                    roots: { main: { js: 'index.js' } },
                     publishSettings: publicPublishSettings
-                }
-            ]
-        }
-    })
-);
-
-test(
-    'config without registry: validation succeeds for the required-common-settings branch',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            commonPackageSettings: {
-                sourcesFolder: 'src',
-                mainPackageJson: { type: 'module' },
-                publishSettings: publicPublishSettings
+                },
+                packages: [{ name: 'pkg', roots: { main: { js: 'index.js' } } }]
             },
-            packages: [{ name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        },
-        expectedData: {
-            commonPackageSettings: {
-                sourcesFolder: 'src',
-                mainPackageJson: { type: 'module' },
-                publishSettings: publicPublishSettings
+            expectedData: {
+                commonPackageSettings: {
+                    sourcesFolder: 'src',
+                    mainPackageJson: { type: 'module' },
+                    publishSettings: publicPublishSettings
+                },
+                packages: [{ name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            }
+        })
+    );
+
+    test(
+        'config without registry: validation succeeds for the required-main-package-json branch',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
+                packages: [{ sourcesFolder: 'src', name: 'pkg', roots: { main: { js: 'index.js' } } }]
             },
-            packages: [{ name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        }
-    })
-);
+            expectedData: {
+                commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
+                packages: [{ sourcesFolder: 'src', name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            }
+        })
+    );
 
-test(
-    'config without registry: validation succeeds for the required-main-package-json branch',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
-            packages: [{ sourcesFolder: 'src', name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        },
-        expectedData: {
-            commonPackageSettings: { mainPackageJson: { type: 'module' }, publishSettings: publicPublishSettings },
-            packages: [{ sourcesFolder: 'src', name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        }
-    })
-);
+    test(
+        'config without registry: validation succeeds for the required-sources-folder branch',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
+                packages: [{ mainPackageJson: { type: 'module' }, name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            },
+            expectedData: {
+                commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
+                packages: [{ mainPackageJson: { type: 'module' }, name: 'pkg', roots: { main: { js: 'index.js' } } }]
+            }
+        })
+    );
 
-test(
-    'config without registry: validation succeeds for the required-sources-folder branch',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
-            packages: [{ mainPackageJson: { type: 'module' }, name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        },
-        expectedData: {
-            commonPackageSettings: { sourcesFolder: 'src', publishSettings: publicPublishSettings },
-            packages: [{ mainPackageJson: { type: 'module' }, name: 'pkg', roots: { main: { js: 'index.js' } } }]
-        }
-    })
-);
+    test(
+        'config without registry: union validation fails when packages is empty',
+        checkValidationFailure({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: { packages: [] },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
 
-test(
-    'config without registry: union validation fails when packages is empty',
-    checkValidationFailure({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: { packages: [] },
-        expectedMessages: ['invalid value doesn’t match expected union']
-    })
-);
+    test(
+        'config without registry: validation succeeds when per-package publishSettings overrides the common default',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: configWithPackageSpecificPublishSettings,
+            expectedData: configWithPackageSpecificPublishSettings
+        })
+    );
 
-test(
-    'config without registry: validation succeeds when per-package publishSettings overrides the common default',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: configWithPackageSpecificPublishSettings,
-        expectedData: configWithPackageSpecificPublishSettings
-    })
-);
-
-test(
-    'config without registry: schema accepts a config without publishSettings (placement is enforced in validateConfig)',
-    checkValidationSuccess({
-        schema: packtoryConfigWithoutRegistrySchema,
-        data: {
-            packages: [packageWithoutPublishSettings]
-        },
-        expectedData: {
-            packages: [packageWithoutPublishSettings]
-        }
-    })
-);
+    test(
+        'config without registry: schema accepts a config without publishSettings (placement is enforced in validateConfig)',
+        checkValidationSuccess({
+            schema: packtoryConfigWithoutRegistrySchema,
+            data: {
+                packages: [packageWithoutPublishSettings]
+            },
+            expectedData: {
+                packages: [packageWithoutPublishSettings]
+            }
+        })
+    );
+});

--- a/source/config/per-package-settings-schema.test.ts
+++ b/source/config/per-package-settings-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     checkValidationFailure,
     checkValidationSuccess,
@@ -17,88 +17,90 @@ const validPerPackageSettings = {
     bundlePeerDependencies: ['peer']
 };
 
-test('per-package settings schema accepts a valid package definition', () => {
-    assert.strictEqual(safeParse(perPackageSettingsSchema, validPerPackageSettings).success, true);
-});
+suite('per-package-settings-schema', function () {
+    test('per-package settings schema accepts a valid package definition', function () {
+        assert.strictEqual(safeParse(perPackageSettingsSchema, validPerPackageSettings).success, true);
+    });
 
-test('per-package settings schema rejects missing roots', () => {
-    assert.strictEqual(safeParse(perPackageSettingsSchema, { name: 'pkg' }).success, false);
-});
+    test('per-package settings schema rejects missing roots', function () {
+        assert.strictEqual(safeParse(perPackageSettingsSchema, { name: 'pkg' }).success, false);
+    });
 
-createTestCasesForRequiredField({
-    schema: perPackageSettingsSchema,
-    data: validPerPackageSettings,
-    path: 'name',
-    expectedFieldType: 'string'
-});
-
-createTestCasesForRequiredField({
-    schema: perPackageSettingsSchema,
-    data: validPerPackageSettings,
-    path: 'roots',
-    expectedFieldType: 'record'
-});
-
-createTestCasesForOptionalField({
-    schema: perPackageSettingsSchema,
-    data: validPerPackageSettings,
-    path: 'versioning',
-    expectedFieldType: 'object'
-});
-
-createTestCasesForOptionalField({
-    schema: perPackageSettingsSchema,
-    data: validPerPackageSettings,
-    path: 'bundleDependencies',
-    expectedFieldType: 'array'
-});
-
-createTestCasesForOptionalField({
-    schema: perPackageSettingsSchema,
-    data: validPerPackageSettings,
-    path: 'bundlePeerDependencies',
-    expectedFieldType: 'array'
-});
-
-createTestCasesForOptionalField({
-    schema: perPackageSettingsSchema,
-    data: validPerPackageSettings,
-    path: 'checks',
-    expectedFieldType: 'object'
-});
-
-test(
-    'per package settings schema: validation succeeds with required fields',
-    checkValidationSuccess({
+    createTestCasesForRequiredField({
         schema: perPackageSettingsSchema,
         data: validPerPackageSettings,
-        expectedData: validPerPackageSettings
-    })
-);
+        path: 'name',
+        expectedFieldType: 'string'
+    });
 
-test(
-    'per package settings schema: validation fails when name is missing',
-    checkValidationFailure({
+    createTestCasesForRequiredField({
         schema: perPackageSettingsSchema,
-        data: { roots: { main: { js: 'index.js' } } },
-        expectedMessages: ['at name: missing property']
-    })
-);
+        data: validPerPackageSettings,
+        path: 'roots',
+        expectedFieldType: 'record'
+    });
 
-test(
-    'per package settings schema: validation fails when roots is missing',
-    checkValidationFailure({
+    createTestCasesForOptionalField({
         schema: perPackageSettingsSchema,
-        data: { name: 'pkg' },
-        expectedMessages: ['at roots: missing property']
-    })
-);
+        data: validPerPackageSettings,
+        path: 'versioning',
+        expectedFieldType: 'object'
+    });
 
-test(
-    'per package settings schema: validation fails when an additional property is given',
-    checkValidationFailure({
+    createTestCasesForOptionalField({
         schema: perPackageSettingsSchema,
-        data: { ...validPerPackageSettings, extra: true },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
+        data: validPerPackageSettings,
+        path: 'bundleDependencies',
+        expectedFieldType: 'array'
+    });
+
+    createTestCasesForOptionalField({
+        schema: perPackageSettingsSchema,
+        data: validPerPackageSettings,
+        path: 'bundlePeerDependencies',
+        expectedFieldType: 'array'
+    });
+
+    createTestCasesForOptionalField({
+        schema: perPackageSettingsSchema,
+        data: validPerPackageSettings,
+        path: 'checks',
+        expectedFieldType: 'object'
+    });
+
+    test(
+        'per package settings schema: validation succeeds with required fields',
+        checkValidationSuccess({
+            schema: perPackageSettingsSchema,
+            data: validPerPackageSettings,
+            expectedData: validPerPackageSettings
+        })
+    );
+
+    test(
+        'per package settings schema: validation fails when name is missing',
+        checkValidationFailure({
+            schema: perPackageSettingsSchema,
+            data: { roots: { main: { js: 'index.js' } } },
+            expectedMessages: ['at name: missing property']
+        })
+    );
+
+    test(
+        'per package settings schema: validation fails when roots is missing',
+        checkValidationFailure({
+            schema: perPackageSettingsSchema,
+            data: { name: 'pkg' },
+            expectedMessages: ['at roots: missing property']
+        })
+    );
+
+    test(
+        'per package settings schema: validation fails when an additional property is given',
+        checkValidationFailure({
+            schema: perPackageSettingsSchema,
+            data: { ...validPerPackageSettings, extra: true },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+});

--- a/source/config/pre-graph-validation.test.ts
+++ b/source/config/pre-graph-validation.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test inputs use `as never` / `as PacktoryConfigWithoutRegistry` to shape narrow partial configs */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { collectPreGraphIssues, packageListToRecord } from './pre-graph-validation.ts';
 
@@ -13,59 +13,61 @@ function pkg(overrides: Partial<PackageConfig>): PackageConfig {
     } as unknown as PackageConfig;
 }
 
-test('packageListToRecord indexes packages by name', () => {
-    const a = pkg({ name: 'a' });
-    const b = pkg({ name: 'b' });
+suite('pre-graph-validation', function () {
+    test('packageListToRecord indexes packages by name', function () {
+        const a = pkg({ name: 'a' });
+        const b = pkg({ name: 'b' });
 
-    assert.deepStrictEqual(packageListToRecord([a, b]), { a, b });
-});
+        assert.deepStrictEqual(packageListToRecord([a, b]), { a, b });
+    });
 
-test('collectPreGraphIssues returns no issues for a well-formed single-package config with publishSettings on the package', () => {
-    const config = {
-        packages: [pkg({ publishSettings: { access: 'public' } as never })]
-    } as PacktoryConfigWithoutRegistry;
+    test('collectPreGraphIssues returns no issues for a well-formed single-package config with publishSettings on the package', function () {
+        const config = {
+            packages: [pkg({ publishSettings: { access: 'public' } as never })]
+        } as PacktoryConfigWithoutRegistry;
 
-    assert.deepStrictEqual(collectPreGraphIssues(config), []);
-});
+        assert.deepStrictEqual(collectPreGraphIssues(config), []);
+    });
 
-test('collectPreGraphIssues reports a missing publishSettings placement', () => {
-    const config = { packages: [pkg({})] } as PacktoryConfigWithoutRegistry;
+    test('collectPreGraphIssues reports a missing publishSettings placement', function () {
+        const config = { packages: [pkg({})] } as PacktoryConfigWithoutRegistry;
 
-    assert.ok(
-        collectPreGraphIssues(config).includes(
-            'publishSettings must be set in commonPackageSettings or in every package'
-        )
-    );
-});
+        assert.ok(
+            collectPreGraphIssues(config).includes(
+                'publishSettings must be set in commonPackageSettings or in every package'
+            )
+        );
+    });
 
-test('collectPreGraphIssues reports a missing bundle dependency target', () => {
-    const config = {
-        packages: [
-            pkg({
-                publishSettings: { access: 'public' } as never,
-                bundleDependencies: ['missing']
-            })
-        ]
-    } as PacktoryConfigWithoutRegistry;
+    test('collectPreGraphIssues reports a missing bundle dependency target', function () {
+        const config = {
+            packages: [
+                pkg({
+                    publishSettings: { access: 'public' } as never,
+                    bundleDependencies: ['missing']
+                })
+            ]
+        } as PacktoryConfigWithoutRegistry;
 
-    assert.ok(
-        collectPreGraphIssues(config).includes('Bundle dependency "missing" referenced in "pkg-a" does not exist')
-    );
-});
+        assert.ok(
+            collectPreGraphIssues(config).includes('Bundle dependency "missing" referenced in "pkg-a" does not exist')
+        );
+    });
 
-test('collectPreGraphIssues reports a root configuration violation', () => {
-    const config = {
-        packages: [
-            pkg({
-                publishSettings: { access: 'public' } as never,
-                roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } }
-            })
-        ]
-    } as PacktoryConfigWithoutRegistry;
+    test('collectPreGraphIssues reports a root configuration violation', function () {
+        const config = {
+            packages: [
+                pkg({
+                    publishSettings: { access: 'public' } as never,
+                    roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } }
+                })
+            ]
+        } as PacktoryConfigWithoutRegistry;
 
-    assert.ok(
-        collectPreGraphIssues(config).includes(
-            'Package "pkg-a" must define defaultModuleRoot when multiple roots exist'
-        )
-    );
+        assert.ok(
+            collectPreGraphIssues(config).includes(
+                'Package "pkg-a" must define defaultModuleRoot when multiple roots exist'
+            )
+        );
+    });
 });

--- a/source/config/publish-settings.report.test.ts
+++ b/source/config/publish-settings.report.test.ts
@@ -1,105 +1,107 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PublishSettings } from './publish-settings.ts';
 import { redactPublishSettings } from './publish-settings.report.ts';
 
-test('emits provenance file path but marks it not inlined', () => {
-    const settings: PublishSettings = {
-        access: 'public',
-        provenance: { type: 'file', path: '/abs/path/to/sbom.json' }
-    };
+suite('publish-settings.report', function () {
+    test('emits provenance file path but marks it not inlined', function () {
+        const settings: PublishSettings = {
+            access: 'public',
+            provenance: { type: 'file', path: '/abs/path/to/sbom.json' }
+        };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        access: 'public',
-        provenance: { type: 'file', path: '/abs/path/to/sbom.json', inlined: false }
+        assert.deepStrictEqual(redacted, {
+            access: 'public',
+            provenance: { type: 'file', path: '/abs/path/to/sbom.json', inlined: false }
+        });
     });
-});
 
-test('preserves auto provenance', () => {
-    const settings: PublishSettings = { access: 'public', provenance: { type: 'auto' } };
+    test('preserves auto provenance', function () {
+        const settings: PublishSettings = { access: 'public', provenance: { type: 'auto' } };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        access: 'public',
-        provenance: { type: 'auto' }
+        assert.deepStrictEqual(redacted, {
+            access: 'public',
+            provenance: { type: 'auto' }
+        });
     });
-});
 
-test('emits allowScripts when present', () => {
-    const settings: PublishSettings = { access: 'restricted', allowScripts: true };
+    test('emits allowScripts when present', function () {
+        const settings: PublishSettings = { access: 'restricted', allowScripts: true };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.deepStrictEqual(redacted, { access: 'restricted', allowScripts: true });
-});
+        assert.deepStrictEqual(redacted, { access: 'restricted', allowScripts: true });
+    });
 
-test('omits allowScripts when absent', () => {
-    const settings: PublishSettings = { access: 'restricted' };
+    test('omits allowScripts when absent', function () {
+        const settings: PublishSettings = { access: 'restricted' };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.strictEqual('allowScripts' in redacted, false);
-});
+        assert.strictEqual('allowScripts' in redacted, false);
+    });
 
-test('emits sbom verbatim when present', () => {
-    const sbom = { enabled: true };
-    const settings: PublishSettings = { access: 'public', sbom };
+    test('emits sbom verbatim when present', function () {
+        const sbom = { enabled: true };
+        const settings: PublishSettings = { access: 'public', sbom };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.deepStrictEqual(redacted.sbom, sbom);
-});
+        assert.deepStrictEqual(redacted.sbom, sbom);
+    });
 
-test('omits sbom when absent', () => {
-    const settings: PublishSettings = { access: 'public' };
+    test('omits sbom when absent', function () {
+        const settings: PublishSettings = { access: 'public' };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.strictEqual('sbom' in redacted, false);
-});
+        assert.strictEqual('sbom' in redacted, false);
+    });
 
-test('omits provenance when access is public but provenance is undefined', () => {
-    const settings: PublishSettings = { access: 'public' };
+    test('omits provenance when access is public but provenance is undefined', function () {
+        const settings: PublishSettings = { access: 'public' };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.strictEqual('provenance' in redacted, false);
-});
+        assert.strictEqual('provenance' in redacted, false);
+    });
 
-test('does not emit provenance for restricted access even when carried alongside', () => {
-    const settings = {
-        access: 'restricted',
-        provenance: { type: 'auto' }
-    } as unknown as PublishSettings;
+    test('does not emit provenance for restricted access even when carried alongside', function () {
+        const settings = {
+            access: 'restricted',
+            provenance: { type: 'auto' }
+        } as unknown as PublishSettings;
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.strictEqual('provenance' in redacted, false);
-});
+        assert.strictEqual('provenance' in redacted, false);
+    });
 
-test('preserves access verbatim', () => {
-    const publicRedacted = redactPublishSettings({ access: 'public' });
-    const restrictedRedacted = redactPublishSettings({ access: 'restricted' });
+    test('preserves access verbatim', function () {
+        const publicRedacted = redactPublishSettings({ access: 'public' });
+        const restrictedRedacted = redactPublishSettings({ access: 'restricted' });
 
-    assert.strictEqual(publicRedacted.access, 'public');
-    assert.strictEqual(restrictedRedacted.access, 'restricted');
-});
+        assert.strictEqual(publicRedacted.access, 'public');
+        assert.strictEqual(restrictedRedacted.access, 'restricted');
+    });
 
-test('emits allowScripts together with provenance when both are set on public access', () => {
-    const settings: PublishSettings = {
-        access: 'public',
-        allowScripts: false,
-        provenance: { type: 'auto' }
-    };
+    test('emits allowScripts together with provenance when both are set on public access', function () {
+        const settings: PublishSettings = {
+            access: 'public',
+            allowScripts: false,
+            provenance: { type: 'auto' }
+        };
 
-    const redacted = redactPublishSettings(settings);
+        const redacted = redactPublishSettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        access: 'public',
-        allowScripts: false,
-        provenance: { type: 'auto' }
+        assert.deepStrictEqual(redacted, {
+            access: 'public',
+            allowScripts: false,
+            provenance: { type: 'auto' }
+        });
     });
 });

--- a/source/config/publish-settings.test.ts
+++ b/source/config/publish-settings.test.ts
@@ -1,216 +1,218 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { publishSettingsSchema } from './publish-settings.ts';
 
-test('schema accepts the minimal public publish settings', () => {
-    assert.strictEqual(safeParse(publishSettingsSchema, { access: 'public' }).success, true);
+suite('publish-settings', function () {
+    test('schema accepts the minimal public publish settings', function () {
+        assert.strictEqual(safeParse(publishSettingsSchema, { access: 'public' }).success, true);
+    });
+
+    test(
+        'validation succeeds with public access and no provenance',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public' },
+            expectedData: { access: 'public' }
+        })
+    );
+
+    test(
+        'validation succeeds with public access and provenance auto mode',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', provenance: { type: 'auto' } },
+            expectedData: { access: 'public', provenance: { type: 'auto' } }
+        })
+    );
+
+    test(
+        'validation succeeds with public access and provenance file mode',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', provenance: { type: 'file', path: './build/pkg.sigstore' } },
+            expectedData: { access: 'public', provenance: { type: 'file', path: './build/pkg.sigstore' } }
+        })
+    );
+
+    test(
+        'validation succeeds with restricted access',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'restricted' },
+            expectedData: { access: 'restricted' }
+        })
+    );
+
+    test(
+        'validation fails when restricted access carries provenance',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'restricted', provenance: { type: 'auto' } },
+            expectedMessages: ['unexpected additional property: "provenance"']
+        })
+    );
+
+    test(
+        'validation fails when access is missing',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { provenance: { type: 'auto' } },
+            expectedMessages: ['at access: missing property']
+        })
+    );
+
+    test(
+        'validation fails when access is an unknown literal',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'private' },
+            expectedMessages: ['at access: invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when provenance type is missing',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', provenance: {} },
+            expectedMessages: ['at provenance.type: missing property']
+        })
+    );
+
+    test(
+        'validation fails when provenance type is unknown',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', provenance: { type: 'unknown' } },
+            expectedMessages: ['at provenance.type: invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when provenance file path is missing',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', provenance: { type: 'file' } },
+            expectedMessages: ['at provenance.path: missing property']
+        })
+    );
+
+    test(
+        'validation fails when provenance file path is empty',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', provenance: { type: 'file', path: '' } },
+            expectedMessages: ['at provenance.path: string must contain at least 1 character']
+        })
+    );
+
+    test(
+        'validation fails when an additional property is given on a public publish settings block',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', extra: 'bar' },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+
+    test(
+        'validation succeeds with public access and sbom enabled true',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', sbom: { enabled: true } },
+            expectedData: { access: 'public', sbom: { enabled: true } }
+        })
+    );
+
+    test(
+        'validation succeeds with public access and sbom enabled false',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', sbom: { enabled: false } },
+            expectedData: { access: 'public', sbom: { enabled: false } }
+        })
+    );
+
+    test(
+        'validation succeeds with restricted access and sbom enabled true',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'restricted', sbom: { enabled: true } },
+            expectedData: { access: 'restricted', sbom: { enabled: true } }
+        })
+    );
+
+    test(
+        'validation fails when sbom carries an unknown property',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', sbom: { enabled: true, extra: 1 } },
+            expectedMessages: ['at sbom: unexpected additional property: "extra"']
+        })
+    );
+
+    test(
+        'validation succeeds with public access and allowScripts true',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', allowScripts: true },
+            expectedData: { access: 'public', allowScripts: true }
+        })
+    );
+
+    test(
+        'validation succeeds with public access and allowScripts false',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', allowScripts: false },
+            expectedData: { access: 'public', allowScripts: false }
+        })
+    );
+
+    test(
+        'validation succeeds with public access and allowScripts undefined',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'public', allowScripts: undefined },
+            expectedData: { access: 'public', allowScripts: undefined }
+        })
+    );
+
+    test(
+        'validation succeeds with restricted access and allowScripts true',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'restricted', allowScripts: true },
+            expectedData: { access: 'restricted', allowScripts: true }
+        })
+    );
+
+    test(
+        'validation succeeds with restricted access and allowScripts false',
+        checkValidationSuccess({
+            schema: publishSettingsSchema,
+            data: { access: 'restricted', allowScripts: false },
+            expectedData: { access: 'restricted', allowScripts: false }
+        })
+    );
+
+    test(
+        'validation fails when allowScripts is not a boolean on public access',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'public', allowScripts: 'yes' },
+            expectedMessages: ['at allowScripts: expected boolean, but got string']
+        })
+    );
+
+    test(
+        'validation fails when allowScripts is not a boolean on restricted access',
+        checkValidationFailure({
+            schema: publishSettingsSchema,
+            data: { access: 'restricted', allowScripts: 1 },
+            expectedMessages: ['at allowScripts: expected boolean, but got number']
+        })
+    );
 });
-
-test(
-    'validation succeeds with public access and no provenance',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public' },
-        expectedData: { access: 'public' }
-    })
-);
-
-test(
-    'validation succeeds with public access and provenance auto mode',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', provenance: { type: 'auto' } },
-        expectedData: { access: 'public', provenance: { type: 'auto' } }
-    })
-);
-
-test(
-    'validation succeeds with public access and provenance file mode',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', provenance: { type: 'file', path: './build/pkg.sigstore' } },
-        expectedData: { access: 'public', provenance: { type: 'file', path: './build/pkg.sigstore' } }
-    })
-);
-
-test(
-    'validation succeeds with restricted access',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'restricted' },
-        expectedData: { access: 'restricted' }
-    })
-);
-
-test(
-    'validation fails when restricted access carries provenance',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'restricted', provenance: { type: 'auto' } },
-        expectedMessages: ['unexpected additional property: "provenance"']
-    })
-);
-
-test(
-    'validation fails when access is missing',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { provenance: { type: 'auto' } },
-        expectedMessages: ['at access: missing property']
-    })
-);
-
-test(
-    'validation fails when access is an unknown literal',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'private' },
-        expectedMessages: ['at access: invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when provenance type is missing',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', provenance: {} },
-        expectedMessages: ['at provenance.type: missing property']
-    })
-);
-
-test(
-    'validation fails when provenance type is unknown',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', provenance: { type: 'unknown' } },
-        expectedMessages: ['at provenance.type: invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when provenance file path is missing',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', provenance: { type: 'file' } },
-        expectedMessages: ['at provenance.path: missing property']
-    })
-);
-
-test(
-    'validation fails when provenance file path is empty',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', provenance: { type: 'file', path: '' } },
-        expectedMessages: ['at provenance.path: string must contain at least 1 character']
-    })
-);
-
-test(
-    'validation fails when an additional property is given on a public publish settings block',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', extra: 'bar' },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
-
-test(
-    'validation succeeds with public access and sbom enabled true',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', sbom: { enabled: true } },
-        expectedData: { access: 'public', sbom: { enabled: true } }
-    })
-);
-
-test(
-    'validation succeeds with public access and sbom enabled false',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', sbom: { enabled: false } },
-        expectedData: { access: 'public', sbom: { enabled: false } }
-    })
-);
-
-test(
-    'validation succeeds with restricted access and sbom enabled true',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'restricted', sbom: { enabled: true } },
-        expectedData: { access: 'restricted', sbom: { enabled: true } }
-    })
-);
-
-test(
-    'validation fails when sbom carries an unknown property',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', sbom: { enabled: true, extra: 1 } },
-        expectedMessages: ['at sbom: unexpected additional property: "extra"']
-    })
-);
-
-test(
-    'validation succeeds with public access and allowScripts true',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', allowScripts: true },
-        expectedData: { access: 'public', allowScripts: true }
-    })
-);
-
-test(
-    'validation succeeds with public access and allowScripts false',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', allowScripts: false },
-        expectedData: { access: 'public', allowScripts: false }
-    })
-);
-
-test(
-    'validation succeeds with public access and allowScripts undefined',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'public', allowScripts: undefined },
-        expectedData: { access: 'public', allowScripts: undefined }
-    })
-);
-
-test(
-    'validation succeeds with restricted access and allowScripts true',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'restricted', allowScripts: true },
-        expectedData: { access: 'restricted', allowScripts: true }
-    })
-);
-
-test(
-    'validation succeeds with restricted access and allowScripts false',
-    checkValidationSuccess({
-        schema: publishSettingsSchema,
-        data: { access: 'restricted', allowScripts: false },
-        expectedData: { access: 'restricted', allowScripts: false }
-    })
-);
-
-test(
-    'validation fails when allowScripts is not a boolean on public access',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'public', allowScripts: 'yes' },
-        expectedMessages: ['at allowScripts: expected boolean, but got string']
-    })
-);
-
-test(
-    'validation fails when allowScripts is not a boolean on restricted access',
-    checkValidationFailure({
-        schema: publishSettingsSchema,
-        data: { access: 'restricted', allowScripts: 1 },
-        expectedMessages: ['at allowScripts: expected boolean, but got number']
-    })
-);

--- a/source/config/registry-settings.report.test.ts
+++ b/source/config/registry-settings.report.test.ts
@@ -1,180 +1,182 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { RegistrySettings } from './registry-settings.ts';
 import { redactRegistrySettings } from './registry-settings.report.ts';
 
-test('redacts a bearer-token auth', () => {
-    const settings = {
-        registryUrl: 'https://registry.example.com',
-        auth: { type: 'bearer-token', token: 'real-secret' }
-    } as unknown as RegistrySettings;
+suite('registry-settings.report', function () {
+    test('redacts a bearer-token auth', function () {
+        const settings = {
+            registryUrl: 'https://registry.example.com',
+            auth: { type: 'bearer-token', token: 'real-secret' }
+        } as unknown as RegistrySettings;
 
-    const redacted = redactRegistrySettings(settings);
+        const redacted = redactRegistrySettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        registryUrl: 'https://registry.example.com',
-        auth: { type: 'bearer-token', token: '[redacted]' }
+        assert.deepStrictEqual(redacted, {
+            registryUrl: 'https://registry.example.com',
+            auth: { type: 'bearer-token', token: '[redacted]' }
+        });
     });
-});
 
-test('redacts a basic auth password but preserves username and email', () => {
-    const settings = {
-        auth: { type: 'basic', username: 'alice', password: 'real-secret', email: 'alice@example.com' }
-    } as unknown as RegistrySettings;
+    test('redacts a basic auth password but preserves username and email', function () {
+        const settings = {
+            auth: { type: 'basic', username: 'alice', password: 'real-secret', email: 'alice@example.com' }
+        } as unknown as RegistrySettings;
 
-    const redacted = redactRegistrySettings(settings);
+        const redacted = redactRegistrySettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        auth: { type: 'basic', username: 'alice', password: '[redacted]', email: 'alice@example.com' }
+        assert.deepStrictEqual(redacted, {
+            auth: { type: 'basic', username: 'alice', password: '[redacted]', email: 'alice@example.com' }
+        });
     });
-});
 
-test('preserves npm-oidc provider and idTokenEnvVar - no secrets to redact', () => {
-    const settings = {
-        auth: { type: 'npm-oidc', provider: 'github-actions', idTokenEnvVar: 'NPM_ID_TOKEN' }
-    } as unknown as RegistrySettings;
+    test('preserves npm-oidc provider and idTokenEnvVar - no secrets to redact', function () {
+        const settings = {
+            auth: { type: 'npm-oidc', provider: 'github-actions', idTokenEnvVar: 'NPM_ID_TOKEN' }
+        } as unknown as RegistrySettings;
 
-    const redacted = redactRegistrySettings(settings);
+        const redacted = redactRegistrySettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        auth: { type: 'npm-oidc', provider: 'github-actions', idTokenEnvVar: 'NPM_ID_TOKEN' }
+        assert.deepStrictEqual(redacted, {
+            auth: { type: 'npm-oidc', provider: 'github-actions', idTokenEnvVar: 'NPM_ID_TOKEN' }
+        });
     });
-});
 
-test('redacts both publish and metadata when auth is expanded', () => {
-    const settings = {
-        auth: {
-            publish: { type: 'bearer-token', token: 'publish-secret' },
-            metadata: { type: 'basic', username: 'm', password: 'metadata-secret' }
-        }
-    } as unknown as RegistrySettings;
+    test('redacts both publish and metadata when auth is expanded', function () {
+        const settings = {
+            auth: {
+                publish: { type: 'bearer-token', token: 'publish-secret' },
+                metadata: { type: 'basic', username: 'm', password: 'metadata-secret' }
+            }
+        } as unknown as RegistrySettings;
 
-    const redacted = redactRegistrySettings(settings);
+        const redacted = redactRegistrySettings(settings);
 
-    assert.deepStrictEqual(redacted, {
-        auth: {
+        assert.deepStrictEqual(redacted, {
+            auth: {
+                publish: { type: 'bearer-token', token: '[redacted]' },
+                metadata: { strategy: { type: 'basic', username: 'm', password: '[redacted]' } }
+            }
+        });
+    });
+
+    test('omits registryUrl when undefined', function () {
+        const settings = {
+            auth: { type: 'bearer-token', token: 'real-secret' }
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.strictEqual('registryUrl' in redacted, false);
+    });
+
+    test('omits email on basic auth when not provided', function () {
+        const settings = {
+            auth: { type: 'basic', username: 'alice', password: 'real-secret' }
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.deepStrictEqual(redacted, {
+            auth: { type: 'basic', username: 'alice', password: '[redacted]' }
+        });
+    });
+
+    test('omits provider on npm-oidc auth when not provided', function () {
+        const settings = {
+            auth: { type: 'npm-oidc', idTokenEnvVar: 'NPM_ID_TOKEN' }
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.deepStrictEqual(redacted, {
+            auth: { type: 'npm-oidc', idTokenEnvVar: 'NPM_ID_TOKEN' }
+        });
+    });
+
+    test('omits idTokenEnvVar on npm-oidc auth when not provided', function () {
+        const settings = {
+            auth: { type: 'npm-oidc', provider: 'github-actions' }
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.deepStrictEqual(redacted, {
+            auth: { type: 'npm-oidc', provider: 'github-actions' }
+        });
+    });
+
+    test('omits both provider and idTokenEnvVar on npm-oidc auth when neither is provided', function () {
+        const settings = {
+            auth: { type: 'npm-oidc' }
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.deepStrictEqual(redacted, { auth: { type: 'npm-oidc' } });
+    });
+
+    test('omits metadata on expanded auth when not provided', function () {
+        const settings = {
+            auth: {
+                publish: { type: 'bearer-token', token: 'publish-secret' }
+            }
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.deepStrictEqual(redacted, {
+            auth: { publish: { type: 'bearer-token', token: '[redacted]' } }
+        });
+    });
+
+    test('represents string metadata modes verbatim under a "mode" key', function () {
+        const autoMode = redactRegistrySettings({
+            auth: {
+                publish: { type: 'bearer-token', token: 'pub' },
+                metadata: 'auto'
+            }
+        } as unknown as RegistrySettings);
+
+        const anonymousMode = redactRegistrySettings({
+            auth: {
+                publish: { type: 'bearer-token', token: 'pub' },
+                metadata: 'anonymous'
+            }
+        } as unknown as RegistrySettings);
+
+        const inheritMode = redactRegistrySettings({
+            auth: {
+                publish: { type: 'bearer-token', token: 'pub' },
+                metadata: 'inherit-publish-auth'
+            }
+        } as unknown as RegistrySettings);
+
+        assert.deepStrictEqual(autoMode.auth, {
             publish: { type: 'bearer-token', token: '[redacted]' },
-            metadata: { strategy: { type: 'basic', username: 'm', password: '[redacted]' } }
-        }
+            metadata: { mode: 'auto' }
+        });
+        assert.deepStrictEqual(anonymousMode.auth, {
+            publish: { type: 'bearer-token', token: '[redacted]' },
+            metadata: { mode: 'anonymous' }
+        });
+        assert.deepStrictEqual(inheritMode.auth, {
+            publish: { type: 'bearer-token', token: '[redacted]' },
+            metadata: { mode: 'inherit-publish-auth' }
+        });
     });
-});
 
-test('omits registryUrl when undefined', () => {
-    const settings = {
-        auth: { type: 'bearer-token', token: 'real-secret' }
-    } as unknown as RegistrySettings;
+    test('represents object metadata strategies under a "strategy" key with redacted secrets', function () {
+        const redacted = redactRegistrySettings({
+            auth: {
+                publish: { type: 'bearer-token', token: 'pub' },
+                metadata: { type: 'bearer-token', token: 'meta-secret' }
+            }
+        } as unknown as RegistrySettings);
 
-    const redacted = redactRegistrySettings(settings);
-
-    assert.strictEqual('registryUrl' in redacted, false);
-});
-
-test('omits email on basic auth when not provided', () => {
-    const settings = {
-        auth: { type: 'basic', username: 'alice', password: 'real-secret' }
-    } as unknown as RegistrySettings;
-
-    const redacted = redactRegistrySettings(settings);
-
-    assert.deepStrictEqual(redacted, {
-        auth: { type: 'basic', username: 'alice', password: '[redacted]' }
-    });
-});
-
-test('omits provider on npm-oidc auth when not provided', () => {
-    const settings = {
-        auth: { type: 'npm-oidc', idTokenEnvVar: 'NPM_ID_TOKEN' }
-    } as unknown as RegistrySettings;
-
-    const redacted = redactRegistrySettings(settings);
-
-    assert.deepStrictEqual(redacted, {
-        auth: { type: 'npm-oidc', idTokenEnvVar: 'NPM_ID_TOKEN' }
-    });
-});
-
-test('omits idTokenEnvVar on npm-oidc auth when not provided', () => {
-    const settings = {
-        auth: { type: 'npm-oidc', provider: 'github-actions' }
-    } as unknown as RegistrySettings;
-
-    const redacted = redactRegistrySettings(settings);
-
-    assert.deepStrictEqual(redacted, {
-        auth: { type: 'npm-oidc', provider: 'github-actions' }
-    });
-});
-
-test('omits both provider and idTokenEnvVar on npm-oidc auth when neither is provided', () => {
-    const settings = {
-        auth: { type: 'npm-oidc' }
-    } as unknown as RegistrySettings;
-
-    const redacted = redactRegistrySettings(settings);
-
-    assert.deepStrictEqual(redacted, { auth: { type: 'npm-oidc' } });
-});
-
-test('omits metadata on expanded auth when not provided', () => {
-    const settings = {
-        auth: {
-            publish: { type: 'bearer-token', token: 'publish-secret' }
-        }
-    } as unknown as RegistrySettings;
-
-    const redacted = redactRegistrySettings(settings);
-
-    assert.deepStrictEqual(redacted, {
-        auth: { publish: { type: 'bearer-token', token: '[redacted]' } }
-    });
-});
-
-test('represents string metadata modes verbatim under a "mode" key', () => {
-    const autoMode = redactRegistrySettings({
-        auth: {
-            publish: { type: 'bearer-token', token: 'pub' },
-            metadata: 'auto'
-        }
-    } as unknown as RegistrySettings);
-
-    const anonymousMode = redactRegistrySettings({
-        auth: {
-            publish: { type: 'bearer-token', token: 'pub' },
-            metadata: 'anonymous'
-        }
-    } as unknown as RegistrySettings);
-
-    const inheritMode = redactRegistrySettings({
-        auth: {
-            publish: { type: 'bearer-token', token: 'pub' },
-            metadata: 'inherit-publish-auth'
-        }
-    } as unknown as RegistrySettings);
-
-    assert.deepStrictEqual(autoMode.auth, {
-        publish: { type: 'bearer-token', token: '[redacted]' },
-        metadata: { mode: 'auto' }
-    });
-    assert.deepStrictEqual(anonymousMode.auth, {
-        publish: { type: 'bearer-token', token: '[redacted]' },
-        metadata: { mode: 'anonymous' }
-    });
-    assert.deepStrictEqual(inheritMode.auth, {
-        publish: { type: 'bearer-token', token: '[redacted]' },
-        metadata: { mode: 'inherit-publish-auth' }
-    });
-});
-
-test('represents object metadata strategies under a "strategy" key with redacted secrets', () => {
-    const redacted = redactRegistrySettings({
-        auth: {
-            publish: { type: 'bearer-token', token: 'pub' },
-            metadata: { type: 'bearer-token', token: 'meta-secret' }
-        }
-    } as unknown as RegistrySettings);
-
-    assert.deepStrictEqual(redacted.auth, {
-        publish: { type: 'bearer-token', token: '[redacted]' },
-        metadata: { strategy: { type: 'bearer-token', token: '[redacted]' } }
+        assert.deepStrictEqual(redacted.auth, {
+            publish: { type: 'bearer-token', token: '[redacted]' },
+            metadata: { strategy: { type: 'bearer-token', token: '[redacted]' } }
+        });
     });
 });

--- a/source/config/registry-settings.test.ts
+++ b/source/config/registry-settings.test.ts
@@ -1,186 +1,188 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { registrySettingsSchema } from './registry-settings.ts';
 
 const bearerTokenAuth = { type: 'bearer-token', token: 'foo' } as const;
 
-test('schema accepts registry settings with shorthand auth', () => {
-    assert.strictEqual(safeParse(registrySettingsSchema, { auth: bearerTokenAuth }).success, true);
+suite('registry-settings', function () {
+    test('schema accepts registry settings with shorthand auth', function () {
+        assert.strictEqual(safeParse(registrySettingsSchema, { auth: bearerTokenAuth }).success, true);
+    });
+
+    test('schema rejects registry settings without auth', function () {
+        assert.strictEqual(safeParse(registrySettingsSchema, { registryUrl: 'bar' }).success, false);
+    });
+
+    test(
+        'validation succeeds when shorthand auth is given',
+        checkValidationSuccess({
+            schema: registrySettingsSchema,
+            data: {
+                auth: bearerTokenAuth
+            },
+            expectedData: {
+                auth: bearerTokenAuth
+            }
+        })
+    );
+
+    test(
+        'validation succeeds when explicit publish and metadata auth are given',
+        checkValidationSuccess({
+            schema: registrySettingsSchema,
+            data: {
+                registryUrl: 'https://registry.example',
+                auth: {
+                    publish: { type: 'basic', username: 'foo', password: 'bar', email: 'foo@example.test' },
+                    metadata: 'auto'
+                }
+            },
+            expectedData: {
+                registryUrl: 'https://registry.example',
+                auth: {
+                    publish: { type: 'basic', username: 'foo', password: 'bar', email: 'foo@example.test' },
+                    metadata: 'auto'
+                }
+            }
+        })
+    );
+
+    test(
+        'validation succeeds when explicit metadata auth inherits separate basic credentials',
+        checkValidationSuccess({
+            schema: registrySettingsSchema,
+            data: {
+                auth: {
+                    publish: { type: 'bearer-token', token: 'writer-token' },
+                    metadata: { type: 'basic', username: 'reader', password: 'secret' }
+                }
+            },
+            expectedData: {
+                auth: {
+                    publish: { type: 'bearer-token', token: 'writer-token' },
+                    metadata: { type: 'basic', username: 'reader', password: 'secret' }
+                }
+            }
+        })
+    );
+
+    test(
+        'validation accepts npm oidc publish auth',
+        checkValidationSuccess({
+            schema: registrySettingsSchema,
+            data: {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' },
+                    metadata: 'anonymous'
+                }
+            },
+            expectedData: {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' },
+                    metadata: 'anonymous'
+                }
+            }
+        })
+    );
+
+    test(
+        'validation accepts npm oidc publish auth for the auto provider',
+        checkValidationSuccess({
+            schema: registrySettingsSchema,
+            data: {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'auto' },
+                    metadata: 'anonymous'
+                }
+            },
+            expectedData: {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'auto' },
+                    metadata: 'anonymous'
+                }
+            }
+        })
+    );
+
+    test(
+        'validation accepts npm oidc publish auth for the GitHub Actions provider',
+        checkValidationSuccess({
+            schema: registrySettingsSchema,
+            data: {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'github-actions' },
+                    metadata: 'anonymous'
+                }
+            },
+            expectedData: {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'github-actions' },
+                    metadata: 'anonymous'
+                }
+            }
+        })
+    );
+
+    test(
+        'validation fails when a non-object value is given',
+        checkValidationFailure({
+            schema: registrySettingsSchema,
+            data: 'foo',
+            expectedMessages: ['expected object, but got string']
+        })
+    );
+
+    test(
+        'validation fails when an empty object is given',
+        checkValidationFailure({
+            schema: registrySettingsSchema,
+            data: {},
+            expectedMessages: ['at auth: missing property']
+        })
+    );
+
+    test(
+        'validation fails when shorthand auth uses an empty token',
+        checkValidationFailure({
+            schema: registrySettingsSchema,
+            data: { auth: { type: 'bearer-token', token: '' } },
+            expectedMessages: ['at auth.token: string must contain at least 1 character']
+        })
+    );
+
+    test(
+        'validation fails when metadata auth uses npm oidc',
+        checkValidationFailure({
+            schema: registrySettingsSchema,
+            data: {
+                auth: {
+                    publish: bearerTokenAuth,
+                    metadata: { type: 'npm-oidc' }
+                }
+            },
+            expectedMessages: [
+                'at auth: invalid value: expected one of "auto", "anonymous" or "inherit-publish-auth", but got object'
+            ]
+        })
+    );
+
+    test(
+        'validation fails when registryUrl is null',
+        checkValidationFailure({
+            schema: registrySettingsSchema,
+            data: { auth: bearerTokenAuth, registryUrl: null },
+            expectedMessages: ['at registryUrl: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when an additional property is given',
+        checkValidationFailure({
+            schema: registrySettingsSchema,
+            data: { auth: bearerTokenAuth, extra: 'bar' },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
 });
-
-test('schema rejects registry settings without auth', () => {
-    assert.strictEqual(safeParse(registrySettingsSchema, { registryUrl: 'bar' }).success, false);
-});
-
-test(
-    'validation succeeds when shorthand auth is given',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: {
-            auth: bearerTokenAuth
-        },
-        expectedData: {
-            auth: bearerTokenAuth
-        }
-    })
-);
-
-test(
-    'validation succeeds when explicit publish and metadata auth are given',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: {
-            registryUrl: 'https://registry.example',
-            auth: {
-                publish: { type: 'basic', username: 'foo', password: 'bar', email: 'foo@example.test' },
-                metadata: 'auto'
-            }
-        },
-        expectedData: {
-            registryUrl: 'https://registry.example',
-            auth: {
-                publish: { type: 'basic', username: 'foo', password: 'bar', email: 'foo@example.test' },
-                metadata: 'auto'
-            }
-        }
-    })
-);
-
-test(
-    'validation succeeds when explicit metadata auth inherits separate basic credentials',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: {
-            auth: {
-                publish: { type: 'bearer-token', token: 'writer-token' },
-                metadata: { type: 'basic', username: 'reader', password: 'secret' }
-            }
-        },
-        expectedData: {
-            auth: {
-                publish: { type: 'bearer-token', token: 'writer-token' },
-                metadata: { type: 'basic', username: 'reader', password: 'secret' }
-            }
-        }
-    })
-);
-
-test(
-    'validation accepts npm oidc publish auth',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' },
-                metadata: 'anonymous'
-            }
-        },
-        expectedData: {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' },
-                metadata: 'anonymous'
-            }
-        }
-    })
-);
-
-test(
-    'validation accepts npm oidc publish auth for the auto provider',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'auto' },
-                metadata: 'anonymous'
-            }
-        },
-        expectedData: {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'auto' },
-                metadata: 'anonymous'
-            }
-        }
-    })
-);
-
-test(
-    'validation accepts npm oidc publish auth for the GitHub Actions provider',
-    checkValidationSuccess({
-        schema: registrySettingsSchema,
-        data: {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'github-actions' },
-                metadata: 'anonymous'
-            }
-        },
-        expectedData: {
-            auth: {
-                publish: { type: 'npm-oidc', provider: 'github-actions' },
-                metadata: 'anonymous'
-            }
-        }
-    })
-);
-
-test(
-    'validation fails when a non-object value is given',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: 'foo',
-        expectedMessages: ['expected object, but got string']
-    })
-);
-
-test(
-    'validation fails when an empty object is given',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: {},
-        expectedMessages: ['at auth: missing property']
-    })
-);
-
-test(
-    'validation fails when shorthand auth uses an empty token',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: { auth: { type: 'bearer-token', token: '' } },
-        expectedMessages: ['at auth.token: string must contain at least 1 character']
-    })
-);
-
-test(
-    'validation fails when metadata auth uses npm oidc',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: {
-            auth: {
-                publish: bearerTokenAuth,
-                metadata: { type: 'npm-oidc' }
-            }
-        },
-        expectedMessages: [
-            'at auth: invalid value: expected one of "auto", "anonymous" or "inherit-publish-auth", but got object'
-        ]
-    })
-);
-
-test(
-    'validation fails when registryUrl is null',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: { auth: bearerTokenAuth, registryUrl: null },
-        expectedMessages: ['at registryUrl: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when an additional property is given',
-    checkValidationFailure({
-        schema: registrySettingsSchema,
-        data: { auth: bearerTokenAuth, extra: 'bar' },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);

--- a/source/config/root-config-validation.test.ts
+++ b/source/config/root-config-validation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfig, PackageConfigsByName } from './config.ts';
 import { validatePackageSurfaceRules } from './root-config-validation.ts';
 
@@ -16,107 +16,109 @@ function configs(...packages: readonly PackageConfig[]): PackageConfigsByName {
     return Object.fromEntries(packages.map((packageConfig) => [packageConfig.name, packageConfig]));
 }
 
-test('validatePackageSurfaceRules returns no issues for a single-root implicit package', () => {
-    assert.deepStrictEqual(validatePackageSurfaceRules(configs(pkg({}))), []);
-});
+suite('root-config-validation', function () {
+    test('validatePackageSurfaceRules returns no issues for a single-root implicit package', function () {
+        assert.deepStrictEqual(validatePackageSurfaceRules(configs(pkg({}))), []);
+    });
 
-test('validatePackageSurfaceRules requires defaultModuleRoot when an implicit package has multiple roots', () => {
-    const result = validatePackageSurfaceRules(
-        configs(pkg({ roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } } }))
-    );
+    test('validatePackageSurfaceRules requires defaultModuleRoot when an implicit package has multiple roots', function () {
+        const result = validatePackageSurfaceRules(
+            configs(pkg({ roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } } }))
+        );
 
-    assert.deepStrictEqual(result, ['Package "pkg-a" must define defaultModuleRoot when multiple roots exist']);
-});
+        assert.deepStrictEqual(result, ['Package "pkg-a" must define defaultModuleRoot when multiple roots exist']);
+    });
 
-test('validatePackageSurfaceRules reports an unknown defaultModuleRoot for an implicit package', () => {
-    const result = validatePackageSurfaceRules(
-        configs(pkg({ roots: { main: { js: 'index.js' } }, defaultModuleRoot: 'missing' } as never))
-    );
+    test('validatePackageSurfaceRules reports an unknown defaultModuleRoot for an implicit package', function () {
+        const result = validatePackageSurfaceRules(
+            configs(pkg({ roots: { main: { js: 'index.js' } }, defaultModuleRoot: 'missing' } as never))
+        );
 
-    assert.deepStrictEqual(result, ['Package "pkg-a" references unknown defaultModuleRoot "missing"']);
-});
+        assert.deepStrictEqual(result, ['Package "pkg-a" references unknown defaultModuleRoot "missing"']);
+    });
 
-test('validatePackageSurfaceRules reports duplicate javascript targets across roots', () => {
-    const result = validatePackageSurfaceRules(
-        configs(pkg({ roots: { a: { js: 'index.js' }, b: { js: 'index.js' } } }))
-    );
+    test('validatePackageSurfaceRules reports duplicate javascript targets across roots', function () {
+        const result = validatePackageSurfaceRules(
+            configs(pkg({ roots: { a: { js: 'index.js' }, b: { js: 'index.js' } } }))
+        );
 
-    assert.ok(result.includes('Package "pkg-a" maps both root "a" and "b" to "index.js"'));
-});
+        assert.ok(result.includes('Package "pkg-a" maps both root "a" and "b" to "index.js"'));
+    });
 
-test('validatePackageSurfaceRules reports explicit module exports that reference unknown roots', () => {
-    const result = validatePackageSurfaceRules(
-        configs(
-            pkg({
-                roots: { main: { js: 'index.js' } },
-                packageInterface: { modules: [{ root: 'missing', export: '.' }] }
-            })
-        )
-    );
+    test('validatePackageSurfaceRules reports explicit module exports that reference unknown roots', function () {
+        const result = validatePackageSurfaceRules(
+            configs(
+                pkg({
+                    roots: { main: { js: 'index.js' } },
+                    packageInterface: { modules: [{ root: 'missing', export: '.' }] }
+                })
+            )
+        );
 
-    assert.ok(
-        result.some(
-            (issue) => issue.includes('module export "."') && issue.includes('references unknown root "missing"')
-        )
-    );
-});
+        assert.ok(
+            result.some(
+                (issue) => issue.includes('module export "."') && issue.includes('references unknown root "missing"')
+            )
+        );
+    });
 
-test('validatePackageSurfaceRules reports duplicate explicit export keys', () => {
-    const result = validatePackageSurfaceRules(
-        configs(
-            pkg({
-                roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } },
-                packageInterface: {
-                    modules: [
-                        { root: 'main', export: '.' },
-                        { root: 'extra', export: '.' }
-                    ]
-                }
-            })
-        )
-    );
+    test('validatePackageSurfaceRules reports duplicate explicit export keys', function () {
+        const result = validatePackageSurfaceRules(
+            configs(
+                pkg({
+                    roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } },
+                    packageInterface: {
+                        modules: [
+                            { root: 'main', export: '.' },
+                            { root: 'extra', export: '.' }
+                        ]
+                    }
+                })
+            )
+        );
 
-    assert.ok(result.some((issue) => issue.includes('duplicate export key "."')));
-});
+        assert.ok(result.some((issue) => issue.includes('duplicate export key "."')));
+    });
 
-test('validatePackageSurfaceRules reports an unused root in explicit mode', () => {
-    const result = validatePackageSurfaceRules(
-        configs(
-            pkg({
-                roots: { main: { js: 'index.js' }, unused: { js: 'unused.js' } },
-                packageInterface: { modules: [{ root: 'main', export: '.' }] }
-            })
-        )
-    );
+    test('validatePackageSurfaceRules reports an unused root in explicit mode', function () {
+        const result = validatePackageSurfaceRules(
+            configs(
+                pkg({
+                    roots: { main: { js: 'index.js' }, unused: { js: 'unused.js' } },
+                    packageInterface: { modules: [{ root: 'main', export: '.' }] }
+                })
+            )
+        );
 
-    assert.ok(result.some((issue) => issue.includes('unused root "unused"')));
-});
+        assert.ok(result.some((issue) => issue.includes('unused root "unused"')));
+    });
 
-test('validatePackageSurfaceRules rejects mixing defaultModuleRoot with packageInterface', () => {
-    const result = validatePackageSurfaceRules(
-        configs(
-            pkg({
-                defaultModuleRoot: 'main',
-                packageInterface: { modules: [{ root: 'main', export: '.' }] }
-            } as never)
-        )
-    );
+    test('validatePackageSurfaceRules rejects mixing defaultModuleRoot with packageInterface', function () {
+        const result = validatePackageSurfaceRules(
+            configs(
+                pkg({
+                    defaultModuleRoot: 'main',
+                    packageInterface: { modules: [{ root: 'main', export: '.' }] }
+                } as never)
+            )
+        );
 
-    assert.ok(result.some((issue) => issue.includes('cannot combine defaultModuleRoot with packageInterface')));
-});
+        assert.ok(result.some((issue) => issue.includes('cannot combine defaultModuleRoot with packageInterface')));
+    });
 
-test('validatePackageSurfaceRules reports a private root that conflicts with a public export', () => {
-    const result = validatePackageSurfaceRules(
-        configs(
-            pkg({
-                roots: { main: { js: 'index.js' } },
-                packageInterface: {
-                    modules: [{ root: 'main', export: '.' }],
-                    privateRoots: ['main']
-                }
-            } as never)
-        )
-    );
+    test('validatePackageSurfaceRules reports a private root that conflicts with a public export', function () {
+        const result = validatePackageSurfaceRules(
+            configs(
+                pkg({
+                    roots: { main: { js: 'index.js' } },
+                    packageInterface: {
+                        modules: [{ root: 'main', export: '.' }],
+                        privateRoots: ['main']
+                    }
+                } as never)
+            )
+        );
 
-    assert.ok(result.some((issue) => issue.includes('cannot be both public and private')));
+        assert.ok(result.some((issue) => issue.includes('cannot be both public and private')));
+    });
 });

--- a/source/config/root.test.ts
+++ b/source/config/root.test.ts
@@ -1,140 +1,142 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { rootSchema } from './root.ts';
 
-test('schema accepts a root with js only', () => {
-    assert.strictEqual(safeParse(rootSchema, { js: 'foo' }).success, true);
+suite('root', function () {
+    test('schema accepts a root with js only', function () {
+        assert.strictEqual(safeParse(rootSchema, { js: 'foo' }).success, true);
+    });
+
+    test('schema rejects a root without js', function () {
+        assert.strictEqual(safeParse(rootSchema, { declarationFile: 'bar' }).success, false);
+    });
+
+    test(
+        'validation succeeds when a minimal root is given',
+        checkValidationSuccess({
+            schema: rootSchema,
+            data: {
+                js: 'foo'
+            },
+            expectedData: {
+                js: 'foo'
+            }
+        })
+    );
+
+    test(
+        'validation succeeds when optional declarationFile is given',
+        checkValidationSuccess({
+            schema: rootSchema,
+            data: {
+                js: 'foo',
+                declarationFile: 'bar'
+            },
+            expectedData: {
+                js: 'foo',
+                declarationFile: 'bar'
+            }
+        })
+    );
+
+    test(
+        'validation fails when a non-object value is given',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: 'foo',
+            expectedMessages: ['expected object, but got string']
+        })
+    );
+
+    test(
+        'validation fails when an empty object is given',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: {},
+            expectedMessages: ['at js: missing property']
+        })
+    );
+
+    test(
+        'validation succeeds when declarationFile is undefined',
+        checkValidationSuccess({
+            schema: rootSchema,
+            data: { declarationFile: undefined, js: 'foo' },
+            expectedData: { declarationFile: undefined, js: 'foo' }
+        })
+    );
+
+    test(
+        'validation fails when declarationFile is null',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { declarationFile: null, js: 'foo' },
+            expectedMessages: ['at declarationFile: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when an additional property is given',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { js: 'foo', extra: 'bar' },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+
+    test(
+        'validation fails when declarationFile is not a string',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { declarationFile: 42, js: 'foo' },
+            expectedMessages: ['at declarationFile: expected string, but got number']
+        })
+    );
+
+    test(
+        'validation fails when declarationFile is an empty string',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { declarationFile: '', js: 'foo' },
+            expectedMessages: ['at declarationFile: string must contain at least 1 character']
+        })
+    );
+
+    test(
+        'validation fails when js is not a string',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { js: 42 },
+            expectedMessages: ['at js: expected string, but got number']
+        })
+    );
+
+    test(
+        'validation fails when js is undefined',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { js: undefined },
+            expectedMessages: ['at js: expected string, but got undefined']
+        })
+    );
+
+    test(
+        'validation fails when js is null',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { js: null },
+            expectedMessages: ['at js: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when js is an empty string',
+        checkValidationFailure({
+            schema: rootSchema,
+            data: { js: '' },
+            expectedMessages: ['at js: string must contain at least 1 character']
+        })
+    );
 });
-
-test('schema rejects a root without js', () => {
-    assert.strictEqual(safeParse(rootSchema, { declarationFile: 'bar' }).success, false);
-});
-
-test(
-    'validation succeeds when a minimal root is given',
-    checkValidationSuccess({
-        schema: rootSchema,
-        data: {
-            js: 'foo'
-        },
-        expectedData: {
-            js: 'foo'
-        }
-    })
-);
-
-test(
-    'validation succeeds when optional declarationFile is given',
-    checkValidationSuccess({
-        schema: rootSchema,
-        data: {
-            js: 'foo',
-            declarationFile: 'bar'
-        },
-        expectedData: {
-            js: 'foo',
-            declarationFile: 'bar'
-        }
-    })
-);
-
-test(
-    'validation fails when a non-object value is given',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: 'foo',
-        expectedMessages: ['expected object, but got string']
-    })
-);
-
-test(
-    'validation fails when an empty object is given',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: {},
-        expectedMessages: ['at js: missing property']
-    })
-);
-
-test(
-    'validation succeeds when declarationFile is undefined',
-    checkValidationSuccess({
-        schema: rootSchema,
-        data: { declarationFile: undefined, js: 'foo' },
-        expectedData: { declarationFile: undefined, js: 'foo' }
-    })
-);
-
-test(
-    'validation fails when declarationFile is null',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { declarationFile: null, js: 'foo' },
-        expectedMessages: ['at declarationFile: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when an additional property is given',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { js: 'foo', extra: 'bar' },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
-
-test(
-    'validation fails when declarationFile is not a string',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { declarationFile: 42, js: 'foo' },
-        expectedMessages: ['at declarationFile: expected string, but got number']
-    })
-);
-
-test(
-    'validation fails when declarationFile is an empty string',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { declarationFile: '', js: 'foo' },
-        expectedMessages: ['at declarationFile: string must contain at least 1 character']
-    })
-);
-
-test(
-    'validation fails when js is not a string',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { js: 42 },
-        expectedMessages: ['at js: expected string, but got number']
-    })
-);
-
-test(
-    'validation fails when js is undefined',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { js: undefined },
-        expectedMessages: ['at js: expected string, but got undefined']
-    })
-);
-
-test(
-    'validation fails when js is null',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { js: null },
-        expectedMessages: ['at js: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when js is an empty string',
-    checkValidationFailure({
-        schema: rootSchema,
-        data: { js: '' },
-        expectedMessages: ['at js: string must contain at least 1 character']
-    })
-);

--- a/source/config/sbom-settings.test.ts
+++ b/source/config/sbom-settings.test.ts
@@ -1,48 +1,50 @@
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { sbomSettingsSchema } from './sbom-settings.ts';
 
-test(
-    'validation succeeds with an empty object',
-    checkValidationSuccess({
-        schema: sbomSettingsSchema,
-        data: {},
-        expectedData: {}
-    })
-);
+suite('sbom-settings', function () {
+    test(
+        'validation succeeds with an empty object',
+        checkValidationSuccess({
+            schema: sbomSettingsSchema,
+            data: {},
+            expectedData: {}
+        })
+    );
 
-test(
-    'validation succeeds with enabled true',
-    checkValidationSuccess({
-        schema: sbomSettingsSchema,
-        data: { enabled: true },
-        expectedData: { enabled: true }
-    })
-);
+    test(
+        'validation succeeds with enabled true',
+        checkValidationSuccess({
+            schema: sbomSettingsSchema,
+            data: { enabled: true },
+            expectedData: { enabled: true }
+        })
+    );
 
-test(
-    'validation succeeds with enabled false',
-    checkValidationSuccess({
-        schema: sbomSettingsSchema,
-        data: { enabled: false },
-        expectedData: { enabled: false }
-    })
-);
+    test(
+        'validation succeeds with enabled false',
+        checkValidationSuccess({
+            schema: sbomSettingsSchema,
+            data: { enabled: false },
+            expectedData: { enabled: false }
+        })
+    );
 
-test(
-    'validation fails when enabled is not a boolean',
-    checkValidationFailure({
-        schema: sbomSettingsSchema,
-        data: { enabled: 'yes' },
-        expectedMessages: ['at enabled: expected boolean, but got string']
-    })
-);
+    test(
+        'validation fails when enabled is not a boolean',
+        checkValidationFailure({
+            schema: sbomSettingsSchema,
+            data: { enabled: 'yes' },
+            expectedMessages: ['at enabled: expected boolean, but got string']
+        })
+    );
 
-test(
-    'validation fails when an unknown property is given',
-    checkValidationFailure({
-        schema: sbomSettingsSchema,
-        data: { enabled: true, extra: 'no' },
-        expectedMessages: ['unexpected additional property: "extra"']
-    })
-);
+    test(
+        'validation fails when an unknown property is given',
+        checkValidationFailure({
+            schema: sbomSettingsSchema,
+            data: { enabled: true, extra: 'no' },
+            expectedMessages: ['unexpected additional property: "extra"']
+        })
+    );
+});

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -1,295 +1,299 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { runNodeProbe } from '../test-libraries/run-node-probe.ts';
 
 const probeTestTimeoutMs = 10_000;
 
-test('leaf config schemas keep their expected object keys and strict object behavior', async () => {
-    const result = await runNodeProbe(`
-        import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
-        import { rootSchema } from './source/config/root.ts';
-        import { mainPackageJsonSchema } from './source/config/main-package-json-schema.ts';
-        import { registrySettingsSchema } from './source/config/registry-settings.ts';
+suite('schema-contracts', function () {
+    test('leaf config schemas keep their expected object keys and strict object behavior', async function () {
+        const result = await runNodeProbe(`
+            import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
+            import { rootSchema } from './source/config/root.ts';
+            import { mainPackageJsonSchema } from './source/config/main-package-json-schema.ts';
+            import { registrySettingsSchema } from './source/config/registry-settings.ts';
 
-        console.log(JSON.stringify({
-            additionalFileShape: Object.keys(additionalFileDescriptionSchema._zod.def.innerType.def.shape),
-            rootShape: Object.keys(rootSchema._zod.def.innerType.def.shape),
-            registrySettingsShape: Object.keys(registrySettingsSchema._zod.def.innerType.def.shape),
-            mainPackageJsonShape: Object.keys(mainPackageJsonSchema._zod.def.innerType.def.shape),
-            additionalFileCatchallType: additionalFileDescriptionSchema._zod.def.innerType.def.catchall.type,
-            rootCatchallType: rootSchema._zod.def.innerType.def.catchall.type,
-            registrySettingsCatchallType: registrySettingsSchema._zod.def.innerType.def.catchall.type
-        }));
-    `);
+            console.log(JSON.stringify({
+                additionalFileShape: Object.keys(additionalFileDescriptionSchema._zod.def.innerType.def.shape),
+                rootShape: Object.keys(rootSchema._zod.def.innerType.def.shape),
+                registrySettingsShape: Object.keys(registrySettingsSchema._zod.def.innerType.def.shape),
+                mainPackageJsonShape: Object.keys(mainPackageJsonSchema._zod.def.innerType.def.shape),
+                additionalFileCatchallType: additionalFileDescriptionSchema._zod.def.innerType.def.catchall.type,
+                rootCatchallType: rootSchema._zod.def.innerType.def.catchall.type,
+                registrySettingsCatchallType: registrySettingsSchema._zod.def.innerType.def.catchall.type
+            }));
+        `);
 
-    assert.deepStrictEqual(result, {
-        additionalFileShape: ['sourceFilePath', 'targetFilePath'],
-        rootShape: ['js', 'declarationFile'],
-        registrySettingsShape: ['registryUrl', 'auth'],
-        mainPackageJsonShape: ['type', 'dependencies', 'devDependencies', 'peerDependencies', 'imports'],
-        additionalFileCatchallType: 'never',
-        rootCatchallType: 'never',
-        registrySettingsCatchallType: 'never'
-    });
-}).timeout(probeTestTimeoutMs);
+        assert.deepStrictEqual(result, {
+            additionalFileShape: ['sourceFilePath', 'targetFilePath'],
+            rootShape: ['js', 'declarationFile'],
+            registrySettingsShape: ['registryUrl', 'auth'],
+            mainPackageJsonShape: ['type', 'dependencies', 'devDependencies', 'peerDependencies', 'imports'],
+            additionalFileCatchallType: 'never',
+            rootCatchallType: 'never',
+            registrySettingsCatchallType: 'never'
+        });
+    }).timeout(probeTestTimeoutMs);
 
-test('versioning schema keeps the discriminant and both branches', async () => {
-    const result = await runNodeProbe(`
-        import { safeParse } from '@schema-hub/zod-error-formatter';
-        import { versioningSettingsSchema } from './source/config/versioning-settings.ts';
+    test('versioning schema keeps the discriminant and both branches', async function () {
+        const result = await runNodeProbe(`
+            import { safeParse } from '@schema-hub/zod-error-formatter';
+            import { versioningSettingsSchema } from './source/config/versioning-settings.ts';
 
-        const unionDef = versioningSettingsSchema._zod.def.innerType.def;
+            const unionDef = versioningSettingsSchema._zod.def.innerType.def;
 
-        console.log(JSON.stringify({
-            discriminator: unionDef.discriminator,
-            optionCount: unionDef.options.length,
-            branchKeys: unionDef.options.map((option) => Object.keys(option.def.innerType.def.shape)),
-            branchLiterals: unionDef.options.map((option) => option.def.innerType.def.shape.automatic.def.values[0]),
-            automaticSuccess: safeParse(versioningSettingsSchema, {
-                automatic: true,
-                minimumVersion: '1.0.0'
-            }).success,
-            manualSuccess: safeParse(versioningSettingsSchema, { automatic: false, version: '1.0.0' }).success,
-            invalidAutomaticBranchSuccess: safeParse(versioningSettingsSchema, {
-                automatic: true,
-                version: '1.0.0'
-            }).success,
-            invalidManualBranchSuccess: safeParse(versioningSettingsSchema, {
-                automatic: false,
-                minimumVersion: '1.0.0'
-            }).success
-        }));
-    `);
+            console.log(JSON.stringify({
+                discriminator: unionDef.discriminator,
+                optionCount: unionDef.options.length,
+                branchKeys: unionDef.options.map((option) => Object.keys(option.def.innerType.def.shape)),
+                branchLiterals: unionDef.options.map((option) => {
+                    return option.def.innerType.def.shape.automatic.def.values[0];
+                }),
+                automaticSuccess: safeParse(versioningSettingsSchema, {
+                    automatic: true,
+                    minimumVersion: '1.0.0'
+                }).success,
+                manualSuccess: safeParse(versioningSettingsSchema, { automatic: false, version: '1.0.0' }).success,
+                invalidAutomaticBranchSuccess: safeParse(versioningSettingsSchema, {
+                    automatic: true,
+                    version: '1.0.0'
+                }).success,
+                invalidManualBranchSuccess: safeParse(versioningSettingsSchema, {
+                    automatic: false,
+                    minimumVersion: '1.0.0'
+                }).success
+            }));
+        `);
 
-    assert.deepStrictEqual(result, {
-        discriminator: 'automatic',
-        optionCount: 2,
-        branchKeys: [
-            ['automatic', 'minimumVersion'],
-            ['automatic', 'version']
-        ],
-        branchLiterals: [true, false],
-        automaticSuccess: true,
-        manualSuccess: true,
-        invalidAutomaticBranchSuccess: false,
-        invalidManualBranchSuccess: false
-    });
-}).timeout(probeTestTimeoutMs);
+        assert.deepStrictEqual(result, {
+            discriminator: 'automatic',
+            optionCount: 2,
+            branchKeys: [
+                ['automatic', 'minimumVersion'],
+                ['automatic', 'version']
+            ],
+            branchLiterals: [true, false],
+            automaticSuccess: true,
+            manualSuccess: true,
+            invalidAutomaticBranchSuccess: false,
+            invalidManualBranchSuccess: false
+        });
+    }).timeout(probeTestTimeoutMs);
 
-test('package json schemas keep their runtime structure and forbidden key behavior', async () => {
-    const result = await runNodeProbe(`
-        import { safeParse } from '@schema-hub/zod-error-formatter';
-        import {
-            additionalPackageJsonAttributesSchema
-        } from './source/config/additional-package-json-attributes-schema.ts';
-        import { mainPackageJsonSchema } from './source/config/main-package-json-schema.ts';
+    test('package json schemas keep their runtime structure and forbidden key behavior', async function () {
+        const result = await runNodeProbe(`
+            import { safeParse } from '@schema-hub/zod-error-formatter';
+            import {
+                additionalPackageJsonAttributesSchema
+            } from './source/config/additional-package-json-attributes-schema.ts';
+            import { mainPackageJsonSchema } from './source/config/main-package-json-schema.ts';
 
-        const mainShape = mainPackageJsonSchema._zod.def.innerType.def.shape;
-        const forbiddenKeySuccesses = [
-            'bin',
-            'dependencies',
-            'peerDependencies',
-            'devDependencies',
-            'exports',
-            'imports',
-            'main',
-            'name',
-            'types',
-            'type',
-            'version'
-        ].map((key) => safeParse(additionalPackageJsonAttributesSchema, { [key]: '1.0.0' }).success);
+            const mainShape = mainPackageJsonSchema._zod.def.innerType.def.shape;
+            const forbiddenKeySuccesses = [
+                'bin',
+                'dependencies',
+                'peerDependencies',
+                'devDependencies',
+                'exports',
+                'imports',
+                'main',
+                'name',
+                'types',
+                'type',
+                'version'
+            ].map((key) => safeParse(additionalPackageJsonAttributesSchema, { [key]: '1.0.0' }).success);
 
-        console.log(JSON.stringify({
-            mainShape: Object.keys(mainShape),
-            typeLiteral: mainShape.type.def.values[0],
-            dependencyRecordType: mainShape.dependencies.def.innerType.def.innerType.def.type,
-            devDependencyRecordType: mainShape.devDependencies.def.innerType.def.innerType.def.type,
-            peerDependencyRecordType: mainShape.peerDependencies.def.innerType.def.innerType.def.type,
-            importsRecordType: mainShape.imports.def.innerType.def.innerType.def.type,
-            validMainSuccess: safeParse(mainPackageJsonSchema, {
-                type: 'module',
-                dependencies: { dep: '1.0.0' }
-            }).success,
-            forbiddenKeySuccesses
-        }));
-    `);
+            console.log(JSON.stringify({
+                mainShape: Object.keys(mainShape),
+                typeLiteral: mainShape.type.def.values[0],
+                dependencyRecordType: mainShape.dependencies.def.innerType.def.innerType.def.type,
+                devDependencyRecordType: mainShape.devDependencies.def.innerType.def.innerType.def.type,
+                peerDependencyRecordType: mainShape.peerDependencies.def.innerType.def.innerType.def.type,
+                importsRecordType: mainShape.imports.def.innerType.def.innerType.def.type,
+                validMainSuccess: safeParse(mainPackageJsonSchema, {
+                    type: 'module',
+                    dependencies: { dep: '1.0.0' }
+                }).success,
+                forbiddenKeySuccesses
+            }));
+        `);
 
-    assert.deepStrictEqual(result, {
-        mainShape: ['type', 'dependencies', 'devDependencies', 'peerDependencies', 'imports'],
-        typeLiteral: 'module',
-        dependencyRecordType: 'record',
-        devDependencyRecordType: 'record',
-        peerDependencyRecordType: 'record',
-        importsRecordType: 'record',
-        validMainSuccess: true,
-        forbiddenKeySuccesses: [false, false, false, false, false, false, false, false, false, false, false]
-    });
-}).timeout(probeTestTimeoutMs);
+        assert.deepStrictEqual(result, {
+            mainShape: ['type', 'dependencies', 'devDependencies', 'peerDependencies', 'imports'],
+            typeLiteral: 'module',
+            dependencyRecordType: 'record',
+            devDependencyRecordType: 'record',
+            peerDependencyRecordType: 'record',
+            importsRecordType: 'record',
+            validMainSuccess: true,
+            forbiddenKeySuccesses: [false, false, false, false, false, false, false, false, false, false, false]
+        });
+    }).timeout(probeTestTimeoutMs);
 
-test('packtory config schemas keep their union and package tuple structure', async () => {
-    const result = await runNodeProbe(`
-        import { safeParse } from '@schema-hub/zod-error-formatter';
-        import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
-        import {
-            packtoryConfigWithoutRegistrySchema
-        } from './source/config/packtory-config-without-registry-schema.ts';
+    test('packtory config schemas keep their union and package tuple structure', async function () {
+        const result = await runNodeProbe(`
+            import { safeParse } from '@schema-hub/zod-error-formatter';
+            import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
+            import {
+                packtoryConfigWithoutRegistrySchema
+            } from './source/config/packtory-config-without-registry-schema.ts';
 
-        const withoutRegistryOptions = packtoryConfigWithoutRegistrySchema._zod.def.options;
-        const firstOptionShape = withoutRegistryOptions[0].def.innerType.def.shape;
-        const packageTuple = firstOptionShape.packages._zod.def.innerType.def;
-        const packageShape = packageTuple.items[0].def.innerType.def.shape;
-        const checksShape = firstOptionShape.checks.def.innerType.def.shape;
-        const commonShape = firstOptionShape.commonPackageSettings.def.innerType.def.shape;
+            const withoutRegistryOptions = packtoryConfigWithoutRegistrySchema._zod.def.options;
+            const firstOptionShape = withoutRegistryOptions[0].def.innerType.def.shape;
+            const packageTuple = firstOptionShape.packages._zod.def.innerType.def;
+            const packageShape = packageTuple.items[0].def.innerType.def.shape;
+            const checksShape = firstOptionShape.checks.def.innerType.def.shape;
+            const commonShape = firstOptionShape.commonPackageSettings.def.innerType.def.shape;
 
-        console.log(JSON.stringify({
-            optionCount: withoutRegistryOptions.length,
-            topLevelKeys: withoutRegistryOptions.map((option) => Object.keys(option.def.innerType.def.shape)),
-            packageTupleItemCounts: withoutRegistryOptions.map((option) =>
-                option.def.innerType.def.shape.packages._zod.def.innerType.def.items.length
-            ),
-            packageTupleHasRest: withoutRegistryOptions.map((option) =>
-                option.def.innerType.def.shape.packages._zod.def.innerType.def.rest !== undefined
-            ),
-            packageShapeKeys: Object.keys(packageShape),
-            checksShapeKeys: Object.keys(checksShape),
-            commonShapeKeys: Object.keys(commonShape),
-            configIntersectionLeftKeys: Object.keys(
-                packtoryConfigSchema._zod.def.left.def.shape
-            ),
-            validWithoutRegistrySuccess: safeParse(packtoryConfigWithoutRegistrySchema, {
-                packages: [
-                    {
-                        name: 'pkg',
+            console.log(JSON.stringify({
+                optionCount: withoutRegistryOptions.length,
+                topLevelKeys: withoutRegistryOptions.map((option) => Object.keys(option.def.innerType.def.shape)),
+                packageTupleItemCounts: withoutRegistryOptions.map((option) =>
+                    option.def.innerType.def.shape.packages._zod.def.innerType.def.items.length
+                ),
+                packageTupleHasRest: withoutRegistryOptions.map((option) =>
+                    option.def.innerType.def.shape.packages._zod.def.innerType.def.rest !== undefined
+                ),
+                packageShapeKeys: Object.keys(packageShape),
+                checksShapeKeys: Object.keys(checksShape),
+                commonShapeKeys: Object.keys(commonShape),
+                configIntersectionLeftKeys: Object.keys(
+                    packtoryConfigSchema._zod.def.left.def.shape
+                ),
+                validWithoutRegistrySuccess: safeParse(packtoryConfigWithoutRegistrySchema, {
+                    packages: [
+                        {
+                            name: 'pkg',
+                            sourcesFolder: 'src',
+                            mainPackageJson: { type: 'module' },
+                            roots: { main: { js: 'index.js' } }
+                        }
+                    ]
+                }).success
+            }));
+        `);
+
+        assert.deepStrictEqual(result, {
+            optionCount: 4,
+            topLevelKeys: [
+                ['checks', 'commonPackageSettings', 'packages'],
+                ['checks', 'commonPackageSettings', 'packages'],
+                ['checks', 'commonPackageSettings', 'packages'],
+                ['checks', 'commonPackageSettings', 'packages']
+            ],
+            packageTupleItemCounts: [1, 1, 1, 1],
+            packageTupleHasRest: [true, true, true, true],
+            packageShapeKeys: [
+                'sourcesFolder',
+                'mainPackageJson',
+                'additionalFiles',
+                'includeSourceMapFiles',
+                'additionalPackageJsonAttributes',
+                'publishSettings',
+                'dependencyPolicy',
+                'deadCodeElimination',
+                'name',
+                'exportPackageJson',
+                'versioning',
+                'bundleDependencies',
+                'bundlePeerDependencies',
+                'checks',
+                'roots',
+                'defaultModuleRoot',
+                'packageInterface'
+            ],
+            checksShapeKeys: [
+                'noDuplicatedFiles',
+                'requiredFiles',
+                'maxBundleSize',
+                'noUnusedBundleDependencies',
+                'noDevDependencyImports',
+                'uniqueTargetPaths',
+                'noSideEffects'
+            ],
+            commonShapeKeys: [
+                'sourcesFolder',
+                'mainPackageJson',
+                'additionalFiles',
+                'includeSourceMapFiles',
+                'additionalPackageJsonAttributes',
+                'publishSettings',
+                'dependencyPolicy',
+                'deadCodeElimination'
+            ],
+            configIntersectionLeftKeys: ['registrySettings'],
+            validWithoutRegistrySuccess: true
+        });
+    }).timeout(probeTestTimeoutMs);
+
+    test('schema source modules still validate representative valid and invalid inputs', async function () {
+        const result = await runNodeProbe(`
+            import { safeParse } from '@schema-hub/zod-error-formatter';
+            import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
+            import { rootSchema } from './source/config/root.ts';
+            import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
+            import { registrySettingsSchema } from './source/config/registry-settings.ts';
+
+            console.log(JSON.stringify({
+                validAdditionalFileSuccess: safeParse(additionalFileDescriptionSchema, {
+                    sourceFilePath: 'README.md',
+                    targetFilePath: 'README.md'
+                }).success,
+                missingAdditionalFileSourceSuccess: safeParse(additionalFileDescriptionSchema, {
+                    targetFilePath: 'README.md'
+                }).success,
+                validRootSuccess: safeParse(rootSchema, {
+                    js: 'index.js',
+                    declarationFile: 'index.d.ts'
+                }).success,
+                missingRootJsSuccess: safeParse(rootSchema, {
+                    declarationFile: 'index.d.ts'
+                }).success,
+                extraRootPropertySuccess: safeParse(rootSchema, {
+                    js: 'index.js',
+                    extra: 'nope'
+                }).success,
+                validRegistrySuccess: safeParse(registrySettingsSchema, {
+                    auth: { type: 'bearer-token', token: 'secret' },
+                    registryUrl: 'https://example.test'
+                }).success,
+                missingRegistryTokenSuccess: safeParse(registrySettingsSchema, {
+                    registryUrl: 'https://example.test'
+                }).success,
+                validConfigSuccess: safeParse(packtoryConfigSchema, {
+                    registrySettings: { auth: { type: 'bearer-token', token: 'secret' } },
+                    packages: [{
                         sourcesFolder: 'src',
                         mainPackageJson: { type: 'module' },
+                        name: 'pkg',
                         roots: { main: { js: 'index.js' } }
-                    }
-                ]
-            }).success
-        }));
-    `);
+                    }]
+                }).success,
+                missingConfigRegistrySuccess: safeParse(packtoryConfigSchema, {
+                    packages: [{
+                        sourcesFolder: 'src',
+                        mainPackageJson: { type: 'module' },
+                        name: 'pkg',
+                        roots: { main: { js: 'index.js' } }
+                    }]
+                }).success,
+                emptyConfigPackagesSuccess: safeParse(packtoryConfigSchema, {
+                    registrySettings: { auth: { type: 'bearer-token', token: 'secret' } },
+                    packages: []
+                }).success
+            }));
+        `);
 
-    assert.deepStrictEqual(result, {
-        optionCount: 4,
-        topLevelKeys: [
-            ['checks', 'commonPackageSettings', 'packages'],
-            ['checks', 'commonPackageSettings', 'packages'],
-            ['checks', 'commonPackageSettings', 'packages'],
-            ['checks', 'commonPackageSettings', 'packages']
-        ],
-        packageTupleItemCounts: [1, 1, 1, 1],
-        packageTupleHasRest: [true, true, true, true],
-        packageShapeKeys: [
-            'sourcesFolder',
-            'mainPackageJson',
-            'additionalFiles',
-            'includeSourceMapFiles',
-            'additionalPackageJsonAttributes',
-            'publishSettings',
-            'dependencyPolicy',
-            'deadCodeElimination',
-            'name',
-            'exportPackageJson',
-            'versioning',
-            'bundleDependencies',
-            'bundlePeerDependencies',
-            'checks',
-            'roots',
-            'defaultModuleRoot',
-            'packageInterface'
-        ],
-        checksShapeKeys: [
-            'noDuplicatedFiles',
-            'requiredFiles',
-            'maxBundleSize',
-            'noUnusedBundleDependencies',
-            'noDevDependencyImports',
-            'uniqueTargetPaths',
-            'noSideEffects'
-        ],
-        commonShapeKeys: [
-            'sourcesFolder',
-            'mainPackageJson',
-            'additionalFiles',
-            'includeSourceMapFiles',
-            'additionalPackageJsonAttributes',
-            'publishSettings',
-            'dependencyPolicy',
-            'deadCodeElimination'
-        ],
-        configIntersectionLeftKeys: ['registrySettings'],
-        validWithoutRegistrySuccess: true
-    });
-}).timeout(probeTestTimeoutMs);
-
-test('schema source modules still validate representative valid and invalid inputs', async () => {
-    const result = await runNodeProbe(`
-        import { safeParse } from '@schema-hub/zod-error-formatter';
-        import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
-        import { rootSchema } from './source/config/root.ts';
-        import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
-        import { registrySettingsSchema } from './source/config/registry-settings.ts';
-
-        console.log(JSON.stringify({
-            validAdditionalFileSuccess: safeParse(additionalFileDescriptionSchema, {
-                sourceFilePath: 'README.md',
-                targetFilePath: 'README.md'
-            }).success,
-            missingAdditionalFileSourceSuccess: safeParse(additionalFileDescriptionSchema, {
-                targetFilePath: 'README.md'
-            }).success,
-            validRootSuccess: safeParse(rootSchema, {
-                js: 'index.js',
-                declarationFile: 'index.d.ts'
-            }).success,
-            missingRootJsSuccess: safeParse(rootSchema, {
-                declarationFile: 'index.d.ts'
-            }).success,
-            extraRootPropertySuccess: safeParse(rootSchema, {
-                js: 'index.js',
-                extra: 'nope'
-            }).success,
-            validRegistrySuccess: safeParse(registrySettingsSchema, {
-                auth: { type: 'bearer-token', token: 'secret' },
-                registryUrl: 'https://example.test'
-            }).success,
-            missingRegistryTokenSuccess: safeParse(registrySettingsSchema, {
-                registryUrl: 'https://example.test'
-            }).success,
-            validConfigSuccess: safeParse(packtoryConfigSchema, {
-                registrySettings: { auth: { type: 'bearer-token', token: 'secret' } },
-                packages: [{
-                    sourcesFolder: 'src',
-                    mainPackageJson: { type: 'module' },
-                    name: 'pkg',
-                    roots: { main: { js: 'index.js' } }
-                }]
-            }).success,
-            missingConfigRegistrySuccess: safeParse(packtoryConfigSchema, {
-                packages: [{
-                    sourcesFolder: 'src',
-                    mainPackageJson: { type: 'module' },
-                    name: 'pkg',
-                    roots: { main: { js: 'index.js' } }
-                }]
-            }).success,
-            emptyConfigPackagesSuccess: safeParse(packtoryConfigSchema, {
-                registrySettings: { auth: { type: 'bearer-token', token: 'secret' } },
-                packages: []
-            }).success
-        }));
-    `);
-
-    assert.deepStrictEqual(result, {
-        validAdditionalFileSuccess: true,
-        missingAdditionalFileSourceSuccess: false,
-        validRootSuccess: true,
-        missingRootJsSuccess: false,
-        extraRootPropertySuccess: false,
-        validRegistrySuccess: true,
-        missingRegistryTokenSuccess: false,
-        validConfigSuccess: true,
-        missingConfigRegistrySuccess: false,
-        emptyConfigPackagesSuccess: false
-    });
-}).timeout(probeTestTimeoutMs);
+        assert.deepStrictEqual(result, {
+            validAdditionalFileSuccess: true,
+            missingAdditionalFileSourceSuccess: false,
+            validRootSuccess: true,
+            missingRootJsSuccess: false,
+            extraRootPropertySuccess: false,
+            validRegistrySuccess: true,
+            missingRegistryTokenSuccess: false,
+            validConfigSuccess: true,
+            missingConfigRegistrySuccess: false,
+            emptyConfigPackagesSuccess: false
+        });
+    }).timeout(probeTestTimeoutMs);
+});

--- a/source/config/settings-validation.test.ts
+++ b/source/config/settings-validation.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test inputs use `as never` to shape narrow partial configs without spelling out every schema field */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { validateAllowScriptsConsistency, validatePublishSettingsArePlaced } from './settings-validation.ts';
 
@@ -17,87 +17,89 @@ function config(overrides: Partial<PacktoryConfigWithoutRegistry>): PacktoryConf
     return { packages: [], ...overrides } as unknown as PacktoryConfigWithoutRegistry;
 }
 
-test('validatePublishSettingsArePlaced returns no issues when commonPackageSettings.publishSettings is provided', () => {
-    const result = validatePublishSettingsArePlaced(
-        config({
-            commonPackageSettings: { publishSettings: { access: 'public' } } as never,
-            packages: [pkg({})]
-        })
-    );
+suite('settings-validation', function () {
+    test('validatePublishSettingsArePlaced returns no issues when commonPackageSettings.publishSettings is provided', function () {
+        const result = validatePublishSettingsArePlaced(
+            config({
+                commonPackageSettings: { publishSettings: { access: 'public' } } as never,
+                packages: [pkg({})]
+            })
+        );
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('validatePublishSettingsArePlaced returns no issues when every package declares publishSettings individually', () => {
-    const result = validatePublishSettingsArePlaced(
-        config({
-            packages: [
-                pkg({ publishSettings: { access: 'public' } as never }),
-                pkg({ name: 'pkg-b', publishSettings: { access: 'public' } as never })
-            ]
-        })
-    );
+    test('validatePublishSettingsArePlaced returns no issues when every package declares publishSettings individually', function () {
+        const result = validatePublishSettingsArePlaced(
+            config({
+                packages: [
+                    pkg({ publishSettings: { access: 'public' } as never }),
+                    pkg({ name: 'pkg-b', publishSettings: { access: 'public' } as never })
+                ]
+            })
+        );
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('validatePublishSettingsArePlaced reports when publishSettings is missing from a package and from commonPackageSettings', () => {
-    const result = validatePublishSettingsArePlaced(
-        config({
-            packages: [pkg({ publishSettings: { access: 'public' } as never }), pkg({ name: 'pkg-b' })]
-        })
-    );
+    test('validatePublishSettingsArePlaced reports when publishSettings is missing from a package and from commonPackageSettings', function () {
+        const result = validatePublishSettingsArePlaced(
+            config({
+                packages: [pkg({ publishSettings: { access: 'public' } as never }), pkg({ name: 'pkg-b' })]
+            })
+        );
 
-    assert.deepStrictEqual(result, ['publishSettings must be set in commonPackageSettings or in every package']);
-});
+        assert.deepStrictEqual(result, ['publishSettings must be set in commonPackageSettings or in every package']);
+    });
 
-test('validateAllowScriptsConsistency returns no issues when no package contributes a scripts attribute', () => {
-    const result = validateAllowScriptsConsistency(config({ packages: [pkg({})] }));
+    test('validateAllowScriptsConsistency returns no issues when no package contributes a scripts attribute', function () {
+        const result = validateAllowScriptsConsistency(config({ packages: [pkg({})] }));
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('validateAllowScriptsConsistency requires allowScripts when a package adds scripts via additionalPackageJsonAttributes', () => {
-    const result = validateAllowScriptsConsistency(
-        config({
-            packages: [
-                pkg({
-                    additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } as never,
-                    publishSettings: { access: 'public' } as never
-                })
-            ]
-        })
-    );
+    test('validateAllowScriptsConsistency requires allowScripts when a package adds scripts via additionalPackageJsonAttributes', function () {
+        const result = validateAllowScriptsConsistency(
+            config({
+                packages: [
+                    pkg({
+                        additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } as never,
+                        publishSettings: { access: 'public' } as never
+                    })
+                ]
+            })
+        );
 
-    assert.deepStrictEqual(result, [
-        'Package "pkg-a": "scripts" in additionalPackageJsonAttributes requires "publishSettings.allowScripts: true"'
-    ]);
-});
+        assert.deepStrictEqual(result, [
+            'Package "pkg-a": "scripts" in additionalPackageJsonAttributes requires "publishSettings.allowScripts: true"'
+        ]);
+    });
 
-test('validateAllowScriptsConsistency permits a scripts attribute when allowScripts is true at the package level', () => {
-    const result = validateAllowScriptsConsistency(
-        config({
-            packages: [
-                pkg({
-                    additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } as never,
-                    publishSettings: { access: 'public', allowScripts: true } as never
-                })
-            ]
-        })
-    );
+    test('validateAllowScriptsConsistency permits a scripts attribute when allowScripts is true at the package level', function () {
+        const result = validateAllowScriptsConsistency(
+            config({
+                packages: [
+                    pkg({
+                        additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } as never,
+                        publishSettings: { access: 'public', allowScripts: true } as never
+                    })
+                ]
+            })
+        );
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('validateAllowScriptsConsistency permits a scripts attribute when allowScripts is true via commonPackageSettings', () => {
-    const result = validateAllowScriptsConsistency(
-        config({
-            commonPackageSettings: {
-                publishSettings: { access: 'public', allowScripts: true }
-            } as never,
-            packages: [pkg({ additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } as never })]
-        })
-    );
+    test('validateAllowScriptsConsistency permits a scripts attribute when allowScripts is true via commonPackageSettings', function () {
+        const result = validateAllowScriptsConsistency(
+            config({
+                commonPackageSettings: {
+                    publishSettings: { access: 'public', allowScripts: true }
+                } as never,
+                packages: [pkg({ additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } as never })]
+            })
+        );
 
-    assert.deepStrictEqual(result, []);
+        assert.deepStrictEqual(result, []);
+    });
 });

--- a/source/config/validation.property.ts
+++ b/source/config/validation.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { validateConfig } from './validation.ts';
 
 const packageNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,7}$/);
@@ -14,63 +14,65 @@ function createValidPackage(name: string) {
     };
 }
 
-test('validateConfig() returns Result.err for malformed non-config values', () => {
-    fc.assert(
-        fc.property(
-            fc.oneof(fc.boolean(), fc.integer(), fc.string(), fc.constant(null), fc.constant(undefined)),
-            (value) => {
-                const result = validateConfig(value);
+suite('validation', function () {
+    test('validateConfig() returns Result.err for malformed non-config values', function () {
+        fc.assert(
+            fc.property(
+                fc.oneof(fc.boolean(), fc.integer(), fc.string(), fc.constant(null), fc.constant(undefined)),
+                (value) => {
+                    const result = validateConfig(value);
+                    assert.strictEqual(result.isErr, true);
+                }
+            )
+        );
+    });
+
+    test('validateConfig() rejects configs with missing bundle dependencies', function () {
+        fc.assert(
+            fc.property(packageNameArbitrary, packageNameArbitrary, (packageName, missingDependencyName) => {
+                fc.pre(packageName !== missingDependencyName);
+
+                const result = validateConfig({
+                    registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                    packages: [
+                        {
+                            ...createValidPackage(packageName),
+                            bundleDependencies: [missingDependencyName]
+                        }
+                    ]
+                });
+
                 assert.strictEqual(result.isErr, true);
-            }
-        )
-    );
-});
+            })
+        );
+    });
 
-test('validateConfig() rejects configs with missing bundle dependencies', () => {
-    fc.assert(
-        fc.property(packageNameArbitrary, packageNameArbitrary, (packageName, missingDependencyName) => {
-            fc.pre(packageName !== missingDependencyName);
+    test('validateConfig() rejects duplicate package definitions and cyclic dependencies', function () {
+        fc.assert(
+            fc.property(packageNameArbitrary, packageNameArbitrary, (firstName, secondName) => {
+                fc.pre(firstName !== secondName);
 
-            const result = validateConfig({
-                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-                packages: [
-                    {
-                        ...createValidPackage(packageName),
-                        bundleDependencies: [missingDependencyName]
-                    }
-                ]
-            });
+                const duplicateResult = validateConfig({
+                    registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                    packages: [createValidPackage(firstName), createValidPackage(firstName)]
+                });
+                assert.strictEqual(duplicateResult.isErr, true);
 
-            assert.strictEqual(result.isErr, true);
-        })
-    );
-});
-
-test('validateConfig() rejects duplicate package definitions and cyclic dependencies', () => {
-    fc.assert(
-        fc.property(packageNameArbitrary, packageNameArbitrary, (firstName, secondName) => {
-            fc.pre(firstName !== secondName);
-
-            const duplicateResult = validateConfig({
-                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-                packages: [createValidPackage(firstName), createValidPackage(firstName)]
-            });
-            assert.strictEqual(duplicateResult.isErr, true);
-
-            const cyclicResult = validateConfig({
-                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-                packages: [
-                    {
-                        ...createValidPackage(firstName),
-                        bundleDependencies: [secondName]
-                    },
-                    {
-                        ...createValidPackage(secondName),
-                        bundleDependencies: [firstName]
-                    }
-                ]
-            });
-            assert.strictEqual(cyclicResult.isErr, true);
-        })
-    );
+                const cyclicResult = validateConfig({
+                    registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                    packages: [
+                        {
+                            ...createValidPackage(firstName),
+                            bundleDependencies: [secondName]
+                        },
+                        {
+                            ...createValidPackage(secondName),
+                            bundleDependencies: [firstName]
+                        }
+                    ]
+                });
+                assert.strictEqual(cyclicResult.isErr, true);
+            })
+        );
+    });
 });

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
 import { minimalPackageConfigFactory } from '../test-libraries/config-fixtures.ts';
 import { validateConfig, validateConfigWithoutRegistry } from './validation.ts';
@@ -33,537 +33,547 @@ function fooPackage(name = 'foo'): ConfigInput {
     return minimalPackageConfigFactory.build({ name });
 }
 
-test('returns the issues when the given config doesn’t match the schema', () => {
-    const result = validateConfig({ not: 'valid' });
-    assert.deepStrictEqual(
-        result,
-        Result.err(['at registrySettings: missing property', 'invalid value doesn’t match expected union'])
-    );
-});
-
-test('returns an issue when a package with the same name exists twice', () => {
-    const result = validateConfig(withRegistry({ packages: [fooPackage(), fooPackage()] }));
-
-    assert.deepStrictEqual(result, Result.err(['Duplicate package definition with the name "foo"']));
-});
-
-test('returns two issues when packages with the same name exists thrice', () => {
-    const result = validateConfig(withRegistry({ packages: [fooPackage(), fooPackage(), fooPackage()] }));
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Duplicate package definition with the name "foo"',
-            'Duplicate package definition with the name "foo"'
-        ])
-    );
-});
-
-test('returns two issues when there are two duplicated package names', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [fooPackage(), fooPackage(), fooPackage('bar'), fooPackage('bar')]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Duplicate package definition with the name "foo"',
-            'Duplicate package definition with the name "bar"'
-        ])
-    );
-});
-
-test('returns an issue when there is a cycle per bundleDependencies', () => {
-    expectCyclicError(
-        [packageWithDeps('a', 'bundleDependencies', ['b']), packageWithDeps('b', 'bundleDependencies', ['a'])],
-        'a→b→a'
-    );
-});
-
-test('returns an issue when there is a long cycle per bundleDependencies', () => {
-    expectCyclicError(
-        [
-            packageWithDeps('a', 'bundleDependencies', ['d']),
-            packageWithDeps('b', 'bundleDependencies', ['a']),
-            packageWithDeps('c', 'bundleDependencies', ['b']),
-            packageWithDeps('d', 'bundleDependencies', ['c'])
-        ],
-        'a→d→c→b→a'
-    );
-});
-
-test('returns an issue when there is a cycle per bundlePeerDependencies', () => {
-    expectCyclicError(
-        [packageWithDeps('a', 'bundlePeerDependencies', ['b']), packageWithDeps('b', 'bundlePeerDependencies', ['a'])],
-        'a→b→a'
-    );
-});
-
-test('returns an issue when there is a cycle per bundleDependencies and bundlePeerDependencies', () => {
-    expectCyclicError(
-        [packageWithDeps('a', 'bundleDependencies', ['b']), packageWithDeps('b', 'bundlePeerDependencies', ['a'])],
-        'a→b→a'
-    );
-});
-
-test('returns an issue when a package depends on itself', () => {
-    expectCyclicError([packageWithDeps('a', 'bundleDependencies', ['a'])], 'a→a');
-});
-
-test('returns an issue when a package bundle dependency does not exit', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [{ name: 'a', roots: { main: { js: 'foo' } }, bundleDependencies: ['b'] }]
-        })
-    );
-
-    assert.deepStrictEqual(result, Result.err(['Bundle dependency "b" referenced in "a" does not exist']));
-});
-
-test('returns an issue when a package bundle peer dependency does not exit', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [{ name: 'a', roots: { main: { js: 'foo' } }, bundlePeerDependencies: ['b'] }]
-        })
-    );
-
-    assert.deepStrictEqual(result, Result.err(['Bundle peer dependency "b" referenced in "a" does not exist']));
-});
-
-test('returns an issue when two roots point at the same js file', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: {
-                        main: { js: 'index.js' },
-                        alias: { js: 'index.js' }
-                    },
-                    defaultModuleRoot: 'main'
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(result, Result.err(['Package "foo" maps both root "main" and "alias" to "index.js"']));
-});
-
-test('returns an issue when implicit packages define multiple roots without defaultModuleRoot', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: {
-                        main: { js: 'index.js' },
-                        feature: { js: 'feature.js' }
-                    }
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err(['Package "foo" must define defaultModuleRoot when multiple roots exist'])
-    );
-});
-
-test('returns an issue when implicit packages reference an unknown defaultModuleRoot', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } },
-                    defaultModuleRoot: 'missing'
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(result, Result.err(['Package "foo" references unknown defaultModuleRoot "missing"']));
-});
-
-test('returns an issue when a package combines defaultModuleRoot with packageInterface', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: { main: { js: 'index.js' } },
-                    defaultModuleRoot: 'main',
-                    packageInterface: {
-                        modules: [{ root: 'main', export: '.' }]
-                    }
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Package "foo" cannot combine defaultModuleRoot with packageInterface; remove defaultModuleRoot in explicit mode'
-        ])
-    );
-});
-
-test('returns issues when explicit modules reference unknown roots or declare duplicate export keys', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: {
-                        main: { js: 'index.js' },
-                        helper: { js: 'helper.js' }
-                    },
-                    packageInterface: {
-                        modules: [
-                            { root: 'missing', export: '.' },
-                            { root: 'main', export: '.' }
-                        ]
-                    }
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Package "foo" module export "." references unknown root "missing"',
-            'Package "foo" declares duplicate export key "."',
-            'Package "foo" defines unused root "helper" in explicit mode'
-        ])
-    );
-});
-
-test('returns issues when explicit bins reference unknown roots, reuse names, or leave roots unused', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: {
-                        main: { js: 'index.js' },
-                        cli: { js: 'cli.js' }
-                    },
-                    packageInterface: {
-                        bins: [
-                            { root: 'missing', name: 'foo' },
-                            { root: 'main', name: 'foo' }
-                        ]
-                    }
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Package "foo" bin "foo" references unknown root "missing"',
-            'Package "foo" declares duplicate bin name "foo"',
-            'Package "foo" defines unused root "cli" in explicit mode'
-        ])
-    );
-});
-
-test('returns issues when explicit privateRoots reference unknown roots, duplicate entries, or overlap with public roots', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                {
-                    name: 'foo',
-                    roots: {
-                        main: { js: 'index.js' },
-                        worker: { js: 'worker.js' },
-                        helper: { js: 'helper.js' }
-                    },
-                    packageInterface: {
-                        modules: [{ root: 'main', export: '.' }],
-                        privateRoots: ['main', 'missing', 'worker', 'worker']
-                    }
-                }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err([
-            'Package "foo" root "main" cannot be both public and private',
-            'Package "foo" private root "missing" references unknown root "missing"',
-            'Package "foo" declares duplicate private root "worker"',
-            'Package "foo" defines unused root "helper" in explicit mode'
-        ])
-    );
-});
-
-test('returns multiple issues of different kind', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                packageWithDeps('a', 'bundleDependencies', ['b']),
-                packageWithDeps('b', 'bundleDependencies', ['a']),
-                fooPackage(),
-                fooPackage()
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err(['Duplicate package definition with the name "foo"', 'Unexpected cyclic dependency path: [a→b→a]'])
-    );
-});
-
-const duplicateCAndMissingBPackages: readonly ConfigInput[] = [
-    packageWithDeps('a', 'bundlePeerDependencies', ['b']),
-    fooPackage('c'),
-    fooPackage('c')
-];
-
-const duplicateCAndMissingBErrors: readonly string[] = [
-    'Duplicate package definition with the name "c"',
-    'Bundle peer dependency "b" referenced in "a" does not exist'
-];
-
-test('returns a missing dependency and duplicate package issue at the same time', () => {
-    const result = validateConfig(withRegistry({ packages: duplicateCAndMissingBPackages }));
-
-    assert.deepStrictEqual(result, Result.err(duplicateCAndMissingBErrors));
-});
-
-test('doesn’t report cyclic dependency issues when there is also a missing dependency', () => {
-    const result = validateConfig(
-        withRegistry({
-            packages: [
-                { name: 'a', roots: { main: { js: 'foo' } }, bundlePeerDependencies: ['b'] },
-                { name: 'c', roots: { main: { js: 'foo' } }, bundlePeerDependencies: ['c'] }
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(result, Result.err(['Bundle peer dependency "b" referenced in "a" does not exist']));
-});
-
-test('accepts a config where checks is defined but noDuplicatedFiles is omitted', () => {
-    const result = validateConfig(
-        withRegistry({
-            checks: {},
-            packages: [{ name: 'a', roots: { main: { js: 'foo' } } }]
-        })
-    );
-
-    assert.strictEqual(result.isOk, true);
-});
-
-test('accepts a config where checks.noDuplicatedFiles is defined without an allowList', () => {
-    const result = validateConfig(
-        withRegistry({
-            checks: { noDuplicatedFiles: { enabled: true } },
-            packages: [{ name: 'a', roots: { main: { js: 'foo' } } }]
-        })
-    );
-
-    assert.strictEqual(result.isOk, true);
-});
-
-test('accepts a config where packages declare per-package noDuplicatedFiles allowList', () => {
-    const result = validateConfig(
-        withRegistry({
-            checks: { noDuplicatedFiles: { enabled: true } },
-            packages: [
-                {
-                    name: 'a',
-                    roots: { main: { js: 'foo' } },
-                    checks: { noDuplicatedFiles: { allowList: ['LICENSE'] } }
-                }
-            ]
-        })
-    );
-
-    assert.strictEqual(result.isOk, true);
-});
-
-test('validateConfigWithoutRegistry() returns schema issues when the config is invalid', () => {
-    const result = validateConfigWithoutRegistry({ not: 'valid' });
-
-    assert.deepStrictEqual(result, Result.err(['invalid value doesn’t match expected union']));
-});
-
-test('validateConfigWithoutRegistry() returns duplicate and missing dependency issues', () => {
-    const result = validateConfigWithoutRegistry({
-        commonPackageSettings: {
-            sourcesFolder: 'foo',
-            mainPackageJson: { type: 'module' },
-            publishSettings: { access: 'public' }
-        },
-        packages: duplicateCAndMissingBPackages
+suite('validation', function () {
+    test('returns the issues when the given config doesn’t match the schema', function () {
+        const result = validateConfig({ not: 'valid' });
+        assert.deepStrictEqual(
+            result,
+            Result.err(['at registrySettings: missing property', 'invalid value doesn’t match expected union'])
+        );
     });
 
-    assert.deepStrictEqual(result, Result.err(duplicateCAndMissingBErrors));
-});
+    test('returns an issue when a package with the same name exists twice', function () {
+        const result = validateConfig(withRegistry({ packages: [fooPackage(), fooPackage()] }));
 
-function withCustomCommon(commonExtras: ConfigInput, packages: readonly ConfigInput[]): ConfigInput {
-    return {
-        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-        commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: { type: 'module' }, ...commonExtras },
-        packages
-    };
-}
+        assert.deepStrictEqual(result, Result.err(['Duplicate package definition with the name "foo"']));
+    });
 
-function withCommonWithoutPublishSettings(packages: readonly ConfigInput[]): ConfigInput {
-    return withCustomCommon({}, packages);
-}
+    test('returns two issues when packages with the same name exists thrice', function () {
+        const result = validateConfig(withRegistry({ packages: [fooPackage(), fooPackage(), fooPackage()] }));
 
-const placementErrorMessage = 'publishSettings must be set in commonPackageSettings or in every package';
-const packageSpecificPublishSettings = [
-    { name: 'foo', roots: { main: { js: 'foo' } }, publishSettings: { access: 'public' } },
-    { name: 'bar', roots: { main: { js: 'bar' } }, publishSettings: { access: 'restricted' } }
-] as const;
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Duplicate package definition with the name "foo"',
+                'Duplicate package definition with the name "foo"'
+            ])
+        );
+    });
 
-test('returns an issue when publishSettings is missing from both commonPackageSettings and every package', () => {
-    const result = validateConfig(withCommonWithoutPublishSettings([{ name: 'foo', roots: { main: { js: 'foo' } } }]));
+    test('returns two issues when there are two duplicated package names', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [fooPackage(), fooPackage(), fooPackage('bar'), fooPackage('bar')]
+            })
+        );
 
-    assert.deepStrictEqual(result, Result.err([placementErrorMessage]));
-});
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Duplicate package definition with the name "foo"',
+                'Duplicate package definition with the name "bar"'
+            ])
+        );
+    });
 
-test('returns an issue when publishSettings is missing for at least one package and not provided in common', () => {
-    const result = validateConfig(
-        withCommonWithoutPublishSettings([
-            { name: 'foo', roots: { main: { js: 'foo' } }, publishSettings: { access: 'public' } },
-            { name: 'bar', roots: { main: { js: 'bar' } } }
-        ])
-    );
+    test('returns an issue when there is a cycle per bundleDependencies', function () {
+        expectCyclicError(
+            [packageWithDeps('a', 'bundleDependencies', ['b']), packageWithDeps('b', 'bundleDependencies', ['a'])],
+            'a→b→a'
+        );
+    });
 
-    assert.deepStrictEqual(result, Result.err([placementErrorMessage]));
-});
+    test('returns an issue when there is a long cycle per bundleDependencies', function () {
+        expectCyclicError(
+            [
+                packageWithDeps('a', 'bundleDependencies', ['d']),
+                packageWithDeps('b', 'bundleDependencies', ['a']),
+                packageWithDeps('c', 'bundleDependencies', ['b']),
+                packageWithDeps('d', 'bundleDependencies', ['c'])
+            ],
+            'a→d→c→b→a'
+        );
+    });
 
-test('accepts a config when publishSettings is set only in commonPackageSettings', () => {
-    const result = validateConfig(withRegistry({ packages: [{ name: 'foo', roots: { main: { js: 'foo' } } }] }));
+    test('returns an issue when there is a cycle per bundlePeerDependencies', function () {
+        expectCyclicError(
+            [
+                packageWithDeps('a', 'bundlePeerDependencies', ['b']),
+                packageWithDeps('b', 'bundlePeerDependencies', ['a'])
+            ],
+            'a→b→a'
+        );
+    });
 
-    assert.strictEqual(result.isOk, true);
-});
+    test('returns an issue when there is a cycle per bundleDependencies and bundlePeerDependencies', function () {
+        expectCyclicError(
+            [packageWithDeps('a', 'bundleDependencies', ['b']), packageWithDeps('b', 'bundlePeerDependencies', ['a'])],
+            'a→b→a'
+        );
+    });
 
-test('accepts a config when publishSettings is set only on every package', () => {
-    const result = validateConfig(withCommonWithoutPublishSettings(packageSpecificPublishSettings));
+    test('returns an issue when a package depends on itself', function () {
+        expectCyclicError([packageWithDeps('a', 'bundleDependencies', ['a'])], 'a→a');
+    });
 
-    assert.strictEqual(result.isOk, true);
-});
+    test('returns an issue when a package bundle dependency does not exit', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [{ name: 'a', roots: { main: { js: 'foo' } }, bundleDependencies: ['b'] }]
+            })
+        );
 
-test('accepts a config when no commonPackageSettings is provided and every package supplies its own publishSettings', () => {
-    const result = validateConfig({
-        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-        packages: [
-            {
+        assert.deepStrictEqual(result, Result.err(['Bundle dependency "b" referenced in "a" does not exist']));
+    });
+
+    test('returns an issue when a package bundle peer dependency does not exit', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [{ name: 'a', roots: { main: { js: 'foo' } }, bundlePeerDependencies: ['b'] }]
+            })
+        );
+
+        assert.deepStrictEqual(result, Result.err(['Bundle peer dependency "b" referenced in "a" does not exist']));
+    });
+
+    test('returns an issue when two roots point at the same js file', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: {
+                            main: { js: 'index.js' },
+                            alias: { js: 'index.js' }
+                        },
+                        defaultModuleRoot: 'main'
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(result, Result.err(['Package "foo" maps both root "main" and "alias" to "index.js"']));
+    });
+
+    test('returns an issue when implicit packages define multiple roots without defaultModuleRoot', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: {
+                            main: { js: 'index.js' },
+                            feature: { js: 'feature.js' }
+                        }
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err(['Package "foo" must define defaultModuleRoot when multiple roots exist'])
+        );
+    });
+
+    test('returns an issue when implicit packages reference an unknown defaultModuleRoot', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } },
+                        defaultModuleRoot: 'missing'
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(result, Result.err(['Package "foo" references unknown defaultModuleRoot "missing"']));
+    });
+
+    test('returns an issue when a package combines defaultModuleRoot with packageInterface', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'index.js' } },
+                        defaultModuleRoot: 'main',
+                        packageInterface: {
+                            modules: [{ root: 'main', export: '.' }]
+                        }
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Package "foo" cannot combine defaultModuleRoot with packageInterface; remove defaultModuleRoot in explicit mode'
+            ])
+        );
+    });
+
+    test('returns issues when explicit modules reference unknown roots or declare duplicate export keys', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: {
+                            main: { js: 'index.js' },
+                            helper: { js: 'helper.js' }
+                        },
+                        packageInterface: {
+                            modules: [
+                                { root: 'missing', export: '.' },
+                                { root: 'main', export: '.' }
+                            ]
+                        }
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Package "foo" module export "." references unknown root "missing"',
+                'Package "foo" declares duplicate export key "."',
+                'Package "foo" defines unused root "helper" in explicit mode'
+            ])
+        );
+    });
+
+    test('returns issues when explicit bins reference unknown roots, reuse names, or leave roots unused', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: {
+                            main: { js: 'index.js' },
+                            cli: { js: 'cli.js' }
+                        },
+                        packageInterface: {
+                            bins: [
+                                { root: 'missing', name: 'foo' },
+                                { root: 'main', name: 'foo' }
+                            ]
+                        }
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Package "foo" bin "foo" references unknown root "missing"',
+                'Package "foo" declares duplicate bin name "foo"',
+                'Package "foo" defines unused root "cli" in explicit mode'
+            ])
+        );
+    });
+
+    test('returns issues when explicit privateRoots reference unknown roots, duplicate entries, or overlap with public roots', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: {
+                            main: { js: 'index.js' },
+                            worker: { js: 'worker.js' },
+                            helper: { js: 'helper.js' }
+                        },
+                        packageInterface: {
+                            modules: [{ root: 'main', export: '.' }],
+                            privateRoots: ['main', 'missing', 'worker', 'worker']
+                        }
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Package "foo" root "main" cannot be both public and private',
+                'Package "foo" private root "missing" references unknown root "missing"',
+                'Package "foo" declares duplicate private root "worker"',
+                'Package "foo" defines unused root "helper" in explicit mode'
+            ])
+        );
+    });
+
+    test('returns multiple issues of different kind', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    packageWithDeps('a', 'bundleDependencies', ['b']),
+                    packageWithDeps('b', 'bundleDependencies', ['a']),
+                    fooPackage(),
+                    fooPackage()
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err([
+                'Duplicate package definition with the name "foo"',
+                'Unexpected cyclic dependency path: [a→b→a]'
+            ])
+        );
+    });
+
+    const duplicateCAndMissingBPackages: readonly ConfigInput[] = [
+        packageWithDeps('a', 'bundlePeerDependencies', ['b']),
+        fooPackage('c'),
+        fooPackage('c')
+    ];
+
+    const duplicateCAndMissingBErrors: readonly string[] = [
+        'Duplicate package definition with the name "c"',
+        'Bundle peer dependency "b" referenced in "a" does not exist'
+    ];
+
+    test('returns a missing dependency and duplicate package issue at the same time', function () {
+        const result = validateConfig(withRegistry({ packages: duplicateCAndMissingBPackages }));
+
+        assert.deepStrictEqual(result, Result.err(duplicateCAndMissingBErrors));
+    });
+
+    test('doesn’t report cyclic dependency issues when there is also a missing dependency', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    { name: 'a', roots: { main: { js: 'foo' } }, bundlePeerDependencies: ['b'] },
+                    { name: 'c', roots: { main: { js: 'foo' } }, bundlePeerDependencies: ['c'] }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(result, Result.err(['Bundle peer dependency "b" referenced in "a" does not exist']));
+    });
+
+    test('accepts a config where checks is defined but noDuplicatedFiles is omitted', function () {
+        const result = validateConfig(
+            withRegistry({
+                checks: {},
+                packages: [{ name: 'a', roots: { main: { js: 'foo' } } }]
+            })
+        );
+
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('accepts a config where checks.noDuplicatedFiles is defined without an allowList', function () {
+        const result = validateConfig(
+            withRegistry({
+                checks: { noDuplicatedFiles: { enabled: true } },
+                packages: [{ name: 'a', roots: { main: { js: 'foo' } } }]
+            })
+        );
+
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('accepts a config where packages declare per-package noDuplicatedFiles allowList', function () {
+        const result = validateConfig(
+            withRegistry({
+                checks: { noDuplicatedFiles: { enabled: true } },
+                packages: [
+                    {
+                        name: 'a',
+                        roots: { main: { js: 'foo' } },
+                        checks: { noDuplicatedFiles: { allowList: ['LICENSE'] } }
+                    }
+                ]
+            })
+        );
+
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('validateConfigWithoutRegistry() returns schema issues when the config is invalid', function () {
+        const result = validateConfigWithoutRegistry({ not: 'valid' });
+
+        assert.deepStrictEqual(result, Result.err(['invalid value doesn’t match expected union']));
+    });
+
+    test('validateConfigWithoutRegistry() returns duplicate and missing dependency issues', function () {
+        const result = validateConfigWithoutRegistry({
+            commonPackageSettings: {
                 sourcesFolder: 'foo',
                 mainPackageJson: { type: 'module' },
-                name: 'foo',
-                roots: { main: { js: 'foo' } },
                 publishSettings: { access: 'public' }
-            }
-        ]
+            },
+            packages: duplicateCAndMissingBPackages
+        });
+
+        assert.deepStrictEqual(result, Result.err(duplicateCAndMissingBErrors));
     });
 
-    assert.strictEqual(result.isOk, true);
-});
+    function withCustomCommon(commonExtras: ConfigInput, packages: readonly ConfigInput[]): ConfigInput {
+        return {
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            commonPackageSettings: { sourcesFolder: 'foo', mainPackageJson: { type: 'module' }, ...commonExtras },
+            packages
+        };
+    }
 
-const allowScriptsErrorFor = (packageName: string): string => {
-    return (
-        `Package "${packageName}": "scripts" in additionalPackageJsonAttributes` +
-        ' requires "publishSettings.allowScripts: true"'
-    );
-};
+    function withCommonWithoutPublishSettings(packages: readonly ConfigInput[]): ConfigInput {
+        return withCustomCommon({}, packages);
+    }
 
-const postinstallScripts = { postinstall: 'echo hi' };
+    const placementErrorMessage = 'publishSettings must be set in commonPackageSettings or in every package';
+    const packageSpecificPublishSettings = [
+        { name: 'foo', roots: { main: { js: 'foo' } }, publishSettings: { access: 'public' } },
+        { name: 'bar', roots: { main: { js: 'bar' } }, publishSettings: { access: 'restricted' } }
+    ] as const;
 
-test('accepts a config without scripts anywhere', () => {
-    const result = validateConfig(withRegistry({ packages: [{ name: 'foo', roots: { main: { js: 'foo' } } }] }));
+    test('returns an issue when publishSettings is missing from both commonPackageSettings and every package', function () {
+        const result = validateConfig(
+            withCommonWithoutPublishSettings([{ name: 'foo', roots: { main: { js: 'foo' } } }])
+        );
 
-    assert.strictEqual(result.isOk, true);
-});
+        assert.deepStrictEqual(result, Result.err([placementErrorMessage]));
+    });
 
-test('accepts a config with per-package scripts and per-package allowScripts true', () => {
-    const result = validateConfig(
-        withRegistry({
+    test('returns an issue when publishSettings is missing for at least one package and not provided in common', function () {
+        const result = validateConfig(
+            withCommonWithoutPublishSettings([
+                { name: 'foo', roots: { main: { js: 'foo' } }, publishSettings: { access: 'public' } },
+                { name: 'bar', roots: { main: { js: 'bar' } } }
+            ])
+        );
+
+        assert.deepStrictEqual(result, Result.err([placementErrorMessage]));
+    });
+
+    test('accepts a config when publishSettings is set only in commonPackageSettings', function () {
+        const result = validateConfig(withRegistry({ packages: [{ name: 'foo', roots: { main: { js: 'foo' } } }] }));
+
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('accepts a config when publishSettings is set only on every package', function () {
+        const result = validateConfig(withCommonWithoutPublishSettings(packageSpecificPublishSettings));
+
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('accepts a config when no commonPackageSettings is provided and every package supplies its own publishSettings', function () {
+        const result = validateConfig({
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
             packages: [
                 {
+                    sourcesFolder: 'foo',
+                    mainPackageJson: { type: 'module' },
                     name: 'foo',
                     roots: { main: { js: 'foo' } },
-                    additionalPackageJsonAttributes: { scripts: postinstallScripts },
-                    publishSettings: { access: 'public', allowScripts: true }
+                    publishSettings: { access: 'public' }
                 }
             ]
-        })
-    );
+        });
 
-    assert.strictEqual(result.isOk, true);
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-const publicWithAllowScripts = { publishSettings: { access: 'public', allowScripts: true } };
-const commonScriptsAttribute = { additionalPackageJsonAttributes: { scripts: postinstallScripts } };
-const fooPackageWithScripts: ConfigInput = {
-    name: 'foo',
-    roots: { main: { js: 'foo' } },
-    additionalPackageJsonAttributes: { scripts: postinstallScripts }
-};
+    const allowScriptsErrorFor = (packageName: string): string => {
+        return (
+            `Package "${packageName}": "scripts" in additionalPackageJsonAttributes` +
+            ' requires "publishSettings.allowScripts: true"'
+        );
+    };
 
-test('accepts a config with per-package scripts and common allowScripts true', () => {
-    const result = validateConfig(withCustomCommon(publicWithAllowScripts, [fooPackageWithScripts]));
+    const postinstallScripts = { postinstall: 'echo hi' };
 
-    assert.strictEqual(result.isOk, true);
-});
+    test('accepts a config without scripts anywhere', function () {
+        const result = validateConfig(withRegistry({ packages: [{ name: 'foo', roots: { main: { js: 'foo' } } }] }));
 
-test('accepts a config with common scripts and common allowScripts true and per-package nothing', () => {
-    const result = validateConfig(
-        withCustomCommon({ ...commonScriptsAttribute, ...publicWithAllowScripts }, [fooPackage()])
-    );
+        assert.strictEqual(result.isOk, true);
+    });
 
-    assert.strictEqual(result.isOk, true);
-});
+    test('accepts a config with per-package scripts and per-package allowScripts true', function () {
+        const result = validateConfig(
+            withRegistry({
+                packages: [
+                    {
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        additionalPackageJsonAttributes: { scripts: postinstallScripts },
+                        publishSettings: { access: 'public', allowScripts: true }
+                    }
+                ]
+            })
+        );
 
-test('accepts a config with allowScripts true but no scripts anywhere', () => {
-    const result = validateConfig(withCustomCommon(publicWithAllowScripts, [fooPackage()]));
+        assert.strictEqual(result.isOk, true);
+    });
 
-    assert.strictEqual(result.isOk, true);
-});
+    const publicWithAllowScripts = { publishSettings: { access: 'public', allowScripts: true } };
+    const commonScriptsAttribute = { additionalPackageJsonAttributes: { scripts: postinstallScripts } };
+    const fooPackageWithScripts: ConfigInput = {
+        name: 'foo',
+        roots: { main: { js: 'foo' } },
+        additionalPackageJsonAttributes: { scripts: postinstallScripts }
+    };
 
-test('rejects a config with per-package scripts and no allowScripts anywhere', () => {
-    const result = validateConfig(withRegistry({ packages: [fooPackageWithScripts] }));
+    test('accepts a config with per-package scripts and common allowScripts true', function () {
+        const result = validateConfig(withCustomCommon(publicWithAllowScripts, [fooPackageWithScripts]));
 
-    assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo')]));
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-test('rejects every package when common scripts and no allowScripts anywhere', () => {
-    const result = validateConfig(
-        withCustomCommon({ ...commonScriptsAttribute, publishSettings: { access: 'public' } }, [
-            fooPackage(),
-            fooPackage('bar')
-        ])
-    );
+    test('accepts a config with common scripts and common allowScripts true and per-package nothing', function () {
+        const result = validateConfig(
+            withCustomCommon({ ...commonScriptsAttribute, ...publicWithAllowScripts }, [fooPackage()])
+        );
 
-    assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo'), allowScriptsErrorFor('bar')]));
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-test('rejects with both placement and allowScripts errors when scripts are set but publishSettings is missing', () => {
-    const result = validateConfig(withCommonWithoutPublishSettings([fooPackageWithScripts]));
+    test('accepts a config with allowScripts true but no scripts anywhere', function () {
+        const result = validateConfig(withCustomCommon(publicWithAllowScripts, [fooPackage()]));
 
-    assert.deepStrictEqual(result, Result.err([placementErrorMessage, allowScriptsErrorFor('foo')]));
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-test('rejects when common allows scripts but per-package replaces publishSettings without allowScripts', () => {
-    const result = validateConfig(
-        withCustomCommon({ ...commonScriptsAttribute, ...publicWithAllowScripts }, [
-            { name: 'foo', roots: { main: { js: 'foo' } }, publishSettings: { access: 'public' } }
-        ])
-    );
+    test('rejects a config with per-package scripts and no allowScripts anywhere', function () {
+        const result = validateConfig(withRegistry({ packages: [fooPackageWithScripts] }));
 
-    assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo')]));
+        assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo')]));
+    });
+
+    test('rejects every package when common scripts and no allowScripts anywhere', function () {
+        const result = validateConfig(
+            withCustomCommon({ ...commonScriptsAttribute, publishSettings: { access: 'public' } }, [
+                fooPackage(),
+                fooPackage('bar')
+            ])
+        );
+
+        assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo'), allowScriptsErrorFor('bar')]));
+    });
+
+    test('rejects with both placement and allowScripts errors when scripts are set but publishSettings is missing', function () {
+        const result = validateConfig(withCommonWithoutPublishSettings([fooPackageWithScripts]));
+
+        assert.deepStrictEqual(result, Result.err([placementErrorMessage, allowScriptsErrorFor('foo')]));
+    });
+
+    test('rejects when common allows scripts but per-package replaces publishSettings without allowScripts', function () {
+        const result = validateConfig(
+            withCustomCommon({ ...commonScriptsAttribute, ...publicWithAllowScripts }, [
+                { name: 'foo', roots: { main: { js: 'foo' } }, publishSettings: { access: 'public' } }
+            ])
+        );
+
+        assert.deepStrictEqual(result, Result.err([allowScriptsErrorFor('foo')]));
+    });
 });

--- a/source/config/versioning-settings.test.ts
+++ b/source/config/versioning-settings.test.ts
@@ -1,196 +1,202 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { versioningSettingsSchema } from './versioning-settings.ts';
 
-test('schema accepts the automatic versioning branch', () => {
-    assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, minimumVersion: 'foo' }).success, true);
+suite('versioning-settings', function () {
+    test('schema accepts the automatic versioning branch', function () {
+        assert.strictEqual(
+            safeParse(versioningSettingsSchema, { automatic: true, minimumVersion: 'foo' }).success,
+            true
+        );
+    });
+
+    test('schema accepts the manual versioning branch', function () {
+        assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: false, version: '1' }).success, true);
+    });
+
+    test('schema rejects mixing automatic with manual-only fields', function () {
+        assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, version: '1' }).success, false);
+    });
+
+    test(
+        'validation succeeds when valid automatic versioning settings are given',
+        checkValidationSuccess({
+            schema: versioningSettingsSchema,
+            data: { automatic: true },
+            expectedData: { automatic: true }
+        })
+    );
+
+    test(
+        'validation succeeds when valid automatic versioning settings are given with a minimumVersion',
+        checkValidationSuccess({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, minimumVersion: 'foo' },
+            expectedData: { automatic: true, minimumVersion: 'foo' }
+        })
+    );
+
+    test(
+        'validation succeeds when valid manual versioning settings are given',
+        checkValidationSuccess({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: '1' },
+            expectedData: { automatic: false, version: '1' }
+        })
+    );
+
+    test(
+        'validation fails when a non-object is given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: 'foo',
+            expectedMessages: ['expected object, but got string']
+        })
+    );
+
+    test(
+        'validation fails when an empty object is given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: {},
+            expectedMessages: ['at automatic: missing property']
+        })
+    );
+
+    test(
+        'validation fails when automatic is not a boolean',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: 'yes' },
+            expectedMessages: ['at automatic: invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when automatic is undefined',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: undefined },
+            expectedMessages: ['at automatic: invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when automatic is null',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: null },
+            expectedMessages: ['at automatic: invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when automatic is true and version is given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, version: '1' },
+            expectedMessages: ['unexpected additional property: "version"']
+        })
+    );
+
+    test(
+        'validation succeeds when automatic is true and minimumVersion is undefined',
+        checkValidationSuccess({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, minimumVersion: undefined },
+            expectedData: { automatic: true, minimumVersion: undefined }
+        })
+    );
+
+    test(
+        'validation fails when automatic is true and additional properties are given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, minimumVersion: '1', foo: 'bar' },
+            expectedMessages: ['unexpected additional property: "foo"']
+        })
+    );
+
+    test(
+        'validation fails when automatic is true and minimumVersion is given but not a string',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, minimumVersion: 42 },
+            expectedMessages: ['at minimumVersion: expected string, but got number']
+        })
+    );
+
+    test(
+        'validation fails when automatic is true and minimumVersion is null',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, minimumVersion: null },
+            expectedMessages: ['at minimumVersion: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when automatic is true and minimumVersion is given but an empty string',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: true, minimumVersion: '' },
+            expectedMessages: ['at minimumVersion: string must contain at least 1 character']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and minimumVersion is given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: '1', minimumVersion: '2' },
+            expectedMessages: ['unexpected additional property: "minimumVersion"']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and an additional property is given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: '1', foo: 'bar' },
+            expectedMessages: ['unexpected additional property: "foo"']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and version is given but not a string',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: 42 },
+            expectedMessages: ['at version: expected string, but got number']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and version is undefined',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: undefined },
+            expectedMessages: ['at version: expected string, but got undefined']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and version is null',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: null },
+            expectedMessages: ['at version: expected string, but got null']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and version is given but an empty string',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: '' },
+            expectedMessages: ['at version: string must contain at least 1 character']
+        })
+    );
 });
-
-test('schema accepts the manual versioning branch', () => {
-    assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: false, version: '1' }).success, true);
-});
-
-test('schema rejects mixing automatic with manual-only fields', () => {
-    assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, version: '1' }).success, false);
-});
-
-test(
-    'validation succeeds when valid automatic versioning settings are given',
-    checkValidationSuccess({
-        schema: versioningSettingsSchema,
-        data: { automatic: true },
-        expectedData: { automatic: true }
-    })
-);
-
-test(
-    'validation succeeds when valid automatic versioning settings are given with a minimumVersion',
-    checkValidationSuccess({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, minimumVersion: 'foo' },
-        expectedData: { automatic: true, minimumVersion: 'foo' }
-    })
-);
-
-test(
-    'validation succeeds when valid manual versioning settings are given',
-    checkValidationSuccess({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: '1' },
-        expectedData: { automatic: false, version: '1' }
-    })
-);
-
-test(
-    'validation fails when a non-object is given',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: 'foo',
-        expectedMessages: ['expected object, but got string']
-    })
-);
-
-test(
-    'validation fails when an empty object is given',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: {},
-        expectedMessages: ['at automatic: missing property']
-    })
-);
-
-test(
-    'validation fails when automatic is not a boolean',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: 'yes' },
-        expectedMessages: ['at automatic: invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when automatic is undefined',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: undefined },
-        expectedMessages: ['at automatic: invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when automatic is null',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: null },
-        expectedMessages: ['at automatic: invalid value doesn’t match expected union']
-    })
-);
-
-test(
-    'validation fails when automatic is true and version is given',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, version: '1' },
-        expectedMessages: ['unexpected additional property: "version"']
-    })
-);
-
-test(
-    'validation succeeds when automatic is true and minimumVersion is undefined',
-    checkValidationSuccess({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, minimumVersion: undefined },
-        expectedData: { automatic: true, minimumVersion: undefined }
-    })
-);
-
-test(
-    'validation fails when automatic is true and additional properties are given',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, minimumVersion: '1', foo: 'bar' },
-        expectedMessages: ['unexpected additional property: "foo"']
-    })
-);
-
-test(
-    'validation fails when automatic is true and minimumVersion is given but not a string',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, minimumVersion: 42 },
-        expectedMessages: ['at minimumVersion: expected string, but got number']
-    })
-);
-
-test(
-    'validation fails when automatic is true and minimumVersion is null',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, minimumVersion: null },
-        expectedMessages: ['at minimumVersion: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when automatic is true and minimumVersion is given but an empty string',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: true, minimumVersion: '' },
-        expectedMessages: ['at minimumVersion: string must contain at least 1 character']
-    })
-);
-test(
-    'validation fails when automatic is false and minimumVersion is given',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: '1', minimumVersion: '2' },
-        expectedMessages: ['unexpected additional property: "minimumVersion"']
-    })
-);
-
-test(
-    'validation fails when automatic is false and an additional property is given',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: '1', foo: 'bar' },
-        expectedMessages: ['unexpected additional property: "foo"']
-    })
-);
-
-test(
-    'validation fails when automatic is false and version is given but not a string',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: 42 },
-        expectedMessages: ['at version: expected string, but got number']
-    })
-);
-
-test(
-    'validation fails when automatic is false and version is undefined',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: undefined },
-        expectedMessages: ['at version: expected string, but got undefined']
-    })
-);
-
-test(
-    'validation fails when automatic is false and version is null',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: null },
-        expectedMessages: ['at version: expected string, but got null']
-    })
-);
-
-test(
-    'validation fails when automatic is false and version is given but an empty string',
-    checkValidationFailure({
-        schema: versioningSettingsSchema,
-        data: { automatic: false, version: '' },
-        expectedMessages: ['at version: string must contain at least 1 character']
-    })
-);

--- a/source/dead-code-eliminator/analyzed-bundle.test.ts
+++ b/source/dead-code-eliminator/analyzed-bundle.test.ts
@@ -1,22 +1,24 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createEmptyFileAnalysis } from './analyzed-bundle.ts';
 
-test('createEmptyFileAnalysis returns an empty survivingBindings set', () => {
-    assert.strictEqual(createEmptyFileAnalysis().survivingBindings.size, 0);
-});
+suite('analyzed-bundle', function () {
+    test('createEmptyFileAnalysis returns an empty survivingBindings set', function () {
+        assert.strictEqual(createEmptyFileAnalysis().survivingBindings.size, 0);
+    });
 
-test('createEmptyFileAnalysis returns an empty sideEffectImports set', () => {
-    assert.strictEqual(createEmptyFileAnalysis().sideEffectImports.size, 0);
-});
+    test('createEmptyFileAnalysis returns an empty sideEffectImports set', function () {
+        assert.strictEqual(createEmptyFileAnalysis().sideEffectImports.size, 0);
+    });
 
-test('createEmptyFileAnalysis returns an empty sideEffectStatements array', () => {
-    assert.deepStrictEqual(Array.from(createEmptyFileAnalysis().sideEffectStatements), []);
-});
+    test('createEmptyFileAnalysis returns an empty sideEffectStatements array', function () {
+        assert.deepStrictEqual(Array.from(createEmptyFileAnalysis().sideEffectStatements), []);
+    });
 
-test('createEmptyFileAnalysis returns independent instances on each call', () => {
-    const first = createEmptyFileAnalysis();
-    const second = createEmptyFileAnalysis();
-    assert.notStrictEqual(first.survivingBindings, second.survivingBindings);
-    assert.notStrictEqual(first.sideEffectImports, second.sideEffectImports);
+    test('createEmptyFileAnalysis returns independent instances on each call', function () {
+        const first = createEmptyFileAnalysis();
+        const second = createEmptyFileAnalysis();
+        assert.notStrictEqual(first.survivingBindings, second.survivingBindings);
+        assert.notStrictEqual(first.sideEffectImports, second.sideEffectImports);
+    });
 });

--- a/source/dead-code-eliminator/class-purity.test.ts
+++ b/source/dead-code-eliminator/class-purity.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind, type ClassDeclaration } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { hasClassImpurity } from './class-purity.ts';
@@ -9,42 +9,44 @@ function classDeclaration(content: string): ClassDeclaration {
     return project.getSourceFileOrThrow('index.ts').getFirstChildByKindOrThrow(SyntaxKind.ClassDeclaration);
 }
 
-test('hasClassImpurity returns false for a class with only methods and unannotated members', () => {
-    const declaration = classDeclaration('class Foo { method() { return 1; } }');
+suite('class-purity', function () {
+    test('hasClassImpurity returns false for a class with only methods and unannotated members', function () {
+        const declaration = classDeclaration('class Foo { method() { return 1; } }');
 
-    assert.strictEqual(hasClassImpurity(declaration, undefined), false);
-});
+        assert.strictEqual(hasClassImpurity(declaration, undefined), false);
+    });
 
-test('hasClassImpurity returns true when the class itself is decorated', () => {
-    const declaration = classDeclaration(
-        'function dec(_: unknown): void {}\n@dec\nclass Foo { method() { return 1; } }'
-    );
+    test('hasClassImpurity returns true when the class itself is decorated', function () {
+        const declaration = classDeclaration(
+            'function dec(_: unknown): void {}\n@dec\nclass Foo { method() { return 1; } }'
+        );
 
-    assert.strictEqual(hasClassImpurity(declaration, undefined), true);
-});
+        assert.strictEqual(hasClassImpurity(declaration, undefined), true);
+    });
 
-test('hasClassImpurity returns true when a method member is decorated', () => {
-    const declaration = classDeclaration(
-        'function dec(_: unknown, __: unknown): void {}\nclass Foo { @dec method() { return 1; } }'
-    );
+    test('hasClassImpurity returns true when a method member is decorated', function () {
+        const declaration = classDeclaration(
+            'function dec(_: unknown, __: unknown): void {}\nclass Foo { @dec method() { return 1; } }'
+        );
 
-    assert.strictEqual(hasClassImpurity(declaration, undefined), true);
-});
+        assert.strictEqual(hasClassImpurity(declaration, undefined), true);
+    });
 
-test('hasClassImpurity returns true when a static field has an impure initializer', () => {
-    const declaration = classDeclaration('class Foo { static items = [].length; }');
+    test('hasClassImpurity returns true when a static field has an impure initializer', function () {
+        const declaration = classDeclaration('class Foo { static items = [].length; }');
 
-    assert.strictEqual(hasClassImpurity(declaration, undefined), true);
-});
+        assert.strictEqual(hasClassImpurity(declaration, undefined), true);
+    });
 
-test('hasClassImpurity returns false when a static field has a pure literal initializer', () => {
-    const declaration = classDeclaration('class Foo { static items = 1; }');
+    test('hasClassImpurity returns false when a static field has a pure literal initializer', function () {
+        const declaration = classDeclaration('class Foo { static items = 1; }');
 
-    assert.strictEqual(hasClassImpurity(declaration, undefined), false);
-});
+        assert.strictEqual(hasClassImpurity(declaration, undefined), false);
+    });
 
-test('hasClassImpurity returns true when the class declares a static initialization block', () => {
-    const declaration = classDeclaration('class Foo { static { console.log("init"); } }');
+    test('hasClassImpurity returns true when the class declares a static initialization block', function () {
+        const declaration = classDeclaration('class Foo { static { console.log("init"); } }');
 
-    assert.strictEqual(hasClassImpurity(declaration, undefined), true);
+        assert.strictEqual(hasClassImpurity(declaration, undefined), true);
+    });
 });

--- a/source/dead-code-eliminator/code-file-analyzer.test.ts
+++ b/source/dead-code-eliminator/code-file-analyzer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { Node as TsMorphNode, Statement } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { buildAnalyzedResource, type AnalysisContext } from './code-file-analyzer.ts';
@@ -51,56 +51,58 @@ const baseContext: AnalysisContext = {
     transformationsEnabled: false
 };
 
-test('buildAnalyzedResource returns an empty analysis for non-code resources without transforms', () => {
-    const loaded = nonCodeResource('readme.md', '# title');
+suite('code-file-analyzer', function () {
+    test('buildAnalyzedResource returns an empty analysis for non-code resources without transforms', function () {
+        const loaded = nonCodeResource('readme.md', '# title');
 
-    const result = buildAnalyzedResource(loaded, baseContext);
+        const result = buildAnalyzedResource(loaded, baseContext);
 
-    assert.deepStrictEqual(result.transforms, []);
-    assert.strictEqual(result.resource.analysis.survivingBindings.size, 0);
-});
+        assert.deepStrictEqual(result.transforms, []);
+        assert.strictEqual(result.resource.analysis.survivingBindings.size, 0);
+    });
 
-test('buildAnalyzedResource leaves the content unchanged when transformations are disabled', () => {
-    const loaded = loadedCodeResource('a.ts', 'export const foo = 1;\n');
+    test('buildAnalyzedResource leaves the content unchanged when transformations are disabled', function () {
+        const loaded = loadedCodeResource('a.ts', 'export const foo = 1;\n');
 
-    const result = buildAnalyzedResource(loaded, baseContext);
+        const result = buildAnalyzedResource(loaded, baseContext);
 
-    assert.deepStrictEqual(result.transforms, []);
-    assert.strictEqual(result.resource.fileDescription.content, 'export const foo = 1;\n');
-});
+        assert.deepStrictEqual(result.transforms, []);
+        assert.strictEqual(result.resource.fileDescription.content, 'export const foo = 1;\n');
+    });
 
-test('buildAnalyzedResource includes side-effect statements in the analysis when transformations are disabled', () => {
-    const loaded = loadedCodeResource('a.ts', 'console.log(1);\nexport const foo = 1;\n');
+    test('buildAnalyzedResource includes side-effect statements in the analysis when transformations are disabled', function () {
+        const loaded = loadedCodeResource('a.ts', 'console.log(1);\nexport const foo = 1;\n');
 
-    const result = buildAnalyzedResource(loaded, baseContext);
+        const result = buildAnalyzedResource(loaded, baseContext);
 
-    assert.strictEqual(result.resource.analysis.sideEffectStatements.length, 1);
-});
+        assert.strictEqual(result.resource.analysis.sideEffectStatements.length, 1);
+    });
 
-test('buildAnalyzedResource leaves the content unchanged when transformations are enabled but the file has side effects', () => {
-    const loaded = loadedCodeResource('a.ts', 'console.log(1);\nexport const foo = 1;\n');
+    test('buildAnalyzedResource leaves the content unchanged when transformations are enabled but the file has side effects', function () {
+        const loaded = loadedCodeResource('a.ts', 'console.log(1);\nexport const foo = 1;\n');
 
-    const result = buildAnalyzedResource(loaded, { ...baseContext, transformationsEnabled: true });
+        const result = buildAnalyzedResource(loaded, { ...baseContext, transformationsEnabled: true });
 
-    assert.deepStrictEqual(result.transforms, []);
-    assert.strictEqual(result.resource.fileDescription.content, 'console.log(1);\nexport const foo = 1;\n');
-});
+        assert.deepStrictEqual(result.transforms, []);
+        assert.strictEqual(result.resource.fileDescription.content, 'console.log(1);\nexport const foo = 1;\n');
+    });
 
-test('buildAnalyzedResource carries through every original binding name on the analysis when no transform happens', () => {
-    const loaded: LoadedCodeResource = {
-        ...loadedCodeResource('a.ts', 'export const foo = 1;\n'),
-        bindings: [
-            {
-                name: 'foo',
-                isExported: true,
-                statement: statementStub as unknown as Statement,
-                declarationNode: declarationStub as unknown as TsMorphNode,
-                referenceNode: referenceStub as unknown as TsMorphNode
-            }
-        ]
-    };
+    test('buildAnalyzedResource carries through every original binding name on the analysis when no transform happens', function () {
+        const loaded: LoadedCodeResource = {
+            ...loadedCodeResource('a.ts', 'export const foo = 1;\n'),
+            bindings: [
+                {
+                    name: 'foo',
+                    isExported: true,
+                    statement: statementStub as unknown as Statement,
+                    declarationNode: declarationStub as unknown as TsMorphNode,
+                    referenceNode: referenceStub as unknown as TsMorphNode
+                }
+            ]
+        };
 
-    const result = buildAnalyzedResource(loaded, baseContext);
+        const result = buildAnalyzedResource(loaded, baseContext);
 
-    assert.strictEqual(result.resource.analysis.survivingBindings.has('foo'), true);
+        assert.strictEqual(result.resource.analysis.survivingBindings.has('foo'), true);
+    });
 });

--- a/source/dead-code-eliminator/cross-bundle/bundle-index.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/bundle-index.test.ts
@@ -1,42 +1,44 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
 import { indexBundles, resolveCrossBundleTarget } from './bundle-index.ts';
 
-test('indexBundles keys bundles by their name', () => {
-    const indexed = indexBundles([
-        { bundle: linkedBundle({ name: 'pkg-a' }), fileBindings: [] },
-        { bundle: linkedBundle({ name: 'pkg-b' }), fileBindings: [] }
-    ]);
-    assert.deepStrictEqual(Array.from(indexed.keys()), ['pkg-a', 'pkg-b']);
-});
+suite('bundle-index', function () {
+    test('indexBundles keys bundles by their name', function () {
+        const indexed = indexBundles([
+            { bundle: linkedBundle({ name: 'pkg-a' }), fileBindings: [] },
+            { bundle: linkedBundle({ name: 'pkg-b' }), fileBindings: [] }
+        ]);
+        assert.deepStrictEqual(Array.from(indexed.keys()), ['pkg-a', 'pkg-b']);
+    });
 
-test('indexBundles places each file binding into its file-path lookup map', () => {
-    const indexed = indexBundles([
-        {
-            bundle: linkedBundle({ name: 'pkg-a' }),
-            fileBindings: [
-                { sourceFilePath: '/a/index.ts', sourceFile: undefined as never, bindings: [] },
-                { sourceFilePath: '/a/helpers.ts', sourceFile: undefined as never, bindings: [] }
-            ]
-        }
-    ]);
-    const bundle = indexed.get('pkg-a');
-    assert.deepStrictEqual(Array.from(bundle?.bindingsByFilePath.keys() ?? []), ['/a/index.ts', '/a/helpers.ts']);
-});
+    test('indexBundles places each file binding into its file-path lookup map', function () {
+        const indexed = indexBundles([
+            {
+                bundle: linkedBundle({ name: 'pkg-a' }),
+                fileBindings: [
+                    { sourceFilePath: '/a/index.ts', sourceFile: undefined as never, bindings: [] },
+                    { sourceFilePath: '/a/helpers.ts', sourceFile: undefined as never, bindings: [] }
+                ]
+            }
+        ]);
+        const bundle = indexed.get('pkg-a');
+        assert.deepStrictEqual(Array.from(bundle?.bindingsByFilePath.keys() ?? []), ['/a/index.ts', '/a/helpers.ts']);
+    });
 
-test('indexBundles attaches the originating bundle to each indexed entry', () => {
-    const bundle = linkedBundle({ name: 'pkg-a' });
-    const indexed = indexBundles([{ bundle, fileBindings: [] }]);
-    assert.strictEqual(indexed.get('pkg-a')?.bundle, bundle);
-});
+    test('indexBundles attaches the originating bundle to each indexed entry', function () {
+        const bundle = linkedBundle({ name: 'pkg-a' });
+        const indexed = indexBundles([{ bundle, fileBindings: [] }]);
+        assert.strictEqual(indexed.get('pkg-a')?.bundle, bundle);
+    });
 
-test('resolveCrossBundleTarget returns undefined when the specifier is undefined', () => {
-    const result = resolveCrossBundleTarget(undefined, new Map());
-    assert.strictEqual(result, undefined);
-});
+    test('resolveCrossBundleTarget returns undefined when the specifier is undefined', function () {
+        const result = resolveCrossBundleTarget(undefined, new Map());
+        assert.strictEqual(result, undefined);
+    });
 
-test('resolveCrossBundleTarget returns undefined when no bundles are indexed', () => {
-    const result = resolveCrossBundleTarget('pkg-b/helpers.ts', new Map());
-    assert.strictEqual(result, undefined);
+    test('resolveCrossBundleTarget returns undefined when no bundles are indexed', function () {
+        const result = resolveCrossBundleTarget('pkg-b/helpers.ts', new Map());
+        assert.strictEqual(result, undefined);
+    });
 });

--- a/source/dead-code-eliminator/cross-bundle/cross-bundle-seeds.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/cross-bundle-seeds.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { LinkedBundle } from '../../linker/linked-bundle.ts';
 import { analyzedBundleResource, linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
 import { createProject } from '../../test-libraries/typescript-project.ts';
@@ -52,314 +52,321 @@ function inputFor(
     return { bundle, sourceFiles, fileBindings, localReachable };
 }
 
-test('returns empty map when no bundles are given', () => {
-    const seeds = buildCrossBundleSeeds([]);
-    assert.strictEqual(seeds.size, 0);
-});
+suite('cross-bundle-seeds', function () {
+    test('returns empty map when no bundles are given', function () {
+        const seeds = buildCrossBundleSeeds([]);
+        assert.strictEqual(seeds.size, 0);
+    });
 
-test('returns empty seeds for a single bundle with no cross-bundle imports', () => {
-    const bundle = bundleWith('pkg-a', [
-        { sourceFilePath: '/a/index.ts', targetFilePath: 'index.ts', content: 'export const x = 1;' }
-    ]);
-    const input = inputFor(bundle, [{ sourceFilePath: '/a/index.ts', content: 'export const x = 1;' }]);
-    const seeds = buildCrossBundleSeeds([input]);
-    assert.strictEqual(seeds.size, 0);
-});
+    test('returns empty seeds for a single bundle with no cross-bundle imports', function () {
+        const bundle = bundleWith('pkg-a', [
+            { sourceFilePath: '/a/index.ts', targetFilePath: 'index.ts', content: 'export const x = 1;' }
+        ]);
+        const input = inputFor(bundle, [{ sourceFilePath: '/a/index.ts', content: 'export const x = 1;' }]);
+        const seeds = buildCrossBundleSeeds([input]);
+        assert.strictEqual(seeds.size, 0);
+    });
 
-test('records a named import as a seed in the target bundle', () => {
-    const consumer = bundleWith('pkg-a', [
-        {
-            sourceFilePath: '/a/index.ts',
-            targetFilePath: 'index.ts',
-            content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
-        }
-    ]);
-    const producer = bundleWith('pkg-b', [
-        {
-            sourceFilePath: '/b/helpers.ts',
-            targetFilePath: 'helpers.ts',
-            content: 'export function used() { return 1; }\nexport function unused() { return 2; }'
-        }
-    ]);
-    const consumerInput = inputFor(consumer, [
-        {
-            sourceFilePath: '/a/index.ts',
-            content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
-        }
-    ]);
-    const producerInput = inputFor(producer, [
-        {
-            sourceFilePath: '/b/helpers.ts',
-            content: 'export function used() { return 1; }\nexport function unused() { return 2; }'
-        }
-    ]);
-    const seeds = buildCrossBundleSeeds([consumerInput, producerInput]);
-    const bSeeds = seeds.get('pkg-b');
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
-    assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
-    assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'default')), false);
-});
-
-test('records a default import as a "default" binding seed', () => {
-    const consumer = bundleWith('pkg-a', [
-        {
-            sourceFilePath: '/a/index.ts',
-            targetFilePath: 'index.ts',
-            content: 'import dep from "pkg-b/main.ts";\nexport function pub() { return dep; }'
-        }
-    ]);
-    const producer = bundleWith('pkg-b', [
-        {
-            sourceFilePath: '/b/main.ts',
-            targetFilePath: 'main.ts',
-            content: 'export default 42;'
-        }
-    ]);
-    const seeds = buildCrossBundleSeeds([
-        inputFor(consumer, [
+    test('records a named import as a seed in the target bundle', function () {
+        const consumer = bundleWith('pkg-a', [
             {
                 sourceFilePath: '/a/index.ts',
-                content: 'import dep from "pkg-b/main.ts";\nexport function pub() { return dep; }'
+                targetFilePath: 'index.ts',
+                content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
             }
-        ]),
-        inputFor(producer, [{ sourceFilePath: '/b/main.ts', content: 'export default 42;' }])
-    ]);
-    const bSeeds = seeds.get('pkg-b');
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/main.ts', 'default')));
-});
-
-function seedsForConsumerProducer(consumerContent: string, producerContent: string): ReadonlySet<string> | undefined {
-    const consumer = bundleWith('pkg-a', [
-        { sourceFilePath: '/a/index.ts', targetFilePath: 'index.ts', content: consumerContent }
-    ]);
-    const producer = bundleWith('pkg-b', [
-        { sourceFilePath: '/b/helpers.ts', targetFilePath: 'helpers.ts', content: producerContent }
-    ]);
-    return buildCrossBundleSeeds([
-        inputFor(consumer, [{ sourceFilePath: '/a/index.ts', content: consumerContent }]),
-        inputFor(producer, [{ sourceFilePath: '/b/helpers.ts', content: producerContent }])
-    ]).get('pkg-b');
-}
-
-function seedsForLoneConsumer(consumerContent: string): SeedMap {
-    const consumer = bundleWith('pkg-a', [
-        { sourceFilePath: '/a/index.ts', targetFilePath: 'index.ts', content: consumerContent }
-    ]);
-    return buildCrossBundleSeeds([inputFor(consumer, [{ sourceFilePath: '/a/index.ts', content: consumerContent }])]);
-}
-
-function assertHelpersBindingsSeeded(bSeeds: ReadonlySet<string> | undefined): void {
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'a')));
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'b')));
-}
-
-test('records a named re-export as a seed in the target bundle', () => {
-    const bSeeds = seedsForConsumerProducer(
-        'export { used } from "pkg-b/helpers.ts";',
-        'export function used() { return 1; }\nexport function unused() { return 2; }'
-    );
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
-    assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
-});
-
-test('records every binding of the target file as a seed for a star re-export', () => {
-    assertHelpersBindingsSeeded(
-        seedsForConsumerProducer('export * from "pkg-b/helpers.ts";', 'export const a = 1;\nexport const b = 2;')
-    );
-});
-
-test('records every binding of the target file as a seed for a namespace re-export', () => {
-    assertHelpersBindingsSeeded(
-        seedsForConsumerProducer(
-            'export * as helpers from "pkg-b/helpers.ts";',
-            'export const a = 1;\nexport const b = 2;'
-        )
-    );
-});
-
-test('ignores a bare local re-export with no module specifier', () => {
-    const seeds = seedsForLoneConsumer('function local() { return 1; }\nexport { local };');
-    assert.strictEqual(seeds.size, 0);
-});
-
-test('does not record a re-export seed when the specifier does not match any bundle name', () => {
-    const seeds = seedsForLoneConsumer('export { x } from "external-pkg";');
-    assert.strictEqual(seeds.size, 0);
-});
-
-test('records every binding of the target file as a seed for a namespace import', () => {
-    assertHelpersBindingsSeeded(
-        seedsForConsumerProducer(
-            'import * as helpers from "pkg-b/helpers.ts";\nexport function pub() { return helpers; }',
-            'export const a = 1;\nexport const b = 2;'
-        )
-    );
-});
-
-test('does not record a seed when the specifier matches a bundle name but not any file in that bundle', () => {
-    const consumer = bundleWith('pkg-a', [
-        {
-            sourceFilePath: '/a/index.ts',
-            targetFilePath: 'index.ts',
-            content: 'import { used } from "pkg-b/missing.ts";\nexport function pub() { return used(); }'
-        }
-    ]);
-    const producer = bundleWith('pkg-b', [
-        {
-            sourceFilePath: '/b/helpers.ts',
-            targetFilePath: 'helpers.ts',
-            content: 'export function used() { return 1; }'
-        }
-    ]);
-    const seeds = buildCrossBundleSeeds([
-        inputFor(consumer, [
+        ]);
+        const producer = bundleWith('pkg-b', [
             {
-                sourceFilePath: '/a/index.ts',
-                content: 'import { used } from "pkg-b/missing.ts";\nexport function pub() { return used(); }'
+                sourceFilePath: '/b/helpers.ts',
+                targetFilePath: 'helpers.ts',
+                content: 'export function used() { return 1; }\nexport function unused() { return 2; }'
             }
-        ]),
-        inputFor(producer, [{ sourceFilePath: '/b/helpers.ts', content: 'export function used() { return 1; }' }])
-    ]);
-    assert.strictEqual(seeds.size, 0);
-});
-
-test('does not record seeds for a namespace import that targets a file with no extracted bindings', () => {
-    const consumer = bundleWith('pkg-a', [
-        {
-            sourceFilePath: '/a/index.ts',
-            targetFilePath: 'index.ts',
-            content: 'import * as data from "pkg-b/data.json";\nexport function pub() { return data; }'
-        }
-    ]);
-    const producer = bundleWith('pkg-b', [
-        {
-            sourceFilePath: '/b/data.json',
-            targetFilePath: 'data.json',
-            content: '{}'
-        }
-    ]);
-    const seeds = buildCrossBundleSeeds([
-        inputFor(consumer, [
-            {
-                sourceFilePath: '/a/index.ts',
-                content: 'import * as data from "pkg-b/data.json";\nexport function pub() { return data; }'
-            }
-        ]),
-        { bundle: producer, sourceFiles: [], fileBindings: [], localReachable: new Set<string>() }
-    ]);
-    assert.strictEqual(seeds.size, 0);
-});
-
-test('records seeds only in the bundle whose name prefixes the specifier, not in other bundles that share a target file path', () => {
-    const consumer = bundleWith('pkg-a', [
-        {
-            sourceFilePath: '/a/index.ts',
-            targetFilePath: 'index.ts',
-            content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
-        },
-        {
-            sourceFilePath: '/a/helpers.ts',
-            targetFilePath: 'helpers.ts',
-            content: 'export function used() { return 0; }'
-        }
-    ]);
-    const producer = bundleWith('pkg-b', [
-        {
-            sourceFilePath: '/b/helpers.ts',
-            targetFilePath: 'helpers.ts',
-            content: 'export function used() { return 1; }'
-        }
-    ]);
-    const seeds = buildCrossBundleSeeds([
-        inputFor(consumer, [
+        ]);
+        const consumerInput = inputFor(consumer, [
             {
                 sourceFilePath: '/a/index.ts',
                 content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
-            },
-            { sourceFilePath: '/a/helpers.ts', content: 'export function used() { return 0; }' }
-        ]),
-        inputFor(producer, [{ sourceFilePath: '/b/helpers.ts', content: 'export function used() { return 1; }' }])
-    ]);
-    assert.strictEqual(seeds.has('pkg-a'), false);
-    const bSeeds = seeds.get('pkg-b');
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
-});
+            }
+        ]);
+        const producerInput = inputFor(producer, [
+            {
+                sourceFilePath: '/b/helpers.ts',
+                content: 'export function used() { return 1; }\nexport function unused() { return 2; }'
+            }
+        ]);
+        const seeds = buildCrossBundleSeeds([consumerInput, producerInput]);
+        const bSeeds = seeds.get('pkg-b');
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
+        assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
+        assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'default')), false);
+    });
 
-test('does not seed a named import whose local binding is only referenced by unreachable code', () => {
-    const bSeeds = seedsForConsumerProducer(
-        'import { used } from "pkg-b/helpers.ts";\nfunction dead() { return used(); }\nexport function pub() { return 1; }',
-        'export function used() { return 1; }'
-    );
-    assert.strictEqual(bSeeds, undefined);
-});
-
-test('does not seed a default import whose local binding is only referenced by unreachable code', () => {
-    const bSeeds = seedsForConsumerProducer(
-        'import dep from "pkg-b/helpers.ts";\nfunction dead() { return dep; }\nexport function pub() { return 1; }',
-        'export default 42;'
-    );
-    assert.strictEqual(bSeeds, undefined);
-});
-
-test('does not seed a namespace import whose local binding is only referenced by unreachable code', () => {
-    const bSeeds = seedsForConsumerProducer(
-        'import * as helpers from "pkg-b/helpers.ts";\nfunction dead() { return helpers; }\nexport function pub() { return 1; }',
-        'export const a = 1;\nexport const b = 2;'
-    );
-    assert.strictEqual(bSeeds, undefined);
-});
-
-test('uses the aliased local name to gate seeding for renamed named imports', () => {
-    const bSeeds = seedsForConsumerProducer(
-        'import { used as renamed } from "pkg-b/helpers.ts";\nexport function pub() { return renamed(); }',
-        'export function used() { return 1; }'
-    );
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
-});
-
-test('does not seed a renamed named import whose aliased local binding is unreachable', () => {
-    const bSeeds = seedsForConsumerProducer(
-        'import { used as renamed } from "pkg-b/helpers.ts";\nfunction dead() { return renamed(); }\nexport function pub() { return 1; }',
-        'export function used() { return 1; }'
-    );
-    assert.strictEqual(bSeeds, undefined);
-});
-
-test('seeds only the named imports whose local bindings are referenced by reachable code', () => {
-    const bSeeds = seedsForConsumerProducer(
-        [
-            'import { used, alsoDead } from "pkg-b/helpers.ts";',
-            'function dead() { return alsoDead(); }',
-            'export function pub() { return used(); }'
-        ].join('\n'),
-        'export function used() { return 1; }\nexport function alsoDead() { return 2; }'
-    );
-    assert.ok(bSeeds !== undefined);
-    assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
-    assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'alsoDead')), false);
-});
-
-test('does not record a seed for an import that does not match any bundle name', () => {
-    const consumer = bundleWith('pkg-a', [
-        {
-            sourceFilePath: '/a/index.ts',
-            targetFilePath: 'index.ts',
-            content: 'import { x } from "external-pkg";\nexport function pub() { return x; }'
-        }
-    ]);
-    const seeds = buildCrossBundleSeeds([
-        inputFor(consumer, [
+    test('records a default import as a "default" binding seed', function () {
+        const consumer = bundleWith('pkg-a', [
             {
                 sourceFilePath: '/a/index.ts',
+                targetFilePath: 'index.ts',
+                content: 'import dep from "pkg-b/main.ts";\nexport function pub() { return dep; }'
+            }
+        ]);
+        const producer = bundleWith('pkg-b', [
+            {
+                sourceFilePath: '/b/main.ts',
+                targetFilePath: 'main.ts',
+                content: 'export default 42;'
+            }
+        ]);
+        const seeds = buildCrossBundleSeeds([
+            inputFor(consumer, [
+                {
+                    sourceFilePath: '/a/index.ts',
+                    content: 'import dep from "pkg-b/main.ts";\nexport function pub() { return dep; }'
+                }
+            ]),
+            inputFor(producer, [{ sourceFilePath: '/b/main.ts', content: 'export default 42;' }])
+        ]);
+        const bSeeds = seeds.get('pkg-b');
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/main.ts', 'default')));
+    });
+
+    function seedsForConsumerProducer(
+        consumerContent: string,
+        producerContent: string
+    ): ReadonlySet<string> | undefined {
+        const consumer = bundleWith('pkg-a', [
+            { sourceFilePath: '/a/index.ts', targetFilePath: 'index.ts', content: consumerContent }
+        ]);
+        const producer = bundleWith('pkg-b', [
+            { sourceFilePath: '/b/helpers.ts', targetFilePath: 'helpers.ts', content: producerContent }
+        ]);
+        return buildCrossBundleSeeds([
+            inputFor(consumer, [{ sourceFilePath: '/a/index.ts', content: consumerContent }]),
+            inputFor(producer, [{ sourceFilePath: '/b/helpers.ts', content: producerContent }])
+        ]).get('pkg-b');
+    }
+
+    function seedsForLoneConsumer(consumerContent: string): SeedMap {
+        const consumer = bundleWith('pkg-a', [
+            { sourceFilePath: '/a/index.ts', targetFilePath: 'index.ts', content: consumerContent }
+        ]);
+        return buildCrossBundleSeeds([
+            inputFor(consumer, [{ sourceFilePath: '/a/index.ts', content: consumerContent }])
+        ]);
+    }
+
+    function assertHelpersBindingsSeeded(bSeeds: ReadonlySet<string> | undefined): void {
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'a')));
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'b')));
+    }
+
+    test('records a named re-export as a seed in the target bundle', function () {
+        const bSeeds = seedsForConsumerProducer(
+            'export { used } from "pkg-b/helpers.ts";',
+            'export function used() { return 1; }\nexport function unused() { return 2; }'
+        );
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
+        assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
+    });
+
+    test('records every binding of the target file as a seed for a star re-export', function () {
+        assertHelpersBindingsSeeded(
+            seedsForConsumerProducer('export * from "pkg-b/helpers.ts";', 'export const a = 1;\nexport const b = 2;')
+        );
+    });
+
+    test('records every binding of the target file as a seed for a namespace re-export', function () {
+        assertHelpersBindingsSeeded(
+            seedsForConsumerProducer(
+                'export * as helpers from "pkg-b/helpers.ts";',
+                'export const a = 1;\nexport const b = 2;'
+            )
+        );
+    });
+
+    test('ignores a bare local re-export with no module specifier', function () {
+        const seeds = seedsForLoneConsumer('function local() { return 1; }\nexport { local };');
+        assert.strictEqual(seeds.size, 0);
+    });
+
+    test('does not record a re-export seed when the specifier does not match any bundle name', function () {
+        const seeds = seedsForLoneConsumer('export { x } from "external-pkg";');
+        assert.strictEqual(seeds.size, 0);
+    });
+
+    test('records every binding of the target file as a seed for a namespace import', function () {
+        assertHelpersBindingsSeeded(
+            seedsForConsumerProducer(
+                'import * as helpers from "pkg-b/helpers.ts";\nexport function pub() { return helpers; }',
+                'export const a = 1;\nexport const b = 2;'
+            )
+        );
+    });
+
+    test('does not record a seed when the specifier matches a bundle name but not any file in that bundle', function () {
+        const consumer = bundleWith('pkg-a', [
+            {
+                sourceFilePath: '/a/index.ts',
+                targetFilePath: 'index.ts',
+                content: 'import { used } from "pkg-b/missing.ts";\nexport function pub() { return used(); }'
+            }
+        ]);
+        const producer = bundleWith('pkg-b', [
+            {
+                sourceFilePath: '/b/helpers.ts',
+                targetFilePath: 'helpers.ts',
+                content: 'export function used() { return 1; }'
+            }
+        ]);
+        const seeds = buildCrossBundleSeeds([
+            inputFor(consumer, [
+                {
+                    sourceFilePath: '/a/index.ts',
+                    content: 'import { used } from "pkg-b/missing.ts";\nexport function pub() { return used(); }'
+                }
+            ]),
+            inputFor(producer, [{ sourceFilePath: '/b/helpers.ts', content: 'export function used() { return 1; }' }])
+        ]);
+        assert.strictEqual(seeds.size, 0);
+    });
+
+    test('does not record seeds for a namespace import that targets a file with no extracted bindings', function () {
+        const consumer = bundleWith('pkg-a', [
+            {
+                sourceFilePath: '/a/index.ts',
+                targetFilePath: 'index.ts',
+                content: 'import * as data from "pkg-b/data.json";\nexport function pub() { return data; }'
+            }
+        ]);
+        const producer = bundleWith('pkg-b', [
+            {
+                sourceFilePath: '/b/data.json',
+                targetFilePath: 'data.json',
+                content: '{}'
+            }
+        ]);
+        const seeds = buildCrossBundleSeeds([
+            inputFor(consumer, [
+                {
+                    sourceFilePath: '/a/index.ts',
+                    content: 'import * as data from "pkg-b/data.json";\nexport function pub() { return data; }'
+                }
+            ]),
+            { bundle: producer, sourceFiles: [], fileBindings: [], localReachable: new Set<string>() }
+        ]);
+        assert.strictEqual(seeds.size, 0);
+    });
+
+    test('records seeds only in the bundle whose name prefixes the specifier, not in other bundles that share a target file path', function () {
+        const consumer = bundleWith('pkg-a', [
+            {
+                sourceFilePath: '/a/index.ts',
+                targetFilePath: 'index.ts',
+                content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
+            },
+            {
+                sourceFilePath: '/a/helpers.ts',
+                targetFilePath: 'helpers.ts',
+                content: 'export function used() { return 0; }'
+            }
+        ]);
+        const producer = bundleWith('pkg-b', [
+            {
+                sourceFilePath: '/b/helpers.ts',
+                targetFilePath: 'helpers.ts',
+                content: 'export function used() { return 1; }'
+            }
+        ]);
+        const seeds = buildCrossBundleSeeds([
+            inputFor(consumer, [
+                {
+                    sourceFilePath: '/a/index.ts',
+                    content: 'import { used } from "pkg-b/helpers.ts";\nexport function pub() { return used(); }'
+                },
+                { sourceFilePath: '/a/helpers.ts', content: 'export function used() { return 0; }' }
+            ]),
+            inputFor(producer, [{ sourceFilePath: '/b/helpers.ts', content: 'export function used() { return 1; }' }])
+        ]);
+        assert.strictEqual(seeds.has('pkg-a'), false);
+        const bSeeds = seeds.get('pkg-b');
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
+    });
+
+    test('does not seed a named import whose local binding is only referenced by unreachable code', function () {
+        const bSeeds = seedsForConsumerProducer(
+            'import { used } from "pkg-b/helpers.ts";\nfunction dead() { return used(); }\nexport function pub() { return 1; }',
+            'export function used() { return 1; }'
+        );
+        assert.strictEqual(bSeeds, undefined);
+    });
+
+    test('does not seed a default import whose local binding is only referenced by unreachable code', function () {
+        const bSeeds = seedsForConsumerProducer(
+            'import dep from "pkg-b/helpers.ts";\nfunction dead() { return dep; }\nexport function pub() { return 1; }',
+            'export default 42;'
+        );
+        assert.strictEqual(bSeeds, undefined);
+    });
+
+    test('does not seed a namespace import whose local binding is only referenced by unreachable code', function () {
+        const bSeeds = seedsForConsumerProducer(
+            'import * as helpers from "pkg-b/helpers.ts";\nfunction dead() { return helpers; }\nexport function pub() { return 1; }',
+            'export const a = 1;\nexport const b = 2;'
+        );
+        assert.strictEqual(bSeeds, undefined);
+    });
+
+    test('uses the aliased local name to gate seeding for renamed named imports', function () {
+        const bSeeds = seedsForConsumerProducer(
+            'import { used as renamed } from "pkg-b/helpers.ts";\nexport function pub() { return renamed(); }',
+            'export function used() { return 1; }'
+        );
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
+    });
+
+    test('does not seed a renamed named import whose aliased local binding is unreachable', function () {
+        const bSeeds = seedsForConsumerProducer(
+            'import { used as renamed } from "pkg-b/helpers.ts";\nfunction dead() { return renamed(); }\nexport function pub() { return 1; }',
+            'export function used() { return 1; }'
+        );
+        assert.strictEqual(bSeeds, undefined);
+    });
+
+    test('seeds only the named imports whose local bindings are referenced by reachable code', function () {
+        const bSeeds = seedsForConsumerProducer(
+            [
+                'import { used, alsoDead } from "pkg-b/helpers.ts";',
+                'function dead() { return alsoDead(); }',
+                'export function pub() { return used(); }'
+            ].join('\n'),
+            'export function used() { return 1; }\nexport function alsoDead() { return 2; }'
+        );
+        assert.ok(bSeeds !== undefined);
+        assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
+        assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'alsoDead')), false);
+    });
+
+    test('does not record a seed for an import that does not match any bundle name', function () {
+        const consumer = bundleWith('pkg-a', [
+            {
+                sourceFilePath: '/a/index.ts',
+                targetFilePath: 'index.ts',
                 content: 'import { x } from "external-pkg";\nexport function pub() { return x; }'
             }
-        ])
-    ]);
-    assert.strictEqual(seeds.size, 0);
+        ]);
+        const seeds = buildCrossBundleSeeds([
+            inputFor(consumer, [
+                {
+                    sourceFilePath: '/a/index.ts',
+                    content: 'import { x } from "external-pkg";\nexport function pub() { return x; }'
+                }
+            ])
+        ]);
+        assert.strictEqual(seeds.size, 0);
+    });
 });

--- a/source/dead-code-eliminator/cross-bundle/import-export-walker.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/import-export-walker.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { indexBundles, type IndexedBundle } from './bundle-index.ts';
@@ -26,18 +26,20 @@ function walkContent(
     return seeds;
 }
 
-test('walkCrossBundleStatements does nothing when the file has no import or export statements', () => {
-    assert.strictEqual(walkContent('const x = 1;').size, 0);
-});
+suite('import-export-walker', function () {
+    test('walkCrossBundleStatements does nothing when the file has no import or export statements', function () {
+        assert.strictEqual(walkContent('const x = 1;').size, 0);
+    });
 
-test('walkCrossBundleStatements ignores imports whose specifier matches no indexed bundle', () => {
-    assert.strictEqual(walkContent('import { x } from "external";', new Set(['x'])).size, 0);
-});
+    test('walkCrossBundleStatements ignores imports whose specifier matches no indexed bundle', function () {
+        assert.strictEqual(walkContent('import { x } from "external";', new Set(['x'])).size, 0);
+    });
 
-test('walkCrossBundleStatements ignores exports whose specifier matches no indexed bundle', () => {
-    assert.strictEqual(walkContent('export { x } from "external";').size, 0);
-});
+    test('walkCrossBundleStatements ignores exports whose specifier matches no indexed bundle', function () {
+        assert.strictEqual(walkContent('export { x } from "external";').size, 0);
+    });
 
-test('walkCrossBundleStatements skips bare re-exports that have no module specifier', () => {
-    assert.strictEqual(walkContent('function helper() { return 1; }\nexport { helper };').size, 0);
+    test('walkCrossBundleStatements skips bare re-exports that have no module specifier', function () {
+        assert.strictEqual(walkContent('function helper() { return 1; }\nexport { helper };').size, 0);
+    });
 });

--- a/source/dead-code-eliminator/cross-bundle/seed-store.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/seed-store.test.ts
@@ -1,82 +1,84 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { bindingId } from '../reachability/binding-id.ts';
 import type { ResolvedTarget } from './bundle-index.ts';
 import { createSeedStore, recordSeed, seedAllBindings } from './seed-store.ts';
 
-test('createSeedStore returns an empty mutable map', () => {
-    const store = createSeedStore();
-    assert.strictEqual(store.size, 0);
-});
+suite('seed-store', function () {
+    test('createSeedStore returns an empty mutable map', function () {
+        const store = createSeedStore();
+        assert.strictEqual(store.size, 0);
+    });
 
-test('recordSeed creates a new bundle entry on first insertion', () => {
-    const store = createSeedStore();
-    recordSeed(store, 'pkg-a', 'seed-1');
-    assert.deepStrictEqual(Array.from(store.get('pkg-a') ?? new Set()), ['seed-1']);
-});
+    test('recordSeed creates a new bundle entry on first insertion', function () {
+        const store = createSeedStore();
+        recordSeed(store, 'pkg-a', 'seed-1');
+        assert.deepStrictEqual(Array.from(store.get('pkg-a') ?? new Set()), ['seed-1']);
+    });
 
-test('recordSeed appends to an existing bundle entry without replacing earlier seeds', () => {
-    const store = createSeedStore();
-    recordSeed(store, 'pkg-a', 'seed-1');
-    recordSeed(store, 'pkg-a', 'seed-2');
-    assert.deepStrictEqual(Array.from(store.get('pkg-a') ?? new Set()), ['seed-1', 'seed-2']);
-});
+    test('recordSeed appends to an existing bundle entry without replacing earlier seeds', function () {
+        const store = createSeedStore();
+        recordSeed(store, 'pkg-a', 'seed-1');
+        recordSeed(store, 'pkg-a', 'seed-2');
+        assert.deepStrictEqual(Array.from(store.get('pkg-a') ?? new Set()), ['seed-1', 'seed-2']);
+    });
 
-test('recordSeed deduplicates identical seeds within the same bundle', () => {
-    const store = createSeedStore();
-    recordSeed(store, 'pkg-a', 'seed-1');
-    recordSeed(store, 'pkg-a', 'seed-1');
-    assert.strictEqual(store.get('pkg-a')?.size, 1);
-});
+    test('recordSeed deduplicates identical seeds within the same bundle', function () {
+        const store = createSeedStore();
+        recordSeed(store, 'pkg-a', 'seed-1');
+        recordSeed(store, 'pkg-a', 'seed-1');
+        assert.strictEqual(store.get('pkg-a')?.size, 1);
+    });
 
-test('recordSeed keeps seeds for different bundles isolated', () => {
-    const store = createSeedStore();
-    recordSeed(store, 'pkg-a', 'seed-a');
-    recordSeed(store, 'pkg-b', 'seed-b');
-    assert.deepStrictEqual(Array.from(store.get('pkg-a') ?? new Set()), ['seed-a']);
-    assert.deepStrictEqual(Array.from(store.get('pkg-b') ?? new Set()), ['seed-b']);
-});
+    test('recordSeed keeps seeds for different bundles isolated', function () {
+        const store = createSeedStore();
+        recordSeed(store, 'pkg-a', 'seed-a');
+        recordSeed(store, 'pkg-b', 'seed-b');
+        assert.deepStrictEqual(Array.from(store.get('pkg-a') ?? new Set()), ['seed-a']);
+        assert.deepStrictEqual(Array.from(store.get('pkg-b') ?? new Set()), ['seed-b']);
+    });
 
-function targetWithBindings(bindings: readonly { readonly name: string }[]): ResolvedTarget {
-    return {
-        bundleName: 'pkg-b',
-        sourceFilePath: '/b/helpers.ts',
-        indexedBundle: {
-            bundle: { name: 'pkg-b' } as never,
-            bindingsByFilePath: new Map([
-                [
-                    '/b/helpers.ts',
-                    {
-                        sourceFilePath: '/b/helpers.ts',
-                        sourceFile: undefined as never,
-                        bindings
-                    } as never
-                ]
-            ])
-        }
-    };
-}
+    function targetWithBindings(bindings: readonly { readonly name: string }[]): ResolvedTarget {
+        return {
+            bundleName: 'pkg-b',
+            sourceFilePath: '/b/helpers.ts',
+            indexedBundle: {
+                bundle: { name: 'pkg-b' } as never,
+                bindingsByFilePath: new Map([
+                    [
+                        '/b/helpers.ts',
+                        {
+                            sourceFilePath: '/b/helpers.ts',
+                            sourceFile: undefined as never,
+                            bindings
+                        } as never
+                    ]
+                ])
+            }
+        };
+    }
 
-test('seedAllBindings records one seed per binding of the resolved target file', () => {
-    const store = createSeedStore();
-    seedAllBindings(store, targetWithBindings([{ name: 'a' }, { name: 'b' }]));
-    assert.deepStrictEqual(Array.from(store.get('pkg-b') ?? new Set()), [
-        bindingId('/b/helpers.ts', 'a'),
-        bindingId('/b/helpers.ts', 'b')
-    ]);
-});
+    test('seedAllBindings records one seed per binding of the resolved target file', function () {
+        const store = createSeedStore();
+        seedAllBindings(store, targetWithBindings([{ name: 'a' }, { name: 'b' }]));
+        assert.deepStrictEqual(Array.from(store.get('pkg-b') ?? new Set()), [
+            bindingId('/b/helpers.ts', 'a'),
+            bindingId('/b/helpers.ts', 'b')
+        ]);
+    });
 
-test('seedAllBindings does nothing when the resolved file has no bindings entry', () => {
-    const store = createSeedStore();
-    const target: ResolvedTarget = {
-        bundleName: 'pkg-b',
-        sourceFilePath: '/b/missing.ts',
-        indexedBundle: {
-            bundle: { name: 'pkg-b' } as never,
-            bindingsByFilePath: new Map()
-        }
-    };
-    seedAllBindings(store, target);
-    assert.strictEqual(store.size, 0);
+    test('seedAllBindings does nothing when the resolved file has no bindings entry', function () {
+        const store = createSeedStore();
+        const target: ResolvedTarget = {
+            bundleName: 'pkg-b',
+            sourceFilePath: '/b/missing.ts',
+            indexedBundle: {
+                bundle: { name: 'pkg-b' } as never,
+                bindingsByFilePath: new Map()
+            }
+        };
+        seedAllBindings(store, target);
+        assert.strictEqual(store.size, 0);
+    });
 });

--- a/source/dead-code-eliminator/elimination-emitter.test.ts
+++ b/source/dead-code-eliminator/elimination-emitter.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
 import { linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import { createSpyingBroadcaster } from '../test-libraries/result-helpers.ts';
@@ -44,171 +44,174 @@ function originalBundle(name: string, resources: readonly AnalyzedBundleResource
     });
 }
 
-test('maybeEmitElimination() does not emit when no subscriber is registered', () => {
-    const wrapped = createSpyingBroadcaster();
+suite('elimination-emitter', function () {
+    test('maybeEmitElimination() does not emit when no subscriber is registered', function () {
+        const wrapped = createSpyingBroadcaster();
 
-    maybeEmitElimination(
-        wrapped.provider,
-        [originalBundle('pkg-a', [resource('/src/a.ts', 'abc')])],
-        [bundle('pkg-a', [resource('/src/a.ts', 'abc')])]
-    );
+        maybeEmitElimination(
+            wrapped.provider,
+            [originalBundle('pkg-a', [resource('/src/a.ts', 'abc')])],
+            [bundle('pkg-a', [resource('/src/a.ts', 'abc')])]
+        );
 
-    assert.strictEqual(wrapped.emitSpy.callCount, 0);
-});
-
-test('maybeEmitElimination() emits eliminationCompleted with per-bundle decisions when a subscriber is registered', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { perBundle: { packageName: string; files: { path: string; sourceBytes: number }[] }[] }[] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        received.push({
-            perBundle: payload.perBundle.map((bundleResult) => {
-                return {
-                    packageName: bundleResult.packageName,
-                    files: bundleResult.files.map((file) => {
-                        return { path: file.path, sourceBytes: file.sourceBytes };
-                    })
-                };
-            })
-        });
+        assert.strictEqual(wrapped.emitSpy.callCount, 0);
     });
 
-    maybeEmitElimination(
-        broadcaster.provider,
-        [
-            originalBundle('pkg-a', [resource('/src/a.ts', 'abcde'), resource('/src/b.ts', 'xy')]),
-            originalBundle('pkg-b', [resource('/src/c.ts', 'hi')])
-        ],
-        [
-            bundle('pkg-a', [resource('/src/a.ts', 'abcde'), resource('/src/b.ts', 'xy')]),
-            bundle('pkg-b', [resource('/src/c.ts', 'hi')])
-        ]
-    );
-
-    assert.deepStrictEqual(received, [
-        {
-            perBundle: [
-                {
-                    packageName: 'pkg-a',
-                    files: [
-                        { path: '/src/a.ts', sourceBytes: 5 },
-                        { path: '/src/b.ts', sourceBytes: 2 }
-                    ]
-                },
-                {
-                    packageName: 'pkg-b',
-                    files: [{ path: '/src/c.ts', sourceBytes: 2 }]
-                }
-            ]
+    test('maybeEmitElimination() emits eliminationCompleted with per-bundle decisions when a subscriber is registered', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { perBundle: { packageName: string; files: { path: string; sourceBytes: number }[] }[] }[] = [];
+        function simplifyFile(file: { path: string; sourceBytes: number }) {
+            return { path: file.path, sourceBytes: file.sourceBytes };
         }
-    ]);
-});
-
-test('maybeEmitElimination() emits each file with decision "kept" and reason "reachable"', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { decision: string; reason: string }[] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        for (const bundleResult of payload.perBundle) {
-            for (const file of bundleResult.files) {
-                received.push({ decision: file.decision, reason: file.reason });
-            }
-        }
-    });
-
-    maybeEmitElimination(
-        broadcaster.provider,
-        [originalBundle('pkg-a', [resource('/src/a.ts', 'x')])],
-        [bundle('pkg-a', [resource('/src/a.ts', 'x')])]
-    );
-
-    assert.deepStrictEqual(received, [{ decision: 'kept', reason: 'reachable' }]);
-});
-
-test('maybeEmitElimination() emits empty droppedSymbols and seeds arrays per bundle', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { droppedSymbols: unknown[]; seeds: unknown[] }[] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        for (const bundleResult of payload.perBundle) {
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
             received.push({
-                droppedSymbols: Array.from(bundleResult.droppedSymbols),
-                seeds: Array.from(bundleResult.seeds)
+                perBundle: payload.perBundle.map((bundleResult) => {
+                    return {
+                        packageName: bundleResult.packageName,
+                        files: bundleResult.files.map(simplifyFile)
+                    };
+                })
             });
-        }
+        });
+
+        maybeEmitElimination(
+            broadcaster.provider,
+            [
+                originalBundle('pkg-a', [resource('/src/a.ts', 'abcde'), resource('/src/b.ts', 'xy')]),
+                originalBundle('pkg-b', [resource('/src/c.ts', 'hi')])
+            ],
+            [
+                bundle('pkg-a', [resource('/src/a.ts', 'abcde'), resource('/src/b.ts', 'xy')]),
+                bundle('pkg-b', [resource('/src/c.ts', 'hi')])
+            ]
+        );
+
+        assert.deepStrictEqual(received, [
+            {
+                perBundle: [
+                    {
+                        packageName: 'pkg-a',
+                        files: [
+                            { path: '/src/a.ts', sourceBytes: 5 },
+                            { path: '/src/b.ts', sourceBytes: 2 }
+                        ]
+                    },
+                    {
+                        packageName: 'pkg-b',
+                        files: [{ path: '/src/c.ts', sourceBytes: 2 }]
+                    }
+                ]
+            }
+        ]);
     });
 
-    maybeEmitElimination(
-        broadcaster.provider,
-        [originalBundle('pkg-a', [resource('/src/a.ts', 'x')])],
-        [bundle('pkg-a', [resource('/src/a.ts', 'x')])]
-    );
+    test('maybeEmitElimination() emits each file with decision "kept" and reason "reachable"', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { decision: string; reason: string }[] = [];
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            for (const bundleResult of payload.perBundle) {
+                for (const file of bundleResult.files) {
+                    received.push({ decision: file.decision, reason: file.reason });
+                }
+            }
+        });
 
-    assert.deepStrictEqual(received, [{ droppedSymbols: [], seeds: [] }]);
-});
+        maybeEmitElimination(
+            broadcaster.provider,
+            [originalBundle('pkg-a', [resource('/src/a.ts', 'x')])],
+            [bundle('pkg-a', [resource('/src/a.ts', 'x')])]
+        );
 
-test('maybeEmitElimination() emits an empty perBundle array when given no bundles and a subscriber is registered', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { perBundle: unknown[] }[] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        received.push({ perBundle: Array.from(payload.perBundle) });
+        assert.deepStrictEqual(received, [{ decision: 'kept', reason: 'reachable' }]);
     });
 
-    maybeEmitElimination(broadcaster.provider, [], []);
-
-    assert.deepStrictEqual(received, [{ perBundle: [] }]);
-});
-
-test('maybeEmitElimination() marks a file as transformed with the rewritten-after-analysis reason', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { decision: string; reason: string; outputBytes?: number }[] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        for (const bundleResult of payload.perBundle) {
-            for (const file of bundleResult.files) {
+    test('maybeEmitElimination() emits empty droppedSymbols and seeds arrays per bundle', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { droppedSymbols: unknown[]; seeds: unknown[] }[] = [];
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            for (const bundleResult of payload.perBundle) {
                 received.push({
-                    decision: file.decision,
-                    reason: file.reason,
-                    ...(file.outputBytes === undefined ? {} : { outputBytes: file.outputBytes })
+                    droppedSymbols: Array.from(bundleResult.droppedSymbols),
+                    seeds: Array.from(bundleResult.seeds)
                 });
             }
-        }
+        });
+
+        maybeEmitElimination(
+            broadcaster.provider,
+            [originalBundle('pkg-a', [resource('/src/a.ts', 'x')])],
+            [bundle('pkg-a', [resource('/src/a.ts', 'x')])]
+        );
+
+        assert.deepStrictEqual(received, [{ droppedSymbols: [], seeds: [] }]);
     });
 
-    maybeEmitElimination(
-        broadcaster.provider,
-        [originalBundle('pkg-a', [resource('/src/a.ts', 'const unused = 1;\n')])],
-        [bundle('pkg-a', [resource('/src/a.ts', 'const kept = 1;\n')])]
-    );
+    test('maybeEmitElimination() emits an empty perBundle array when given no bundles and a subscriber is registered', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { perBundle: unknown[] }[] = [];
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            received.push({ perBundle: Array.from(payload.perBundle) });
+        });
 
-    assert.deepStrictEqual(received, [
-        { decision: 'transformed', reason: 'rewritten-after-analysis', outputBytes: 16 }
-    ]);
-});
+        maybeEmitElimination(broadcaster.provider, [], []);
 
-test('maybeEmitElimination() marks a missing analyzed file as eliminated with the not-emitted-after-analysis reason', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { decision: string; path: string; reason: string }[] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        for (const bundleResult of payload.perBundle) {
-            for (const file of bundleResult.files) {
-                received.push({ decision: file.decision, path: file.path, reason: file.reason });
+        assert.deepStrictEqual(received, [{ perBundle: [] }]);
+    });
+
+    test('maybeEmitElimination() marks a file as transformed with the rewritten-after-analysis reason', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { decision: string; reason: string; outputBytes?: number }[] = [];
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            for (const bundleResult of payload.perBundle) {
+                for (const file of bundleResult.files) {
+                    received.push({
+                        decision: file.decision,
+                        reason: file.reason,
+                        ...(file.outputBytes === undefined ? {} : { outputBytes: file.outputBytes })
+                    });
+                }
             }
-        }
+        });
+
+        maybeEmitElimination(
+            broadcaster.provider,
+            [originalBundle('pkg-a', [resource('/src/a.ts', 'const unused = 1;\n')])],
+            [bundle('pkg-a', [resource('/src/a.ts', 'const kept = 1;\n')])]
+        );
+
+        assert.deepStrictEqual(received, [
+            { decision: 'transformed', reason: 'rewritten-after-analysis', outputBytes: 16 }
+        ]);
     });
 
-    maybeEmitElimination(
-        broadcaster.provider,
-        [originalBundle('pkg-a', [resource('/src/a.ts', 'const unused = 1;\n')])],
-        [bundle('pkg-a', [])]
-    );
+    test('maybeEmitElimination() marks a missing analyzed file as eliminated with the not-emitted-after-analysis reason', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { decision: string; path: string; reason: string }[] = [];
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            for (const bundleResult of payload.perBundle) {
+                for (const file of bundleResult.files) {
+                    received.push({ decision: file.decision, path: file.path, reason: file.reason });
+                }
+            }
+        });
 
-    assert.deepStrictEqual(received, [
-        { decision: 'eliminated', path: '/src/a.ts', reason: 'not-emitted-after-analysis' }
-    ]);
-});
+        maybeEmitElimination(
+            broadcaster.provider,
+            [originalBundle('pkg-a', [resource('/src/a.ts', 'const unused = 1;\n')])],
+            [bundle('pkg-a', [])]
+        );
 
-test('maybeEmitElimination() throws when an analyzed bundle has no matching original bundle', () => {
-    const broadcaster = createProgressBroadcaster();
-    broadcaster.consumer.on('eliminationCompleted', () => undefined);
+        assert.deepStrictEqual(received, [
+            { decision: 'eliminated', path: '/src/a.ts', reason: 'not-emitted-after-analysis' }
+        ]);
+    });
 
-    assert.throws(() => {
-        maybeEmitElimination(broadcaster.provider, [], [bundle('pkg-a', [resource('/src/a.ts', 'x')])]);
-    }, /Original bundle missing/);
+    test('maybeEmitElimination() throws when an analyzed bundle has no matching original bundle', function () {
+        const broadcaster = createProgressBroadcaster();
+        broadcaster.consumer.on('eliminationCompleted', () => undefined);
+
+        assert.throws(() => {
+            maybeEmitElimination(broadcaster.provider, [], [bundle('pkg-a', [resource('/src/a.ts', 'x')])]);
+        }, /Original bundle missing/);
+    });
 });

--- a/source/dead-code-eliminator/eliminator.test.ts
+++ b/source/dead-code-eliminator/eliminator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { LinkedBundle, LinkedBundleResource } from '../linker/linked-bundle.ts';
 import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
 import { analyzedBundle, bundleResource, linkedBundle } from '../test-libraries/bundle-fixtures.ts';
@@ -52,493 +52,498 @@ function collectTargetPaths(analyzed: AnalyzedBundle | undefined): readonly stri
     });
 }
 
-test('eliminate returns one analyzed bundle per linked bundle', async () => {
-    const eliminator = createTestEliminator();
-    const result = await eliminator.eliminate(inputs(linkedBundle({ name: 'a' }), linkedBundle({ name: 'b' })));
-    assert.strictEqual(result.length, 2);
-});
+suite('eliminator', function () {
+    test('eliminate returns one analyzed bundle per linked bundle', async function () {
+        const eliminator = createTestEliminator();
+        const result = await eliminator.eliminate(inputs(linkedBundle({ name: 'a' }), linkedBundle({ name: 'b' })));
+        assert.strictEqual(result.length, 2);
+    });
 
-test('eliminate preserves the bundle name', async () => {
-    const eliminator = createTestEliminator();
-    const [analyzed] = await eliminator.eliminate(inputs(linkedBundle({ name: 'pkg' })));
-    assert.strictEqual(analyzed?.name, 'pkg');
-});
+    test('eliminate preserves the bundle name', async function () {
+        const eliminator = createTestEliminator();
+        const [analyzed] = await eliminator.eliminate(inputs(linkedBundle({ name: 'pkg' })));
+        assert.strictEqual(analyzed?.name, 'pkg');
+    });
 
-test('eliminate returns no bundles when given no input', async () => {
-    const eliminator = createTestEliminator();
-    const result = await eliminator.eliminate([]);
-    assert.deepStrictEqual(result, []);
-});
+    test('eliminate returns no bundles when given no input', async function () {
+        const eliminator = createTestEliminator();
+        const result = await eliminator.eliminate([]);
+        assert.deepStrictEqual(result, []);
+    });
 
-test('eliminate emits elimination progress for the original input bundles', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: string[][] = [];
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        received.push(
-            payload.perBundle.map((bundle) => {
-                return bundle.packageName;
-            })
+    test('eliminate emits elimination progress for the original input bundles', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: string[][] = [];
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            received.push(
+                payload.perBundle.map((bundle) => {
+                    return bundle.packageName;
+                })
+            );
+        });
+        const eliminator = createDeadCodeEliminator({
+            createProject: () => createProject(),
+            progressBroadcaster: broadcaster.provider
+        });
+
+        await eliminator.eliminate(inputs(linkedBundle({ name: 'pkg-a' }), linkedBundle({ name: 'pkg-b' })));
+
+        assert.deepStrictEqual(received, [['pkg-a', 'pkg-b']]);
+    });
+
+    test('eliminate populates analysis on every resource', async function () {
+        const eliminator = createTestEliminator();
+        const [analyzed] = await eliminator.eliminate(
+            inputs(
+                linkedBundle({
+                    name: 'pkg',
+                    contents: [
+                        { ...bundleResource('/a.ts'), isSubstituted: false },
+                        { ...bundleResource('/b.ts'), isSubstituted: false }
+                    ]
+                })
+            )
         );
+        assert.strictEqual(analyzed?.contents.length, 2);
+        for (const resource of analyzed.contents) {
+            assert.deepStrictEqual(resource.analysis, {
+                survivingBindings: new Set<string>(),
+                sideEffectStatements: [],
+                sideEffectImports: new Set<string>()
+            });
+        }
     });
-    const eliminator = createDeadCodeEliminator({
-        createProject: () => createProject(),
-        progressBroadcaster: broadcaster.provider
+
+    test('eliminate sets sideEffectsField to false for empty bundles', async function () {
+        const eliminator = createTestEliminator();
+        const result = await eliminator.eliminate(inputs(linkedBundle({ name: 'a' }), linkedBundle({ name: 'b' })));
+        for (const bundle of result) {
+            assert.strictEqual(bundle.sideEffectsField, false);
+        }
     });
 
-    await eliminator.eliminate(inputs(linkedBundle({ name: 'pkg-a' }), linkedBundle({ name: 'pkg-b' })));
+    test('eliminate copies roots, externalDependencies, and linkedBundleDependencies through unchanged', async function () {
+        const eliminator = createTestEliminator();
+        const input = linkedBundle({
+            name: 'a',
+            externalDependencies: new Map([['dep', { name: 'dep', referencedFrom: ['/src/index.js'] }]]),
+            linkedBundleDependencies: new Map([['bundle', { name: 'bundle', referencedFrom: ['/src/index.js'] }]])
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(input));
+        assert.strictEqual(analyzed?.roots, input.roots);
+        assert.strictEqual(analyzed.externalDependencies, input.externalDependencies);
+        assert.strictEqual(analyzed.linkedBundleDependencies, input.linkedBundleDependencies);
+    });
 
-    assert.deepStrictEqual(received, [['pkg-a', 'pkg-b']]);
-});
-
-test('eliminate populates analysis on every resource', async () => {
-    const eliminator = createTestEliminator();
-    const [analyzed] = await eliminator.eliminate(
-        inputs(
-            linkedBundle({
-                name: 'pkg',
-                contents: [
-                    { ...bundleResource('/a.ts'), isSubstituted: false },
-                    { ...bundleResource('/b.ts'), isSubstituted: false }
-                ]
-            })
-        )
-    );
-    assert.strictEqual(analyzed?.contents.length, 2);
-    for (const resource of analyzed.contents) {
-        assert.deepStrictEqual(resource.analysis, {
+    test('eliminate preserves resource fields and uses empty analysis defaults on non-code files', async function () {
+        const eliminator = createTestEliminator();
+        const resource = { ...bundleResource('/src/LICENSE', { content: 'Hello' }), isSubstituted: false };
+        const [analyzed] = await eliminator.eliminate(inputs(linkedBundle({ name: 'pkg', contents: [resource] })));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription, resource.fileDescription);
+        assert.strictEqual(emitted.isSubstituted, false);
+        assert.strictEqual(emitted.directDependencies, resource.directDependencies);
+        assert.strictEqual(emitted.isExplicitlyIncluded, resource.isExplicitlyIncluded);
+        assert.deepStrictEqual(emitted.analysis, {
             survivingBindings: new Set<string>(),
             sideEffectStatements: [],
             sideEffectImports: new Set<string>()
         });
-    }
-});
-
-test('eliminate sets sideEffectsField to false for empty bundles', async () => {
-    const eliminator = createTestEliminator();
-    const result = await eliminator.eliminate(inputs(linkedBundle({ name: 'a' }), linkedBundle({ name: 'b' })));
-    for (const bundle of result) {
-        assert.strictEqual(bundle.sideEffectsField, false);
-    }
-});
-
-test('eliminate copies roots, externalDependencies, and linkedBundleDependencies through unchanged', async () => {
-    const eliminator = createTestEliminator();
-    const input = linkedBundle({
-        name: 'a',
-        externalDependencies: new Map([['dep', { name: 'dep', referencedFrom: ['/src/index.js'] }]]),
-        linkedBundleDependencies: new Map([['bundle', { name: 'bundle', referencedFrom: ['/src/index.js'] }]])
     });
-    const [analyzed] = await eliminator.eliminate(inputs(input));
-    assert.strictEqual(analyzed?.roots, input.roots);
-    assert.strictEqual(analyzed.externalDependencies, input.externalDependencies);
-    assert.strictEqual(analyzed.linkedBundleDependencies, input.linkedBundleDependencies);
-});
 
-test('eliminate preserves resource fields and uses empty analysis defaults on non-code files', async () => {
-    const eliminator = createTestEliminator();
-    const resource = { ...bundleResource('/src/LICENSE', { content: 'Hello' }), isSubstituted: false };
-    const [analyzed] = await eliminator.eliminate(inputs(linkedBundle({ name: 'pkg', contents: [resource] })));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription, resource.fileDescription);
-    assert.strictEqual(emitted.isSubstituted, false);
-    assert.strictEqual(emitted.directDependencies, resource.directDependencies);
-    assert.strictEqual(emitted.isExplicitlyIncluded, resource.isExplicitlyIncluded);
-    assert.deepStrictEqual(emitted.analysis, {
-        survivingBindings: new Set<string>(),
-        sideEffectStatements: [],
-        sideEffectImports: new Set<string>()
+    test('eliminate accepts an analyzed bundle fixture and treats it like any linked bundle', async function () {
+        const eliminator = createTestEliminator();
+        const input: AnalyzedBundle = analyzedBundle({ name: 'pkg' });
+        const [analyzed] = await eliminator.eliminate(inputs(input));
+        assert.strictEqual(analyzed?.name, 'pkg');
+        assert.strictEqual(analyzed.sideEffectsField, false);
     });
-});
 
-test('eliminate accepts an analyzed bundle fixture and treats it like any linked bundle', async () => {
-    const eliminator = createTestEliminator();
-    const input: AnalyzedBundle = analyzedBundle({ name: 'pkg' });
-    const [analyzed] = await eliminator.eliminate(inputs(input));
-    assert.strictEqual(analyzed?.name, 'pkg');
-    assert.strictEqual(analyzed.sideEffectsField, false);
-});
-
-const indexTsContent = ['function dead() { return 1; }', 'export function live() { return 2; }'].join('\n');
-const indexTsBundle = (extraResources: readonly LinkedBundleResource[] = []): LinkedBundle => {
-    return bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: indexTsContent,
-        extraResources
-    });
-};
-
-test('eliminate removes an unreachable function declaration and records the surviving bindings when transformations are enabled', async () => {
-    const eliminator = createTestEliminator();
-    const [analyzed] = await eliminator.eliminate(inputs(indexTsBundle()));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription.content.includes('dead'), false);
-    assert.strictEqual(emitted.fileDescription.content.includes('live'), true);
-    assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['live']));
-});
-
-test('eliminate keeps exported destructuring bindings in an entry file', async () => {
-    const eliminator = createTestEliminator();
-    const bundle = bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: [
-            'const api = { live() { return 1; }, dead() { return 2; } };',
-            'export const { live, dead } = api;'
-        ].join('\n')
-    });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription.content.includes('export const { live, dead } = api;'), true);
-    assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['api', 'live', 'dead']));
-});
-
-test('eliminate keeps a whole destructuring declarator when one bound identifier is reachable', async () => {
-    const eliminator = createTestEliminator();
-    const bundle = bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: [
-            'function build() { return { helper() { return 1; }, other() { return 2; } }; }',
-            'const { helper, other } = build();',
-            'export function live() { return helper(); }'
-        ].join('\n')
-    });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription.content.includes('const { helper, other } = build();'), true);
-    assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['helper', 'other', 'build', 'live']));
-});
-
-test('eliminate preserves a pure destructuring declarator when one bound identifier is reachable', async () => {
-    const eliminator = createTestEliminator();
-    const bundle = bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: ['const { helper, other } = { helper: 1, other: 2 };', 'export const live = helper;'].join('\n')
-    });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(
-        emitted.fileDescription.content.includes('const { helper, other } = { helper: 1, other: 2 };'),
-        true
-    );
-    assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['helper', 'other', 'live']));
-});
-
-test('eliminate keeps shorthand property value bindings when an exported object literal uses them', async () => {
-    const eliminator = createTestEliminator();
-    const bundle = bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: [
-            'const globalSchema = 1;',
-            'const perPackageSchema = 2;',
-            'function run() { return 3; }',
-            'export const rule = { globalSchema, perPackageSchema, run };'
-        ].join('\n')
-    });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription.content.includes('const globalSchema = 1;'), true);
-    assert.strictEqual(emitted.fileDescription.content.includes('const perPackageSchema = 2;'), true);
-    assert.strictEqual(emitted.fileDescription.content.includes('function run()'), true);
-    assert.deepStrictEqual(
-        emitted.analysis.survivingBindings,
-        new Set(['globalSchema', 'perPackageSchema', 'run', 'rule'])
-    );
-});
-
-test('eliminate keeps unreachable declarations when transformations are disabled', async () => {
-    const eliminator = createTestEliminator();
-    const result = await eliminator.eliminate([{ bundle: indexTsBundle(), transformationsEnabled: false }]);
-    const emitted = result[0]?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription.content, indexTsContent);
-});
-
-test('eliminate recomposes the paired source map when a code file is transformed', async () => {
-    const eliminator = createTestEliminator();
-    const originalMap = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        sources: ['index.ts'],
-        sourcesContent: [indexTsContent],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA,SAAS,IAAI,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC;AAC5B,OAAO,SAAS,IAAI,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC,CAAC'
-    });
-    const mapResource = {
-        ...bundleResource('/src/index.ts.map', { content: originalMap, targetFilePath: 'index.ts.map' }),
-        isSubstituted: false
+    const indexTsContent = ['function dead() { return 1; }', 'export function live() { return 2; }'].join('\n');
+    const indexTsBundle = (extraResources: readonly LinkedBundleResource[] = []): LinkedBundle => {
+        return bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: indexTsContent,
+            extraResources
+        });
     };
-    const [analyzed] = await eliminator.eliminate(inputs(indexTsBundle([mapResource])));
-    const emittedTargetPaths = collectTargetPaths(analyzed);
-    assert.strictEqual(emittedTargetPaths.includes('index.ts.map'), true);
-    assert.strictEqual(emittedTargetPaths.includes('index.ts'), true);
-    const emittedMap = analyzed?.contents.find((resource) => {
-        return resource.fileDescription.targetFilePath === 'index.ts.map';
-    });
-    assert.ok(emittedMap !== undefined);
-    assert.notStrictEqual(emittedMap.fileDescription.content, originalMap);
-    const parsed = JSON.parse(emittedMap.fileDescription.content) as { mappings: string; version: number };
-    assert.strictEqual(parsed.version, 3);
-    assert.ok(parsed.mappings.length > 0);
-});
 
-test('eliminate keeps the paired source map untouched when no transformation occurs', async () => {
-    const eliminator = createTestEliminator();
-    const liveOnlyContent = 'export function live() { return 2; }';
-    const validMapContent = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        sources: ['index.ts'],
-        sourcesContent: [liveOnlyContent],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA,OAAO,SAAS,IAAI,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC,CAAC'
+    test('eliminate removes an unreachable function declaration and records the surviving bindings when transformations are enabled', async function () {
+        const eliminator = createTestEliminator();
+        const [analyzed] = await eliminator.eliminate(inputs(indexTsBundle()));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription.content.includes('dead'), false);
+        assert.strictEqual(emitted.fileDescription.content.includes('live'), true);
+        assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['live']));
     });
-    const mapResource = {
-        ...bundleResource('/src/index.ts.map', { content: validMapContent, targetFilePath: 'index.ts.map' }),
-        isSubstituted: false
-    };
-    const bundle = bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: liveOnlyContent,
-        extraResources: [mapResource]
-    });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const emittedMap = analyzed?.contents.find((resource) => {
-        return resource.fileDescription.targetFilePath === 'index.ts.map';
-    });
-    assert.ok(emittedMap !== undefined);
-    assert.strictEqual(emittedMap.fileDescription.content, validMapContent);
-});
 
-test('eliminate honours a root declaration file when seeding reachability', async () => {
-    const eliminator = createTestEliminator();
-    const declarationContent = 'export type Public = number;\nexport type Private = string;';
-    const declarationFile = {
-        content: declarationContent,
-        isExecutable: false,
-        sourceFilePath: '/src/index.d.ts',
-        targetFilePath: 'index.d.ts'
-    };
-    const resource = { ...bundleResource('/src/index.d.ts', declarationFile), isSubstituted: false };
-    const [analyzed] = await eliminator.eliminate(
-        inputs(
-            linkedBundle({
-                name: 'pkg',
-                contents: [resource],
-                roots: {
-                    main: {
-                        js: {
-                            content: '',
-                            isExecutable: false,
-                            sourceFilePath: '/src/index.js',
-                            targetFilePath: 'index.js'
-                        },
-                        declarationFile
-                    }
-                },
-                surface: { mode: 'implicit', defaultModuleRoot: 'main' }
-            })
-        )
-    );
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['Public', 'Private']));
-});
+    test('eliminate keeps exported destructuring bindings in an entry file', async function () {
+        const eliminator = createTestEliminator();
+        const bundle = bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: [
+                'const api = { live() { return 1; }, dead() { return 2; } };',
+                'export const { live, dead } = api;'
+            ].join('\n')
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription.content.includes('export const { live, dead } = api;'), true);
+        assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['api', 'live', 'dead']));
+    });
 
-test('eliminate honours explicit private roots when seeding reachability', async () => {
-    const eliminator = createTestEliminator();
-    const mainResource = {
-        ...bundleResource('/src/index.js', { content: 'export const main = 1;\n', targetFilePath: 'index.js' }),
-        isSubstituted: false
-    };
-    const workerResource = {
-        ...bundleResource('/src/worker.js', {
-            content: 'export const workerPublic = 1;\nexport const workerPrivate = 2;\n',
-            targetFilePath: 'worker.js'
-        }),
-        isSubstituted: false
-    };
-    const [analyzed] = await eliminator.eliminate(
-        inputs(
-            linkedBundle({
-                name: 'pkg',
-                contents: [mainResource, workerResource],
-                roots: {
-                    main: {
-                        js: {
-                            content: '',
-                            isExecutable: false,
-                            sourceFilePath: '/src/index.js',
-                            targetFilePath: 'index.js'
+    test('eliminate keeps a whole destructuring declarator when one bound identifier is reachable', async function () {
+        const eliminator = createTestEliminator();
+        const bundle = bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: [
+                'function build() { return { helper() { return 1; }, other() { return 2; } }; }',
+                'const { helper, other } = build();',
+                'export function live() { return helper(); }'
+            ].join('\n')
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription.content.includes('const { helper, other } = build();'), true);
+        assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['helper', 'other', 'build', 'live']));
+    });
+
+    test('eliminate preserves a pure destructuring declarator when one bound identifier is reachable', async function () {
+        const eliminator = createTestEliminator();
+        const bundle = bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: ['const { helper, other } = { helper: 1, other: 2 };', 'export const live = helper;'].join('\n')
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(
+            emitted.fileDescription.content.includes('const { helper, other } = { helper: 1, other: 2 };'),
+            true
+        );
+        assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['helper', 'other', 'live']));
+    });
+
+    test('eliminate keeps shorthand property value bindings when an exported object literal uses them', async function () {
+        const eliminator = createTestEliminator();
+        const bundle = bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: [
+                'const globalSchema = 1;',
+                'const perPackageSchema = 2;',
+                'function run() { return 3; }',
+                'export const rule = { globalSchema, perPackageSchema, run };'
+            ].join('\n')
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription.content.includes('const globalSchema = 1;'), true);
+        assert.strictEqual(emitted.fileDescription.content.includes('const perPackageSchema = 2;'), true);
+        assert.strictEqual(emitted.fileDescription.content.includes('function run()'), true);
+        assert.deepStrictEqual(
+            emitted.analysis.survivingBindings,
+            new Set(['globalSchema', 'perPackageSchema', 'run', 'rule'])
+        );
+    });
+
+    test('eliminate keeps unreachable declarations when transformations are disabled', async function () {
+        const eliminator = createTestEliminator();
+        const result = await eliminator.eliminate([{ bundle: indexTsBundle(), transformationsEnabled: false }]);
+        const emitted = result[0]?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription.content, indexTsContent);
+    });
+
+    test('eliminate recomposes the paired source map when a code file is transformed', async function () {
+        const eliminator = createTestEliminator();
+        const originalMap = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            sources: ['index.ts'],
+            sourcesContent: [indexTsContent],
+            names: [],
+            mappings:
+                // cspell:disable-next-line
+                'AAAA,SAAS,IAAI,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC;AAC5B,OAAO,SAAS,IAAI,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC,CAAC'
+        });
+        const mapResource = {
+            ...bundleResource('/src/index.ts.map', { content: originalMap, targetFilePath: 'index.ts.map' }),
+            isSubstituted: false
+        };
+        const [analyzed] = await eliminator.eliminate(inputs(indexTsBundle([mapResource])));
+        const emittedTargetPaths = collectTargetPaths(analyzed);
+        assert.strictEqual(emittedTargetPaths.includes('index.ts.map'), true);
+        assert.strictEqual(emittedTargetPaths.includes('index.ts'), true);
+        const emittedMap = analyzed?.contents.find((resource) => {
+            return resource.fileDescription.targetFilePath === 'index.ts.map';
+        });
+        assert.ok(emittedMap !== undefined);
+        assert.notStrictEqual(emittedMap.fileDescription.content, originalMap);
+        const parsed = JSON.parse(emittedMap.fileDescription.content) as { mappings: string; version: number };
+        assert.strictEqual(parsed.version, 3);
+        assert.ok(parsed.mappings.length > 0);
+    });
+
+    test('eliminate keeps the paired source map untouched when no transformation occurs', async function () {
+        const eliminator = createTestEliminator();
+        const liveOnlyContent = 'export function live() { return 2; }';
+        const validMapContent = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            sources: ['index.ts'],
+            sourcesContent: [liveOnlyContent],
+            names: [],
+            // cspell:disable-next-line
+            mappings: 'AAAA,OAAO,SAAS,IAAI,IAAI,CAAC,OAAO,CAAC,CAAC,CAAC,CAAC'
+        });
+        const mapResource = {
+            ...bundleResource('/src/index.ts.map', { content: validMapContent, targetFilePath: 'index.ts.map' }),
+            isSubstituted: false
+        };
+        const bundle = bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: liveOnlyContent,
+            extraResources: [mapResource]
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const emittedMap = analyzed?.contents.find((resource) => {
+            return resource.fileDescription.targetFilePath === 'index.ts.map';
+        });
+        assert.ok(emittedMap !== undefined);
+        assert.strictEqual(emittedMap.fileDescription.content, validMapContent);
+    });
+
+    test('eliminate honours a root declaration file when seeding reachability', async function () {
+        const eliminator = createTestEliminator();
+        const declarationContent = 'export type Public = number;\nexport type Private = string;';
+        const declarationFile = {
+            content: declarationContent,
+            isExecutable: false,
+            sourceFilePath: '/src/index.d.ts',
+            targetFilePath: 'index.d.ts'
+        };
+        const resource = { ...bundleResource('/src/index.d.ts', declarationFile), isSubstituted: false };
+        const [analyzed] = await eliminator.eliminate(
+            inputs(
+                linkedBundle({
+                    name: 'pkg',
+                    contents: [resource],
+                    roots: {
+                        main: {
+                            js: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/src/index.js',
+                                targetFilePath: 'index.js'
+                            },
+                            declarationFile
                         }
                     },
-                    worker: {
-                        js: {
-                            content: '',
-                            isExecutable: false,
-                            sourceFilePath: '/src/worker.js',
-                            targetFilePath: 'worker.js'
+                    surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+                })
+            )
+        );
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['Public', 'Private']));
+    });
+
+    test('eliminate honours explicit private roots when seeding reachability', async function () {
+        const eliminator = createTestEliminator();
+        const mainResource = {
+            ...bundleResource('/src/index.js', { content: 'export const main = 1;\n', targetFilePath: 'index.js' }),
+            isSubstituted: false
+        };
+        const workerResource = {
+            ...bundleResource('/src/worker.js', {
+                content: 'export const workerPublic = 1;\nexport const workerPrivate = 2;\n',
+                targetFilePath: 'worker.js'
+            }),
+            isSubstituted: false
+        };
+        const [analyzed] = await eliminator.eliminate(
+            inputs(
+                linkedBundle({
+                    name: 'pkg',
+                    contents: [mainResource, workerResource],
+                    roots: {
+                        main: {
+                            js: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/src/index.js',
+                                targetFilePath: 'index.js'
+                            }
+                        },
+                        worker: {
+                            js: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/src/worker.js',
+                                targetFilePath: 'worker.js'
+                            }
+                        }
+                    },
+                    surface: {
+                        mode: 'explicit',
+                        packageInterface: {
+                            modules: [{ root: 'main', export: '.' }],
+                            privateRoots: ['worker']
                         }
                     }
-                },
-                surface: {
-                    mode: 'explicit',
-                    packageInterface: {
-                        modules: [{ root: 'main', export: '.' }],
-                        privateRoots: ['worker']
+                })
+            )
+        );
+        const emittedWorker = analyzed?.contents.find((resource) => {
+            return resource.fileDescription.sourceFilePath === '/src/worker.js';
+        });
+        assert.ok(emittedWorker !== undefined);
+        assert.deepStrictEqual(emittedWorker.analysis.survivingBindings, new Set(['workerPublic', 'workerPrivate']));
+    });
+
+    function producerBundleWith(helpersContent: string): LinkedBundle {
+        const producerHelpers = {
+            ...bundleResource('/producer/helpers.ts', { content: helpersContent, targetFilePath: 'helpers.ts' }),
+            isSubstituted: false
+        };
+        return linkedBundle({
+            name: 'producer',
+            contents: [producerHelpers],
+            roots: {
+                main: {
+                    js: {
+                        content: '',
+                        isExecutable: false,
+                        sourceFilePath: '/producer/index.js',
+                        targetFilePath: 'index.js'
                     }
                 }
-            })
-        )
-    );
-    const emittedWorker = analyzed?.contents.find((resource) => {
-        return resource.fileDescription.sourceFilePath === '/src/worker.js';
-    });
-    assert.ok(emittedWorker !== undefined);
-    assert.deepStrictEqual(emittedWorker.analysis.survivingBindings, new Set(['workerPublic', 'workerPrivate']));
-});
+            },
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        });
+    }
 
-function producerBundleWith(helpersContent: string): LinkedBundle {
-    const producerHelpers = {
-        ...bundleResource('/producer/helpers.ts', { content: helpersContent, targetFilePath: 'helpers.ts' }),
-        isSubstituted: false
-    };
-    return linkedBundle({
-        name: 'producer',
-        contents: [producerHelpers],
-        roots: {
-            main: {
-                js: {
-                    content: '',
-                    isExecutable: false,
-                    sourceFilePath: '/producer/index.js',
-                    targetFilePath: 'index.js'
+    function consumerBundleWith(content: string): LinkedBundle {
+        return bundleForCodeFile({
+            name: 'consumer',
+            sourceFilePath: '/consumer/index.ts',
+            targetFilePath: 'index.ts',
+            content
+        });
+    }
+
+    test('eliminate uses cross-bundle seeds to keep an exported function reachable when consumed by another bundle', async function () {
+        const eliminator = createTestEliminator();
+        const result = await eliminator.eliminate(
+            inputs(
+                consumerBundleWith(
+                    'import { used } from "producer/helpers.ts";\nexport function pub() { return used(); }'
+                ),
+                producerBundleWith('export function used() { return 1; }\nexport function unused() { return 2; }')
+            )
+        );
+        const producerEmitted = result[1]?.contents[0];
+        assert.ok(producerEmitted !== undefined);
+        assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), true);
+        assert.strictEqual(producerEmitted.fileDescription.content.includes('unused'), false);
+    });
+
+    test('eliminate keeps a runtime js dependency reachable even when a sibling declaration file is present', async function () {
+        const eliminator = createTestEliminator();
+        const entryResource = {
+            ...bundleResource('/src/index.js', {
+                content: 'import { used } from "./helpers.js";\nexport function live() { return used(); }',
+                targetFilePath: 'index.js'
+            }),
+            isSubstituted: false
+        };
+        const helperRuntimeResource = {
+            ...bundleResource('/src/helpers.js', {
+                content: 'export function used() { return 1; }\nexport function unused() { return 2; }',
+                targetFilePath: 'helpers.js'
+            }),
+            isSubstituted: false
+        };
+        const helperDeclarationResource = {
+            ...bundleResource('/src/helpers.d.ts', {
+                content: 'export declare function used(): number;\nexport declare function unused(): number;\n',
+                targetFilePath: 'helpers.d.ts'
+            }),
+            isSubstituted: false
+        };
+        const bundle = linkedBundle({
+            name: 'pkg',
+            contents: [entryResource, helperRuntimeResource, helperDeclarationResource],
+            roots: {
+                main: {
+                    js: {
+                        content: entryResource.fileDescription.content,
+                        isExecutable: false,
+                        sourceFilePath: '/src/index.js',
+                        targetFilePath: 'index.js'
+                    }
                 }
-            }
-        },
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+            },
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const runtimeHelper = analyzed?.contents.find((resource) => {
+            return resource.fileDescription.sourceFilePath === '/src/helpers.js';
+        });
+        assert.ok(runtimeHelper !== undefined);
+        assert.strictEqual(runtimeHelper.fileDescription.content.includes('used'), true);
+        assert.strictEqual(runtimeHelper.fileDescription.content.includes('unused'), false);
     });
-}
 
-function consumerBundleWith(content: string): LinkedBundle {
-    return bundleForCodeFile({
-        name: 'consumer',
-        sourceFilePath: '/consumer/index.ts',
-        targetFilePath: 'index.ts',
-        content
+    test('eliminate drops a producer binding whose only consumer-side reference is in unreachable code', async function () {
+        const eliminator = createTestEliminator();
+        const consumerContent = [
+            'import { used } from "producer/helpers.ts";',
+            'function dead() { return used(); }',
+            'export function pub() { return 1; }'
+        ].join('\n');
+        const result = await eliminator.eliminate(
+            inputs(consumerBundleWith(consumerContent), producerBundleWith('export function used() { return 1; }'))
+        );
+        const producerEmitted = result[1]?.contents[0];
+        assert.ok(producerEmitted !== undefined);
+        assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), false);
     });
-}
 
-test('eliminate uses cross-bundle seeds to keep an exported function reachable when consumed by another bundle', async () => {
-    const eliminator = createTestEliminator();
-    const result = await eliminator.eliminate(
-        inputs(
-            consumerBundleWith('import { used } from "producer/helpers.ts";\nexport function pub() { return used(); }'),
-            producerBundleWith('export function used() { return 1; }\nexport function unused() { return 2; }')
-        )
-    );
-    const producerEmitted = result[1]?.contents[0];
-    assert.ok(producerEmitted !== undefined);
-    assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), true);
-    assert.strictEqual(producerEmitted.fileDescription.content.includes('unused'), false);
-});
-
-test('eliminate keeps a runtime js dependency reachable even when a sibling declaration file is present', async () => {
-    const eliminator = createTestEliminator();
-    const entryResource = {
-        ...bundleResource('/src/index.js', {
-            content: 'import { used } from "./helpers.js";\nexport function live() { return used(); }',
-            targetFilePath: 'index.js'
-        }),
-        isSubstituted: false
-    };
-    const helperRuntimeResource = {
-        ...bundleResource('/src/helpers.js', {
-            content: 'export function used() { return 1; }\nexport function unused() { return 2; }',
-            targetFilePath: 'helpers.js'
-        }),
-        isSubstituted: false
-    };
-    const helperDeclarationResource = {
-        ...bundleResource('/src/helpers.d.ts', {
-            content: 'export declare function used(): number;\nexport declare function unused(): number;\n',
-            targetFilePath: 'helpers.d.ts'
-        }),
-        isSubstituted: false
-    };
-    const bundle = linkedBundle({
-        name: 'pkg',
-        contents: [entryResource, helperRuntimeResource, helperDeclarationResource],
-        roots: {
-            main: {
-                js: {
-                    content: entryResource.fileDescription.content,
-                    isExecutable: false,
-                    sourceFilePath: '/src/index.js',
-                    targetFilePath: 'index.js'
-                }
-            }
-        },
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+    test('eliminate keeps all declarations and reports them as surviving when the file has top-level side effects', async function () {
+        const eliminator = createTestEliminator();
+        const sideEffectContent = [
+            'function dead() { return 1; }',
+            'export function live() { return 2; }',
+            'console.log("init");'
+        ].join('\n');
+        const bundle = bundleForCodeFile({
+            name: 'pkg',
+            sourceFilePath: '/src/index.ts',
+            targetFilePath: 'index.ts',
+            content: sideEffectContent
+        });
+        const [analyzed] = await eliminator.eliminate(inputs(bundle));
+        const emitted = analyzed?.contents[0];
+        assert.ok(emitted !== undefined);
+        assert.strictEqual(emitted.fileDescription.content.includes('dead'), true);
+        assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['dead', 'live']));
     });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const runtimeHelper = analyzed?.contents.find((resource) => {
-        return resource.fileDescription.sourceFilePath === '/src/helpers.js';
-    });
-    assert.ok(runtimeHelper !== undefined);
-    assert.strictEqual(runtimeHelper.fileDescription.content.includes('used'), true);
-    assert.strictEqual(runtimeHelper.fileDescription.content.includes('unused'), false);
-});
-
-test('eliminate drops a producer binding whose only consumer-side reference is in unreachable code', async () => {
-    const eliminator = createTestEliminator();
-    const consumerContent = [
-        'import { used } from "producer/helpers.ts";',
-        'function dead() { return used(); }',
-        'export function pub() { return 1; }'
-    ].join('\n');
-    const result = await eliminator.eliminate(
-        inputs(consumerBundleWith(consumerContent), producerBundleWith('export function used() { return 1; }'))
-    );
-    const producerEmitted = result[1]?.contents[0];
-    assert.ok(producerEmitted !== undefined);
-    assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), false);
-});
-
-test('eliminate keeps all declarations and reports them as surviving when the file has top-level side effects', async () => {
-    const eliminator = createTestEliminator();
-    const sideEffectContent = [
-        'function dead() { return 1; }',
-        'export function live() { return 2; }',
-        'console.log("init");'
-    ].join('\n');
-    const bundle = bundleForCodeFile({
-        name: 'pkg',
-        sourceFilePath: '/src/index.ts',
-        targetFilePath: 'index.ts',
-        content: sideEffectContent
-    });
-    const [analyzed] = await eliminator.eliminate(inputs(bundle));
-    const emitted = analyzed?.contents[0];
-    assert.ok(emitted !== undefined);
-    assert.strictEqual(emitted.fileDescription.content.includes('dead'), true);
-    assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set(['dead', 'live']));
 });

--- a/source/dead-code-eliminator/expression-unwrapping.test.ts
+++ b/source/dead-code-eliminator/expression-unwrapping.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind, type Expression } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { unwrapExpression } from './expression-unwrapping.ts';
@@ -11,38 +11,40 @@ function firstInitializer(content: string): Expression {
     return variableStatement.getDeclarations()[0]!.getInitializerOrThrow();
 }
 
-test('unwrapExpression returns the same node when there are no wrapping expressions', () => {
-    const expression = firstInitializer('const a = 1;');
+suite('expression-unwrapping', function () {
+    test('unwrapExpression returns the same node when there are no wrapping expressions', function () {
+        const expression = firstInitializer('const a = 1;');
 
-    assert.strictEqual(unwrapExpression(expression), expression);
-});
+        assert.strictEqual(unwrapExpression(expression), expression);
+    });
 
-test('unwrapExpression strips parenthesized expressions', () => {
-    const result = unwrapExpression(firstInitializer('const a = (1);'));
+    test('unwrapExpression strips parenthesized expressions', function () {
+        const result = unwrapExpression(firstInitializer('const a = (1);'));
 
-    assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
-});
+        assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
+    });
 
-test('unwrapExpression strips as expressions', () => {
-    const result = unwrapExpression(firstInitializer('const a = 1 as number;'));
+    test('unwrapExpression strips as expressions', function () {
+        const result = unwrapExpression(firstInitializer('const a = 1 as number;'));
 
-    assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
-});
+        assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
+    });
 
-test('unwrapExpression strips satisfies expressions', () => {
-    const result = unwrapExpression(firstInitializer('const a = 1 satisfies number;'));
+    test('unwrapExpression strips satisfies expressions', function () {
+        const result = unwrapExpression(firstInitializer('const a = 1 satisfies number;'));
 
-    assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
-});
+        assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
+    });
 
-test('unwrapExpression strips non-null assertions', () => {
-    const result = unwrapExpression(firstInitializer('const a = (1 as number | undefined)!;'));
+    test('unwrapExpression strips non-null assertions', function () {
+        const result = unwrapExpression(firstInitializer('const a = (1 as number | undefined)!;'));
 
-    assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
-});
+        assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
+    });
 
-test('unwrapExpression strips multiple nested wrappers in a single pass', () => {
-    const result = unwrapExpression(firstInitializer('const a = ((1 as number) satisfies number);'));
+    test('unwrapExpression strips multiple nested wrappers in a single pass', function () {
+        const result = unwrapExpression(firstInitializer('const a = ((1 as number) satisfies number);'));
 
-    assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
+        assert.strictEqual(result.getKind(), SyntaxKind.NumericLiteral);
+    });
 });

--- a/source/dead-code-eliminator/imported-expression-origin.test.ts
+++ b/source/dead-code-eliminator/imported-expression-origin.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind, type Expression } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { resolveImportedExpressionOrigin } from './imported-expression-origin.ts';
@@ -20,62 +20,64 @@ function pureRecurseStub(): boolean {
     return true;
 }
 
-test('resolveImportedExpressionOrigin returns undefined for a literal identifier with no import binding', () => {
-    const expression = firstInitializer('const x = 1;\nconst a = x;');
+suite('imported-expression-origin', function () {
+    test('resolveImportedExpressionOrigin returns undefined for a literal identifier with no import binding', function () {
+        const expression = firstInitializer('const x = 1;\nconst a = x;');
 
-    assert.strictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), undefined);
-});
-
-test('resolveImportedExpressionOrigin resolves an identifier originating from a named import', () => {
-    const expression = firstInitializer('import { x } from "lib";\nconst a = x;');
-
-    assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
-        from: 'lib',
-        path: ['x']
+        assert.strictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), undefined);
     });
-});
 
-test('resolveImportedExpressionOrigin resolves a namespace import access to an empty path', () => {
-    const expression = firstInitializer('import * as ns from "lib";\nconst a = ns;');
+    test('resolveImportedExpressionOrigin resolves an identifier originating from a named import', function () {
+        const expression = firstInitializer('import { x } from "lib";\nconst a = x;');
 
-    assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
-        from: 'lib',
-        path: []
+        assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
+            from: 'lib',
+            path: ['x']
+        });
     });
-});
 
-test('resolveImportedExpressionOrigin resolves a default import to the "default" path entry', () => {
-    const expression = firstInitializer('import x from "lib";\nconst a = x;');
+    test('resolveImportedExpressionOrigin resolves a namespace import access to an empty path', function () {
+        const expression = firstInitializer('import * as ns from "lib";\nconst a = ns;');
 
-    assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
-        from: 'lib',
-        path: ['default']
+        assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
+            from: 'lib',
+            path: []
+        });
     });
-});
 
-test('resolveImportedExpressionOrigin appends property accesses onto the base import path', () => {
-    const expression = firstInitializer('import * as ns from "lib";\nconst a = ns.foo.bar;');
+    test('resolveImportedExpressionOrigin resolves a default import to the "default" path entry', function () {
+        const expression = firstInitializer('import x from "lib";\nconst a = x;');
 
-    assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
-        from: 'lib',
-        path: ['foo', 'bar']
+        assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
+            from: 'lib',
+            path: ['default']
+        });
     });
-});
 
-test('resolveImportedExpressionOrigin returns undefined for a call whose callee is not from a trusted import', () => {
-    const expression = firstInitializer('import { x } from "lib";\nconst a = x();');
+    test('resolveImportedExpressionOrigin appends property accesses onto the base import path', function () {
+        const expression = firstInitializer('import * as ns from "lib";\nconst a = ns.foo.bar;');
 
-    assert.strictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), undefined);
-});
+        assert.deepStrictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), {
+            from: 'lib',
+            path: ['foo', 'bar']
+        });
+    });
 
-test('resolveImportedExpressionOrigin returns the callee origin for a call whose callee is from a trusted import', () => {
-    const expression = firstInitializer('import { x } from "lib";\nconst a = x();');
+    test('resolveImportedExpressionOrigin returns undefined for a call whose callee is not from a trusted import', function () {
+        const expression = firstInitializer('import { x } from "lib";\nconst a = x();');
 
-    assert.deepStrictEqual(
-        resolveImportedExpressionOrigin(expression, pureRecurseStub, {
-            enabled: true,
-            pureImports: [{ from: 'lib' }]
-        }),
-        { from: 'lib', path: ['x'] }
-    );
+        assert.strictEqual(resolveImportedExpressionOrigin(expression, pureRecurseStub, undefined), undefined);
+    });
+
+    test('resolveImportedExpressionOrigin returns the callee origin for a call whose callee is from a trusted import', function () {
+        const expression = firstInitializer('import { x } from "lib";\nconst a = x();');
+
+        assert.deepStrictEqual(
+            resolveImportedExpressionOrigin(expression, pureRecurseStub, {
+                enabled: true,
+                pureImports: [{ from: 'lib' }]
+            }),
+            { from: 'lib', path: ['x'] }
+        );
+    });
 });

--- a/source/dead-code-eliminator/load-bundle.test.ts
+++ b/source/dead-code-eliminator/load-bundle.test.ts
@@ -1,40 +1,42 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { linkedBundle, bundleResource } from '../test-libraries/bundle-fixtures.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { loadBundle } from './load-bundle.ts';
 
-test('loadBundle() throws when the public surface references a missing root', () => {
-    const bundle = linkedBundle({
-        name: 'package-a',
-        roots: {
-            main: {
-                js: {
-                    sourceFilePath: '/src/index.js',
-                    targetFilePath: 'index.js',
-                    content: 'export const value = 1;\n',
-                    isExecutable: false
+suite('load-bundle', function () {
+    test('loadBundle() throws when the public surface references a missing root', function () {
+        const bundle = linkedBundle({
+            name: 'package-a',
+            roots: {
+                main: {
+                    js: {
+                        sourceFilePath: '/src/index.js',
+                        targetFilePath: 'index.js',
+                        content: 'export const value = 1;\n',
+                        isExecutable: false
+                    }
+                }
+            },
+            contents: [
+                {
+                    ...bundleResource('/src/index.js', {
+                        content: 'export const value = 1;\n',
+                        targetFilePath: 'index.js'
+                    }),
+                    isSubstituted: false
+                }
+            ],
+            surface: {
+                mode: 'explicit',
+                packageInterface: {
+                    modules: [{ root: 'missing', export: '.' }]
                 }
             }
-        },
-        contents: [
-            {
-                ...bundleResource('/src/index.js', {
-                    content: 'export const value = 1;\n',
-                    targetFilePath: 'index.js'
-                }),
-                isSubstituted: false
-            }
-        ],
-        surface: {
-            mode: 'explicit',
-            packageInterface: {
-                modules: [{ root: 'missing', export: '.' }]
-            }
-        }
-    });
+        });
 
-    assert.throws(() => {
-        loadBundle(createProject, { bundle, transformationsEnabled: true });
-    }, /^Error: Bundle "package-a" is missing root "missing" referenced by its entry surface$/u);
+        assert.throws(() => {
+            loadBundle(createProject, { bundle, transformationsEnabled: true });
+        }, /^Error: Bundle "package-a" is missing root "missing" referenced by its entry surface$/u);
+    });
 });

--- a/source/dead-code-eliminator/pure-expression.test.ts
+++ b/source/dead-code-eliminator/pure-expression.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind, type Expression } from 'ts-morph';
 import type { DeadCodeEliminationSettings } from '../config/dead-code-elimination-settings.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
@@ -17,61 +17,63 @@ function firstInitializer(content: string): Expression {
     throw new Error('no variable initializer found in test source');
 }
 
-test('isPureExpression returns true for a primitive literal', () => {
-    assert.strictEqual(isPureExpression(firstInitializer('const a = 1;'), undefined), true);
-});
+suite('pure-expression', function () {
+    test('isPureExpression returns true for a primitive literal', function () {
+        assert.strictEqual(isPureExpression(firstInitializer('const a = 1;'), undefined), true);
+    });
 
-test('isPureExpression returns true for a function expression', () => {
-    assert.strictEqual(isPureExpression(firstInitializer('const a = function () {};'), undefined), true);
-});
+    test('isPureExpression returns true for a function expression', function () {
+        assert.strictEqual(isPureExpression(firstInitializer('const a = function () {};'), undefined), true);
+    });
 
-test('isPureExpression returns true for an array literal of pure elements', () => {
-    assert.strictEqual(isPureExpression(firstInitializer('const a = [1, "x", true];'), undefined), true);
-});
+    test('isPureExpression returns true for an array literal of pure elements', function () {
+        assert.strictEqual(isPureExpression(firstInitializer('const a = [1, "x", true];'), undefined), true);
+    });
 
-test('isPureExpression returns false for an array literal containing a non-pure call', () => {
-    assert.strictEqual(isPureExpression(firstInitializer('const a = [Math.random()];'), undefined), false);
-});
+    test('isPureExpression returns false for an array literal containing a non-pure call', function () {
+        assert.strictEqual(isPureExpression(firstInitializer('const a = [Math.random()];'), undefined), false);
+    });
 
-test('isPureExpression returns true for an object literal of pure assignments', () => {
-    assert.strictEqual(
-        isPureExpression(firstInitializer('const a = { x: 1, get y() { return 2; } };'), undefined),
-        true
-    );
-});
+    test('isPureExpression returns true for an object literal of pure assignments', function () {
+        assert.strictEqual(
+            isPureExpression(firstInitializer('const a = { x: 1, get y() { return 2; } };'), undefined),
+            true
+        );
+    });
 
-test('isPureExpression returns true for a strict-equality binary expression of pure operands', () => {
-    assert.strictEqual(isPureExpression(firstInitializer('const a = 1 === 2;'), undefined), true);
-});
+    test('isPureExpression returns true for a strict-equality binary expression of pure operands', function () {
+        assert.strictEqual(isPureExpression(firstInitializer('const a = 1 === 2;'), undefined), true);
+    });
 
-test('isPureExpression returns false for a binary expression with a disallowed operator', () => {
-    assert.strictEqual(isPureExpression(firstInitializer('const a = 1 == 2;'), undefined), false);
-});
+    test('isPureExpression returns false for a binary expression with a disallowed operator', function () {
+        assert.strictEqual(isPureExpression(firstInitializer('const a = 1 == 2;'), undefined), false);
+    });
 
-test('isPureExpression returns false for a call expression to an unknown function', () => {
-    assert.strictEqual(
-        isPureExpression(firstInitializer('declare const f: () => number;\nconst a = f();'), undefined),
-        false
-    );
-});
+    test('isPureExpression returns false for a call expression to an unknown function', function () {
+        assert.strictEqual(
+            isPureExpression(firstInitializer('declare const f: () => number;\nconst a = f();'), undefined),
+            false
+        );
+    });
 
-test('isPureExpression returns true for a call to a function imported from a trusted pureImports entry', () => {
-    const settings: DeadCodeEliminationSettings = { enabled: true, pureImports: [{ from: 'lib' }] };
-    const expression = firstInitializer('import { x } from "lib";\nconst a = x();');
+    test('isPureExpression returns true for a call to a function imported from a trusted pureImports entry', function () {
+        const settings: DeadCodeEliminationSettings = { enabled: true, pureImports: [{ from: 'lib' }] };
+        const expression = firstInitializer('import { x } from "lib";\nconst a = x();');
 
-    assert.strictEqual(isPureExpression(expression, settings), true);
-});
+        assert.strictEqual(isPureExpression(expression, settings), true);
+    });
 
-test('isPureExpression returns true for a new expression of a trusted pureConstructor name', () => {
-    const settings: DeadCodeEliminationSettings = { enabled: true, pureConstructors: ['Foo'] };
-    const expression = firstInitializer('declare class Foo {}\nconst a = new Foo();');
+    test('isPureExpression returns true for a new expression of a trusted pureConstructor name', function () {
+        const settings: DeadCodeEliminationSettings = { enabled: true, pureConstructors: ['Foo'] };
+        const expression = firstInitializer('declare class Foo {}\nconst a = new Foo();');
 
-    assert.strictEqual(isPureExpression(expression, settings), true);
-});
+        assert.strictEqual(isPureExpression(expression, settings), true);
+    });
 
-test('isPureExpression returns false for a new expression whose constructor name is not on the trusted list', () => {
-    const settings: DeadCodeEliminationSettings = { enabled: true, pureConstructors: ['Foo'] };
-    const expression = firstInitializer('declare class Bar {}\nconst a = new Bar();');
+    test('isPureExpression returns false for a new expression whose constructor name is not on the trusted list', function () {
+        const settings: DeadCodeEliminationSettings = { enabled: true, pureConstructors: ['Foo'] };
+        const expression = firstInitializer('declare class Bar {}\nconst a = new Bar();');
 
-    assert.strictEqual(isPureExpression(expression, settings), false);
+        assert.strictEqual(isPureExpression(expression, settings), false);
+    });
 });

--- a/source/dead-code-eliminator/reachability/bfs-closure.test.ts
+++ b/source/dead-code-eliminator/reachability/bfs-closure.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { bfsClosure, type BfsClosureDependencies } from './bfs-closure.ts';
 
 const defaultDependencies: BfsClosureDependencies = {
@@ -25,56 +25,61 @@ function noNeighbors(): readonly string[] {
     return [];
 }
 
-test('bfsClosure returns just the seeds when the expand function yields no neighbors', () => {
-    assert.deepStrictEqual(runBfs(['a', 'b'], noNeighbors), new Set(['a', 'b']));
-});
+suite('bfs-closure', function () {
+    test('bfsClosure returns just the seeds when the expand function yields no neighbors', function () {
+        assert.deepStrictEqual(runBfs(['a', 'b'], noNeighbors), new Set(['a', 'b']));
+    });
 
-test('bfsClosure returns the initial visited set when no seeds are provided', () => {
-    assert.deepStrictEqual(runBfs([], noNeighbors, new Set(['pre-a'])), new Set(['pre-a']));
-});
+    test('bfsClosure returns the initial visited set when no seeds are provided', function () {
+        assert.deepStrictEqual(runBfs([], noNeighbors, new Set(['pre-a'])), new Set(['pre-a']));
+    });
 
-test('bfsClosure expands transitively through neighbors yielded by expand', () => {
-    assert.deepStrictEqual(runBfs(['a'], fromGraph({ a: ['b'], b: ['c'], c: [] })), new Set(['a', 'b', 'c']));
-});
+    test('bfsClosure expands transitively through neighbors yielded by expand', function () {
+        assert.deepStrictEqual(runBfs(['a'], fromGraph({ a: ['b'], b: ['c'], c: [] })), new Set(['a', 'b', 'c']));
+    });
 
-test('bfsClosure does not re-add neighbors that are already in the initial visited set', () => {
-    const expandedNeighbors = new Set<string>();
+    test('bfsClosure does not re-add neighbors that are already in the initial visited set', function () {
+        const expandedNeighbors = new Set<string>();
 
-    const result = runBfs(
-        ['a'],
-        (id) => {
-            const neighbors = id === 'a' ? ['b'] : [];
-            for (const neighbor of neighbors) {
-                expandedNeighbors.add(neighbor);
-            }
-            return neighbors;
-        },
-        new Set(['b'])
-    );
-
-    assert.deepStrictEqual(result, new Set(['a', 'b']));
-    assert.deepStrictEqual(expandedNeighbors, new Set(['b']));
-});
-
-test('bfsClosure terminates on cycles without revisiting visited nodes', () => {
-    assert.deepStrictEqual(runBfs(['a'], fromGraph({ a: ['b'], b: ['a', 'c'], c: [] })), new Set(['a', 'b', 'c']));
-});
-
-test('bfsClosure throws when the iteration budget is exhausted', () => {
-    let nextId = 0;
-    try {
-        runBfs(
-            ['root'],
-            () => {
-                const next = `${nextId}`;
-                nextId += 1;
-                return [next];
+        const result = runBfs(
+            ['a'],
+            (id) => {
+                const neighbors = id === 'a' ? ['b'] : [];
+                for (const neighbor of neighbors) {
+                    expandedNeighbors.add(neighbor);
+                }
+                return neighbors;
             },
-            new Set<string>(),
-            2
+            new Set(['b'])
         );
-        assert.fail('Expected bfsClosure() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Reachability traversal exceeded the maximum iteration budget');
-    }
+
+        assert.deepStrictEqual(result, new Set(['a', 'b']));
+        assert.deepStrictEqual(expandedNeighbors, new Set(['b']));
+    });
+
+    test('bfsClosure terminates on cycles without revisiting visited nodes', function () {
+        assert.deepStrictEqual(runBfs(['a'], fromGraph({ a: ['b'], b: ['a', 'c'], c: [] })), new Set(['a', 'b', 'c']));
+    });
+
+    test('bfsClosure throws when the iteration budget is exhausted', function () {
+        let nextId = 0;
+        try {
+            runBfs(
+                ['root'],
+                () => {
+                    const next = `${nextId}`;
+                    nextId += 1;
+                    return [next];
+                },
+                new Set<string>(),
+                2
+            );
+            assert.fail('Expected bfsClosure() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Reachability traversal exceeded the maximum iteration budget'
+            );
+        }
+    });
 });

--- a/source/dead-code-eliminator/reachability/binding-extractor.test.ts
+++ b/source/dead-code-eliminator/reachability/binding-extractor.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { extractTopLevelBindings } from './binding-extractor.ts';
 
@@ -17,142 +17,144 @@ function descriptors(content: string): readonly { readonly name: string; readonl
     });
 }
 
-test('extracts a function declaration name', () => {
-    assert.deepStrictEqual(names('function foo() {}'), ['foo']);
-});
+suite('binding-extractor', function () {
+    test('extracts a function declaration name', function () {
+        assert.deepStrictEqual(names('function foo() {}'), ['foo']);
+    });
 
-test('extracts a class declaration name', () => {
-    assert.deepStrictEqual(names('class Foo {}'), ['Foo']);
-});
+    test('extracts a class declaration name', function () {
+        assert.deepStrictEqual(names('class Foo {}'), ['Foo']);
+    });
 
-test('extracts an interface declaration name', () => {
-    assert.deepStrictEqual(names('interface Foo {}'), ['Foo']);
-});
+    test('extracts an interface declaration name', function () {
+        assert.deepStrictEqual(names('interface Foo {}'), ['Foo']);
+    });
 
-test('extracts a type alias name', () => {
-    assert.deepStrictEqual(names('type Foo = string;'), ['Foo']);
-});
+    test('extracts a type alias name', function () {
+        assert.deepStrictEqual(names('type Foo = string;'), ['Foo']);
+    });
 
-test('extracts an enum declaration name', () => {
-    assert.deepStrictEqual(names('enum Foo { A }'), ['Foo']);
-});
+    test('extracts an enum declaration name', function () {
+        assert.deepStrictEqual(names('enum Foo { A }'), ['Foo']);
+    });
 
-test('extracts a namespace declaration name', () => {
-    assert.deepStrictEqual(names('namespace Foo {}'), ['Foo']);
-});
+    test('extracts a namespace declaration name', function () {
+        assert.deepStrictEqual(names('namespace Foo {}'), ['Foo']);
+    });
 
-test('extracts every variable declarator name from a single statement', () => {
-    assert.deepStrictEqual(names('const a = 1, b = 2, c = 3;'), ['a', 'b', 'c']);
-});
+    test('extracts every variable declarator name from a single statement', function () {
+        assert.deepStrictEqual(names('const a = 1, b = 2, c = 3;'), ['a', 'b', 'c']);
+    });
 
-test('extracts every bound identifier from an object destructuring declaration', () => {
-    assert.deepStrictEqual(names('const { a, b: c, ...rest } = value;'), ['a', 'c', 'rest']);
-});
+    test('extracts every bound identifier from an object destructuring declaration', function () {
+        assert.deepStrictEqual(names('const { a, b: c, ...rest } = value;'), ['a', 'c', 'rest']);
+    });
 
-test('extracts every bound identifier from an array destructuring declaration', () => {
-    assert.deepStrictEqual(names('const [first, , third, ...rest] = value;'), ['first', 'third', 'rest']);
-});
+    test('extracts every bound identifier from an array destructuring declaration', function () {
+        assert.deepStrictEqual(names('const [first, , third, ...rest] = value;'), ['first', 'third', 'rest']);
+    });
 
-test('extracts the local name of a default import', () => {
-    assert.deepStrictEqual(names('import foo from "./other";'), ['foo']);
-});
+    test('extracts the local name of a default import', function () {
+        assert.deepStrictEqual(names('import foo from "./other";'), ['foo']);
+    });
 
-test('extracts the local name of a namespace import', () => {
-    assert.deepStrictEqual(names('import * as ns from "./other";'), ['ns']);
-});
+    test('extracts the local name of a namespace import', function () {
+        assert.deepStrictEqual(names('import * as ns from "./other";'), ['ns']);
+    });
 
-test('extracts named import bindings using their local names', () => {
-    assert.deepStrictEqual(names('import { foo, bar } from "./other";'), ['foo', 'bar']);
-});
+    test('extracts named import bindings using their local names', function () {
+        assert.deepStrictEqual(names('import { foo, bar } from "./other";'), ['foo', 'bar']);
+    });
 
-test('uses the alias when a named import is renamed', () => {
-    assert.deepStrictEqual(names('import { foo as bar } from "./other";'), ['bar']);
-});
+    test('uses the alias when a named import is renamed', function () {
+        assert.deepStrictEqual(names('import { foo as bar } from "./other";'), ['bar']);
+    });
 
-test('extracts default plus named imports together', () => {
-    assert.deepStrictEqual(names('import def, { foo } from "./other";'), ['def', 'foo']);
-});
+    test('extracts default plus named imports together', function () {
+        assert.deepStrictEqual(names('import def, { foo } from "./other";'), ['def', 'foo']);
+    });
 
-test('returns no bindings for an empty file', () => {
-    assert.deepStrictEqual(names(''), []);
-});
+    test('returns no bindings for an empty file', function () {
+        assert.deepStrictEqual(names(''), []);
+    });
 
-test('skips a default-exported anonymous function declaration without a name', () => {
-    assert.deepStrictEqual(names('export default function () {}'), []);
-});
+    test('skips a default-exported anonymous function declaration without a name', function () {
+        assert.deepStrictEqual(names('export default function () {}'), []);
+    });
 
-test('skips a default-exported anonymous class declaration without a name', () => {
-    assert.deepStrictEqual(names('export default class {}'), []);
-});
+    test('skips a default-exported anonymous class declaration without a name', function () {
+        assert.deepStrictEqual(names('export default class {}'), []);
+    });
 
-test('returns no bindings for a file with only impure top-level code', () => {
-    assert.deepStrictEqual(names('console.log("hi");'), []);
-});
+    test('returns no bindings for a file with only impure top-level code', function () {
+        assert.deepStrictEqual(names('console.log("hi");'), []);
+    });
 
-test('marks an exported function as exported', () => {
-    assert.deepStrictEqual(descriptors('export function foo() {}'), [{ name: 'foo', isExported: true }]);
-});
+    test('marks an exported function as exported', function () {
+        assert.deepStrictEqual(descriptors('export function foo() {}'), [{ name: 'foo', isExported: true }]);
+    });
 
-test('marks a default-exported function as exported', () => {
-    assert.deepStrictEqual(descriptors('export default function foo() {}'), [{ name: 'foo', isExported: true }]);
-});
+    test('marks a default-exported function as exported', function () {
+        assert.deepStrictEqual(descriptors('export default function foo() {}'), [{ name: 'foo', isExported: true }]);
+    });
 
-test('marks an ESM default export assignment as exported', () => {
-    assert.deepStrictEqual(descriptors('const foo = 1;\nexport default foo;'), [
-        { name: 'foo', isExported: false },
-        { name: 'default', isExported: true }
-    ]);
-});
+    test('marks an ESM default export assignment as exported', function () {
+        assert.deepStrictEqual(descriptors('const foo = 1;\nexport default foo;'), [
+            { name: 'foo', isExported: false },
+            { name: 'default', isExported: true }
+        ]);
+    });
 
-test('skips CommonJS export-equals assignments because they do not create an ESM binding', () => {
-    assert.deepStrictEqual(names('const foo = 1;\nexport = foo;'), ['foo']);
-});
+    test('skips CommonJS export-equals assignments because they do not create an ESM binding', function () {
+        assert.deepStrictEqual(names('const foo = 1;\nexport = foo;'), ['foo']);
+    });
 
-test('marks an exported class as exported', () => {
-    assert.deepStrictEqual(descriptors('export class Foo {}'), [{ name: 'Foo', isExported: true }]);
-});
+    test('marks an exported class as exported', function () {
+        assert.deepStrictEqual(descriptors('export class Foo {}'), [{ name: 'Foo', isExported: true }]);
+    });
 
-test('marks every declarator of an exported variable statement as exported', () => {
-    assert.deepStrictEqual(descriptors('export const a = 1, b = 2;'), [
-        { name: 'a', isExported: true },
-        { name: 'b', isExported: true }
-    ]);
-});
+    test('marks every declarator of an exported variable statement as exported', function () {
+        assert.deepStrictEqual(descriptors('export const a = 1, b = 2;'), [
+            { name: 'a', isExported: true },
+            { name: 'b', isExported: true }
+        ]);
+    });
 
-test('marks every bound identifier of an exported destructuring statement as exported', () => {
-    assert.deepStrictEqual(descriptors('export const { a, b: c } = value;'), [
-        { name: 'a', isExported: true },
-        { name: 'c', isExported: true }
-    ]);
-});
+    test('marks every bound identifier of an exported destructuring statement as exported', function () {
+        assert.deepStrictEqual(descriptors('export const { a, b: c } = value;'), [
+            { name: 'a', isExported: true },
+            { name: 'c', isExported: true }
+        ]);
+    });
 
-test('marks an unexported function as not exported', () => {
-    assert.deepStrictEqual(descriptors('function foo() {}'), [{ name: 'foo', isExported: false }]);
-});
+    test('marks an unexported function as not exported', function () {
+        assert.deepStrictEqual(descriptors('function foo() {}'), [{ name: 'foo', isExported: false }]);
+    });
 
-test('marks imports as not exported', () => {
-    assert.deepStrictEqual(descriptors('import { foo } from "./other";'), [{ name: 'foo', isExported: false }]);
-});
+    test('marks imports as not exported', function () {
+        assert.deepStrictEqual(descriptors('import { foo } from "./other";'), [{ name: 'foo', isExported: false }]);
+    });
 
-test('marks a default import as not exported', () => {
-    assert.deepStrictEqual(descriptors('import foo from "./other";'), [{ name: 'foo', isExported: false }]);
-});
+    test('marks a default import as not exported', function () {
+        assert.deepStrictEqual(descriptors('import foo from "./other";'), [{ name: 'foo', isExported: false }]);
+    });
 
-test('marks a namespace import as not exported', () => {
-    assert.deepStrictEqual(descriptors('import * as ns from "./other";'), [{ name: 'ns', isExported: false }]);
-});
+    test('marks a namespace import as not exported', function () {
+        assert.deepStrictEqual(descriptors('import * as ns from "./other";'), [{ name: 'ns', isExported: false }]);
+    });
 
-test('extracts bindings from a mixed file in declaration order', () => {
-    assert.deepStrictEqual(
-        names(
-            [
-                'import { dep } from "./other";',
-                'const helper = 1;',
-                'function pub() {}',
-                'export class Public {}',
-                'type Alias = string;'
-            ].join('\n')
-        ),
-        ['dep', 'helper', 'pub', 'Public', 'Alias']
-    );
+    test('extracts bindings from a mixed file in declaration order', function () {
+        assert.deepStrictEqual(
+            names(
+                [
+                    'import { dep } from "./other";',
+                    'const helper = 1;',
+                    'function pub() {}',
+                    'export class Public {}',
+                    'type Alias = string;'
+                ].join('\n')
+            ),
+            ['dep', 'helper', 'pub', 'Public', 'Alias']
+        );
+    });
 });

--- a/source/dead-code-eliminator/reachability/binding-id.test.ts
+++ b/source/dead-code-eliminator/reachability/binding-id.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { Node as TsMorphNode, Statement } from 'ts-morph';
 import {
     bindingId,
@@ -32,38 +32,40 @@ function fileBindings(sourceFilePath: string, bindings: readonly BindingDescript
     return { sourceFilePath, bindings };
 }
 
-test('bindingId joins the file path and name with a double colon delimiter', () => {
-    assert.strictEqual(bindingId('/src/a.ts', 'foo'), '/src/a.ts::foo');
-});
+suite('binding-id', function () {
+    test('bindingId joins the file path and name with a double colon delimiter', function () {
+        assert.strictEqual(bindingId('/src/a.ts', 'foo'), '/src/a.ts::foo');
+    });
 
-test('buildDeclarationNodeIndex maps every declaration node to its binding id', () => {
-    const declarationA = { id: 'decl-a' };
-    const declarationB = { id: 'decl-b' };
+    test('buildDeclarationNodeIndex maps every declaration node to its binding id', function () {
+        const declarationA = { id: 'decl-a' };
+        const declarationB = { id: 'decl-b' };
 
-    const a = descriptor('a', { declarationNode: declarationA as unknown as TsMorphNode });
+        const a = descriptor('a', { declarationNode: declarationA as unknown as TsMorphNode });
 
-    const b = descriptor('b', { declarationNode: declarationB as unknown as TsMorphNode });
-    const index = buildDeclarationNodeIndex([fileBindings('/src/a.ts', [a, b])]);
-    assert.strictEqual(index.get(declarationA as unknown as TsMorphNode), '/src/a.ts::a');
+        const b = descriptor('b', { declarationNode: declarationB as unknown as TsMorphNode });
+        const index = buildDeclarationNodeIndex([fileBindings('/src/a.ts', [a, b])]);
+        assert.strictEqual(index.get(declarationA as unknown as TsMorphNode), '/src/a.ts::a');
 
-    assert.strictEqual(index.get(declarationB as unknown as TsMorphNode), '/src/a.ts::b');
-});
+        assert.strictEqual(index.get(declarationB as unknown as TsMorphNode), '/src/a.ts::b');
+    });
 
-test('buildBindingsByFile groups binding ids by their source file', () => {
-    const result = buildBindingsByFile([
-        fileBindings('/src/a.ts', [descriptor('a'), descriptor('b')]),
-        fileBindings('/src/b.ts', [descriptor('c')])
-    ]);
+    test('buildBindingsByFile groups binding ids by their source file', function () {
+        const result = buildBindingsByFile([
+            fileBindings('/src/a.ts', [descriptor('a'), descriptor('b')]),
+            fileBindings('/src/b.ts', [descriptor('c')])
+        ]);
 
-    assert.deepStrictEqual(result.get('/src/a.ts'), new Set(['/src/a.ts::a', '/src/a.ts::b']));
-    assert.deepStrictEqual(result.get('/src/b.ts'), new Set(['/src/b.ts::c']));
-});
+        assert.deepStrictEqual(result.get('/src/a.ts'), new Set(['/src/a.ts::a', '/src/a.ts::b']));
+        assert.deepStrictEqual(result.get('/src/b.ts'), new Set(['/src/b.ts::c']));
+    });
 
-test('buildNodeById maps every binding id back to its reference node', () => {
-    const referenceA = { id: 'ref-a' };
+    test('buildNodeById maps every binding id back to its reference node', function () {
+        const referenceA = { id: 'ref-a' };
 
-    const a = descriptor('a', { referenceNode: referenceA as unknown as TsMorphNode });
-    const map = buildNodeById([fileBindings('/src/a.ts', [a])]);
+        const a = descriptor('a', { referenceNode: referenceA as unknown as TsMorphNode });
+        const map = buildNodeById([fileBindings('/src/a.ts', [a])]);
 
-    assert.strictEqual(map.get('/src/a.ts::a'), referenceA as unknown as TsMorphNode);
+        assert.strictEqual(map.get('/src/a.ts::a'), referenceA as unknown as TsMorphNode);
+    });
 });

--- a/source/dead-code-eliminator/reachability/identifier-target-collector.test.ts
+++ b/source/dead-code-eliminator/reachability/identifier-target-collector.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { SyntaxKind, type Node as TsMorphNode, type SourceFile } from 'ts-morph';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { collectIdentifierTargets, type DeclarationNodeIndex } from './identifier-target-collector.ts';
 
@@ -18,34 +18,36 @@ function indexedDeclaration(sourceFile: SourceFile, statementOffset: number, bin
     return new Map<TsMorphNode, string>([[declaration, bindingId]]);
 }
 
-test('collectIdentifierTargets returns an empty set when the root has no identifiers', () => {
-    assert.deepStrictEqual(collectIdentifierTargets(rootSourceFile(''), new Map()), new Set<string>());
-});
+suite('identifier-target-collector', function () {
+    test('collectIdentifierTargets returns an empty set when the root has no identifiers', function () {
+        assert.deepStrictEqual(collectIdentifierTargets(rootSourceFile(''), new Map()), new Set<string>());
+    });
 
-test('collectIdentifierTargets returns an empty set when no identifier matches a known declaration', () => {
-    const sourceFile = rootSourceFile('const x = 1;\nconsole.log(x);');
+    test('collectIdentifierTargets returns an empty set when no identifier matches a known declaration', function () {
+        const sourceFile = rootSourceFile('const x = 1;\nconsole.log(x);');
 
-    assert.deepStrictEqual(collectIdentifierTargets(sourceFile, new Map()), new Set<string>());
-});
+        assert.deepStrictEqual(collectIdentifierTargets(sourceFile, new Map()), new Set<string>());
+    });
 
-test('collectIdentifierTargets maps each identifier symbol back to its declaration id when indexed', () => {
-    const sourceFile = rootSourceFile('const x = 1;\nconst y = x;');
-    const declarationIndex = indexedDeclaration(sourceFile, 0, '/index.ts::x');
+    test('collectIdentifierTargets maps each identifier symbol back to its declaration id when indexed', function () {
+        const sourceFile = rootSourceFile('const x = 1;\nconst y = x;');
+        const declarationIndex = indexedDeclaration(sourceFile, 0, '/index.ts::x');
 
-    const targets = collectIdentifierTargets(sourceFile, declarationIndex);
+        const targets = collectIdentifierTargets(sourceFile, declarationIndex);
 
-    assert.strictEqual(targets.has('/index.ts::x'), true);
-});
+        assert.strictEqual(targets.has('/index.ts::x'), true);
+    });
 
-test('collectIdentifierTargets follows shorthand property assignments to the referenced symbol', () => {
-    const sourceFile = rootSourceFile('const x = 1;\nconst obj = { x };');
-    const declarationIndex = indexedDeclaration(sourceFile, 0, '/index.ts::x');
-    const objStatement = sourceFile.getStatements()[1];
-    if (objStatement === undefined) {
-        assert.fail('expected obj declaration statement');
-    }
+    test('collectIdentifierTargets follows shorthand property assignments to the referenced symbol', function () {
+        const sourceFile = rootSourceFile('const x = 1;\nconst obj = { x };');
+        const declarationIndex = indexedDeclaration(sourceFile, 0, '/index.ts::x');
+        const objStatement = sourceFile.getStatements()[1];
+        if (objStatement === undefined) {
+            assert.fail('expected obj declaration statement');
+        }
 
-    const targets = collectIdentifierTargets(objStatement, declarationIndex);
+        const targets = collectIdentifierTargets(objStatement, declarationIndex);
 
-    assert.strictEqual(targets.has('/index.ts::x'), true);
+        assert.strictEqual(targets.has('/index.ts::x'), true);
+    });
 });

--- a/source/dead-code-eliminator/reachability/impure-statements.test.ts
+++ b/source/dead-code-eliminator/reachability/impure-statements.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Node as TsMorphNode } from 'ts-morph';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { collectImpureStatements } from './impure-statements.ts';
@@ -12,22 +12,24 @@ function impureLinesFor(content: string): readonly number[] {
     });
 }
 
-test('collectImpureStatements returns no statements for a file with only pure declarations', () => {
-    assert.deepStrictEqual(impureLinesFor('export const x = 1;\nexport function f() { return 1; }'), []);
-});
-
-test('collectImpureStatements flags top-level side-effecting expression statements', () => {
-    assert.deepStrictEqual(impureLinesFor('console.log("hi");'), [1]);
-});
-
-test('collectImpureStatements excludes import declarations even when classified as side-effecting', () => {
-    const project = createProject({
-        withFiles: [{ filePath: '/source.ts', content: 'import "./side-effect.ts";\nconsole.log("hi");' }]
+suite('impure-statements', function () {
+    test('collectImpureStatements returns no statements for a file with only pure declarations', function () {
+        assert.deepStrictEqual(impureLinesFor('export const x = 1;\nexport function f() { return 1; }'), []);
     });
-    const sourceFile = project.getSourceFileOrThrow('/source.ts');
 
-    const impure = collectImpureStatements(sourceFile, undefined);
+    test('collectImpureStatements flags top-level side-effecting expression statements', function () {
+        assert.deepStrictEqual(impureLinesFor('console.log("hi");'), [1]);
+    });
 
-    assert.strictEqual(impure.length, 1);
-    assert.strictEqual(TsMorphNode.isImportDeclaration(impure[0]), false);
+    test('collectImpureStatements excludes import declarations even when classified as side-effecting', function () {
+        const project = createProject({
+            withFiles: [{ filePath: '/source.ts', content: 'import "./side-effect.ts";\nconsole.log("hi");' }]
+        });
+        const sourceFile = project.getSourceFileOrThrow('/source.ts');
+
+        const impure = collectImpureStatements(sourceFile, undefined);
+
+        assert.strictEqual(impure.length, 1);
+        assert.strictEqual(TsMorphNode.isImportDeclaration(impure[0]), false);
+    });
 });

--- a/source/dead-code-eliminator/reachability/local-seed-gathering.test.ts
+++ b/source/dead-code-eliminator/reachability/local-seed-gathering.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import type { Node as TsMorphNode, SourceFile, Statement } from 'ts-morph';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import type { BindingDescriptor } from './binding-extractor.ts';
 import { buildDeclarationNodeIndex } from './binding-id.ts';
@@ -34,43 +34,45 @@ function exportedBinding(name: string, declarationNode: TsMorphNode): BindingDes
     };
 }
 
-test('gatherLocalSeeds adds entry-point exported bindings to the seed set', () => {
-    const sourceFile = sourceFileFor('export const foo = 1;');
-    const declaration = sourceFile.getVariableDeclarationOrThrow('foo');
-    const binding = exportedBinding('foo', declaration);
-    const file = fileBindings('/index.ts', sourceFile, [binding]);
+suite('local-seed-gathering', function () {
+    test('gatherLocalSeeds adds entry-point exported bindings to the seed set', function () {
+        const sourceFile = sourceFileFor('export const foo = 1;');
+        const declaration = sourceFile.getVariableDeclarationOrThrow('foo');
+        const binding = exportedBinding('foo', declaration);
+        const file = fileBindings('/index.ts', sourceFile, [binding]);
 
-    const seeds = gatherLocalSeeds([file], new Set(['/index.ts']), buildDeclarationNodeIndex([file]), undefined);
+        const seeds = gatherLocalSeeds([file], new Set(['/index.ts']), buildDeclarationNodeIndex([file]), undefined);
 
-    assert.strictEqual(seeds.has('/index.ts::foo'), true);
-});
+        assert.strictEqual(seeds.has('/index.ts::foo'), true);
+    });
 
-test('gatherLocalSeeds ignores exported bindings of non-entry-point files', () => {
-    const sourceFile = sourceFileFor('export const foo = 1;');
-    const declaration = sourceFile.getVariableDeclarationOrThrow('foo');
-    const binding = exportedBinding('foo', declaration);
-    const file = fileBindings('/lib.ts', sourceFile, [binding]);
+    test('gatherLocalSeeds ignores exported bindings of non-entry-point files', function () {
+        const sourceFile = sourceFileFor('export const foo = 1;');
+        const declaration = sourceFile.getVariableDeclarationOrThrow('foo');
+        const binding = exportedBinding('foo', declaration);
+        const file = fileBindings('/lib.ts', sourceFile, [binding]);
 
-    const seeds = gatherLocalSeeds([file], new Set(['/index.ts']), buildDeclarationNodeIndex([file]), undefined);
+        const seeds = gatherLocalSeeds([file], new Set(['/index.ts']), buildDeclarationNodeIndex([file]), undefined);
 
-    assert.strictEqual(seeds.has('/lib.ts::foo'), false);
-});
+        assert.strictEqual(seeds.has('/lib.ts::foo'), false);
+    });
 
-test('gatherLocalSeeds returns an empty set when the bundle has no impure statements and no entry exports', () => {
-    const sourceFile = sourceFileFor('const foo = 1;');
-    const declaration = sourceFile.getVariableDeclarationOrThrow('foo');
-    const binding: BindingDescriptor = {
-        name: 'foo',
-        isExported: false,
+    test('gatherLocalSeeds returns an empty set when the bundle has no impure statements and no entry exports', function () {
+        const sourceFile = sourceFileFor('const foo = 1;');
+        const declaration = sourceFile.getVariableDeclarationOrThrow('foo');
+        const binding: BindingDescriptor = {
+            name: 'foo',
+            isExported: false,
 
-        statement: statementStub as unknown as Statement,
-        declarationNode: declaration,
+            statement: statementStub as unknown as Statement,
+            declarationNode: declaration,
 
-        referenceNode: referenceStub as unknown as TsMorphNode
-    };
-    const file = fileBindings('/index.ts', sourceFile, [binding]);
+            referenceNode: referenceStub as unknown as TsMorphNode
+        };
+        const file = fileBindings('/index.ts', sourceFile, [binding]);
 
-    const seeds = gatherLocalSeeds([file], new Set<string>(), buildDeclarationNodeIndex([file]), undefined);
+        const seeds = gatherLocalSeeds([file], new Set<string>(), buildDeclarationNodeIndex([file]), undefined);
 
-    assert.deepStrictEqual(seeds, new Set<string>());
+        assert.deepStrictEqual(seeds, new Set<string>());
+    });
 });

--- a/source/dead-code-eliminator/reachability/reachability.test.ts
+++ b/source/dead-code-eliminator/reachability/reachability.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { runNodeProbe } from '../../test-libraries/run-node-probe.ts';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { extractTopLevelBindings } from './binding-extractor.ts';
@@ -27,241 +27,249 @@ function multiFileBindingsFor(
     });
 }
 
-test('keeps every exported entry-point binding reachable', () => {
-    const files = [fileBindingsFor('entry.ts', 'export function pub() {}\nexport class Pub {}')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+suite('reachability', function () {
+    test('keeps every exported entry-point binding reachable', function () {
+        const files = [fileBindingsFor('entry.ts', 'export function pub() {}\nexport class Pub {}')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'pub')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'Pub')));
-});
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'pub')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'Pub')));
+    });
 
-test('does not keep an unexported and unused helper reachable', () => {
-    const files = [fileBindingsFor('entry.ts', 'function helper() {}\nexport function pub() { return 1; }')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+    test('does not keep an unexported and unused helper reachable', function () {
+        const files = [fileBindingsFor('entry.ts', 'function helper() {}\nexport function pub() { return 1; }')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'helper')), false);
-});
+        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'helper')), false);
+    });
 
-test('keeps an unexported helper reachable when an exported binding references it', () => {
-    const files = [
-        fileBindingsFor('entry.ts', 'function helper() { return 1; }\nexport function pub() { return helper(); }')
-    ];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+    test('keeps an unexported helper reachable when an exported binding references it', function () {
+        const files = [
+            fileBindingsFor('entry.ts', 'function helper() { return 1; }\nexport function pub() { return helper(); }')
+        ];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'helper')));
-});
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'helper')));
+    });
 
-test('keeps the whole destructuring declarator reachable when an exported binding references one of its bindings', () => {
-    const files = [
-        fileBindingsFor(
-            'entry.ts',
-            'const { helper, other } = { helper() { return 1; }, other() { return 2; } };\nexport function pub() { return helper(); }'
-        )
-    ];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+    test('keeps the whole destructuring declarator reachable when an exported binding references one of its bindings', function () {
+        const files = [
+            fileBindingsFor(
+                'entry.ts',
+                'const { helper, other } = { helper() { return 1; }, other() { return 2; } };\nexport function pub() { return helper(); }'
+            )
+        ];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'helper')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'other')));
-});
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'helper')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'other')));
+    });
 
-test('keeps a destructuring initializer reachable when an exported destructured binding is live', () => {
-    const files = [
-        fileBindingsFor(
-            'entry.ts',
-            'function createApi() { return { publish() { return 1; } }; }\nconst api = createApi();\nexport const { publish } = api;'
-        )
-    ];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+    test('keeps a destructuring initializer reachable when an exported destructured binding is live', function () {
+        const files = [
+            fileBindingsFor(
+                'entry.ts',
+                'function createApi() { return { publish() { return 1; } }; }\nconst api = createApi();\nexport const { publish } = api;'
+            )
+        ];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'publish')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'api')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'createApi')));
-});
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'publish')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'api')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'createApi')));
+    });
 
-test('keeps shorthand property value bindings reachable when an exported object literal uses them', () => {
-    const files = [
-        fileBindingsFor(
-            'entry.ts',
-            'const globalSchema = 1;\nconst perPackageSchema = 2;\nfunction run() { return 3; }\nexport const rule = { globalSchema, perPackageSchema, run };'
-        )
-    ];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+    test('keeps shorthand property value bindings reachable when an exported object literal uses them', function () {
+        const files = [
+            fileBindingsFor(
+                'entry.ts',
+                'const globalSchema = 1;\nconst perPackageSchema = 2;\nfunction run() { return 3; }\nexport const rule = { globalSchema, perPackageSchema, run };'
+            )
+        ];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'rule')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'globalSchema')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'perPackageSchema')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'run')));
-});
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'rule')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'globalSchema')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'perPackageSchema')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'run')));
+    });
 
-test('ignores shorthand properties whose value symbol cannot be resolved', () => {
-    const files = [fileBindingsFor('entry.ts', 'export const rule = { missing };')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+    test('ignores shorthand properties whose value symbol cannot be resolved', function () {
+        const files = [fileBindingsFor('entry.ts', 'export const rule = { missing };')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'rule')));
-    assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'missing')), false);
-});
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'rule')));
+        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'missing')), false);
+    });
 
-test('keeps cross-file imports reachable when an entry-point uses them', () => {
-    const files = multiFileBindingsFor([
-        {
-            filePath: 'entry.ts',
-            content: 'import { used } from "./helpers.ts";\nexport function pub() { return used(); }'
-        },
-        {
-            filePath: 'helpers.ts',
-            content: 'export function used() { return 1; }\nexport function unused() { return 2; }'
-        }
-    ]);
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-
-    assert.ok(index.localReachable.has(bindingId('helpers.ts', 'used')));
-    assert.strictEqual(index.localReachable.has(bindingId('helpers.ts', 'unused')), false);
-});
-
-test('keeps every binding reachable that an impure top-level statement references', () => {
-    const files = [fileBindingsFor('entry.ts', 'function setup() {}\nfunction unused() {}\nsetup();')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'setup')));
-    assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'unused')), false);
-});
-
-test('preserves helpers transitively reached through internal calls', () => {
-    const content = [
-        'function deep() { return 1; }',
-        'function middle() { return deep(); }',
-        'export function top() { return middle(); }'
-    ].join('\n');
-    const files = [fileBindingsFor('entry.ts', content)];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'deep')));
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'middle')));
-});
-
-test('expandWith honours external seeds passed in by callers', () => {
-    const files = [fileBindingsFor('lib.ts', 'export function used() {}\nexport function unused() {}')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
-    const reachable = index.expandWith(new Set([bindingId('lib.ts', 'used')]));
-
-    assert.ok(reachable.has(bindingId('lib.ts', 'used')));
-    assert.strictEqual(reachable.has(bindingId('lib.ts', 'unused')), false);
-});
-
-test('returns no reachable bindings when no entry points and no external seeds are given', () => {
-    const files = [fileBindingsFor('lib.ts', 'export function isolated() {}')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
-
-    assert.strictEqual(index.localReachable.size, 0);
-});
-
-test('expandWith tolerates external seeds that do not exist in the bundle edge map', () => {
-    const files = [fileBindingsFor('lib.ts', 'export function used() {}')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
-    const reachable = index.expandWith(new Set([bindingId('not-in-bundle.ts', 'mystery')]));
-
-    assert.ok(reachable.has(bindingId('not-in-bundle.ts', 'mystery')));
-    assert.strictEqual(reachable.size, 1);
-});
-
-test('expandWith returns the localReachable set unchanged when given no external seeds', () => {
-    const files = [fileBindingsFor('entry.ts', 'export function pub() { return 1; }')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-
-    assert.strictEqual(index.expandWith(undefined), index.localReachable);
-    assert.strictEqual(index.expandWith(new Set<string>()), index.localReachable);
-});
-
-test('expandWith preserves localReachable bindings that the external seeds do not transitively reach', () => {
-    const files = [
-        fileBindingsFor('entry.ts', 'export function pub() { return 1; }\nexport function other() { return 2; }')
-    ];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-    const reachable = index.expandWith(new Set([bindingId('entry.ts', 'pub')]));
-
-    assert.ok(reachable.has(bindingId('entry.ts', 'pub')));
-    assert.ok(reachable.has(bindingId('entry.ts', 'other')));
-});
-
-test('expandWith reuses the injected visitedHas dependency', () => {
-    const files = [
-        fileBindingsFor('entry.ts', 'function helper() { return pub(); }\nexport function pub() { return helper(); }')
-    ];
-    const index = buildReachabilityIndex(
-        { files, entryPointFilePaths: new Set<string>() },
-        {
-            visitedHas(visited, value) {
-                if (typeof value === 'string' && value.includes('::')) {
-                    return false;
-                }
-                return visited.has(value);
+    test('keeps cross-file imports reachable when an entry-point uses them', function () {
+        const files = multiFileBindingsFor([
+            {
+                filePath: 'entry.ts',
+                content: 'import { used } from "./helpers.ts";\nexport function pub() { return used(); }'
+            },
+            {
+                filePath: 'helpers.ts',
+                content: 'export function used() { return 1; }\nexport function unused() { return 2; }'
             }
-        }
-    );
+        ]);
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-    assert.throws(() => {
-        index.expandWith(new Set([bindingId('entry.ts', 'pub')]));
-    }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
+        assert.ok(index.localReachable.has(bindingId('helpers.ts', 'used')));
+        assert.strictEqual(index.localReachable.has(bindingId('helpers.ts', 'unused')), false);
+    });
+
+    test('keeps every binding reachable that an impure top-level statement references', function () {
+        const files = [fileBindingsFor('entry.ts', 'function setup() {}\nfunction unused() {}\nsetup();')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'setup')));
+        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'unused')), false);
+    });
+
+    test('preserves helpers transitively reached through internal calls', function () {
+        const content = [
+            'function deep() { return 1; }',
+            'function middle() { return deep(); }',
+            'export function top() { return middle(); }'
+        ].join('\n');
+        const files = [fileBindingsFor('entry.ts', content)];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'deep')));
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'middle')));
+    });
+
+    test('expandWith honours external seeds passed in by callers', function () {
+        const files = [fileBindingsFor('lib.ts', 'export function used() {}\nexport function unused() {}')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
+        const reachable = index.expandWith(new Set([bindingId('lib.ts', 'used')]));
+
+        assert.ok(reachable.has(bindingId('lib.ts', 'used')));
+        assert.strictEqual(reachable.has(bindingId('lib.ts', 'unused')), false);
+    });
+
+    test('returns no reachable bindings when no entry points and no external seeds are given', function () {
+        const files = [fileBindingsFor('lib.ts', 'export function isolated() {}')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
+
+        assert.strictEqual(index.localReachable.size, 0);
+    });
+
+    test('expandWith tolerates external seeds that do not exist in the bundle edge map', function () {
+        const files = [fileBindingsFor('lib.ts', 'export function used() {}')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
+        const reachable = index.expandWith(new Set([bindingId('not-in-bundle.ts', 'mystery')]));
+
+        assert.ok(reachable.has(bindingId('not-in-bundle.ts', 'mystery')));
+        assert.strictEqual(reachable.size, 1);
+    });
+
+    test('expandWith returns the localReachable set unchanged when given no external seeds', function () {
+        const files = [fileBindingsFor('entry.ts', 'export function pub() { return 1; }')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+
+        assert.strictEqual(index.expandWith(undefined), index.localReachable);
+        assert.strictEqual(index.expandWith(new Set<string>()), index.localReachable);
+    });
+
+    test('expandWith preserves localReachable bindings that the external seeds do not transitively reach', function () {
+        const files = [
+            fileBindingsFor('entry.ts', 'export function pub() { return 1; }\nexport function other() { return 2; }')
+        ];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+        const reachable = index.expandWith(new Set([bindingId('entry.ts', 'pub')]));
+
+        assert.ok(reachable.has(bindingId('entry.ts', 'pub')));
+        assert.ok(reachable.has(bindingId('entry.ts', 'other')));
+    });
+
+    test('expandWith reuses the injected visitedHas dependency', function () {
+        const files = [
+            fileBindingsFor(
+                'entry.ts',
+                'function helper() { return pub(); }\nexport function pub() { return helper(); }'
+            )
+        ];
+        const index = buildReachabilityIndex(
+            { files, entryPointFilePaths: new Set<string>() },
+            {
+                visitedHas(visited, value) {
+                    if (typeof value === 'string' && value.includes('::')) {
+                        return false;
+                    }
+                    return visited.has(value);
+                }
+            }
+        );
+
+        assert.throws(() => {
+            index.expandWith(new Set([bindingId('entry.ts', 'pub')]));
+        }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
+    });
+
+    test('does not record any unresolved binding ids when a function references its own parameters', function () {
+        const files = [fileBindingsFor('entry.ts', 'export function pub(x: number) { return x; }')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+
+        assert.strictEqual(index.localReachable.size, 1);
+        assert.ok(index.localReachable.has(bindingId('entry.ts', 'pub')));
+    });
+
+    test('includes every file in bindingIdsByFile, even unreachable ones', function () {
+        const files = [fileBindingsFor('isolated.ts', 'export function never() {}')];
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
+
+        const isolatedIds = index.bindingIdsByFile.get('isolated.ts');
+        assert.ok(isolatedIds !== undefined);
+        assert.ok(isolatedIds.has(bindingId('isolated.ts', 'never')));
+    });
+
+    test('buildReachabilityIndex completes promptly for cyclic binding graphs', async function () {
+        const result = await runNodeProbe(
+            `
+import { createProject } from './source/test-libraries/typescript-project.ts';
+import { extractTopLevelBindings } from './source/dead-code-eliminator/reachability/binding-extractor.ts';
+import { buildReachabilityIndex } from './source/dead-code-eliminator/reachability/reachability.ts';
+
+const project = createProject({
+    withFiles: [{
+        filePath: 'entry.ts',
+        content: 'function helper() { return pub(); }\\nexport function pub() { return helper(); }'
+    }]
 });
+const sourceFile = project.getSourceFileOrThrow('entry.ts');
+const files = [{
+    sourceFilePath: 'entry.ts',
+    sourceFile,
+    bindings: extractTopLevelBindings(sourceFile)
+}];
+const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 
-test('does not record any unresolved binding ids when a function references its own parameters', () => {
-    const files = [fileBindingsFor('entry.ts', 'export function pub(x: number) { return x; }')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+console.log(JSON.stringify(Array.from(index.localReachable).toSorted()));
+`,
+            { timeoutMs: 8000 }
+        );
 
-    assert.strictEqual(index.localReachable.size, 1);
-    assert.ok(index.localReachable.has(bindingId('entry.ts', 'pub')));
-});
+        assert.deepStrictEqual(result, ['entry.ts::helper', 'entry.ts::pub']);
+    }).timeout(probeTestTimeoutMs);
 
-test('includes every file in bindingIdsByFile, even unreachable ones', () => {
-    const files = [fileBindingsFor('isolated.ts', 'export function never() {}')];
-    const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
+    test('buildReachabilityIndex throws when traversal exceeds the iteration budget', function () {
+        const files = [
+            fileBindingsFor(
+                'entry.ts',
+                'function helper() { return pub(); }\nexport function pub() { return helper(); }'
+            )
+        ];
+        const visitedHas = <T>(visited: ReadonlySet<T>, value: T): boolean => {
+            if (typeof value === 'string' && value.includes('::')) {
+                return false;
+            }
+            return visited.has(value);
+        };
 
-    const isolatedIds = index.bindingIdsByFile.get('isolated.ts');
-    assert.ok(isolatedIds !== undefined);
-    assert.ok(isolatedIds.has(bindingId('isolated.ts', 'never')));
-});
-
-test('buildReachabilityIndex completes promptly for cyclic binding graphs', async () => {
-    const result = await runNodeProbe(
-        `
-            import { createProject } from './source/test-libraries/typescript-project.ts';
-            import { extractTopLevelBindings } from './source/dead-code-eliminator/reachability/binding-extractor.ts';
-            import { buildReachabilityIndex } from './source/dead-code-eliminator/reachability/reachability.ts';
-
-            const project = createProject({
-                withFiles: [{
-                    filePath: 'entry.ts',
-                    content: 'function helper() { return pub(); }\\nexport function pub() { return helper(); }'
-                }]
-            });
-            const sourceFile = project.getSourceFileOrThrow('entry.ts');
-            const files = [{
-                sourceFilePath: 'entry.ts',
-                sourceFile,
-                bindings: extractTopLevelBindings(sourceFile)
-            }];
-            const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
-
-            console.log(JSON.stringify(Array.from(index.localReachable).toSorted()));
-        `,
-        { timeoutMs: 8000 }
-    );
-
-    assert.deepStrictEqual(result, ['entry.ts::helper', 'entry.ts::pub']);
-}).timeout(probeTestTimeoutMs);
-
-test('buildReachabilityIndex throws when traversal exceeds the iteration budget', () => {
-    const files = [
-        fileBindingsFor('entry.ts', 'function helper() { return pub(); }\nexport function pub() { return helper(); }')
-    ];
-    const visitedHas = <T>(visited: ReadonlySet<T>, value: T): boolean => {
-        if (typeof value === 'string' && value.includes('::')) {
-            return false;
-        }
-        return visited.has(value);
-    };
-
-    assert.throws(() => {
-        buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) }, { visitedHas });
-    }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
+        assert.throws(() => {
+            buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) }, { visitedHas });
+        }, /^Error: Reachability traversal exceeded the maximum iteration budget$/u);
+    });
 });

--- a/source/dead-code-eliminator/side-effect-classifier.test.ts
+++ b/source/dead-code-eliminator/side-effect-classifier.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { DeadCodeEliminationSettings } from '../config/dead-code-elimination-settings.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { classifySideEffects } from './side-effect-classifier.ts';
@@ -17,564 +17,573 @@ function classify(
     });
 }
 
-test('reports nothing for an empty file', () => {
-    assert.deepStrictEqual(classify(''), []);
-});
-
-test('treats a function declaration as pure', () => {
-    assert.deepStrictEqual(classify('function foo() { return 1; }'), []);
-});
-
-test('treats a class declaration without decorators as pure', () => {
-    assert.deepStrictEqual(classify('class Foo { method() { return 1; } }'), []);
-});
-
-test('treats an interface declaration as pure', () => {
-    assert.deepStrictEqual(classify('interface Foo { x: number; }'), []);
-});
-
-test('treats a type alias as pure', () => {
-    assert.deepStrictEqual(classify('type Foo = string;'), []);
-});
-
-test('treats an enum declaration as pure', () => {
-    assert.deepStrictEqual(classify('enum Foo { A, B }'), []);
-});
-
-test('treats a const enum declaration as pure', () => {
-    assert.deepStrictEqual(classify('const enum Foo { A = 1 }'), []);
-});
-
-test('treats a namespace declaration as pure', () => {
-    assert.deepStrictEqual(classify('namespace Foo { export const x: number = 1; }'), []);
-});
-
-test('treats an empty statement as pure', () => {
-    assert.deepStrictEqual(classify(';'), []);
-});
-
-test('treats a re-export as pure', () => {
-    assert.deepStrictEqual(classify('export { foo } from "./other";'), []);
-});
-
-test('treats a star re-export as pure', () => {
-    assert.deepStrictEqual(classify('export * from "./other";'), []);
-});
-
-test('treats a regular ESM import as pure', () => {
-    assert.deepStrictEqual(classify('import { foo } from "./other";'), []);
-});
-
-test('treats a default import as pure', () => {
-    assert.deepStrictEqual(classify('import foo from "./other";'), []);
-});
-
-test('treats a namespace import as pure', () => {
-    assert.deepStrictEqual(classify('import * as foo from "./other";'), []);
-});
-
-test('treats a bare import of a JS module as pure', () => {
-    assert.deepStrictEqual(classify('import "./other";'), []);
-});
-
-test('flags a bare import of a CSS module as impure', () => {
-    assert.deepStrictEqual(classify('import "./styles.css";'), [{ line: 1, kind: 'css import' }]);
-});
-
-test('treats a top-level call as an impure expression statement', () => {
-    assert.deepStrictEqual(classify('console.log("hi");'), [{ line: 1, kind: 'expression statement' }]);
-});
-
-test('treats a top-level IIFE as an impure expression statement', () => {
-    assert.deepStrictEqual(classify('(function() { return 1; })();'), [{ line: 1, kind: 'expression statement' }]);
-});
-
-test('treats a top-level if statement as impure', () => {
-    assert.deepStrictEqual(classify('if (true) { console.log(1); }'), [{ line: 1, kind: 'if statement' }]);
-});
-
-test('treats a top-level for statement as impure', () => {
-    assert.deepStrictEqual(classify('for (let i = 0; i < 1; i++) { console.log(i); }'), [
-        { line: 1, kind: 'for statement' }
-    ]);
-});
-
-test('treats a top-level for-in statement as impure', () => {
-    assert.deepStrictEqual(classify('for (const k in {}) { console.log(k); }'), [
-        { line: 1, kind: 'for-in statement' }
-    ]);
-});
-
-test('treats a top-level for-of statement as impure', () => {
-    assert.deepStrictEqual(classify('for (const v of []) { console.log(v); }'), [
-        { line: 1, kind: 'for-of statement' }
-    ]);
-});
-
-test('treats a top-level while statement as impure', () => {
-    assert.deepStrictEqual(classify('while (false) { break; }'), [{ line: 1, kind: 'while statement' }]);
-});
-
-test('treats a top-level do-while statement as impure', () => {
-    assert.deepStrictEqual(classify('do { break; } while (false);'), [{ line: 1, kind: 'do-while statement' }]);
-});
-
-test('treats a top-level switch statement as impure', () => {
-    assert.deepStrictEqual(classify('switch (1) { case 1: break; }'), [{ line: 1, kind: 'switch statement' }]);
-});
-
-test('treats a top-level try statement as impure', () => {
-    assert.deepStrictEqual(classify('try { } catch (e) { }'), [{ line: 1, kind: 'try statement' }]);
-});
-
-test('treats a top-level throw statement as impure', () => {
-    assert.deepStrictEqual(classify('throw new Error("oops");'), [{ line: 1, kind: 'throw statement' }]);
-});
-
-test('treats a labeled statement as impure', () => {
-    assert.deepStrictEqual(classify('outer: { console.log(1); }'), [{ line: 1, kind: 'labeled statement' }]);
-});
-
-test('treats a top-level block statement as impure', () => {
-    assert.deepStrictEqual(classify('{ const x = 1; }'), [{ line: 1, kind: 'block statement' }]);
-});
-
-test('treats a const with a literal initializer as pure', () => {
-    assert.deepStrictEqual(classify('const x = 1;'), []);
-});
-
-test('treats a const with a string initializer as pure', () => {
-    assert.deepStrictEqual(classify('const x = "hello";'), []);
-});
-
-test('treats a const with a template literal of pure interpolations as pure', () => {
-    // eslint-disable-next-line no-template-curly-in-string -- template literal embedded in source-under-test
-    assert.deepStrictEqual(classify('const x = `hello ${1 + 2}`;'), []);
-});
-
-test('treats a const with a template literal containing a call as impure', () => {
-    // eslint-disable-next-line no-template-curly-in-string -- template literal embedded in source-under-test
-    assert.deepStrictEqual(classify('const x = `hello ${compute()}`;'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with a template literal mixing pure and impure spans as impure', () => {
-    // eslint-disable-next-line no-template-curly-in-string -- template literal embedded in source-under-test
-    assert.deepStrictEqual(classify('const x = `pure ${1} mixed ${compute()}`;'), [
-        { line: 1, kind: 'variable initializer' }
-    ]);
-});
-
-test('treats a const with a function expression as pure', () => {
-    assert.deepStrictEqual(classify('const x = function () { return 1; };'), []);
-});
-
-test('treats a const with an arrow function as pure', () => {
-    assert.deepStrictEqual(classify('const x = () => 1;'), []);
-});
-
-test('treats a const with a class expression as pure', () => {
-    assert.deepStrictEqual(classify('const x = class { method() {} };'), []);
-});
-
-test('treats a const with an array literal of pure values as pure', () => {
-    assert.deepStrictEqual(classify('const x = [1, 2, "three", () => 4];'), []);
-});
-
-test('treats a const with a sparse array literal as pure', () => {
-    assert.deepStrictEqual(classify('const x = [1, , 3];'), []);
-});
-
-test('treats a const with an array literal containing a call as impure', () => {
-    assert.deepStrictEqual(classify('const x = [compute()];'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with an array literal mixing pure and impure elements as impure', () => {
-    assert.deepStrictEqual(classify('const x = [1, compute()];'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with a spread of an array literal as pure', () => {
-    assert.deepStrictEqual(classify('const x = [...[1, 2]];'), []);
-});
-
-test('treats a const with a spread of a call expression as impure', () => {
-    assert.deepStrictEqual(classify('const x = [...compute()];'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with an object literal of pure properties as pure', () => {
-    assert.deepStrictEqual(classify('const x = { a: 1, b: "two", c: () => 3 };'), []);
-});
-
-test('treats a const with an object literal whose value is a call as impure', () => {
-    assert.deepStrictEqual(classify('const x = { a: compute() };'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with an object literal mixing pure and impure properties as impure', () => {
-    assert.deepStrictEqual(classify('const x = { a: 1, b: compute() };'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with an object spread of a pure literal as pure', () => {
-    assert.deepStrictEqual(classify('const x = { ...{ a: 1 } };'), []);
-});
-
-test('treats a const with an object shorthand reference as pure', () => {
-    assert.deepStrictEqual(classify('const a = 1; const x = { a };'), []);
-});
-
-test('treats a const with an object method as pure', () => {
-    assert.deepStrictEqual(classify('const x = { method() { return 1; } };'), []);
-});
-
-test('treats a const with an object getter as pure', () => {
-    assert.deepStrictEqual(classify('const x = { get prop() { return 1; } };'), []);
-});
-
-test('treats a const with an "as" cast wrapping a pure expression as pure', () => {
-    assert.deepStrictEqual(classify('const x = 1 as number;'), []);
-});
-
-test('treats a const with a "satisfies" wrapping a pure expression as pure', () => {
-    assert.deepStrictEqual(classify('const x = 1 satisfies number;'), []);
-});
-
-test('treats a const with a legacy angle-bracket type assertion of a pure expression as pure', () => {
-    assert.deepStrictEqual(classify('const x = <number>1;'), []);
-});
-
-test('treats a const with a parenthesized pure expression as pure', () => {
-    assert.deepStrictEqual(classify('const x = (1 + 2);'), []);
-});
-
-test('treats a const with a non-null assertion of a pure expression as pure', () => {
-    assert.deepStrictEqual(classify('const a = 1; const x = a!;'), []);
-});
-
-test('treats a const with a unary minus on a pure operand as pure', () => {
-    assert.deepStrictEqual(classify('const x = -5;'), []);
-});
-
-test('treats a const with a logical not on a pure operand as pure', () => {
-    assert.deepStrictEqual(classify('const x = !false;'), []);
-});
-
-test('treats a const with an unsupported prefix unary operator as impure', () => {
-    assert.deepStrictEqual(classify('let a = 1; const x = ++a;'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with an arithmetic binary expression of pure operands as pure', () => {
-    assert.deepStrictEqual(classify('const x = 1 + 2 * 3;'), []);
-});
-
-test('treats a const with a logical binary of pure operands as pure', () => {
-    assert.deepStrictEqual(classify('const x = true && false;'), []);
-});
-
-test('treats a const with a strict equality binary as pure', () => {
-    assert.deepStrictEqual(classify('const x = 1 === 1;'), []);
-});
-
-test('treats a const with a loose equality binary as impure', () => {
-    assert.deepStrictEqual(classify('const x = 1 == 1;'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with a binary expression containing a call as impure', () => {
-    assert.deepStrictEqual(classify('const x = 1 + compute();'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with an identifier reference as pure', () => {
-    assert.deepStrictEqual(classify('const a = 1; const x = a;'), []);
-});
-
-test('treats a const with a property access as impure', () => {
-    assert.deepStrictEqual(classify('declare const obj: { x: number }; const x = obj.x;'), [
-        { line: 1, kind: 'variable initializer' }
-    ]);
-});
-
-test('treats a const with a call expression as impure', () => {
-    assert.deepStrictEqual(classify('const x = compute();'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with a trusted imported call as pure', () => {
-    assert.deepStrictEqual(
-        classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['bold'] }]
-        }),
-        []
-    );
-});
-
-test('treats a const with a wrapped trusted imported call and spread arguments as pure', () => {
-    assert.deepStrictEqual(
-        classify('import { bold } from "yoctocolors"; const x = (((bold as typeof bold))!)(...[\'hi\']);', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['bold'] }]
-        }),
-        []
-    );
-});
-
-test('treats a const with a trusted namespace import call as pure', () => {
-    assert.deepStrictEqual(
-        classify('import * as colors from "yoctocolors"; const x = colors.green("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors' }]
-        }),
-        []
-    );
-});
-
-test('treats a const with a trusted namespace import call as pure when the allow-list names the accessed member', () => {
-    assert.deepStrictEqual(
-        classify('import * as colors from "yoctocolors"; const x = colors.green("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['green'] }]
-        }),
-        []
-    );
-});
-
-test('treats a namespace import call chain as impure when only a later accessed member is trusted', () => {
-    assert.deepStrictEqual(
-        classify('import * as colors from "yoctocolors"; const x = colors.bold.green("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['green'] }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a const with a trusted default import call as pure', () => {
-    assert.deepStrictEqual(
-        classify('import format from "trusted-formatter"; const x = format("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'trusted-formatter', imports: ['default'] }]
-        }),
-        []
-    );
-});
-
-test('treats a const with a named import as impure when only default imports are trusted', () => {
-    assert.deepStrictEqual(
-        classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['default'] }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a const with a trusted imported call as pure when a later trust rule matches', () => {
-    assert.deepStrictEqual(
-        classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'trusted-formatter' }, { from: 'yoctocolors', imports: ['bold'] }]
-        }),
-        []
-    );
-});
-
-test('treats a const with a trusted namespace builder call chain as pure', () => {
-    assert.deepStrictEqual(
-        classify('import { z } from "zod/mini"; const x = z.string().check(z.minLength(1));', {
-            enabled: true,
-            pureImports: [{ from: 'zod/mini' }]
-        }),
-        []
-    );
-});
-
-test('treats an untrusted imported call as impure', () => {
-    assert.deepStrictEqual(
-        classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['green'] }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a namespace import call as impure when the module is not trusted', () => {
-    assert.deepStrictEqual(
-        classify('import * as colors from "yoctocolors"; const x = colors.green("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'trusted-formatter' }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a const with an imported call as impure when no pure import settings are configured', () => {
-    assert.deepStrictEqual(classify('import { bold } from "yoctocolors"; const x = bold("hi");', { enabled: true }), [
-        { line: 1, kind: 'variable initializer' }
-    ]);
-});
-
-test('treats a const with an imported call as impure when purity settings are omitted entirely', () => {
-    assert.deepStrictEqual(classify('import { bold } from "yoctocolors"; const x = bold("hi");'), [
-        { line: 1, kind: 'variable initializer' }
-    ]);
-});
-
-test('treats a trusted imported call with an impure argument as impure', () => {
-    assert.deepStrictEqual(
-        classify('import { bold } from "yoctocolors"; const x = bold(compute());', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors', imports: ['bold'] }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a call through an untrusted property base as impure', () => {
-    assert.deepStrictEqual(
-        classify('declare const obj: { format(value: string): string }; const x = obj.format("hi");'),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a call through an unsupported imported element access as impure', () => {
-    assert.deepStrictEqual(
-        classify('import * as colors from "yoctocolors"; const x = colors["green"]("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'yoctocolors' }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a const with a default import as impure when only namespace members are trusted', () => {
-    assert.deepStrictEqual(
-        classify('import format from "trusted-formatter"; const x = format("hi");', {
-            enabled: true,
-            pureImports: [{ from: 'trusted-formatter', imports: ['green'] }]
-        }),
-        [{ line: 1, kind: 'variable initializer' }]
-    );
-});
-
-test('treats a const with a new expression as impure', () => {
-    assert.deepStrictEqual(classify('const x = new Date();'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a const with a trusted constructor call as pure', () => {
-    assert.deepStrictEqual(
-        classify('const x = new Set([1, 2, 3]);', {
-            enabled: true,
-            pureConstructors: ['Set']
-        }),
-        []
-    );
-});
-
-test('treats a constructor call as impure when constructor trust settings are omitted', () => {
-    assert.deepStrictEqual(classify('const x = new Set([1, 2, 3]);', { enabled: true }), [
-        { line: 1, kind: 'variable initializer' }
-    ]);
-});
-
-test('treats multiple variable declarators as impure if any initializer is impure', () => {
-    assert.deepStrictEqual(classify('const a = 1, b = compute();'), [{ line: 1, kind: 'variable initializer' }]);
-});
-
-test('treats a class with a method decorator as impure', () => {
-    assert.deepStrictEqual(classify('function dec() { return () => {}; }\nclass Foo { @dec method() {} }'), [
-        { line: 2, kind: 'class declaration' }
-    ]);
-});
-
-test('treats a class with a class decorator as impure', () => {
-    assert.deepStrictEqual(classify('function dec() { return () => {}; }\n@dec\nclass Foo {}'), [
-        { line: 2, kind: 'class declaration' }
-    ]);
-});
-
-test('treats a class with a static block as impure', () => {
-    assert.deepStrictEqual(classify('class Foo { static { console.log("init"); } }'), [
-        { line: 1, kind: 'class declaration' }
-    ]);
-});
-
-test('treats a class with an impure static initializer as impure', () => {
-    assert.deepStrictEqual(classify('class Foo { static x = compute(); }'), [{ line: 1, kind: 'class declaration' }]);
-});
-
-test('treats a class with a decorated set accessor as impure', () => {
-    assert.deepStrictEqual(
-        classify('function dec() { return () => {}; }\nclass Foo { @dec set value(v: number) {} }'),
-        [{ line: 2, kind: 'class declaration' }]
-    );
-});
-
-test('does not flag a class whose only members are constructors', () => {
-    assert.deepStrictEqual(classify('class Foo { constructor() {} }'), []);
-});
-
-test('treats a top-level debugger statement as an impure unknown statement', () => {
-    assert.deepStrictEqual(classify('debugger;'), [{ line: 1, kind: 'unknown statement' }]);
-});
-
-test('treats a class with a pure static initializer as pure', () => {
-    assert.deepStrictEqual(classify('class Foo { static x = 1; }'), []);
-});
-
-test('treats a class with a static property without an initializer as pure', () => {
-    assert.deepStrictEqual(classify('class Foo { static x: number; }'), []);
-});
-
-test('treats a class with a non-static impure initializer as pure (set per-instance)', () => {
-    assert.deepStrictEqual(classify('class Foo { x = compute(); }'), []);
-});
-
-test('treats an export default class declaration as pure', () => {
-    assert.deepStrictEqual(classify('export default class Foo {}'), []);
-});
-
-test('treats an export default function declaration as pure', () => {
-    assert.deepStrictEqual(classify('export default function foo() {}'), []);
-});
-
-test('treats an export default of a pure expression as pure', () => {
-    assert.deepStrictEqual(classify('export default 42;'), []);
-});
-
-test('treats an export default of a call expression as impure', () => {
-    assert.deepStrictEqual(classify('declare function compute(): number; export default compute();'), [
-        { line: 1, kind: 'export assignment' }
-    ]);
-});
-
-test('treats an export-equals of a pure identifier as pure', () => {
-    assert.deepStrictEqual(classify('declare const value: number; export = value;'), []);
-});
-
-test('treats an export-equals of a call as impure', () => {
-    assert.deepStrictEqual(classify('declare function compute(): number; export = compute();'), [
-        { line: 1, kind: 'export assignment' }
-    ]);
-});
-
-test('reports the line of every impure statement', () => {
-    const content = ['const a = 1;', 'console.log(a);', 'function foo() {}', 'compute();'].join('\n');
-    assert.deepStrictEqual(classify(content), [
-        { line: 2, kind: 'expression statement' },
-        { line: 4, kind: 'expression statement' }
-    ]);
-});
-
-test('treats ambient declare statements as pure', () => {
-    assert.deepStrictEqual(
-        classify(['declare const x: number;', 'declare function foo(): void;', 'declare class Bar {}'].join('\n')),
-        []
-    );
-});
-
-test('treats top-level await as impure (parsed inside an expression statement)', () => {
-    const content = ['async function main() {', '  await Promise.resolve();', '}'].join('\n');
-    assert.deepStrictEqual(classify(content), []);
-});
-
-test('treats a const with an await initializer as impure', () => {
-    const content = 'const x = await Promise.resolve(1);';
-    assert.deepStrictEqual(classify(content), [{ line: 1, kind: 'variable initializer' }]);
+suite('side-effect-classifier', function () {
+    test('reports nothing for an empty file', function () {
+        assert.deepStrictEqual(classify(''), []);
+    });
+
+    test('treats a function declaration as pure', function () {
+        assert.deepStrictEqual(classify('function foo() { return 1; }'), []);
+    });
+
+    test('treats a class declaration without decorators as pure', function () {
+        assert.deepStrictEqual(classify('class Foo { method() { return 1; } }'), []);
+    });
+
+    test('treats an interface declaration as pure', function () {
+        assert.deepStrictEqual(classify('interface Foo { x: number; }'), []);
+    });
+
+    test('treats a type alias as pure', function () {
+        assert.deepStrictEqual(classify('type Foo = string;'), []);
+    });
+
+    test('treats an enum declaration as pure', function () {
+        assert.deepStrictEqual(classify('enum Foo { A, B }'), []);
+    });
+
+    test('treats a const enum declaration as pure', function () {
+        assert.deepStrictEqual(classify('const enum Foo { A = 1 }'), []);
+    });
+
+    test('treats a namespace declaration as pure', function () {
+        assert.deepStrictEqual(classify('namespace Foo { export const x: number = 1; }'), []);
+    });
+
+    test('treats an empty statement as pure', function () {
+        assert.deepStrictEqual(classify(';'), []);
+    });
+
+    test('treats a re-export as pure', function () {
+        assert.deepStrictEqual(classify('export { foo } from "./other";'), []);
+    });
+
+    test('treats a star re-export as pure', function () {
+        assert.deepStrictEqual(classify('export * from "./other";'), []);
+    });
+
+    test('treats a regular ESM import as pure', function () {
+        assert.deepStrictEqual(classify('import { foo } from "./other";'), []);
+    });
+
+    test('treats a default import as pure', function () {
+        assert.deepStrictEqual(classify('import foo from "./other";'), []);
+    });
+
+    test('treats a namespace import as pure', function () {
+        assert.deepStrictEqual(classify('import * as foo from "./other";'), []);
+    });
+
+    test('treats a bare import of a JS module as pure', function () {
+        assert.deepStrictEqual(classify('import "./other";'), []);
+    });
+
+    test('flags a bare import of a CSS module as impure', function () {
+        assert.deepStrictEqual(classify('import "./styles.css";'), [{ line: 1, kind: 'css import' }]);
+    });
+
+    test('treats a top-level call as an impure expression statement', function () {
+        assert.deepStrictEqual(classify('console.log("hi");'), [{ line: 1, kind: 'expression statement' }]);
+    });
+
+    test('treats a top-level IIFE as an impure expression statement', function () {
+        assert.deepStrictEqual(classify('(function() { return 1; })();'), [{ line: 1, kind: 'expression statement' }]);
+    });
+
+    test('treats a top-level if statement as impure', function () {
+        assert.deepStrictEqual(classify('if (true) { console.log(1); }'), [{ line: 1, kind: 'if statement' }]);
+    });
+
+    test('treats a top-level for statement as impure', function () {
+        assert.deepStrictEqual(classify('for (let i = 0; i < 1; i++) { console.log(i); }'), [
+            { line: 1, kind: 'for statement' }
+        ]);
+    });
+
+    test('treats a top-level for-in statement as impure', function () {
+        assert.deepStrictEqual(classify('for (const k in {}) { console.log(k); }'), [
+            { line: 1, kind: 'for-in statement' }
+        ]);
+    });
+
+    test('treats a top-level for-of statement as impure', function () {
+        assert.deepStrictEqual(classify('for (const v of []) { console.log(v); }'), [
+            { line: 1, kind: 'for-of statement' }
+        ]);
+    });
+
+    test('treats a top-level while statement as impure', function () {
+        assert.deepStrictEqual(classify('while (false) { break; }'), [{ line: 1, kind: 'while statement' }]);
+    });
+
+    test('treats a top-level do-while statement as impure', function () {
+        assert.deepStrictEqual(classify('do { break; } while (false);'), [{ line: 1, kind: 'do-while statement' }]);
+    });
+
+    test('treats a top-level switch statement as impure', function () {
+        assert.deepStrictEqual(classify('switch (1) { case 1: break; }'), [{ line: 1, kind: 'switch statement' }]);
+    });
+
+    test('treats a top-level try statement as impure', function () {
+        assert.deepStrictEqual(classify('try { } catch (e) { }'), [{ line: 1, kind: 'try statement' }]);
+    });
+
+    test('treats a top-level throw statement as impure', function () {
+        assert.deepStrictEqual(classify('throw new Error("oops");'), [{ line: 1, kind: 'throw statement' }]);
+    });
+
+    test('treats a labeled statement as impure', function () {
+        assert.deepStrictEqual(classify('outer: { console.log(1); }'), [{ line: 1, kind: 'labeled statement' }]);
+    });
+
+    test('treats a top-level block statement as impure', function () {
+        assert.deepStrictEqual(classify('{ const x = 1; }'), [{ line: 1, kind: 'block statement' }]);
+    });
+
+    test('treats a const with a literal initializer as pure', function () {
+        assert.deepStrictEqual(classify('const x = 1;'), []);
+    });
+
+    test('treats a const with a string initializer as pure', function () {
+        assert.deepStrictEqual(classify('const x = "hello";'), []);
+    });
+
+    test('treats a const with a template literal of pure interpolations as pure', function () {
+        // eslint-disable-next-line no-template-curly-in-string -- template literal embedded in source-under-test
+        assert.deepStrictEqual(classify('const x = `hello ${1 + 2}`;'), []);
+    });
+
+    test('treats a const with a template literal containing a call as impure', function () {
+        // eslint-disable-next-line no-template-curly-in-string -- template literal embedded in source-under-test
+        assert.deepStrictEqual(classify('const x = `hello ${compute()}`;'), [
+            { line: 1, kind: 'variable initializer' }
+        ]);
+    });
+
+    test('treats a const with a template literal mixing pure and impure spans as impure', function () {
+        // eslint-disable-next-line no-template-curly-in-string -- template literal embedded in source-under-test
+        assert.deepStrictEqual(classify('const x = `pure ${1} mixed ${compute()}`;'), [
+            { line: 1, kind: 'variable initializer' }
+        ]);
+    });
+
+    test('treats a const with a function expression as pure', function () {
+        assert.deepStrictEqual(classify('const x = function () { return 1; };'), []);
+    });
+
+    test('treats a const with an arrow function as pure', function () {
+        assert.deepStrictEqual(classify('const x = () => 1;'), []);
+    });
+
+    test('treats a const with a class expression as pure', function () {
+        assert.deepStrictEqual(classify('const x = class { method() {} };'), []);
+    });
+
+    test('treats a const with an array literal of pure values as pure', function () {
+        assert.deepStrictEqual(classify('const x = [1, 2, "three", () => 4];'), []);
+    });
+
+    test('treats a const with a sparse array literal as pure', function () {
+        assert.deepStrictEqual(classify('const x = [1, , 3];'), []);
+    });
+
+    test('treats a const with an array literal containing a call as impure', function () {
+        assert.deepStrictEqual(classify('const x = [compute()];'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with an array literal mixing pure and impure elements as impure', function () {
+        assert.deepStrictEqual(classify('const x = [1, compute()];'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with a spread of an array literal as pure', function () {
+        assert.deepStrictEqual(classify('const x = [...[1, 2]];'), []);
+    });
+
+    test('treats a const with a spread of a call expression as impure', function () {
+        assert.deepStrictEqual(classify('const x = [...compute()];'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with an object literal of pure properties as pure', function () {
+        assert.deepStrictEqual(classify('const x = { a: 1, b: "two", c: () => 3 };'), []);
+    });
+
+    test('treats a const with an object literal whose value is a call as impure', function () {
+        assert.deepStrictEqual(classify('const x = { a: compute() };'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with an object literal mixing pure and impure properties as impure', function () {
+        assert.deepStrictEqual(classify('const x = { a: 1, b: compute() };'), [
+            { line: 1, kind: 'variable initializer' }
+        ]);
+    });
+
+    test('treats a const with an object spread of a pure literal as pure', function () {
+        assert.deepStrictEqual(classify('const x = { ...{ a: 1 } };'), []);
+    });
+
+    test('treats a const with an object shorthand reference as pure', function () {
+        assert.deepStrictEqual(classify('const a = 1; const x = { a };'), []);
+    });
+
+    test('treats a const with an object method as pure', function () {
+        assert.deepStrictEqual(classify('const x = { method() { return 1; } };'), []);
+    });
+
+    test('treats a const with an object getter as pure', function () {
+        assert.deepStrictEqual(classify('const x = { get prop() { return 1; } };'), []);
+    });
+
+    test('treats a const with an "as" cast wrapping a pure expression as pure', function () {
+        assert.deepStrictEqual(classify('const x = 1 as number;'), []);
+    });
+
+    test('treats a const with a "satisfies" wrapping a pure expression as pure', function () {
+        assert.deepStrictEqual(classify('const x = 1 satisfies number;'), []);
+    });
+
+    test('treats a const with a legacy angle-bracket type assertion of a pure expression as pure', function () {
+        assert.deepStrictEqual(classify('const x = <number>1;'), []);
+    });
+
+    test('treats a const with a parenthesized pure expression as pure', function () {
+        assert.deepStrictEqual(classify('const x = (1 + 2);'), []);
+    });
+
+    test('treats a const with a non-null assertion of a pure expression as pure', function () {
+        assert.deepStrictEqual(classify('const a = 1; const x = a!;'), []);
+    });
+
+    test('treats a const with a unary minus on a pure operand as pure', function () {
+        assert.deepStrictEqual(classify('const x = -5;'), []);
+    });
+
+    test('treats a const with a logical not on a pure operand as pure', function () {
+        assert.deepStrictEqual(classify('const x = !false;'), []);
+    });
+
+    test('treats a const with an unsupported prefix unary operator as impure', function () {
+        assert.deepStrictEqual(classify('let a = 1; const x = ++a;'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with an arithmetic binary expression of pure operands as pure', function () {
+        assert.deepStrictEqual(classify('const x = 1 + 2 * 3;'), []);
+    });
+
+    test('treats a const with a logical binary of pure operands as pure', function () {
+        assert.deepStrictEqual(classify('const x = true && false;'), []);
+    });
+
+    test('treats a const with a strict equality binary as pure', function () {
+        assert.deepStrictEqual(classify('const x = 1 === 1;'), []);
+    });
+
+    test('treats a const with a loose equality binary as impure', function () {
+        assert.deepStrictEqual(classify('const x = 1 == 1;'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with a binary expression containing a call as impure', function () {
+        assert.deepStrictEqual(classify('const x = 1 + compute();'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with an identifier reference as pure', function () {
+        assert.deepStrictEqual(classify('const a = 1; const x = a;'), []);
+    });
+
+    test('treats a const with a property access as impure', function () {
+        assert.deepStrictEqual(classify('declare const obj: { x: number }; const x = obj.x;'), [
+            { line: 1, kind: 'variable initializer' }
+        ]);
+    });
+
+    test('treats a const with a call expression as impure', function () {
+        assert.deepStrictEqual(classify('const x = compute();'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with a trusted imported call as pure', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['bold'] }]
+            }),
+            []
+        );
+    });
+
+    test('treats a const with a wrapped trusted imported call and spread arguments as pure', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = (((bold as typeof bold))!)(...[\'hi\']);', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['bold'] }]
+            }),
+            []
+        );
+    });
+
+    test('treats a const with a trusted namespace import call as pure', function () {
+        assert.deepStrictEqual(
+            classify('import * as colors from "yoctocolors"; const x = colors.green("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors' }]
+            }),
+            []
+        );
+    });
+
+    test('treats a const with a trusted namespace import call as pure when the allow-list names the accessed member', function () {
+        assert.deepStrictEqual(
+            classify('import * as colors from "yoctocolors"; const x = colors.green("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['green'] }]
+            }),
+            []
+        );
+    });
+
+    test('treats a namespace import call chain as impure when only a later accessed member is trusted', function () {
+        assert.deepStrictEqual(
+            classify('import * as colors from "yoctocolors"; const x = colors.bold.green("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['green'] }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a const with a trusted default import call as pure', function () {
+        assert.deepStrictEqual(
+            classify('import format from "trusted-formatter"; const x = format("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'trusted-formatter', imports: ['default'] }]
+            }),
+            []
+        );
+    });
+
+    test('treats a const with a named import as impure when only default imports are trusted', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['default'] }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a const with a trusted imported call as pure when a later trust rule matches', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'trusted-formatter' }, { from: 'yoctocolors', imports: ['bold'] }]
+            }),
+            []
+        );
+    });
+
+    test('treats a const with a trusted namespace builder call chain as pure', function () {
+        assert.deepStrictEqual(
+            classify('import { z } from "zod/mini"; const x = z.string().check(z.minLength(1));', {
+                enabled: true,
+                pureImports: [{ from: 'zod/mini' }]
+            }),
+            []
+        );
+    });
+
+    test('treats an untrusted imported call as impure', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = bold("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['green'] }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a namespace import call as impure when the module is not trusted', function () {
+        assert.deepStrictEqual(
+            classify('import * as colors from "yoctocolors"; const x = colors.green("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'trusted-formatter' }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a const with an imported call as impure when no pure import settings are configured', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = bold("hi");', { enabled: true }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a const with an imported call as impure when purity settings are omitted entirely', function () {
+        assert.deepStrictEqual(classify('import { bold } from "yoctocolors"; const x = bold("hi");'), [
+            { line: 1, kind: 'variable initializer' }
+        ]);
+    });
+
+    test('treats a trusted imported call with an impure argument as impure', function () {
+        assert.deepStrictEqual(
+            classify('import { bold } from "yoctocolors"; const x = bold(compute());', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors', imports: ['bold'] }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a call through an untrusted property base as impure', function () {
+        assert.deepStrictEqual(
+            classify('declare const obj: { format(value: string): string }; const x = obj.format("hi");'),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a call through an unsupported imported element access as impure', function () {
+        assert.deepStrictEqual(
+            classify('import * as colors from "yoctocolors"; const x = colors["green"]("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'yoctocolors' }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a const with a default import as impure when only namespace members are trusted', function () {
+        assert.deepStrictEqual(
+            classify('import format from "trusted-formatter"; const x = format("hi");', {
+                enabled: true,
+                pureImports: [{ from: 'trusted-formatter', imports: ['green'] }]
+            }),
+            [{ line: 1, kind: 'variable initializer' }]
+        );
+    });
+
+    test('treats a const with a new expression as impure', function () {
+        assert.deepStrictEqual(classify('const x = new Date();'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a const with a trusted constructor call as pure', function () {
+        assert.deepStrictEqual(
+            classify('const x = new Set([1, 2, 3]);', {
+                enabled: true,
+                pureConstructors: ['Set']
+            }),
+            []
+        );
+    });
+
+    test('treats a constructor call as impure when constructor trust settings are omitted', function () {
+        assert.deepStrictEqual(classify('const x = new Set([1, 2, 3]);', { enabled: true }), [
+            { line: 1, kind: 'variable initializer' }
+        ]);
+    });
+
+    test('treats multiple variable declarators as impure if any initializer is impure', function () {
+        assert.deepStrictEqual(classify('const a = 1, b = compute();'), [{ line: 1, kind: 'variable initializer' }]);
+    });
+
+    test('treats a class with a method decorator as impure', function () {
+        assert.deepStrictEqual(classify('function dec() { return () => {}; }\nclass Foo { @dec method() {} }'), [
+            { line: 2, kind: 'class declaration' }
+        ]);
+    });
+
+    test('treats a class with a class decorator as impure', function () {
+        assert.deepStrictEqual(classify('function dec() { return () => {}; }\n@dec\nclass Foo {}'), [
+            { line: 2, kind: 'class declaration' }
+        ]);
+    });
+
+    test('treats a class with a static block as impure', function () {
+        assert.deepStrictEqual(classify('class Foo { static { console.log("init"); } }'), [
+            { line: 1, kind: 'class declaration' }
+        ]);
+    });
+
+    test('treats a class with an impure static initializer as impure', function () {
+        assert.deepStrictEqual(classify('class Foo { static x = compute(); }'), [
+            { line: 1, kind: 'class declaration' }
+        ]);
+    });
+
+    test('treats a class with a decorated set accessor as impure', function () {
+        assert.deepStrictEqual(
+            classify('function dec() { return () => {}; }\nclass Foo { @dec set value(v: number) {} }'),
+            [{ line: 2, kind: 'class declaration' }]
+        );
+    });
+
+    test('does not flag a class whose only members are constructors', function () {
+        assert.deepStrictEqual(classify('class Foo { constructor() {} }'), []);
+    });
+
+    test('treats a top-level debugger statement as an impure unknown statement', function () {
+        assert.deepStrictEqual(classify('debugger;'), [{ line: 1, kind: 'unknown statement' }]);
+    });
+
+    test('treats a class with a pure static initializer as pure', function () {
+        assert.deepStrictEqual(classify('class Foo { static x = 1; }'), []);
+    });
+
+    test('treats a class with a static property without an initializer as pure', function () {
+        assert.deepStrictEqual(classify('class Foo { static x: number; }'), []);
+    });
+
+    test('treats a class with a non-static impure initializer as pure (set per-instance)', function () {
+        assert.deepStrictEqual(classify('class Foo { x = compute(); }'), []);
+    });
+
+    test('treats an export default class declaration as pure', function () {
+        assert.deepStrictEqual(classify('export default class Foo {}'), []);
+    });
+
+    test('treats an export default function declaration as pure', function () {
+        assert.deepStrictEqual(classify('export default function foo() {}'), []);
+    });
+
+    test('treats an export default of a pure expression as pure', function () {
+        assert.deepStrictEqual(classify('export default 42;'), []);
+    });
+
+    test('treats an export default of a call expression as impure', function () {
+        assert.deepStrictEqual(classify('declare function compute(): number; export default compute();'), [
+            { line: 1, kind: 'export assignment' }
+        ]);
+    });
+
+    test('treats an export-equals of a pure identifier as pure', function () {
+        assert.deepStrictEqual(classify('declare const value: number; export = value;'), []);
+    });
+
+    test('treats an export-equals of a call as impure', function () {
+        assert.deepStrictEqual(classify('declare function compute(): number; export = compute();'), [
+            { line: 1, kind: 'export assignment' }
+        ]);
+    });
+
+    test('reports the line of every impure statement', function () {
+        const content = ['const a = 1;', 'console.log(a);', 'function foo() {}', 'compute();'].join('\n');
+        assert.deepStrictEqual(classify(content), [
+            { line: 2, kind: 'expression statement' },
+            { line: 4, kind: 'expression statement' }
+        ]);
+    });
+
+    test('treats ambient declare statements as pure', function () {
+        assert.deepStrictEqual(
+            classify(['declare const x: number;', 'declare function foo(): void;', 'declare class Bar {}'].join('\n')),
+            []
+        );
+    });
+
+    test('treats top-level await as impure (parsed inside an expression statement)', function () {
+        const content = ['async function main() {', '  await Promise.resolve();', '}'].join('\n');
+        assert.deepStrictEqual(classify(content), []);
+    });
+
+    test('treats a const with an await initializer as impure', function () {
+        const content = 'const x = await Promise.resolve(1);';
+        assert.deepStrictEqual(classify(content), [{ line: 1, kind: 'variable initializer' }]);
+    });
 });

--- a/source/dead-code-eliminator/side-effects-field.test.ts
+++ b/source/dead-code-eliminator/side-effects-field.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundleResource } from './analyzed-bundle.ts';
 import { computeSideEffectsField } from './side-effects-field.ts';
 
@@ -17,58 +17,60 @@ function resource(targetFilePath: string, hasSideEffects = false): AnalyzedBundl
     };
 }
 
-test('returns false when there are no resources at all', () => {
-    assert.strictEqual(computeSideEffectsField([]), false);
-});
+suite('side-effects-field', function () {
+    test('returns false when there are no resources at all', function () {
+        assert.strictEqual(computeSideEffectsField([]), false);
+    });
 
-test('returns false when there are no code files', () => {
-    assert.strictEqual(computeSideEffectsField([resource('LICENSE'), resource('readme.md')]), false);
-});
+    test('returns false when there are no code files', function () {
+        assert.strictEqual(computeSideEffectsField([resource('LICENSE'), resource('readme.md')]), false);
+    });
 
-test('returns false when every code file is pure', () => {
-    assert.strictEqual(computeSideEffectsField([resource('a.js'), resource('b.ts')]), false);
-});
+    test('returns false when every code file is pure', function () {
+        assert.strictEqual(computeSideEffectsField([resource('a.js'), resource('b.ts')]), false);
+    });
 
-test('returns undefined when every code file has side effects', () => {
-    assert.strictEqual(computeSideEffectsField([resource('a.js', true), resource('b.ts', true)]), undefined);
-});
+    test('returns undefined when every code file has side effects', function () {
+        assert.strictEqual(computeSideEffectsField([resource('a.js', true), resource('b.ts', true)]), undefined);
+    });
 
-test('returns the impure file paths when only some code files have side effects', () => {
-    assert.deepStrictEqual(computeSideEffectsField([resource('a.js'), resource('b.js', true), resource('c.js')]), [
-        './b.js'
-    ]);
-});
+    test('returns the impure file paths when only some code files have side effects', function () {
+        assert.deepStrictEqual(computeSideEffectsField([resource('a.js'), resource('b.js', true), resource('c.js')]), [
+            './b.js'
+        ]);
+    });
 
-test('returns the impure file paths sorted alphabetically', () => {
-    assert.deepStrictEqual(
-        computeSideEffectsField([resource('zeta.js', true), resource('alpha.js', true), resource('beta.js')]),
-        ['./alpha.js', './zeta.js']
-    );
-});
+    test('returns the impure file paths sorted alphabetically', function () {
+        assert.deepStrictEqual(
+            computeSideEffectsField([resource('zeta.js', true), resource('alpha.js', true), resource('beta.js')]),
+            ['./alpha.js', './zeta.js']
+        );
+    });
 
-test('returns false when only non-code files exist, even if they carry side-effect statements', () => {
-    assert.strictEqual(computeSideEffectsField([resource('LICENSE', true), resource('readme.md', true)]), false);
-});
+    test('returns false when only non-code files exist, even if they carry side-effect statements', function () {
+        assert.strictEqual(computeSideEffectsField([resource('LICENSE', true), resource('readme.md', true)]), false);
+    });
 
-test('ignores non-code files when classifying purity', () => {
-    assert.strictEqual(
-        computeSideEffectsField([resource('a.js'), resource('LICENSE'), resource('package.json')]),
-        false
-    );
-});
+    test('ignores non-code files when classifying purity', function () {
+        assert.strictEqual(
+            computeSideEffectsField([resource('a.js'), resource('LICENSE'), resource('package.json')]),
+            false
+        );
+    });
 
-test('reports the impure file even when pure non-code files are also present', () => {
-    const field = computeSideEffectsField([resource('a.js', true), resource('b.js'), resource('LICENSE')]);
-    assert.deepStrictEqual(field, ['./a.js']);
-});
+    test('reports the impure file even when pure non-code files are also present', function () {
+        const field = computeSideEffectsField([resource('a.js', true), resource('b.js'), resource('LICENSE')]);
+        assert.deepStrictEqual(field, ['./a.js']);
+    });
 
-test('emits paths with a leading "./" prefix', () => {
-    const field = computeSideEffectsField([resource('a.js', true), resource('b.js')]);
-    if (!Array.isArray(field)) {
-        assert.fail('Expected sideEffects field to be an array');
-        return;
-    }
-    for (const path of field as readonly string[]) {
-        assert.strictEqual(path.startsWith('./'), true);
-    }
+    test('emits paths with a leading "./" prefix', function () {
+        const field = computeSideEffectsField([resource('a.js', true), resource('b.js')]);
+        if (!Array.isArray(field)) {
+            assert.fail('Expected sideEffects field to be an array');
+            return;
+        }
+        for (const path of field as readonly string[]) {
+            assert.strictEqual(path.startsWith('./'), true);
+        }
+    });
 });

--- a/source/dead-code-eliminator/source-map-recomposition.test.ts
+++ b/source/dead-code-eliminator/source-map-recomposition.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundleResource } from './analyzed-bundle.ts';
 import type { AnalyzedResourceOutput, TransformRecord } from './code-file-analyzer.ts';
 import { buildMapPathTransformIndex, recomposePairedSourceMaps } from './source-map-recomposition.ts';
@@ -23,33 +23,35 @@ const transformRecord: TransformRecord = {
     atoms: []
 };
 
-test('buildMapPathTransformIndex maps each transform to the matching .map file path', () => {
-    const index = buildMapPathTransformIndex([resourceOutput('a.js', [transformRecord])]);
+suite('source-map-recomposition', function () {
+    test('buildMapPathTransformIndex maps each transform to the matching .map file path', function () {
+        const index = buildMapPathTransformIndex([resourceOutput('a.js', [transformRecord])]);
 
-    assert.strictEqual(index.get('a.js.map'), transformRecord);
-});
+        assert.strictEqual(index.get('a.js.map'), transformRecord);
+    });
 
-test('buildMapPathTransformIndex omits entries for resources without transforms', () => {
-    const index = buildMapPathTransformIndex([resourceOutput('a.js', [])]);
+    test('buildMapPathTransformIndex omits entries for resources without transforms', function () {
+        const index = buildMapPathTransformIndex([resourceOutput('a.js', [])]);
 
-    assert.strictEqual(index.size, 0);
-});
+        assert.strictEqual(index.size, 0);
+    });
 
-test('recomposePairedSourceMaps leaves unrelated resources unchanged when no transform matches', () => {
-    const resource = mapResource('a.js.map', 'original-map');
+    test('recomposePairedSourceMaps leaves unrelated resources unchanged when no transform matches', function () {
+        const resource = mapResource('a.js.map', 'original-map');
 
-    assert.deepStrictEqual(recomposePairedSourceMaps([resource], new Map()), [resource]);
-});
+        assert.deepStrictEqual(recomposePairedSourceMaps([resource], new Map()), [resource]);
+    });
 
-test('recomposePairedSourceMaps replaces the content for a resource whose map path has a transform', () => {
-    const resource = mapResource(
-        'a.js.map',
-        JSON.stringify({ version: 3, file: 'a.js', sources: ['/src/x.ts'], sourcesContent: [], mappings: '' })
-    );
-    const index = new Map([['a.js.map', transformRecord]]);
+    test('recomposePairedSourceMaps replaces the content for a resource whose map path has a transform', function () {
+        const resource = mapResource(
+            'a.js.map',
+            JSON.stringify({ version: 3, file: 'a.js', sources: ['/src/x.ts'], sourcesContent: [], mappings: '' })
+        );
+        const index = new Map([['a.js.map', transformRecord]]);
 
-    const recomposed = recomposePairedSourceMaps([resource], index);
+        const recomposed = recomposePairedSourceMaps([resource], index);
 
-    assert.strictEqual(recomposed.length, 1);
-    assert.notStrictEqual(recomposed[0]?.fileDescription.content, resource.fileDescription.content);
+        assert.strictEqual(recomposed.length, 1);
+        assert.notStrictEqual(recomposed[0]?.fileDescription.content, resource.fileDescription.content);
+    });
 });

--- a/source/dead-code-eliminator/statement-classifiers.test.ts
+++ b/source/dead-code-eliminator/statement-classifiers.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind, type SourceFile, type Statement } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { statementClassifiers } from './statement-classifiers.ts';
@@ -11,68 +11,70 @@ function firstStatementOfKind(content: string, kind: SyntaxKind): Statement {
     return sourceFile.getFirstChildByKindOrThrow(kind) as Statement;
 }
 
-test('statementClassifiers maps ImportDeclaration to a classifier that flags .css imports', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ImportDeclaration);
-    const statement = firstStatementOfKind('import "./style.css";', SyntaxKind.ImportDeclaration);
+suite('statement-classifiers', function () {
+    test('statementClassifiers maps ImportDeclaration to a classifier that flags .css imports', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ImportDeclaration);
+        const statement = firstStatementOfKind('import "./style.css";', SyntaxKind.ImportDeclaration);
 
-    assert.strictEqual(classifier?.(statement, undefined), 'css import');
-});
+        assert.strictEqual(classifier?.(statement, undefined), 'css import');
+    });
 
-test('statementClassifiers maps ImportDeclaration to a classifier that returns undefined for non-css imports', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ImportDeclaration);
-    const statement = firstStatementOfKind('import "./other.js";', SyntaxKind.ImportDeclaration);
+    test('statementClassifiers maps ImportDeclaration to a classifier that returns undefined for non-css imports', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ImportDeclaration);
+        const statement = firstStatementOfKind('import "./other.js";', SyntaxKind.ImportDeclaration);
 
-    assert.strictEqual(classifier?.(statement, undefined), undefined);
-});
+        assert.strictEqual(classifier?.(statement, undefined), undefined);
+    });
 
-test('statementClassifiers maps ExpressionStatement to a classifier that always reports it as a side effect', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ExpressionStatement);
-    const statement = firstStatementOfKind('foo();', SyntaxKind.ExpressionStatement);
+    test('statementClassifiers maps ExpressionStatement to a classifier that always reports it as a side effect', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ExpressionStatement);
+        const statement = firstStatementOfKind('foo();', SyntaxKind.ExpressionStatement);
 
-    assert.strictEqual(classifier?.(statement, undefined), 'expression statement');
-});
+        assert.strictEqual(classifier?.(statement, undefined), 'expression statement');
+    });
 
-test('statementClassifiers maps VariableStatement to a classifier that flags impure initializers', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.VariableStatement);
-    const statement = firstStatementOfKind('const x = Math.random();', SyntaxKind.VariableStatement);
+    test('statementClassifiers maps VariableStatement to a classifier that flags impure initializers', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.VariableStatement);
+        const statement = firstStatementOfKind('const x = Math.random();', SyntaxKind.VariableStatement);
 
-    assert.strictEqual(classifier?.(statement, undefined), 'variable initializer');
-});
+        assert.strictEqual(classifier?.(statement, undefined), 'variable initializer');
+    });
 
-test('statementClassifiers maps VariableStatement to a classifier that returns undefined for pure initializers', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.VariableStatement);
-    const statement = firstStatementOfKind('const x = 1;', SyntaxKind.VariableStatement);
+    test('statementClassifiers maps VariableStatement to a classifier that returns undefined for pure initializers', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.VariableStatement);
+        const statement = firstStatementOfKind('const x = 1;', SyntaxKind.VariableStatement);
 
-    assert.strictEqual(classifier?.(statement, undefined), undefined);
-});
+        assert.strictEqual(classifier?.(statement, undefined), undefined);
+    });
 
-test('statementClassifiers maps ClassDeclaration to a classifier that flags decorated classes', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ClassDeclaration);
-    const statement = firstStatementOfKind(
-        'function dec(_: unknown): void {}\n@dec\nclass Foo { method() { return 1; } }',
-        SyntaxKind.ClassDeclaration
-    );
+    test('statementClassifiers maps ClassDeclaration to a classifier that flags decorated classes', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ClassDeclaration);
+        const statement = firstStatementOfKind(
+            'function dec(_: unknown): void {}\n@dec\nclass Foo { method() { return 1; } }',
+            SyntaxKind.ClassDeclaration
+        );
 
-    assert.strictEqual(classifier?.(statement, undefined), 'class declaration');
-});
+        assert.strictEqual(classifier?.(statement, undefined), 'class declaration');
+    });
 
-test('statementClassifiers maps ClassDeclaration to a classifier that returns undefined for plain classes', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ClassDeclaration);
-    const statement = firstStatementOfKind('class Foo { method() { return 1; } }', SyntaxKind.ClassDeclaration);
+    test('statementClassifiers maps ClassDeclaration to a classifier that returns undefined for plain classes', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ClassDeclaration);
+        const statement = firstStatementOfKind('class Foo { method() { return 1; } }', SyntaxKind.ClassDeclaration);
 
-    assert.strictEqual(classifier?.(statement, undefined), undefined);
-});
+        assert.strictEqual(classifier?.(statement, undefined), undefined);
+    });
 
-test('statementClassifiers maps ExportAssignment to a classifier that flags impure default exports', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ExportAssignment);
-    const statement = firstStatementOfKind('export default Math.random();', SyntaxKind.ExportAssignment);
+    test('statementClassifiers maps ExportAssignment to a classifier that flags impure default exports', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ExportAssignment);
+        const statement = firstStatementOfKind('export default Math.random();', SyntaxKind.ExportAssignment);
 
-    assert.strictEqual(classifier?.(statement, undefined), 'export assignment');
-});
+        assert.strictEqual(classifier?.(statement, undefined), 'export assignment');
+    });
 
-test('statementClassifiers maps ExportAssignment to a classifier that returns undefined for pure default exports', () => {
-    const classifier = statementClassifiers.get(SyntaxKind.ExportAssignment);
-    const statement = firstStatementOfKind('export default 1;', SyntaxKind.ExportAssignment);
+    test('statementClassifiers maps ExportAssignment to a classifier that returns undefined for pure default exports', function () {
+        const classifier = statementClassifiers.get(SyntaxKind.ExportAssignment);
+        const statement = firstStatementOfKind('export default 1;', SyntaxKind.ExportAssignment);
 
-    assert.strictEqual(classifier?.(statement, undefined), undefined);
+        assert.strictEqual(classifier?.(statement, undefined), undefined);
+    });
 });

--- a/source/dead-code-eliminator/syntax-kind-sets.test.ts
+++ b/source/dead-code-eliminator/syntax-kind-sets.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind } from 'ts-morph';
 import {
     allowedBinaryOperators,
@@ -10,70 +10,72 @@ import {
     pureLeafKinds
 } from './syntax-kind-sets.ts';
 
-test('pureLeafKinds classifies primitive literals and function expressions as pure leaves', () => {
-    for (const kind of [
-        SyntaxKind.StringLiteral,
-        SyntaxKind.NumericLiteral,
-        SyntaxKind.TrueKeyword,
-        SyntaxKind.NullKeyword,
-        SyntaxKind.Identifier,
-        SyntaxKind.ArrowFunction
-    ]) {
-        assert.strictEqual(pureLeafKinds.has(kind), true);
-    }
-});
+suite('syntax-kind-sets', function () {
+    test('pureLeafKinds classifies primitive literals and function expressions as pure leaves', function () {
+        for (const kind of [
+            SyntaxKind.StringLiteral,
+            SyntaxKind.NumericLiteral,
+            SyntaxKind.TrueKeyword,
+            SyntaxKind.NullKeyword,
+            SyntaxKind.Identifier,
+            SyntaxKind.ArrowFunction
+        ]) {
+            assert.strictEqual(pureLeafKinds.has(kind), true);
+        }
+    });
 
-test('pureLeafKinds does not classify object or array literals as pure leaves', () => {
-    assert.strictEqual(pureLeafKinds.has(SyntaxKind.ObjectLiteralExpression), false);
-    assert.strictEqual(pureLeafKinds.has(SyntaxKind.ArrayLiteralExpression), false);
-});
+    test('pureLeafKinds does not classify object or array literals as pure leaves', function () {
+        assert.strictEqual(pureLeafKinds.has(SyntaxKind.ObjectLiteralExpression), false);
+        assert.strictEqual(pureLeafKinds.has(SyntaxKind.ArrayLiteralExpression), false);
+    });
 
-test('allowedPrefixUnaryOperators only permits arithmetic and boolean prefixes', () => {
-    for (const kind of [
-        SyntaxKind.MinusToken,
-        SyntaxKind.PlusToken,
-        SyntaxKind.ExclamationToken,
-        SyntaxKind.TildeToken
-    ]) {
-        assert.strictEqual(allowedPrefixUnaryOperators.has(kind), true);
-    }
-});
+    test('allowedPrefixUnaryOperators only permits arithmetic and boolean prefixes', function () {
+        for (const kind of [
+            SyntaxKind.MinusToken,
+            SyntaxKind.PlusToken,
+            SyntaxKind.ExclamationToken,
+            SyntaxKind.TildeToken
+        ]) {
+            assert.strictEqual(allowedPrefixUnaryOperators.has(kind), true);
+        }
+    });
 
-test('allowedBinaryOperators permits arithmetic and strict equality but not assignment', () => {
-    assert.strictEqual(allowedBinaryOperators.has(SyntaxKind.PlusToken), true);
-    assert.strictEqual(allowedBinaryOperators.has(SyntaxKind.EqualsEqualsEqualsToken), true);
-    assert.strictEqual(allowedBinaryOperators.has(SyntaxKind.EqualsToken), false);
-});
+    test('allowedBinaryOperators permits arithmetic and strict equality but not assignment', function () {
+        assert.strictEqual(allowedBinaryOperators.has(SyntaxKind.PlusToken), true);
+        assert.strictEqual(allowedBinaryOperators.has(SyntaxKind.EqualsEqualsEqualsToken), true);
+        assert.strictEqual(allowedBinaryOperators.has(SyntaxKind.EqualsToken), false);
+    });
 
-test('inherentlyPurePropertyKinds includes accessors, methods, and shorthand properties', () => {
-    for (const kind of [
-        SyntaxKind.ShorthandPropertyAssignment,
-        SyntaxKind.MethodDeclaration,
-        SyntaxKind.GetAccessor,
-        SyntaxKind.SetAccessor
-    ]) {
-        assert.strictEqual(inherentlyPurePropertyKinds.has(kind), true);
-    }
-});
+    test('inherentlyPurePropertyKinds includes accessors, methods, and shorthand properties', function () {
+        for (const kind of [
+            SyntaxKind.ShorthandPropertyAssignment,
+            SyntaxKind.MethodDeclaration,
+            SyntaxKind.GetAccessor,
+            SyntaxKind.SetAccessor
+        ]) {
+            assert.strictEqual(inherentlyPurePropertyKinds.has(kind), true);
+        }
+    });
 
-test('pureDeclarationKinds includes function, interface, type alias, enum, namespace, and export declarations', () => {
-    for (const kind of [
-        SyntaxKind.FunctionDeclaration,
-        SyntaxKind.InterfaceDeclaration,
-        SyntaxKind.TypeAliasDeclaration,
-        SyntaxKind.EnumDeclaration,
-        SyntaxKind.ModuleDeclaration,
-        SyntaxKind.ExportDeclaration,
-        SyntaxKind.EmptyStatement
-    ]) {
-        assert.strictEqual(pureDeclarationKinds.has(kind), true);
-    }
-});
+    test('pureDeclarationKinds includes function, interface, type alias, enum, namespace, and export declarations', function () {
+        for (const kind of [
+            SyntaxKind.FunctionDeclaration,
+            SyntaxKind.InterfaceDeclaration,
+            SyntaxKind.TypeAliasDeclaration,
+            SyntaxKind.EnumDeclaration,
+            SyntaxKind.ModuleDeclaration,
+            SyntaxKind.ExportDeclaration,
+            SyntaxKind.EmptyStatement
+        ]) {
+            assert.strictEqual(pureDeclarationKinds.has(kind), true);
+        }
+    });
 
-test('controlFlowStatementKinds maps if, for, while, switch, and try statements to a label', () => {
-    assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.IfStatement), 'if statement');
-    assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.ForStatement), 'for statement');
-    assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.WhileStatement), 'while statement');
-    assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.SwitchStatement), 'switch statement');
-    assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.TryStatement), 'try statement');
+    test('controlFlowStatementKinds maps if, for, while, switch, and try statements to a label', function () {
+        assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.IfStatement), 'if statement');
+        assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.ForStatement), 'for statement');
+        assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.WhileStatement), 'while statement');
+        assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.SwitchStatement), 'switch statement');
+        assert.strictEqual(controlFlowStatementKinds.get(SyntaxKind.TryStatement), 'try statement');
+    });
 });

--- a/source/dead-code-eliminator/transform/atom-translator.test.ts
+++ b/source/dead-code-eliminator/transform/atom-translator.test.ts
@@ -1,40 +1,42 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { translateGeneratedOffset } from './atom-translator.ts';
 import type { PositionAtom } from './declaration-remover.ts';
 
-test('translateGeneratedOffset shifts the offset by the atom delta when the offset is inside an atom', () => {
-    const atoms: readonly PositionAtom[] = [{ originalStart: 10, originalEnd: 20, newStart: 3 }];
-    assert.strictEqual(translateGeneratedOffset(15, atoms), 8);
-});
+suite('atom-translator', function () {
+    test('translateGeneratedOffset shifts the offset by the atom delta when the offset is inside an atom', function () {
+        const atoms: readonly PositionAtom[] = [{ originalStart: 10, originalEnd: 20, newStart: 3 }];
+        assert.strictEqual(translateGeneratedOffset(15, atoms), 8);
+    });
 
-test('translateGeneratedOffset returns undefined when the offset is past every atom', () => {
-    const atoms: readonly PositionAtom[] = [{ originalStart: 0, originalEnd: 5, newStart: 0 }];
-    assert.strictEqual(translateGeneratedOffset(20, atoms), undefined);
-});
+    test('translateGeneratedOffset returns undefined when the offset is past every atom', function () {
+        const atoms: readonly PositionAtom[] = [{ originalStart: 0, originalEnd: 5, newStart: 0 }];
+        assert.strictEqual(translateGeneratedOffset(20, atoms), undefined);
+    });
 
-test('translateGeneratedOffset returns undefined for an offset equal to an atom originalEnd (exclusive upper bound)', () => {
-    const atoms: readonly PositionAtom[] = [{ originalStart: 0, originalEnd: 5, newStart: 0 }];
-    assert.strictEqual(translateGeneratedOffset(5, atoms), undefined);
-});
+    test('translateGeneratedOffset returns undefined for an offset equal to an atom originalEnd (exclusive upper bound)', function () {
+        const atoms: readonly PositionAtom[] = [{ originalStart: 0, originalEnd: 5, newStart: 0 }];
+        assert.strictEqual(translateGeneratedOffset(5, atoms), undefined);
+    });
 
-test('translateGeneratedOffset shifts an offset equal to an atom originalStart (inclusive lower bound)', () => {
-    const atoms: readonly PositionAtom[] = [{ originalStart: 5, originalEnd: 10, newStart: 2 }];
-    assert.strictEqual(translateGeneratedOffset(5, atoms), 2);
-});
+    test('translateGeneratedOffset shifts an offset equal to an atom originalStart (inclusive lower bound)', function () {
+        const atoms: readonly PositionAtom[] = [{ originalStart: 5, originalEnd: 10, newStart: 2 }];
+        assert.strictEqual(translateGeneratedOffset(5, atoms), 2);
+    });
 
-test('translateGeneratedOffset picks the atom whose range contains the offset', () => {
-    const atoms: readonly PositionAtom[] = [
-        { originalStart: 0, originalEnd: 5, newStart: 0 },
-        { originalStart: 10, originalEnd: 20, newStart: 5 }
-    ];
-    assert.strictEqual(translateGeneratedOffset(12, atoms), 7);
-});
+    test('translateGeneratedOffset picks the atom whose range contains the offset', function () {
+        const atoms: readonly PositionAtom[] = [
+            { originalStart: 0, originalEnd: 5, newStart: 0 },
+            { originalStart: 10, originalEnd: 20, newStart: 5 }
+        ];
+        assert.strictEqual(translateGeneratedOffset(12, atoms), 7);
+    });
 
-test('translateGeneratedOffset returns undefined for an offset that falls in the gap between atoms', () => {
-    const atoms: readonly PositionAtom[] = [
-        { originalStart: 0, originalEnd: 5, newStart: 0 },
-        { originalStart: 10, originalEnd: 20, newStart: 5 }
-    ];
-    assert.strictEqual(translateGeneratedOffset(7, atoms), undefined);
+    test('translateGeneratedOffset returns undefined for an offset that falls in the gap between atoms', function () {
+        const atoms: readonly PositionAtom[] = [
+            { originalStart: 0, originalEnd: 5, newStart: 0 },
+            { originalStart: 10, originalEnd: 20, newStart: 5 }
+        ];
+        assert.strictEqual(translateGeneratedOffset(7, atoms), undefined);
+    });
 });

--- a/source/dead-code-eliminator/transform/declaration-removal.test.ts
+++ b/source/dead-code-eliminator/transform/declaration-removal.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { processStatement } from './declaration-removal.ts';
 
@@ -8,38 +8,40 @@ function withSource(content: string) {
     return project.getSourceFileOrThrow('/source.ts');
 }
 
-test('processStatement removes a named declaration when its name is not in the surviving set', () => {
-    const sourceFile = withSource('function keep() {}\nfunction drop() {}');
+suite('declaration-removal', function () {
+    test('processStatement removes a named declaration when its name is not in the surviving set', function () {
+        const sourceFile = withSource('function keep() {}\nfunction drop() {}');
 
-    const dropStatement = sourceFile.getFunctionOrThrow('drop');
-    const mutated = processStatement(dropStatement, new Set(['keep']));
+        const dropStatement = sourceFile.getFunctionOrThrow('drop');
+        const mutated = processStatement(dropStatement, new Set(['keep']));
 
-    assert.strictEqual(mutated, true);
-    assert.strictEqual(sourceFile.getFunction('drop'), undefined);
-});
+        assert.strictEqual(mutated, true);
+        assert.strictEqual(sourceFile.getFunction('drop'), undefined);
+    });
 
-test('processStatement leaves a named declaration in place when it is in the surviving set', () => {
-    const sourceFile = withSource('function keep() {}');
+    test('processStatement leaves a named declaration in place when it is in the surviving set', function () {
+        const sourceFile = withSource('function keep() {}');
 
-    const mutated = processStatement(sourceFile.getFunctionOrThrow('keep'), new Set(['keep']));
+        const mutated = processStatement(sourceFile.getFunctionOrThrow('keep'), new Set(['keep']));
 
-    assert.strictEqual(mutated, false);
-    assert.ok(sourceFile.getFunction('keep') !== undefined);
-});
+        assert.strictEqual(mutated, false);
+        assert.ok(sourceFile.getFunction('keep') !== undefined);
+    });
 
-test('processStatement drops only the non-surviving declarators inside a variable statement', () => {
-    const sourceFile = withSource('const a = 1, b = 2;');
-    const [statement] = sourceFile.getStatements();
+    test('processStatement drops only the non-surviving declarators inside a variable statement', function () {
+        const sourceFile = withSource('const a = 1, b = 2;');
+        const [statement] = sourceFile.getStatements();
 
-    const mutated = processStatement(statement!, new Set(['a']));
+        const mutated = processStatement(statement!, new Set(['a']));
 
-    assert.strictEqual(mutated, true);
-    assert.strictEqual(sourceFile.getFullText(), 'const a = 1;');
-});
+        assert.strictEqual(mutated, true);
+        assert.strictEqual(sourceFile.getFullText(), 'const a = 1;');
+    });
 
-test('processStatement returns false for an expression statement that is neither named nor a variable declaration', () => {
-    const sourceFile = withSource('console.log("hi");');
-    const [statement] = sourceFile.getStatements();
+    test('processStatement returns false for an expression statement that is neither named nor a variable declaration', function () {
+        const sourceFile = withSource('console.log("hi");');
+        const [statement] = sourceFile.getStatements();
 
-    assert.strictEqual(processStatement(statement!, new Set()), false);
+        assert.strictEqual(processStatement(statement!, new Set()), false);
+    });
 });

--- a/source/dead-code-eliminator/transform/declaration-remover.test.ts
+++ b/source/dead-code-eliminator/transform/declaration-remover.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { applyRemovalPlan, type PositionAtom } from './declaration-remover.ts';
 
@@ -13,129 +13,131 @@ function transform(
     return { text: sourceFile.getFullText(), mutated: result.mutated, atoms: result.atoms };
 }
 
-test('removes an unreachable function declaration', () => {
-    const { text, mutated } = transform('function dead() {}\nexport function live() {}', new Set(['live']));
-    assert.strictEqual(text.includes('dead'), false);
-    assert.strictEqual(text.includes('live'), true);
-    assert.strictEqual(mutated, true);
-});
+suite('declaration-remover', function () {
+    test('removes an unreachable function declaration', function () {
+        const { text, mutated } = transform('function dead() {}\nexport function live() {}', new Set(['live']));
+        assert.strictEqual(text.includes('dead'), false);
+        assert.strictEqual(text.includes('live'), true);
+        assert.strictEqual(mutated, true);
+    });
 
-test('keeps a reachable function declaration', () => {
-    const { text, mutated } = transform('function alive() {}', new Set(['alive']));
-    assert.strictEqual(text.includes('alive'), true);
-    assert.strictEqual(mutated, false);
-});
+    test('keeps a reachable function declaration', function () {
+        const { text, mutated } = transform('function alive() {}', new Set(['alive']));
+        assert.strictEqual(text.includes('alive'), true);
+        assert.strictEqual(mutated, false);
+    });
 
-test('removes the whole VariableStatement when every declarator is unreachable', () => {
-    const { text, mutated } = transform('const a = 1, b = 2;\nexport const live = 3;', new Set(['live']));
-    assert.strictEqual(text.includes('const a'), false);
-    assert.strictEqual(text.includes('const b'), false);
-    assert.strictEqual(text.includes('live'), true);
-    assert.strictEqual(mutated, true);
-});
+    test('removes the whole VariableStatement when every declarator is unreachable', function () {
+        const { text, mutated } = transform('const a = 1, b = 2;\nexport const live = 3;', new Set(['live']));
+        assert.strictEqual(text.includes('const a'), false);
+        assert.strictEqual(text.includes('const b'), false);
+        assert.strictEqual(text.includes('live'), true);
+        assert.strictEqual(mutated, true);
+    });
 
-test('removes only the dead declarators when some are reachable', () => {
-    const { text, mutated } = transform('export const a = 1, b = 2;', new Set(['a']));
-    assert.strictEqual(text.includes('a'), true);
-    assert.strictEqual(text.includes('b = 2'), false);
-    assert.strictEqual(mutated, true);
-});
+    test('removes only the dead declarators when some are reachable', function () {
+        const { text, mutated } = transform('export const a = 1, b = 2;', new Set(['a']));
+        assert.strictEqual(text.includes('a'), true);
+        assert.strictEqual(text.includes('b = 2'), false);
+        assert.strictEqual(mutated, true);
+    });
 
-test('keeps a whole destructuring declarator when any bound identifier survives', () => {
-    const { text, mutated } = transform('export const { a, b } = value;', new Set(['a']));
-    assert.strictEqual(text.includes('{ a, b }'), true);
-    assert.strictEqual(mutated, false);
-});
+    test('keeps a whole destructuring declarator when any bound identifier survives', function () {
+        const { text, mutated } = transform('export const { a, b } = value;', new Set(['a']));
+        assert.strictEqual(text.includes('{ a, b }'), true);
+        assert.strictEqual(mutated, false);
+    });
 
-test('removes a whole destructuring declarator when no bound identifier survives', () => {
-    const { text, mutated } = transform('export const { a, b } = value;', new Set<string>());
-    assert.strictEqual(text.includes('{ a, b }'), false);
-    assert.strictEqual(mutated, true);
-});
+    test('removes a whole destructuring declarator when no bound identifier survives', function () {
+        const { text, mutated } = transform('export const { a, b } = value;', new Set<string>());
+        assert.strictEqual(text.includes('{ a, b }'), false);
+        assert.strictEqual(mutated, true);
+    });
 
-test('returns false when nothing needs to change', () => {
-    const { text, mutated } = transform('export const a = 1;', new Set(['a']));
-    assert.strictEqual(text.includes('a'), true);
-    assert.strictEqual(mutated, false);
-});
+    test('returns false when nothing needs to change', function () {
+        const { text, mutated } = transform('export const a = 1;', new Set(['a']));
+        assert.strictEqual(text.includes('a'), true);
+        assert.strictEqual(mutated, false);
+    });
 
-test('removes class declarations whose name is not surviving', () => {
-    const { text } = transform('class Dead {}\nexport class Live {}', new Set(['Live']));
-    assert.strictEqual(text.includes('class Dead'), false);
-    assert.strictEqual(text.includes('class Live'), true);
-});
+    test('removes class declarations whose name is not surviving', function () {
+        const { text } = transform('class Dead {}\nexport class Live {}', new Set(['Live']));
+        assert.strictEqual(text.includes('class Dead'), false);
+        assert.strictEqual(text.includes('class Live'), true);
+    });
 
-test('removes interface, type alias, enum, and namespace declarations whose names are unreachable', () => {
-    const content = [
-        'interface DeadInterface {}',
-        'type DeadAlias = string;',
-        'enum DeadEnum { A }',
-        'namespace DeadNamespace {}',
-        'export interface LiveInterface {}'
-    ].join('\n');
-    const { text } = transform(content, new Set(['LiveInterface']));
-    assert.strictEqual(text.includes('DeadInterface'), false);
-    assert.strictEqual(text.includes('DeadAlias'), false);
-    assert.strictEqual(text.includes('DeadEnum'), false);
-    assert.strictEqual(text.includes('DeadNamespace'), false);
-    assert.strictEqual(text.includes('LiveInterface'), true);
-});
+    test('removes interface, type alias, enum, and namespace declarations whose names are unreachable', function () {
+        const content = [
+            'interface DeadInterface {}',
+            'type DeadAlias = string;',
+            'enum DeadEnum { A }',
+            'namespace DeadNamespace {}',
+            'export interface LiveInterface {}'
+        ].join('\n');
+        const { text } = transform(content, new Set(['LiveInterface']));
+        assert.strictEqual(text.includes('DeadInterface'), false);
+        assert.strictEqual(text.includes('DeadAlias'), false);
+        assert.strictEqual(text.includes('DeadEnum'), false);
+        assert.strictEqual(text.includes('DeadNamespace'), false);
+        assert.strictEqual(text.includes('LiveInterface'), true);
+    });
 
-test('does not affect imports, exports, or other non-declaration statements', () => {
-    const content = ['import { x } from "./other";', 'export { something } from "./other";'].join('\n');
-    const { text, mutated } = transform(content, new Set<string>());
-    assert.strictEqual(text.includes('import'), true);
-    assert.strictEqual(text.includes('export'), true);
-    assert.strictEqual(mutated, false);
-});
+    test('does not affect imports, exports, or other non-declaration statements', function () {
+        const content = ['import { x } from "./other";', 'export { something } from "./other";'].join('\n');
+        const { text, mutated } = transform(content, new Set<string>());
+        assert.strictEqual(text.includes('import'), true);
+        assert.strictEqual(text.includes('export'), true);
+        assert.strictEqual(mutated, false);
+    });
 
-test('returns true if any statement was mutated', () => {
-    const { mutated } = transform('function dead() {}', new Set<string>());
-    assert.strictEqual(mutated, true);
-});
+    test('returns true if any statement was mutated', function () {
+        const { mutated } = transform('function dead() {}', new Set<string>());
+        assert.strictEqual(mutated, true);
+    });
 
-test('an empty file produces no mutations', () => {
-    const { text, mutated } = transform('', new Set<string>());
-    assert.strictEqual(text, '');
-    assert.strictEqual(mutated, false);
-});
+    test('an empty file produces no mutations', function () {
+        const { text, mutated } = transform('', new Set<string>());
+        assert.strictEqual(text, '');
+        assert.strictEqual(mutated, false);
+    });
 
-test('keeps an anonymous default-exported function declaration whose name cannot be resolved', () => {
-    const { text, mutated } = transform('export default function() { return 1; }', new Set<string>());
-    assert.strictEqual(text.includes('default'), true);
-    assert.strictEqual(text.includes('function'), true);
-    assert.strictEqual(mutated, false);
-});
+    test('keeps an anonymous default-exported function declaration whose name cannot be resolved', function () {
+        const { text, mutated } = transform('export default function() { return 1; }', new Set<string>());
+        assert.strictEqual(text.includes('default'), true);
+        assert.strictEqual(text.includes('function'), true);
+        assert.strictEqual(mutated, false);
+    });
 
-test('captures an atom for an anonymous default-exported function declaration', () => {
-    const { atoms } = transform('export default function() { return 1; }', new Set<string>());
-    assert.strictEqual(atoms.length, 1);
-});
+    test('captures an atom for an anonymous default-exported function declaration', function () {
+        const { atoms } = transform('export default function() { return 1; }', new Set<string>());
+        assert.strictEqual(atoms.length, 1);
+    });
 
-test('captures one atom per surviving variable declarator when at least one is removed', () => {
-    const { atoms } = transform('export const a = 1, b = 2;', new Set(['a']));
-    assert.strictEqual(atoms.length, 1);
-});
+    test('captures one atom per surviving variable declarator when at least one is removed', function () {
+        const { atoms } = transform('export const a = 1, b = 2;', new Set(['a']));
+        assert.strictEqual(atoms.length, 1);
+    });
 
-test('captures a single atom covering the whole variable statement when every declarator survives', () => {
-    const { atoms } = transform('export const a = 1, b = 2;', new Set(['a', 'b']));
-    assert.strictEqual(atoms.length, 1);
-    const [atom] = atoms;
-    assert.ok(atom !== undefined);
-    assert.strictEqual(atom.originalStart, 0);
-});
+    test('captures a single atom covering the whole variable statement when every declarator survives', function () {
+        const { atoms } = transform('export const a = 1, b = 2;', new Set(['a', 'b']));
+        assert.strictEqual(atoms.length, 1);
+        const [atom] = atoms;
+        assert.ok(atom !== undefined);
+        assert.strictEqual(atom.originalStart, 0);
+    });
 
-test('captures an atom for non-declaration top-level statements (imports, re-exports)', () => {
-    const content = ['import { x } from "./other";', 'export { something } from "./other";'].join('\n');
-    const { atoms } = transform(content, new Set<string>());
-    assert.strictEqual(atoms.length, 2);
-});
+    test('captures an atom for non-declaration top-level statements (imports, re-exports)', function () {
+        const content = ['import { x } from "./other";', 'export { something } from "./other";'].join('\n');
+        const { atoms } = transform(content, new Set<string>());
+        assert.strictEqual(atoms.length, 2);
+    });
 
-test('captures atoms whose newStart reflects the post-removal position', () => {
-    const { atoms } = transform('function dead() {}\nexport function live() {}', new Set(['live']));
-    assert.strictEqual(atoms.length, 1);
-    const [atom] = atoms;
-    assert.ok(atom !== undefined);
-    assert.strictEqual(atom.originalStart, 19);
-    assert.strictEqual(atom.newStart, 0);
+    test('captures atoms whose newStart reflects the post-removal position', function () {
+        const { atoms } = transform('function dead() {}\nexport function live() {}', new Set(['live']));
+        assert.strictEqual(atoms.length, 1);
+        const [atom] = atoms;
+        assert.ok(atom !== undefined);
+        assert.strictEqual(atom.originalStart, 19);
+        assert.strictEqual(atom.newStart, 0);
+    });
 });

--- a/source/dead-code-eliminator/transform/line-index.test.ts
+++ b/source/dead-code-eliminator/transform/line-index.test.ts
@@ -1,41 +1,43 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { buildLineIndex, lineColumnToOffset, offsetToLineColumn } from './line-index.ts';
 
-test('buildLineIndex returns a single entry for an empty string', () => {
-    assert.deepStrictEqual(buildLineIndex(''), [{ lineNumber: 1, lineStart: 0 }]);
-});
+suite('line-index', function () {
+    test('buildLineIndex returns a single entry for an empty string', function () {
+        assert.deepStrictEqual(buildLineIndex(''), [{ lineNumber: 1, lineStart: 0 }]);
+    });
 
-test('buildLineIndex returns one entry per newline-terminated line plus the first line', () => {
-    assert.deepStrictEqual(buildLineIndex('a\nb\nc'), [
-        { lineNumber: 1, lineStart: 0 },
-        { lineNumber: 2, lineStart: 2 },
-        { lineNumber: 3, lineStart: 4 }
-    ]);
-});
+    test('buildLineIndex returns one entry per newline-terminated line plus the first line', function () {
+        assert.deepStrictEqual(buildLineIndex('a\nb\nc'), [
+            { lineNumber: 1, lineStart: 0 },
+            { lineNumber: 2, lineStart: 2 },
+            { lineNumber: 3, lineStart: 4 }
+        ]);
+    });
 
-test('lineColumnToOffset returns the lineStart plus the column for a known line', () => {
-    const index = buildLineIndex('hello\nworld');
-    assert.strictEqual(lineColumnToOffset(index, 2, 3), 9);
-});
+    test('lineColumnToOffset returns the lineStart plus the column for a known line', function () {
+        const index = buildLineIndex('hello\nworld');
+        assert.strictEqual(lineColumnToOffset(index, 2, 3), 9);
+    });
 
-test('lineColumnToOffset returns just the column when the line is past the file', () => {
-    const index = buildLineIndex('hello\nworld');
-    assert.strictEqual(lineColumnToOffset(index, 99, 4), 4);
-});
+    test('lineColumnToOffset returns just the column when the line is past the file', function () {
+        const index = buildLineIndex('hello\nworld');
+        assert.strictEqual(lineColumnToOffset(index, 99, 4), 4);
+    });
 
-test('offsetToLineColumn returns line 1 column 0 for offset 0', () => {
-    assert.deepStrictEqual(offsetToLineColumn(buildLineIndex('hello\nworld'), 0), { line: 1, column: 0 });
-});
+    test('offsetToLineColumn returns line 1 column 0 for offset 0', function () {
+        assert.deepStrictEqual(offsetToLineColumn(buildLineIndex('hello\nworld'), 0), { line: 1, column: 0 });
+    });
 
-test('offsetToLineColumn returns the line containing the offset for a mid-file offset', () => {
-    assert.deepStrictEqual(offsetToLineColumn(buildLineIndex('hello\nworld'), 8), { line: 2, column: 2 });
-});
+    test('offsetToLineColumn returns the line containing the offset for a mid-file offset', function () {
+        assert.deepStrictEqual(offsetToLineColumn(buildLineIndex('hello\nworld'), 8), { line: 2, column: 2 });
+    });
 
-test('offsetToLineColumn returns the last line when the offset is past the last newline', () => {
-    assert.deepStrictEqual(offsetToLineColumn(buildLineIndex('hello\nworld'), 100), { line: 2, column: 94 });
-});
+    test('offsetToLineColumn returns the last line when the offset is past the last newline', function () {
+        assert.deepStrictEqual(offsetToLineColumn(buildLineIndex('hello\nworld'), 100), { line: 2, column: 94 });
+    });
 
-test('offsetToLineColumn returns the initial entry for an empty index', () => {
-    assert.deepStrictEqual(offsetToLineColumn([], 7), { line: 1, column: 7 });
+    test('offsetToLineColumn returns the initial entry for an empty index', function () {
+        assert.deepStrictEqual(offsetToLineColumn([], 7), { line: 1, column: 7 });
+    });
 });

--- a/source/dead-code-eliminator/transform/named-declaration-kinds.test.ts
+++ b/source/dead-code-eliminator/transform/named-declaration-kinds.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { isNamedDeclaration } from './named-declaration-kinds.ts';
 
@@ -8,21 +8,28 @@ function statementsFor(content: string) {
     return project.getSourceFileOrThrow('/source.ts').getStatements();
 }
 
-test('isNamedDeclaration returns true for function, class, interface, type-alias, enum, and module declarations', () => {
-    const statements = statementsFor(
-        ['function f() {}', 'class C {}', 'interface I {}', 'type T = number;', 'enum E { A }', 'namespace N {}'].join(
-            '\n'
-        )
-    );
+suite('named-declaration-kinds', function () {
+    test('isNamedDeclaration returns true for function, class, interface, type-alias, enum, and module declarations', function () {
+        const statements = statementsFor(
+            [
+                'function f() {}',
+                'class C {}',
+                'interface I {}',
+                'type T = number;',
+                'enum E { A }',
+                'namespace N {}'
+            ].join('\n')
+        );
 
-    for (const statement of statements) {
-        assert.strictEqual(isNamedDeclaration(statement), true, `expected named for ${statement.getKindName()}`);
-    }
-});
+        for (const statement of statements) {
+            assert.strictEqual(isNamedDeclaration(statement), true, `expected named for ${statement.getKindName()}`);
+        }
+    });
 
-test('isNamedDeclaration returns false for variable statements and side-effecting expressions', () => {
-    const [variableStatement, expressionStatement] = statementsFor('const x = 1;\nconsole.log("hi");');
+    test('isNamedDeclaration returns false for variable statements and side-effecting expressions', function () {
+        const [variableStatement, expressionStatement] = statementsFor('const x = 1;\nconsole.log("hi");');
 
-    assert.strictEqual(isNamedDeclaration(variableStatement!), false);
-    assert.strictEqual(isNamedDeclaration(expressionStatement!), false);
+        assert.strictEqual(isNamedDeclaration(variableStatement!), false);
+        assert.strictEqual(isNamedDeclaration(expressionStatement!), false);
+    });
 });

--- a/source/dead-code-eliminator/transform/source-map-composer.test.ts
+++ b/source/dead-code-eliminator/transform/source-map-composer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { TraceMap, eachMapping } from '@jridgewell/trace-mapping';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PositionAtom } from './declaration-remover.ts';
 import { recomposeSourceMap } from './source-map-composer.ts';
 
@@ -42,254 +42,256 @@ const originalMap = JSON.stringify({
 
 const removeFunctionDeadAtoms: readonly PositionAtom[] = [{ originalStart: 30, originalEnd: 66, newStart: 1 }];
 
-test('recomposeSourceMap drops mappings inside the removed range', () => {
-    const result = recomposeSourceMap({
-        originalMap,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
+suite('source-map-composer', function () {
+    test('recomposeSourceMap drops mappings inside the removed range', function () {
+        const result = recomposeSourceMap({
+            originalMap,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const mappings = listMappings(result);
+        for (const mapping of mappings) {
+            assert.ok(mapping.generatedLine !== 1, 'no mapping should land on the removed line 1');
+        }
     });
-    const mappings = listMappings(result);
-    for (const mapping of mappings) {
-        assert.ok(mapping.generatedLine !== 1, 'no mapping should land on the removed line 1');
+
+    function recomposedMappings(): readonly Mapping[] {
+        return listMappings(
+            recomposeSourceMap({ originalMap, originalCode, transformedCode, atoms: removeFunctionDeadAtoms })
+        );
     }
-});
 
-function recomposedMappings(): readonly Mapping[] {
-    return listMappings(
-        recomposeSourceMap({ originalMap, originalCode, transformedCode, atoms: removeFunctionDeadAtoms })
-    );
-}
+    test('recomposeSourceMap shifts surviving mappings to their new generated positions', function () {
+        const mappings = recomposedMappings();
+        assert.ok(mappings.length > 0);
+        for (const mapping of mappings) {
+            assert.strictEqual(mapping.source, 'index.ts');
+        }
+    });
 
-test('recomposeSourceMap shifts surviving mappings to their new generated positions', () => {
-    const mappings = recomposedMappings();
-    assert.ok(mappings.length > 0);
-    for (const mapping of mappings) {
-        assert.strictEqual(mapping.source, 'index.ts');
-    }
-});
+    test('recomposeSourceMap returns the original map unchanged when it cannot be parsed', function () {
+        const result = recomposeSourceMap({
+            originalMap: 'not-json',
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        assert.strictEqual(result, 'not-json');
+    });
 
-test('recomposeSourceMap returns the original map unchanged when it cannot be parsed', () => {
-    const result = recomposeSourceMap({
-        originalMap: 'not-json',
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
+    test('recomposeSourceMap returns the original map unchanged when the v3 input has no mappings field', function () {
+        const minimal = JSON.stringify({ version: 3 });
+        const result = recomposeSourceMap({
+            originalMap: minimal,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        assert.strictEqual(result, minimal);
     });
-    assert.strictEqual(result, 'not-json');
-});
 
-test('recomposeSourceMap returns the original map unchanged when the v3 input has no mappings field', () => {
-    const minimal = JSON.stringify({ version: 3 });
-    const result = recomposeSourceMap({
-        originalMap: minimal,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
+    test('recomposeSourceMap produces a valid v3 map for a no-op atom list', function () {
+        const result = recomposeSourceMap({
+            originalMap,
+            originalCode,
+            transformedCode: originalCode,
+            atoms: [{ originalStart: 0, originalEnd: originalCode.length, newStart: 0 }]
+        });
+        const parsed = JSON.parse(result) as { readonly version: number };
+        assert.strictEqual(parsed.version, 3);
     });
-    assert.strictEqual(result, minimal);
-});
 
-test('recomposeSourceMap produces a valid v3 map for a no-op atom list', () => {
-    const result = recomposeSourceMap({
-        originalMap,
-        originalCode,
-        transformedCode: originalCode,
-        atoms: [{ originalStart: 0, originalEnd: originalCode.length, newStart: 0 }]
+    test('recomposeSourceMap preserves the `file` field from the input map', function () {
+        const result = recomposeSourceMap({
+            originalMap,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as { readonly file?: string };
+        assert.strictEqual(parsed.file, 'index.ts');
     });
-    const parsed = JSON.parse(result) as { readonly version: number };
-    assert.strictEqual(parsed.version, 3);
-});
 
-test('recomposeSourceMap preserves the `file` field from the input map', () => {
-    const result = recomposeSourceMap({
-        originalMap,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
+    test('recomposeSourceMap preserves sourcesContent from the input map', function () {
+        const result = recomposeSourceMap({
+            originalMap,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as { readonly sourcesContent?: readonly string[] };
+        assert.deepStrictEqual(parsed.sourcesContent, [originalCode]);
     });
-    const parsed = JSON.parse(result) as { readonly file?: string };
-    assert.strictEqual(parsed.file, 'index.ts');
-});
 
-test('recomposeSourceMap preserves sourcesContent from the input map', () => {
-    const result = recomposeSourceMap({
-        originalMap,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
+    test('recomposeSourceMap handles a map without a file field', function () {
+        const mapWithoutFile = JSON.stringify({
+            version: 3,
+            sources: ['index.ts'],
+            sourcesContent: [originalCode],
+            names: [],
+            // cspell:disable-next-line
+            mappings: 'AAAA;AACA,SAAS,IAAI;AACX,OAAO,CAAC,CAAC;AACX'
+        });
+        const result = recomposeSourceMap({
+            originalMap: mapWithoutFile,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as { readonly file?: string };
+        assert.strictEqual(parsed.file, undefined);
     });
-    const parsed = JSON.parse(result) as { readonly sourcesContent?: readonly string[] };
-    assert.deepStrictEqual(parsed.sourcesContent, [originalCode]);
-});
 
-test('recomposeSourceMap handles a map without a file field', () => {
-    const mapWithoutFile = JSON.stringify({
-        version: 3,
-        sources: ['index.ts'],
-        sourcesContent: [originalCode],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA;AACA,SAAS,IAAI;AACX,OAAO,CAAC,CAAC;AACX'
+    test('recomposeSourceMap preserves the `name` field on named mappings', function () {
+        const namedMap = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            sources: ['index.ts'],
+            sourcesContent: [originalCode],
+            names: ['live'],
+            // cspell:disable-next-line
+            mappings: 'AAAA;AACA,SAASA,IAAI'
+        });
+        const result = recomposeSourceMap({
+            originalMap: namedMap,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as { readonly names?: readonly string[] };
+        assert.deepStrictEqual(parsed.names, ['live']);
     });
-    const result = recomposeSourceMap({
-        originalMap: mapWithoutFile,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    const parsed = JSON.parse(result) as { readonly file?: string };
-    assert.strictEqual(parsed.file, undefined);
-});
 
-test('recomposeSourceMap preserves the `name` field on named mappings', () => {
-    const namedMap = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        sources: ['index.ts'],
-        sourcesContent: [originalCode],
-        names: ['live'],
-        // cspell:disable-next-line
-        mappings: 'AAAA;AACA,SAASA,IAAI'
+    test('recomposeSourceMap drops mappings with a null source even when the position falls inside a surviving atom', function () {
+        // Null-source segment at the start of line 2 (which is inside the surviving atom range).
+        const mapWithUnsourcedSegmentInRange = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            sources: ['index.ts'],
+            sourcesContent: [originalCode],
+            names: [],
+            // line 1: AAAA (gen col 0 → source 0 line 1 col 0)
+            // line 2 starts with `A` (1-field segment at col 0, null source), then standard mappings
+            // cspell:disable-next-line
+            mappings: 'AAAA;A,AACA,SAAS'
+        });
+        const result = recomposeSourceMap({
+            originalMap: mapWithUnsourcedSegmentInRange,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const mappings = listMappings(result);
+        for (const mapping of mappings) {
+            assert.notStrictEqual(mapping.source, null);
+        }
     });
-    const result = recomposeSourceMap({
-        originalMap: namedMap,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    const parsed = JSON.parse(result) as { readonly names?: readonly string[] };
-    assert.deepStrictEqual(parsed.names, ['live']);
-});
 
-test('recomposeSourceMap drops mappings with a null source even when the position falls inside a surviving atom', () => {
-    // Null-source segment at the start of line 2 (which is inside the surviving atom range).
-    const mapWithUnsourcedSegmentInRange = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        sources: ['index.ts'],
-        sourcesContent: [originalCode],
-        names: [],
-        // line 1: AAAA (gen col 0 → source 0 line 1 col 0)
-        // line 2 starts with `A` (1-field segment at col 0, null source), then standard mappings
-        // cspell:disable-next-line
-        mappings: 'AAAA;A,AACA,SAAS'
+    test('recomposeSourceMap preserves originalLine and originalColumn as numbers on translated mappings', function () {
+        const mappings = recomposedMappings();
+        assert.ok(mappings.length > 0);
+        for (const mapping of mappings) {
+            assert.strictEqual(typeof mapping.originalLine, 'number');
+            assert.strictEqual(typeof mapping.originalColumn, 'number');
+        }
     });
-    const result = recomposeSourceMap({
-        originalMap: mapWithUnsourcedSegmentInRange,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    const mappings = listMappings(result);
-    for (const mapping of mappings) {
-        assert.notStrictEqual(mapping.source, null);
-    }
-});
 
-test('recomposeSourceMap preserves originalLine and originalColumn as numbers on translated mappings', () => {
-    const mappings = recomposedMappings();
-    assert.ok(mappings.length > 0);
-    for (const mapping of mappings) {
-        assert.strictEqual(typeof mapping.originalLine, 'number');
-        assert.strictEqual(typeof mapping.originalColumn, 'number');
-    }
-});
+    test('recomposeSourceMap copies the original line and column values from each surviving mapping', function () {
+        const mappings = recomposedMappings();
+        const hasNonInitialOriginal = mappings.some((mapping) => {
+            return (mapping.originalLine ?? 0) > 1 || (mapping.originalColumn ?? 0) > 0;
+        });
+        assert.ok(hasNonInitialOriginal);
+    });
 
-test('recomposeSourceMap copies the original line and column values from each surviving mapping', () => {
-    const mappings = recomposedMappings();
-    const hasNonInitialOriginal = mappings.some((mapping) => {
-        return (mapping.originalLine ?? 0) > 1 || (mapping.originalColumn ?? 0) > 0;
+    test('recomposeSourceMap emits exactly the mappings that translate into the transformed range', function () {
+        const mappings = recomposedMappings();
+        assert.strictEqual(mappings.length, 3);
     });
-    assert.ok(hasNonInitialOriginal);
-});
 
-test('recomposeSourceMap emits exactly the mappings that translate into the transformed range', () => {
-    const mappings = recomposedMappings();
-    assert.strictEqual(mappings.length, 3);
-});
+    test('recomposeSourceMap preserves a non-null sourceRoot from the input map', function () {
+        const mapWithSourceRoot = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            sourceRoot: 'src',
+            sources: ['index.ts'],
+            sourcesContent: [originalCode],
+            names: [],
+            // cspell:disable-next-line
+            mappings: 'AAAA;AACA'
+        });
+        const result = recomposeSourceMap({
+            originalMap: mapWithSourceRoot,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as { readonly sourceRoot?: string };
+        assert.strictEqual(parsed.sourceRoot, 'src');
+    });
 
-test('recomposeSourceMap preserves a non-null sourceRoot from the input map', () => {
-    const mapWithSourceRoot = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        sourceRoot: 'src',
-        sources: ['index.ts'],
-        sourcesContent: [originalCode],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA;AACA'
+    test('recomposeSourceMap omits the file field for an input map that explicitly has null file', function () {
+        const mapWithNullFile = JSON.stringify({
+            version: 3,
+            file: null,
+            sources: ['index.ts'],
+            sourcesContent: [originalCode],
+            names: [],
+            // cspell:disable-next-line
+            mappings: 'AAAA;AACA'
+        });
+        const result = recomposeSourceMap({
+            originalMap: mapWithNullFile,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as Record<string, unknown>;
+        assert.strictEqual('file' in parsed, false);
     });
-    const result = recomposeSourceMap({
-        originalMap: mapWithSourceRoot,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    const parsed = JSON.parse(result) as { readonly sourceRoot?: string };
-    assert.strictEqual(parsed.sourceRoot, 'src');
-});
 
-test('recomposeSourceMap omits the file field for an input map that explicitly has null file', () => {
-    const mapWithNullFile = JSON.stringify({
-        version: 3,
-        file: null,
-        sources: ['index.ts'],
-        sourcesContent: [originalCode],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA;AACA'
+    test('recomposeSourceMap copies sources whose sourcesContent is null in the input map', function () {
+        const mapWithNullContent = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            sources: ['index.ts'],
+            sourcesContent: [null],
+            names: [],
+            // cspell:disable-next-line
+            mappings: 'AAAA;AACA'
+        });
+        const result = recomposeSourceMap({
+            originalMap: mapWithNullContent,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        const parsed = JSON.parse(result) as { readonly sourcesContent?: readonly (string | null)[] };
+        for (const entry of parsed.sourcesContent ?? []) {
+            assert.ok(entry === null || typeof entry === 'string');
+        }
     });
-    const result = recomposeSourceMap({
-        originalMap: mapWithNullFile,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    const parsed = JSON.parse(result) as Record<string, unknown>;
-    assert.strictEqual('file' in parsed, false);
-});
 
-test('recomposeSourceMap copies sources whose sourcesContent is null in the input map', () => {
-    const mapWithNullContent = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        sources: ['index.ts'],
-        sourcesContent: [null],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA;AACA'
+    test('recomposeSourceMap omits null entries in sources', function () {
+        const mapWithNullSource = JSON.stringify({
+            version: 3,
+            file: 'index.ts',
+            // null source entries are allowed by the v3 spec
+            sources: [null, 'index.ts'],
+            sourcesContent: [null, originalCode],
+            names: [],
+            // cspell:disable-next-line
+            mappings: 'AAAA;AACA,SAAS'
+        });
+        const result = recomposeSourceMap({
+            originalMap: mapWithNullSource,
+            originalCode,
+            transformedCode,
+            atoms: removeFunctionDeadAtoms
+        });
+        // Should not crash and produce a valid map.
+        const parsed = JSON.parse(result) as { readonly version: number };
+        assert.strictEqual(parsed.version, 3);
     });
-    const result = recomposeSourceMap({
-        originalMap: mapWithNullContent,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    const parsed = JSON.parse(result) as { readonly sourcesContent?: readonly (string | null)[] };
-    for (const entry of parsed.sourcesContent ?? []) {
-        assert.ok(entry === null || typeof entry === 'string');
-    }
-});
-
-test('recomposeSourceMap omits null entries in sources', () => {
-    const mapWithNullSource = JSON.stringify({
-        version: 3,
-        file: 'index.ts',
-        // null source entries are allowed by the v3 spec
-        sources: [null, 'index.ts'],
-        sourcesContent: [null, originalCode],
-        names: [],
-        // cspell:disable-next-line
-        mappings: 'AAAA;AACA,SAAS'
-    });
-    const result = recomposeSourceMap({
-        originalMap: mapWithNullSource,
-        originalCode,
-        transformedCode,
-        atoms: removeFunctionDeadAtoms
-    });
-    // Should not crash and produce a valid map.
-    const parsed = JSON.parse(result) as { readonly version: number };
-    assert.strictEqual(parsed.version, 3);
 });

--- a/source/dead-code-eliminator/transform/survivor-capture.test.ts
+++ b/source/dead-code-eliminator/transform/survivor-capture.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { captureSurvivorsForStatement } from './survivor-capture.ts';
 
@@ -8,52 +8,54 @@ function withSource(content: string) {
     return project.getSourceFileOrThrow('/source.ts');
 }
 
-test('captureSurvivorsForStatement keeps a named declaration when its name is in the surviving set', () => {
-    const sourceFile = withSource('function keep() {}');
-    const [statement] = sourceFile.getStatements();
+suite('survivor-capture', function () {
+    test('captureSurvivorsForStatement keeps a named declaration when its name is in the surviving set', function () {
+        const sourceFile = withSource('function keep() {}');
+        const [statement] = sourceFile.getStatements();
 
-    const survivors = captureSurvivorsForStatement(statement!, new Set(['keep']));
+        const survivors = captureSurvivorsForStatement(statement!, new Set(['keep']));
 
-    assert.strictEqual(survivors.length, 1);
-    assert.strictEqual(survivors[0]?.node, statement);
-});
+        assert.strictEqual(survivors.length, 1);
+        assert.strictEqual(survivors[0]?.node, statement);
+    });
 
-test('captureSurvivorsForStatement drops a named declaration whose name is not in the surviving set', () => {
-    const sourceFile = withSource('function drop() {}');
-    const [statement] = sourceFile.getStatements();
+    test('captureSurvivorsForStatement drops a named declaration whose name is not in the surviving set', function () {
+        const sourceFile = withSource('function drop() {}');
+        const [statement] = sourceFile.getStatements();
 
-    const survivors = captureSurvivorsForStatement(statement!, new Set());
+        const survivors = captureSurvivorsForStatement(statement!, new Set());
 
-    assert.deepStrictEqual(survivors, []);
-});
+        assert.deepStrictEqual(survivors, []);
+    });
 
-test('captureSurvivorsForStatement returns the whole variable statement when every declarator survives', () => {
-    const sourceFile = withSource('const a = 1, b = 2;');
-    const [statement] = sourceFile.getStatements();
+    test('captureSurvivorsForStatement returns the whole variable statement when every declarator survives', function () {
+        const sourceFile = withSource('const a = 1, b = 2;');
+        const [statement] = sourceFile.getStatements();
 
-    const survivors = captureSurvivorsForStatement(statement!, new Set(['a', 'b']));
+        const survivors = captureSurvivorsForStatement(statement!, new Set(['a', 'b']));
 
-    assert.strictEqual(survivors.length, 1);
-    assert.strictEqual(survivors[0]?.node, statement);
-});
+        assert.strictEqual(survivors.length, 1);
+        assert.strictEqual(survivors[0]?.node, statement);
+    });
 
-test('captureSurvivorsForStatement returns only the surviving declarators when some are dropped', () => {
-    const sourceFile = withSource('const a = 1, b = 2;');
-    const [statement] = sourceFile.getStatements();
-    const [firstDeclarator] = sourceFile.getVariableStatements()[0]?.getDeclarations() ?? [];
+    test('captureSurvivorsForStatement returns only the surviving declarators when some are dropped', function () {
+        const sourceFile = withSource('const a = 1, b = 2;');
+        const [statement] = sourceFile.getStatements();
+        const [firstDeclarator] = sourceFile.getVariableStatements()[0]?.getDeclarations() ?? [];
 
-    const survivors = captureSurvivorsForStatement(statement!, new Set(['a']));
+        const survivors = captureSurvivorsForStatement(statement!, new Set(['a']));
 
-    assert.strictEqual(survivors.length, 1);
-    assert.strictEqual(survivors[0]?.node, firstDeclarator);
-});
+        assert.strictEqual(survivors.length, 1);
+        assert.strictEqual(survivors[0]?.node, firstDeclarator);
+    });
 
-test('captureSurvivorsForStatement keeps an unclassified expression statement unconditionally', () => {
-    const sourceFile = withSource('console.log("hi");');
-    const [statement] = sourceFile.getStatements();
+    test('captureSurvivorsForStatement keeps an unclassified expression statement unconditionally', function () {
+        const sourceFile = withSource('console.log("hi");');
+        const [statement] = sourceFile.getStatements();
 
-    const survivors = captureSurvivorsForStatement(statement!, new Set());
+        const survivors = captureSurvivorsForStatement(statement!, new Set());
 
-    assert.strictEqual(survivors.length, 1);
-    assert.strictEqual(survivors[0]?.node, statement);
+        assert.strictEqual(survivors.length, 1);
+        assert.strictEqual(survivors[0]?.node, statement);
+    });
 });

--- a/source/dead-code-eliminator/variable-declaration-bindings.test.ts
+++ b/source/dead-code-eliminator/variable-declaration-bindings.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { SyntaxKind, type VariableDeclaration } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { collectVariableDeclarationBindings, variableDeclarationSurvives } from './variable-declaration-bindings.ts';
@@ -10,47 +10,49 @@ function declaratorFor(content: string): VariableDeclaration {
     return sourceFile.getFirstDescendantByKindOrThrow(SyntaxKind.VariableDeclaration);
 }
 
-test('collectVariableDeclarationBindings returns a single identifier binding for a simple declarator', () => {
-    const declarator = declaratorFor('const x = 1;');
+suite('variable-declaration-bindings', function () {
+    test('collectVariableDeclarationBindings returns a single identifier binding for a simple declarator', function () {
+        const declarator = declaratorFor('const x = 1;');
 
-    const bindings = collectVariableDeclarationBindings(declarator);
+        const bindings = collectVariableDeclarationBindings(declarator);
 
-    assert.deepStrictEqual(
-        bindings.map((binding) => binding.name),
-        ['x']
-    );
-});
+        assert.deepStrictEqual(
+            bindings.map((binding) => binding.name),
+            ['x']
+        );
+    });
 
-test('collectVariableDeclarationBindings flattens an array destructuring pattern into one binding per element', () => {
-    const declarator = declaratorFor('const [a, b] = [1, 2];');
+    test('collectVariableDeclarationBindings flattens an array destructuring pattern into one binding per element', function () {
+        const declarator = declaratorFor('const [a, b] = [1, 2];');
 
-    const bindings = collectVariableDeclarationBindings(declarator);
+        const bindings = collectVariableDeclarationBindings(declarator);
 
-    assert.deepStrictEqual(
-        bindings.map((binding) => binding.name),
-        ['a', 'b']
-    );
-});
+        assert.deepStrictEqual(
+            bindings.map((binding) => binding.name),
+            ['a', 'b']
+        );
+    });
 
-test('collectVariableDeclarationBindings flattens an object destructuring pattern into one binding per property', () => {
-    const declarator = declaratorFor('const { a, b: renamed } = { a: 1, b: 2 };');
+    test('collectVariableDeclarationBindings flattens an object destructuring pattern into one binding per property', function () {
+        const declarator = declaratorFor('const { a, b: renamed } = { a: 1, b: 2 };');
 
-    const bindings = collectVariableDeclarationBindings(declarator);
+        const bindings = collectVariableDeclarationBindings(declarator);
 
-    assert.deepStrictEqual(
-        bindings.map((binding) => binding.name),
-        ['a', 'renamed']
-    );
-});
+        assert.deepStrictEqual(
+            bindings.map((binding) => binding.name),
+            ['a', 'renamed']
+        );
+    });
 
-test('variableDeclarationSurvives returns true when any declared name is in the surviving set', () => {
-    const declarator = declaratorFor('const [a, b] = [1, 2];');
+    test('variableDeclarationSurvives returns true when any declared name is in the surviving set', function () {
+        const declarator = declaratorFor('const [a, b] = [1, 2];');
 
-    assert.strictEqual(variableDeclarationSurvives(declarator, new Set(['b'])), true);
-});
+        assert.strictEqual(variableDeclarationSurvives(declarator, new Set(['b'])), true);
+    });
 
-test('variableDeclarationSurvives returns false when no declared name is in the surviving set', () => {
-    const declarator = declaratorFor('const [a, b] = [1, 2];');
+    test('variableDeclarationSurvives returns false when no declared name is in the surviving set', function () {
+        const declarator = declaratorFor('const [a, b] = [1, 2];');
 
-    assert.strictEqual(variableDeclarationSurvives(declarator, new Set(['c'])), false);
+        assert.strictEqual(variableDeclarationSurvives(declarator, new Set(['c'])), false);
+    });
 });

--- a/source/dependency-scanner/dependency-graph.property.ts
+++ b/source/dependency-scanner/dependency-graph.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { unique } from 'remeda';
 import { Maybe } from 'true-myth';
 import {
@@ -76,50 +76,52 @@ const localFilesArbitrary: fc.Arbitrary<readonly LocalFile[]> = fc
         });
     });
 
-test('flatten() only references known file paths or generated source-map files', () => {
-    fc.assert(
-        fc.property(dependencyFilesArbitrary, (dependencyFiles) => {
-            const filePaths = new Set(
-                dependencyFiles.localFiles.map((file) => {
+suite('dependency-graph', function () {
+    test('flatten() only references known file paths or generated source-map files', function () {
+        fc.assert(
+            fc.property(dependencyFilesArbitrary, (dependencyFiles) => {
+                const filePaths = new Set(
+                    dependencyFiles.localFiles.map((file) => {
+                        return file.filePath;
+                    })
+                );
+
+                for (const file of dependencyFiles.localFiles) {
+                    for (const dependency of file.directDependencies) {
+                        assert.ok(filePaths.has(dependency) || dependency.endsWith('.js.map'));
+                    }
+                }
+
+                for (const dependency of dependencyFiles.externalDependencies.values()) {
+                    for (const reference of dependency.referencedFrom) {
+                        assert.ok(filePaths.has(reference));
+                    }
+                }
+            }),
+            { numRuns: 5 }
+        );
+    });
+
+    test('mergeDependencyFiles() preserves uniqueness by file path', function () {
+        fc.assert(
+            fc.property(localFilesArbitrary, localFilesArbitrary, (firstLocalFiles, secondLocalFiles) => {
+                const first: DependencyFiles = {
+                    localFiles: firstLocalFiles,
+                    externalDependencies: new Map()
+                };
+                const second: DependencyFiles = {
+                    localFiles: secondLocalFiles,
+                    externalDependencies: new Map()
+                };
+
+                const merged = mergeDependencyFiles(first, second);
+                const mergedPaths = merged.localFiles.map((file) => {
                     return file.filePath;
-                })
-            );
-
-            dependencyFiles.localFiles.forEach((file) => {
-                file.directDependencies.forEach((dependency) => {
-                    assert.ok(filePaths.has(dependency) || dependency.endsWith('.js.map'));
                 });
-            });
 
-            dependencyFiles.externalDependencies.forEach((dependency) => {
-                dependency.referencedFrom.forEach((reference) => {
-                    assert.ok(filePaths.has(reference));
-                });
-            });
-        }),
-        { numRuns: 5 }
-    );
-});
-
-test('mergeDependencyFiles() preserves uniqueness by file path', () => {
-    fc.assert(
-        fc.property(localFilesArbitrary, localFilesArbitrary, (firstLocalFiles, secondLocalFiles) => {
-            const first: DependencyFiles = {
-                localFiles: firstLocalFiles,
-                externalDependencies: new Map()
-            };
-            const second: DependencyFiles = {
-                localFiles: secondLocalFiles,
-                externalDependencies: new Map()
-            };
-
-            const merged = mergeDependencyFiles(first, second);
-            const mergedPaths = merged.localFiles.map((file) => {
-                return file.filePath;
-            });
-
-            assert.deepStrictEqual(mergedPaths, unique(mergedPaths));
-        }),
-        { numRuns: 5 }
-    );
+                assert.deepStrictEqual(mergedPaths, unique(mergedPaths));
+            }),
+            { numRuns: 5 }
+        );
+    });
 });

--- a/source/dependency-scanner/dependency-graph.test.ts
+++ b/source/dependency-scanner/dependency-graph.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Maybe } from 'true-myth';
 import { type SinonSpy, fake } from 'sinon';
 import {
@@ -28,173 +28,175 @@ function dependencyGraphNodeDataFactory(overrides: Overrides = {}): DependencyGr
     } as unknown as DependencyGraphNodeData;
 }
 
-test('isKnown() returns false when the given file hasn’t been added', () => {
-    const graph = createDependencyGraph();
-    assert.strictEqual(graph.isKnown('foo.js'), false);
-});
-
-test('isKnown() returns true when the given file has been added', () => {
-    const graph = createDependencyGraph();
-
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
-
-    assert.strictEqual(graph.isKnown('foo.js'), true);
-});
-
-test('hasConnection() returns false when the given files are not connected', () => {
-    const graph = createDependencyGraph();
-
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
-    graph.addDependency('bar.js', dependencyGraphNodeDataFactory());
-
-    assert.strictEqual(graph.hasConnection('foo.js', 'bar.js'), false);
-});
-
-test('hasConnection() returns true when the given files are connected', () => {
-    const graph = createDependencyGraph();
-
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
-    graph.addDependency('bar.js', dependencyGraphNodeDataFactory());
-    graph.connect('foo.js', 'bar.js');
-
-    assert.strictEqual(graph.hasConnection('foo.js', 'bar.js'), true);
-});
-
-function collectVisitorNodes(graph: DependencyGraph, startFilePath: string): readonly DependencyNode[] {
-    const collected: DependencyNode[] = [];
-
-    graph.walk(startFilePath, (node) => {
-        collected.push(node);
+suite('dependency-graph', function () {
+    test('isKnown() returns false when the given file hasn’t been added', function () {
+        const graph = createDependencyGraph();
+        assert.strictEqual(graph.isKnown('foo.js'), false);
     });
 
-    return collected;
-}
+    test('isKnown() returns true when the given file has been added', function () {
+        const graph = createDependencyGraph();
 
-test('walk() visits the start node only if it has no connections', () => {
-    const graph = createDependencyGraph();
-    const getProject = fake.returns({});
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
 
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory({ getProject }));
-    const result = collectVisitorNodes(graph, 'foo.js');
-
-    assert.deepStrictEqual(result, [
-        {
-            filePath: 'foo.js',
-            sourceMapFilePath: Maybe.nothing(),
-            externalDependencies: [],
-            localFiles: [],
-            project: { getProject }
-        }
-    ]);
-});
-
-test('walk() visits the start node and all its connections', () => {
-    const graph = createDependencyGraph();
-    const getProject = fake.returns({});
-
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory({ getProject }));
-    graph.addDependency('bar.js', dependencyGraphNodeDataFactory({ getProject }));
-    graph.addDependency('baz.js', dependencyGraphNodeDataFactory({ getProject }));
-    graph.connect('foo.js', 'bar.js');
-    graph.connect('bar.js', 'baz.js');
-
-    const result = collectVisitorNodes(graph, 'foo.js');
-
-    assert.deepStrictEqual(result, [
-        {
-            filePath: 'foo.js',
-            sourceMapFilePath: Maybe.nothing(),
-            externalDependencies: [],
-            localFiles: ['bar.js'],
-            project: { getProject }
-        },
-        {
-            filePath: 'bar.js',
-            sourceMapFilePath: Maybe.nothing(),
-            externalDependencies: [],
-            localFiles: ['baz.js'],
-            project: { getProject }
-        },
-        {
-            filePath: 'baz.js',
-            sourceMapFilePath: Maybe.nothing(),
-            externalDependencies: [],
-            localFiles: [],
-            project: { getProject }
-        }
-    ]);
-});
-
-const fooBarLocalFiles = [
-    { directDependencies: new Set(['bar.js']), filePath: 'foo.js', project: {} },
-    { directDependencies: new Set(), filePath: 'bar.js', project: {} }
-];
-
-test('flatten() collects all nodes and returns a single list for all local files', () => {
-    const graph = createDependencyGraph();
-
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
-    graph.addDependency('bar.js', dependencyGraphNodeDataFactory());
-    graph.connect('foo.js', 'bar.js');
-    const result = graph.flatten('foo.js');
-
-    assert.deepStrictEqual(result, {
-        localFiles: fooBarLocalFiles,
-        externalDependencies: new Map()
+        assert.strictEqual(graph.isKnown('foo.js'), true);
     });
-});
 
-test('flatten() collects all nodes and returns a single map for topLevelDependencies eliminating duplicates', () => {
-    const graph = createDependencyGraph();
+    test('hasConnection() returns false when the given files are not connected', function () {
+        const graph = createDependencyGraph();
 
-    graph.addDependency('foo.js', dependencyGraphNodeDataFactory({ topLevelDependencies: ['a', 'b'] }));
-    graph.addDependency('bar.js', dependencyGraphNodeDataFactory({ topLevelDependencies: ['b', 'c'] }));
-    graph.connect('foo.js', 'bar.js');
-    const result = graph.flatten('foo.js');
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
+        graph.addDependency('bar.js', dependencyGraphNodeDataFactory());
 
-    assert.deepStrictEqual(result, {
-        localFiles: fooBarLocalFiles,
-        externalDependencies: new Map([
-            ['a', { name: 'a', referencedFrom: ['foo.js'] }],
-            ['b', { name: 'b', referencedFrom: ['foo.js', 'bar.js'] }],
-            ['c', { name: 'c', referencedFrom: ['bar.js'] }]
-        ])
+        assert.strictEqual(graph.hasConnection('foo.js', 'bar.js'), false);
     });
-});
 
-test('mergeDependencyFiles() merges two sets of dependency files', () => {
-    const firstSet: DependencyFiles = {
-        localFiles: [
-            { filePath: 'foo.js', directDependencies: new Set() },
-            { filePath: 'bar.js', directDependencies: new Set() }
-        ],
-        externalDependencies: new Map([
-            ['a', { name: 'a', referencedFrom: ['foo.js'] }],
-            ['b', { name: 'b', referencedFrom: ['foo.js'] }]
-        ])
-    };
-    const secondSet: DependencyFiles = {
-        localFiles: [
-            { filePath: 'bar.js', directDependencies: new Set() },
-            { filePath: 'baz.js', directDependencies: new Set() }
-        ],
-        externalDependencies: new Map([
-            ['b', { name: 'b', referencedFrom: ['baz.js'] }],
-            ['d', { name: 'c', referencedFrom: ['baz.js'] }]
-        ])
-    };
-    const result = mergeDependencyFiles(firstSet, secondSet);
+    test('hasConnection() returns true when the given files are connected', function () {
+        const graph = createDependencyGraph();
 
-    assert.deepStrictEqual(result, {
-        localFiles: [
-            { filePath: 'foo.js', directDependencies: new Set() },
-            { filePath: 'bar.js', directDependencies: new Set() },
-            { filePath: 'baz.js', directDependencies: new Set() }
-        ],
-        externalDependencies: new Map([
-            ['a', { name: 'a', referencedFrom: ['foo.js'] }],
-            ['b', { name: 'b', referencedFrom: ['foo.js', 'baz.js'] }],
-            ['c', { name: 'c', referencedFrom: ['baz.js'] }]
-        ])
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
+        graph.addDependency('bar.js', dependencyGraphNodeDataFactory());
+        graph.connect('foo.js', 'bar.js');
+
+        assert.strictEqual(graph.hasConnection('foo.js', 'bar.js'), true);
+    });
+
+    function collectVisitorNodes(graph: DependencyGraph, startFilePath: string): readonly DependencyNode[] {
+        const collected: DependencyNode[] = [];
+
+        graph.walk(startFilePath, (node) => {
+            collected.push(node);
+        });
+
+        return collected;
+    }
+
+    test('walk() visits the start node only if it has no connections', function () {
+        const graph = createDependencyGraph();
+        const getProject = fake.returns({});
+
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory({ getProject }));
+        const result = collectVisitorNodes(graph, 'foo.js');
+
+        assert.deepStrictEqual(result, [
+            {
+                filePath: 'foo.js',
+                sourceMapFilePath: Maybe.nothing(),
+                externalDependencies: [],
+                localFiles: [],
+                project: { getProject }
+            }
+        ]);
+    });
+
+    test('walk() visits the start node and all its connections', function () {
+        const graph = createDependencyGraph();
+        const getProject = fake.returns({});
+
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory({ getProject }));
+        graph.addDependency('bar.js', dependencyGraphNodeDataFactory({ getProject }));
+        graph.addDependency('baz.js', dependencyGraphNodeDataFactory({ getProject }));
+        graph.connect('foo.js', 'bar.js');
+        graph.connect('bar.js', 'baz.js');
+
+        const result = collectVisitorNodes(graph, 'foo.js');
+
+        assert.deepStrictEqual(result, [
+            {
+                filePath: 'foo.js',
+                sourceMapFilePath: Maybe.nothing(),
+                externalDependencies: [],
+                localFiles: ['bar.js'],
+                project: { getProject }
+            },
+            {
+                filePath: 'bar.js',
+                sourceMapFilePath: Maybe.nothing(),
+                externalDependencies: [],
+                localFiles: ['baz.js'],
+                project: { getProject }
+            },
+            {
+                filePath: 'baz.js',
+                sourceMapFilePath: Maybe.nothing(),
+                externalDependencies: [],
+                localFiles: [],
+                project: { getProject }
+            }
+        ]);
+    });
+
+    const fooBarLocalFiles = [
+        { directDependencies: new Set(['bar.js']), filePath: 'foo.js', project: {} },
+        { directDependencies: new Set(), filePath: 'bar.js', project: {} }
+    ];
+
+    test('flatten() collects all nodes and returns a single list for all local files', function () {
+        const graph = createDependencyGraph();
+
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory());
+        graph.addDependency('bar.js', dependencyGraphNodeDataFactory());
+        graph.connect('foo.js', 'bar.js');
+        const result = graph.flatten('foo.js');
+
+        assert.deepStrictEqual(result, {
+            localFiles: fooBarLocalFiles,
+            externalDependencies: new Map()
+        });
+    });
+
+    test('flatten() collects all nodes and returns a single map for topLevelDependencies eliminating duplicates', function () {
+        const graph = createDependencyGraph();
+
+        graph.addDependency('foo.js', dependencyGraphNodeDataFactory({ topLevelDependencies: ['a', 'b'] }));
+        graph.addDependency('bar.js', dependencyGraphNodeDataFactory({ topLevelDependencies: ['b', 'c'] }));
+        graph.connect('foo.js', 'bar.js');
+        const result = graph.flatten('foo.js');
+
+        assert.deepStrictEqual(result, {
+            localFiles: fooBarLocalFiles,
+            externalDependencies: new Map([
+                ['a', { name: 'a', referencedFrom: ['foo.js'] }],
+                ['b', { name: 'b', referencedFrom: ['foo.js', 'bar.js'] }],
+                ['c', { name: 'c', referencedFrom: ['bar.js'] }]
+            ])
+        });
+    });
+
+    test('mergeDependencyFiles() merges two sets of dependency files', function () {
+        const firstSet: DependencyFiles = {
+            localFiles: [
+                { filePath: 'foo.js', directDependencies: new Set() },
+                { filePath: 'bar.js', directDependencies: new Set() }
+            ],
+            externalDependencies: new Map([
+                ['a', { name: 'a', referencedFrom: ['foo.js'] }],
+                ['b', { name: 'b', referencedFrom: ['foo.js'] }]
+            ])
+        };
+        const secondSet: DependencyFiles = {
+            localFiles: [
+                { filePath: 'bar.js', directDependencies: new Set() },
+                { filePath: 'baz.js', directDependencies: new Set() }
+            ],
+            externalDependencies: new Map([
+                ['b', { name: 'b', referencedFrom: ['baz.js'] }],
+                ['d', { name: 'c', referencedFrom: ['baz.js'] }]
+            ])
+        };
+        const result = mergeDependencyFiles(firstSet, secondSet);
+
+        assert.deepStrictEqual(result, {
+            localFiles: [
+                { filePath: 'foo.js', directDependencies: new Set() },
+                { filePath: 'bar.js', directDependencies: new Set() },
+                { filePath: 'baz.js', directDependencies: new Set() }
+            ],
+            externalDependencies: new Map([
+                ['a', { name: 'a', referencedFrom: ['foo.js'] }],
+                ['b', { name: 'b', referencedFrom: ['foo.js', 'baz.js'] }],
+                ['c', { name: 'c', referencedFrom: ['baz.js'] }]
+            ])
+        });
     });
 });

--- a/source/dependency-scanner/external-dependencies.test.ts
+++ b/source/dependency-scanner/external-dependencies.test.ts
@@ -1,39 +1,41 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { mergeExternalDependencies, type ExternalDependency } from './external-dependencies.ts';
 
 function asMap(...entries: readonly ExternalDependency[]): ReadonlyMap<string, ExternalDependency> {
     return new Map(entries.map((entry) => [entry.name, entry]));
 }
 
-test('mergeExternalDependencies returns the first map when the second is empty', () => {
-    const a = asMap({ name: 'lodash', referencedFrom: ['/a.ts'] });
-    const merged = mergeExternalDependencies(a, asMap());
-    assert.deepStrictEqual(Array.from(merged), Array.from(a));
-});
+suite('external-dependencies', function () {
+    test('mergeExternalDependencies returns the first map when the second is empty', function () {
+        const a = asMap({ name: 'lodash', referencedFrom: ['/a.ts'] });
+        const merged = mergeExternalDependencies(a, asMap());
+        assert.deepStrictEqual(Array.from(merged), Array.from(a));
+    });
 
-test('mergeExternalDependencies adds entries that exist only in the second map', () => {
-    const merged = mergeExternalDependencies(
-        asMap({ name: 'lodash', referencedFrom: ['/a.ts'] }),
-        asMap({ name: 'react', referencedFrom: ['/b.ts'] })
-    );
-    assert.deepStrictEqual(Array.from(merged.keys()), ['lodash', 'react']);
-});
+    test('mergeExternalDependencies adds entries that exist only in the second map', function () {
+        const merged = mergeExternalDependencies(
+            asMap({ name: 'lodash', referencedFrom: ['/a.ts'] }),
+            asMap({ name: 'react', referencedFrom: ['/b.ts'] })
+        );
+        assert.deepStrictEqual(Array.from(merged.keys()), ['lodash', 'react']);
+    });
 
-test('mergeExternalDependencies unions the referencedFrom paths for entries present in both maps', () => {
-    const merged = mergeExternalDependencies(
-        asMap({ name: 'lodash', referencedFrom: ['/a.ts'] }),
-        asMap({ name: 'lodash', referencedFrom: ['/b.ts'] })
-    );
+    test('mergeExternalDependencies unions the referencedFrom paths for entries present in both maps', function () {
+        const merged = mergeExternalDependencies(
+            asMap({ name: 'lodash', referencedFrom: ['/a.ts'] }),
+            asMap({ name: 'lodash', referencedFrom: ['/b.ts'] })
+        );
 
-    assert.deepStrictEqual(merged.get('lodash')?.referencedFrom, ['/a.ts', '/b.ts']);
-});
+        assert.deepStrictEqual(merged.get('lodash')?.referencedFrom, ['/a.ts', '/b.ts']);
+    });
 
-test('mergeExternalDependencies deduplicates duplicate referencedFrom entries', () => {
-    const merged = mergeExternalDependencies(
-        asMap({ name: 'lodash', referencedFrom: ['/a.ts', '/b.ts'] }),
-        asMap({ name: 'lodash', referencedFrom: ['/b.ts', '/c.ts'] })
-    );
+    test('mergeExternalDependencies deduplicates duplicate referencedFrom entries', function () {
+        const merged = mergeExternalDependencies(
+            asMap({ name: 'lodash', referencedFrom: ['/a.ts', '/b.ts'] }),
+            asMap({ name: 'lodash', referencedFrom: ['/b.ts', '/c.ts'] })
+        );
 
-    assert.deepStrictEqual(merged.get('lodash')?.referencedFrom, ['/a.ts', '/b.ts', '/c.ts']);
+        assert.deepStrictEqual(merged.get('lodash')?.referencedFrom, ['/a.ts', '/b.ts', '/c.ts']);
+    });
 });

--- a/source/dependency-scanner/file-host-predicates.test.ts
+++ b/source/dependency-scanner/file-host-predicates.test.ts
@@ -1,27 +1,29 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { isDeclarationFile, isTypesRootFolder } from './file-host-predicates.ts';
 
-test('isDeclarationFile recognizes .d.ts, .d.cts, and .d.mts paths regardless of case', () => {
-    assert.strictEqual(isDeclarationFile('/p/types.d.ts'), true);
-    assert.strictEqual(isDeclarationFile('/P/types.D.CTS'), true);
-    assert.strictEqual(isDeclarationFile('/p/Types.D.Mts'), true);
-});
+suite('file-host-predicates', function () {
+    test('isDeclarationFile recognizes .d.ts, .d.cts, and .d.mts paths regardless of case', function () {
+        assert.strictEqual(isDeclarationFile('/p/types.d.ts'), true);
+        assert.strictEqual(isDeclarationFile('/P/types.D.CTS'), true);
+        assert.strictEqual(isDeclarationFile('/p/Types.D.Mts'), true);
+    });
 
-test('isDeclarationFile returns false for plain source files', () => {
-    assert.strictEqual(isDeclarationFile('/p/index.ts'), false);
-    assert.strictEqual(isDeclarationFile('/p/index.js'), false);
-});
+    test('isDeclarationFile returns false for plain source files', function () {
+        assert.strictEqual(isDeclarationFile('/p/index.ts'), false);
+        assert.strictEqual(isDeclarationFile('/p/index.js'), false);
+    });
 
-test('isTypesRootFolder returns true for a directory ending in /node_modules/@types', () => {
-    assert.strictEqual(isTypesRootFolder('/project/node_modules/@types'), true);
-});
+    test('isTypesRootFolder returns true for a directory ending in /node_modules/@types', function () {
+        assert.strictEqual(isTypesRootFolder('/project/node_modules/@types'), true);
+    });
 
-test('isTypesRootFolder returns true for a nested @types package directory', () => {
-    assert.strictEqual(isTypesRootFolder('/project/node_modules/@types/node'), true);
-});
+    test('isTypesRootFolder returns true for a nested @types package directory', function () {
+        assert.strictEqual(isTypesRootFolder('/project/node_modules/@types/node'), true);
+    });
 
-test('isTypesRootFolder returns false for unrelated directories', () => {
-    assert.strictEqual(isTypesRootFolder('/project/source'), false);
-    assert.strictEqual(isTypesRootFolder('/project/node_modules/lodash'), false);
+    test('isTypesRootFolder returns false for unrelated directories', function () {
+        assert.strictEqual(isTypesRootFolder('/project/source'), false);
+        assert.strictEqual(isTypesRootFolder('/project/node_modules/lodash'), false);
+    });
 });

--- a/source/dependency-scanner/host-method-binding.test.ts
+++ b/source/dependency-scanner/host-method-binding.test.ts
@@ -1,52 +1,54 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { isString } from 'remeda';
 import type { FileSystemHost } from 'ts-morph';
 import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
 
-test('syncMethodNames maps each async name to its synchronous counterpart', () => {
-    assert.deepStrictEqual(syncMethodNames, {
-        fileExists: 'fileExistsSync',
-        directoryExists: 'directoryExistsSync',
-        readFile: 'readFileSync'
+suite('host-method-binding', function () {
+    test('syncMethodNames maps each async name to its synchronous counterpart', function () {
+        assert.deepStrictEqual(syncMethodNames, {
+            fileExists: 'fileExistsSync',
+            directoryExists: 'directoryExistsSync',
+            readFile: 'readFileSync'
+        });
     });
-});
 
-test('bindRequiredMethod throws when the host does not expose the named method', () => {
-    const host = {} as unknown as FileSystemHost;
-    try {
-        bindRequiredMethod(host, 'missingMethod', 'a string', isString);
-        assert.fail('expected bindRequiredMethod to throw');
-    } catch (error) {
-        assert.ok(error instanceof TypeError);
-        assert.strictEqual(error.message, 'Expected missingMethod to be a function');
-    }
-});
-
-test('bindRequiredMethod returns a callable that forwards the file path to the method', () => {
-    const calls: string[] = [];
-    const host = {
-        readFileSync(filePath: string) {
-            calls.push(filePath);
-            return 'content';
+    test('bindRequiredMethod throws when the host does not expose the named method', function () {
+        const host = {} as unknown as FileSystemHost;
+        try {
+            bindRequiredMethod(host, 'missingMethod', 'a string', isString);
+            assert.fail('expected bindRequiredMethod to throw');
+        } catch (error) {
+            assert.ok(error instanceof TypeError);
+            assert.strictEqual(error.message, 'Expected missingMethod to be a function');
         }
-    } as unknown as FileSystemHost;
+    });
 
-    const read = bindRequiredMethod(host, 'readFileSync', 'a string', isString);
+    test('bindRequiredMethod returns a callable that forwards the file path to the method', function () {
+        const calls: string[] = [];
+        const host = {
+            readFileSync(filePath: string) {
+                calls.push(filePath);
+                return 'content';
+            }
+        } as unknown as FileSystemHost;
 
-    assert.strictEqual(read('/p/a.ts'), 'content');
-    assert.deepStrictEqual(calls, ['/p/a.ts']);
-});
+        const read = bindRequiredMethod(host, 'readFileSync', 'a string', isString);
 
-test('bindRequiredMethod throws when the method returns a value that fails validation', () => {
-    const host = { readFileSync: () => 42 } as unknown as FileSystemHost;
-    const read = bindRequiredMethod(host, 'readFileSync', 'a string', isString);
+        assert.strictEqual(read('/p/a.ts'), 'content');
+        assert.deepStrictEqual(calls, ['/p/a.ts']);
+    });
 
-    try {
-        read('/p/a.ts');
-        assert.fail('expected the bound method to throw');
-    } catch (error) {
-        assert.ok(error instanceof TypeError);
-        assert.strictEqual(error.message, 'Expected readFileSync to return a string');
-    }
+    test('bindRequiredMethod throws when the method returns a value that fails validation', function () {
+        const host = { readFileSync: () => 42 } as unknown as FileSystemHost;
+        const read = bindRequiredMethod(host, 'readFileSync', 'a string', isString);
+
+        try {
+            read('/p/a.ts');
+            assert.fail('expected the bound method to throw');
+        } catch (error) {
+            assert.ok(error instanceof TypeError);
+            assert.strictEqual(error.message, 'Expected readFileSync to return a string');
+        }
+    });
 });

--- a/source/dependency-scanner/module-path-classifier.test.ts
+++ b/source/dependency-scanner/module-path-classifier.test.ts
@@ -1,34 +1,41 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { determineExternalDependencies, determineLocalDependencies } from './module-path-classifier.ts';
 
-test('determineLocalDependencies keeps paths that do not include /node_modules/', () => {
-    assert.deepStrictEqual(determineLocalDependencies(['/src/a.ts', '/src/b.ts']), ['/src/a.ts', '/src/b.ts']);
-});
+suite('module-path-classifier', function () {
+    test('determineLocalDependencies keeps paths that do not include /node_modules/', function () {
+        assert.deepStrictEqual(determineLocalDependencies(['/src/a.ts', '/src/b.ts']), ['/src/a.ts', '/src/b.ts']);
+    });
 
-test('determineLocalDependencies excludes any path that includes /node_modules/', () => {
-    assert.deepStrictEqual(determineLocalDependencies(['/src/a.ts', '/proj/node_modules/lodash/index.js']), [
-        '/src/a.ts'
-    ]);
-});
+    test('determineLocalDependencies excludes any path that includes /node_modules/', function () {
+        assert.deepStrictEqual(determineLocalDependencies(['/src/a.ts', '/proj/node_modules/lodash/index.js']), [
+            '/src/a.ts'
+        ]);
+    });
 
-test('determineExternalDependencies returns the unscoped module name for a node_modules path', () => {
-    assert.deepStrictEqual(determineExternalDependencies(['/proj/node_modules/lodash/index.js']), ['lodash']);
-});
+    test('determineExternalDependencies returns the unscoped module name for a node_modules path', function () {
+        assert.deepStrictEqual(determineExternalDependencies(['/proj/node_modules/lodash/index.js']), ['lodash']);
+    });
 
-test('determineExternalDependencies returns the full scope/name pair for scoped packages', () => {
-    assert.deepStrictEqual(determineExternalDependencies(['/proj/node_modules/@scope/pkg/index.js']), ['@scope/pkg']);
-});
+    test('determineExternalDependencies returns the full scope/name pair for scoped packages', function () {
+        assert.deepStrictEqual(determineExternalDependencies(['/proj/node_modules/@scope/pkg/index.js']), [
+            '@scope/pkg'
+        ]);
+    });
 
-test('determineExternalDependencies deduplicates module names across multiple paths', () => {
-    assert.deepStrictEqual(
-        determineExternalDependencies(['/proj/node_modules/lodash/index.js', '/proj/node_modules/lodash/cloneDeep.js']),
-        ['lodash']
-    );
-});
+    test('determineExternalDependencies deduplicates module names across multiple paths', function () {
+        assert.deepStrictEqual(
+            determineExternalDependencies([
+                '/proj/node_modules/lodash/index.js',
+                '/proj/node_modules/lodash/cloneDeep.js'
+            ]),
+            ['lodash']
+        );
+    });
 
-test('determineExternalDependencies ignores paths outside node_modules', () => {
-    assert.deepStrictEqual(determineExternalDependencies(['/src/local.ts', '/proj/node_modules/react/index.js']), [
-        'react'
-    ]);
+    test('determineExternalDependencies ignores paths outside node_modules', function () {
+        assert.deepStrictEqual(determineExternalDependencies(['/src/local.ts', '/proj/node_modules/react/index.js']), [
+            'react'
+        ]);
+    });
 });

--- a/source/dependency-scanner/scanner.test.ts
+++ b/source/dependency-scanner/scanner.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { stub, fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
 import type { MainPackageJson } from '../config/package-json.ts';
@@ -37,242 +37,250 @@ function dependencyScannerFactory(overrides: Overrides = {}): DependencyScanner 
     return createDependencyScanner(fakeDependencies);
 }
 
-test('analyzes the given entryPoint file in the given folder as a typescript project', async () => {
-    const analyzeProject = createFakeAnalyzeProject();
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+suite('scanner', function () {
+    test('analyzes the given entryPoint file in the given folder as a typescript project', async function () {
+        const analyzeProject = createFakeAnalyzeProject();
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject });
 
-    await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
+        await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
 
-    assert.strictEqual(analyzeProject.callCount, 1);
-    assert.deepStrictEqual(analyzeProject.firstCall.args, [
-        '/foo',
-        { resolveDeclarationFiles: false, mainPackageJson: defaultMainPackageJson }
-    ]);
-});
-
-test('passes the resolveDeclarationFiles option to the project analyzer', async () => {
-    const analyzeProject = createFakeAnalyzeProject();
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject });
-
-    await dependencyScanner.scan('/foo/bar.js', '/foo', {
-        resolveDeclarationFiles: true,
-        mainPackageJson: defaultMainPackageJson
+        assert.strictEqual(analyzeProject.callCount, 1);
+        assert.deepStrictEqual(analyzeProject.firstCall.args, [
+            '/foo',
+            { resolveDeclarationFiles: false, mainPackageJson: defaultMainPackageJson }
+        ]);
     });
 
-    assert.strictEqual(analyzeProject.callCount, 1);
-    assert.deepStrictEqual(analyzeProject.firstCall.args, [
-        '/foo',
-        { resolveDeclarationFiles: true, mainPackageJson: defaultMainPackageJson }
-    ]);
-});
+    test('passes the resolveDeclarationFiles option to the project analyzer', async function () {
+        const analyzeProject = createFakeAnalyzeProject();
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject });
 
-test('scans the dependencies of the given entryPoint file', async () => {
-    const getReferencedSourceFilePaths = fake.returns([]);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+        await dependencyScanner.scan('/foo/bar.js', '/foo', {
+            resolveDeclarationFiles: true,
+            mainPackageJson: defaultMainPackageJson
+        });
 
-    await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
-
-    assert.strictEqual(getReferencedSourceFilePaths.callCount, 1);
-    assert.deepStrictEqual(getReferencedSourceFilePaths.firstCall.args, ['/foo/bar.js']);
-});
-
-async function expectScanReturnsOnlyEntry(scanArgs: Parameters<DependencyScanner['scan']>): Promise<void> {
-    const getReferencedSourceFilePaths = fake.returns([]);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({
-        analyzeProject,
-        locate: fake.resolves(Maybe.just('/dir/foo.map'))
+        assert.strictEqual(analyzeProject.callCount, 1);
+        assert.deepStrictEqual(analyzeProject.firstCall.args, [
+            '/foo',
+            { resolveDeclarationFiles: true, mainPackageJson: defaultMainPackageJson }
+        ]);
     });
 
-    const graph = await dependencyScanner.scan(...scanArgs);
-    const result = graph.flatten('/dir/entry.js');
+    test('scans the dependencies of the given entryPoint file', async function () {
+        const getReferencedSourceFilePaths = fake.returns([]);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject });
 
-    assert.deepStrictEqual(result, {
-        localFiles: [{ directDependencies: new Set(), filePath: '/dir/entry.js', project: {} }],
-        externalDependencies: new Map()
-    });
-}
+        await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
 
-test('returns no dependencies if the given file doesn’t have any dependencies', async () => {
-    await expectScanReturnsOnlyEntry(['/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson }]);
-});
-
-test('doesn’t try to locate source map files by default', async () => {
-    const locate = fake.resolves(Maybe.nothing());
-    const dependencyScanner = dependencyScannerFactory({ locate });
-
-    await dependencyScanner.scan('/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson });
-
-    assert.strictEqual(locate.callCount, 0);
-});
-
-test('tries to locate source map files for all local files when includeSourceMapFiles is true', async () => {
-    const locate = fake.resolves(Maybe.nothing());
-    const getReferencedSourceFilePaths = stub()
-        .onFirstCall()
-        .returns(['/dir/foo.js'])
-        .onSecondCall()
-        .returns(['/dir/bar.js'])
-        .onThirdCall()
-        .returns([]);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject, locate });
-
-    await dependencyScanner.scan('/dir/entry.js', '/dir', {
-        includeSourceMapFiles: true,
-        mainPackageJson: defaultMainPackageJson
+        assert.strictEqual(getReferencedSourceFilePaths.callCount, 1);
+        assert.deepStrictEqual(getReferencedSourceFilePaths.firstCall.args, ['/foo/bar.js']);
     });
 
-    assert.strictEqual(locate.callCount, 3);
-    assert.deepStrictEqual(locate.firstCall.args, ['/dir/entry.js']);
-    assert.deepStrictEqual(locate.secondCall.args, ['/dir/foo.js']);
-    assert.deepStrictEqual(locate.thirdCall.args, ['/dir/bar.js']);
-});
+    async function expectScanReturnsOnlyEntry(scanArgs: Parameters<DependencyScanner['scan']>): Promise<void> {
+        const getReferencedSourceFilePaths = fake.returns([]);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({
+            analyzeProject,
+            locate: fake.resolves(Maybe.just('/dir/foo.map'))
+        });
 
-async function scanWithSourceMapLocate(locate: SinonSpy): Promise<DependencyFiles> {
-    const getReferencedSourceFilePaths = fake.returns([]);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject, locate });
+        const graph = await dependencyScanner.scan(...scanArgs);
+        const result = graph.flatten('/dir/entry.js');
 
-    const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', {
-        includeSourceMapFiles: true,
-        mainPackageJson: defaultMainPackageJson
-    });
-    return graph.flatten('/dir/entry.js');
-}
+        assert.deepStrictEqual(result, {
+            localFiles: [{ directDependencies: new Set(), filePath: '/dir/entry.js', project: {} }],
+            externalDependencies: new Map()
+        });
+    }
 
-test('returns no additional dependencies for source maps if they don’t exist', async () => {
-    const locate = fake.resolves(Maybe.nothing());
-    const result = await scanWithSourceMapLocate(locate);
-
-    assert.strictEqual(locate.callCount, 1);
-    assert.deepStrictEqual(result, {
-        localFiles: [{ directDependencies: new Set(), filePath: '/dir/entry.js', project: {} }],
-        externalDependencies: new Map()
-    });
-});
-
-test('returns additional dependencies for source maps if they exist', async () => {
-    const result = await scanWithSourceMapLocate(fake.resolves(Maybe.just('/dir/foo.map')));
-
-    assert.deepStrictEqual(result, {
-        localFiles: [
-            { directDependencies: new Set(), filePath: '/dir/foo.map', project: {} },
-            { directDependencies: new Set(['/dir/foo.map']), filePath: '/dir/entry.js', project: {} }
-        ],
-        externalDependencies: new Map()
-    });
-});
-
-test('returns no additional dependencies for source maps if they exist, but includeSourceMapFiles is false', async () => {
-    await expectScanReturnsOnlyEntry([
-        '/dir/entry.js',
-        '/dir',
-        { includeSourceMapFiles: false, mainPackageJson: defaultMainPackageJson }
-    ]);
-});
-
-test('returns the local dependency files', async () => {
-    const getReferencedSourceFilePaths = fake.returns(['/dir/foo.js', '/dir/bar.js']);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject });
-
-    const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson });
-    const result = graph.flatten('/dir/entry.js');
-
-    assert.deepStrictEqual(result.localFiles, [
-        { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/entry.js', project: {} },
-        { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/foo.js', project: {} },
-        { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/bar.js', project: {} }
-    ]);
-});
-
-test('returns the local dependency files found in subsequent dependencies', async () => {
-    const getReferencedSourceFilePaths = stub()
-        .onFirstCall()
-        .returns(['/dir/foo.js', '/dir/bar.js'])
-        .onSecondCall()
-        .returns([])
-        .onThirdCall()
-        .returns(['/dir/baz.js'])
-        .onCall(3)
-        .returns([]);
-    const dependencyScanner = dependencyScannerFactory({
-        analyzeProject: createFakeAnalyzeProject({ getReferencedSourceFilePaths })
+    test('returns no dependencies if the given file doesn’t have any dependencies', async function () {
+        await expectScanReturnsOnlyEntry(['/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson }]);
     });
 
-    const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson });
-    const result = graph.flatten('/dir/entry.js');
+    test('doesn’t try to locate source map files by default', async function () {
+        const locate = fake.resolves(Maybe.nothing());
+        const dependencyScanner = dependencyScannerFactory({ locate });
 
-    assert.strictEqual(getReferencedSourceFilePaths.callCount, 4);
-    assert.deepStrictEqual(getReferencedSourceFilePaths.firstCall.args, ['/dir/entry.js']);
-    assert.deepStrictEqual(getReferencedSourceFilePaths.secondCall.args, ['/dir/foo.js']);
-    assert.deepStrictEqual(getReferencedSourceFilePaths.thirdCall.args, ['/dir/bar.js']);
-    assert.deepStrictEqual(getReferencedSourceFilePaths.getCall(3).args, ['/dir/baz.js']);
-    assert.deepStrictEqual(result.localFiles, [
-        { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/entry.js', project: {} },
-        { directDependencies: new Set(), filePath: '/dir/foo.js', project: {} },
-        { directDependencies: new Set(['/dir/baz.js']), filePath: '/dir/bar.js', project: {} },
-        { directDependencies: new Set(), filePath: '/dir/baz.js', project: {} }
-    ]);
-});
-
-async function scanWithReferencedPaths(referencedPaths: readonly string[]): Promise<DependencyFiles> {
-    const getReferencedSourceFilePaths = fake.returns(referencedPaths);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject });
-
-    const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson });
-    return graph.flatten('/dir/entry.js');
-}
-
-async function expectLocalFilesContainOnlyFoo(referencedPaths: readonly string[]): Promise<void> {
-    const result = await scanWithReferencedPaths(referencedPaths);
-
-    assert.deepStrictEqual(result.localFiles, [
-        { directDependencies: new Set(['/dir/foo.js']), filePath: '/dir/entry.js', project: {} },
-        { directDependencies: new Set(['/dir/foo.js']), filePath: '/dir/foo.js', project: {} }
-    ]);
-}
-
-test('doesn’t include any files from node_modules in localFiles', async () => {
-    await expectLocalFilesContainOnlyFoo(['/dir/foo.js', '/dir/node_modules/any-module/bar.js']);
-});
-
-async function expectExternalDependency(scannedPath: string, expectedName: string): Promise<void> {
-    const result = await scanWithReferencedPaths([scannedPath]);
-
-    assert.deepStrictEqual(
-        result.externalDependencies,
-        new Map([[expectedName, { name: expectedName, referencedFrom: ['/dir/entry.js'] }]])
-    );
-}
-
-test('returns all detected node_modules dependencies with its corresponding version', async () => {
-    await expectExternalDependency('/dir/node_modules/any-module/foo.js', 'any-module');
-});
-
-test('returns the scoped package name for scoped node_modules dependencies', async () => {
-    await expectExternalDependency('/dir/node_modules/@scope/any-module/foo.js', '@scope/any-module');
-});
-
-test('throws an error when an invalid node_modules path is returned', async () => {
-    const getReferencedSourceFilePaths = fake.returns(['/invalid/node_modules/']);
-    const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
-    const dependencyScanner = dependencyScannerFactory({ analyzeProject });
-
-    try {
         await dependencyScanner.scan('/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson });
-        assert.fail('Expected scan() to throw but it didn’t');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            "Couldn’t find node_modules package name for '/invalid/node_modules/'"
+
+        assert.strictEqual(locate.callCount, 0);
+    });
+
+    test('tries to locate source map files for all local files when includeSourceMapFiles is true', async function () {
+        const locate = fake.resolves(Maybe.nothing());
+        const getReferencedSourceFilePaths = stub()
+            .onFirstCall()
+            .returns(['/dir/foo.js'])
+            .onSecondCall()
+            .returns(['/dir/bar.js'])
+            .onThirdCall()
+            .returns([]);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject, locate });
+
+        await dependencyScanner.scan('/dir/entry.js', '/dir', {
+            includeSourceMapFiles: true,
+            mainPackageJson: defaultMainPackageJson
+        });
+
+        assert.strictEqual(locate.callCount, 3);
+        assert.deepStrictEqual(locate.firstCall.args, ['/dir/entry.js']);
+        assert.deepStrictEqual(locate.secondCall.args, ['/dir/foo.js']);
+        assert.deepStrictEqual(locate.thirdCall.args, ['/dir/bar.js']);
+    });
+
+    async function scanWithSourceMapLocate(locate: SinonSpy): Promise<DependencyFiles> {
+        const getReferencedSourceFilePaths = fake.returns([]);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject, locate });
+
+        const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', {
+            includeSourceMapFiles: true,
+            mainPackageJson: defaultMainPackageJson
+        });
+        return graph.flatten('/dir/entry.js');
+    }
+
+    test('returns no additional dependencies for source maps if they don’t exist', async function () {
+        const locate = fake.resolves(Maybe.nothing());
+        const result = await scanWithSourceMapLocate(locate);
+
+        assert.strictEqual(locate.callCount, 1);
+        assert.deepStrictEqual(result, {
+            localFiles: [{ directDependencies: new Set(), filePath: '/dir/entry.js', project: {} }],
+            externalDependencies: new Map()
+        });
+    });
+
+    test('returns additional dependencies for source maps if they exist', async function () {
+        const result = await scanWithSourceMapLocate(fake.resolves(Maybe.just('/dir/foo.map')));
+
+        assert.deepStrictEqual(result, {
+            localFiles: [
+                { directDependencies: new Set(), filePath: '/dir/foo.map', project: {} },
+                { directDependencies: new Set(['/dir/foo.map']), filePath: '/dir/entry.js', project: {} }
+            ],
+            externalDependencies: new Map()
+        });
+    });
+
+    test('returns no additional dependencies for source maps if they exist, but includeSourceMapFiles is false', async function () {
+        await expectScanReturnsOnlyEntry([
+            '/dir/entry.js',
+            '/dir',
+            { includeSourceMapFiles: false, mainPackageJson: defaultMainPackageJson }
+        ]);
+    });
+
+    test('returns the local dependency files', async function () {
+        const getReferencedSourceFilePaths = fake.returns(['/dir/foo.js', '/dir/bar.js']);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+
+        const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', {
+            mainPackageJson: defaultMainPackageJson
+        });
+        const result = graph.flatten('/dir/entry.js');
+
+        assert.deepStrictEqual(result.localFiles, [
+            { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/entry.js', project: {} },
+            { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/foo.js', project: {} },
+            { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/bar.js', project: {} }
+        ]);
+    });
+
+    test('returns the local dependency files found in subsequent dependencies', async function () {
+        const getReferencedSourceFilePaths = stub()
+            .onFirstCall()
+            .returns(['/dir/foo.js', '/dir/bar.js'])
+            .onSecondCall()
+            .returns([])
+            .onThirdCall()
+            .returns(['/dir/baz.js'])
+            .onCall(3)
+            .returns([]);
+        const dependencyScanner = dependencyScannerFactory({
+            analyzeProject: createFakeAnalyzeProject({ getReferencedSourceFilePaths })
+        });
+
+        const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', {
+            mainPackageJson: defaultMainPackageJson
+        });
+        const result = graph.flatten('/dir/entry.js');
+
+        assert.strictEqual(getReferencedSourceFilePaths.callCount, 4);
+        assert.deepStrictEqual(getReferencedSourceFilePaths.firstCall.args, ['/dir/entry.js']);
+        assert.deepStrictEqual(getReferencedSourceFilePaths.secondCall.args, ['/dir/foo.js']);
+        assert.deepStrictEqual(getReferencedSourceFilePaths.thirdCall.args, ['/dir/bar.js']);
+        assert.deepStrictEqual(getReferencedSourceFilePaths.getCall(3).args, ['/dir/baz.js']);
+        assert.deepStrictEqual(result.localFiles, [
+            { directDependencies: new Set(['/dir/foo.js', '/dir/bar.js']), filePath: '/dir/entry.js', project: {} },
+            { directDependencies: new Set(), filePath: '/dir/foo.js', project: {} },
+            { directDependencies: new Set(['/dir/baz.js']), filePath: '/dir/bar.js', project: {} },
+            { directDependencies: new Set(), filePath: '/dir/baz.js', project: {} }
+        ]);
+    });
+
+    async function scanWithReferencedPaths(referencedPaths: readonly string[]): Promise<DependencyFiles> {
+        const getReferencedSourceFilePaths = fake.returns(referencedPaths);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+
+        const graph = await dependencyScanner.scan('/dir/entry.js', '/dir', {
+            mainPackageJson: defaultMainPackageJson
+        });
+        return graph.flatten('/dir/entry.js');
+    }
+
+    async function expectLocalFilesContainOnlyFoo(referencedPaths: readonly string[]): Promise<void> {
+        const result = await scanWithReferencedPaths(referencedPaths);
+
+        assert.deepStrictEqual(result.localFiles, [
+            { directDependencies: new Set(['/dir/foo.js']), filePath: '/dir/entry.js', project: {} },
+            { directDependencies: new Set(['/dir/foo.js']), filePath: '/dir/foo.js', project: {} }
+        ]);
+    }
+
+    test('doesn’t include any files from node_modules in localFiles', async function () {
+        await expectLocalFilesContainOnlyFoo(['/dir/foo.js', '/dir/node_modules/any-module/bar.js']);
+    });
+
+    async function expectExternalDependency(scannedPath: string, expectedName: string): Promise<void> {
+        const result = await scanWithReferencedPaths([scannedPath]);
+
+        assert.deepStrictEqual(
+            result.externalDependencies,
+            new Map([[expectedName, { name: expectedName, referencedFrom: ['/dir/entry.js'] }]])
         );
     }
-});
 
-test('doesn’t include the same dependency twice', async () => {
-    await expectLocalFilesContainOnlyFoo(['/dir/foo.js', '/dir/foo.js']);
+    test('returns all detected node_modules dependencies with its corresponding version', async function () {
+        await expectExternalDependency('/dir/node_modules/any-module/foo.js', 'any-module');
+    });
+
+    test('returns the scoped package name for scoped node_modules dependencies', async function () {
+        await expectExternalDependency('/dir/node_modules/@scope/any-module/foo.js', '@scope/any-module');
+    });
+
+    test('throws an error when an invalid node_modules path is returned', async function () {
+        const getReferencedSourceFilePaths = fake.returns(['/invalid/node_modules/']);
+        const analyzeProject = createFakeAnalyzeProject({ getReferencedSourceFilePaths });
+        const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+
+        try {
+            await dependencyScanner.scan('/dir/entry.js', '/dir', { mainPackageJson: defaultMainPackageJson });
+            assert.fail('Expected scan() to throw but it didn’t');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                "Couldn’t find node_modules package name for '/invalid/node_modules/'"
+            );
+        }
+    });
+
+    test('doesn’t include the same dependency twice', async function () {
+        await expectLocalFilesContainOnlyFoo(['/dir/foo.js', '/dir/foo.js']);
+    });
 });

--- a/source/dependency-scanner/source-file-references.property.ts
+++ b/source/dependency-scanner/source-file-references.property.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { builtinModules } from 'node:module';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { getReferencedSourceFiles } from './source-file-references.ts';
 
@@ -14,30 +14,32 @@ const unresolvedImportArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,10}$/).fil
     return !builtinModules.includes(moduleName) && !builtinModules.includes(`node:${moduleName}`);
 });
 
-test('getReferencedSourceFiles() does not throw for builtin imports', () => {
-    fc.assert(
-        fc.property(builtinImportArbitrary, (moduleName) => {
-            const project = createProject({
-                withFiles: [{ filePath: 'main.ts', content: `import value from "${moduleName}";` }]
-            });
+suite('source-file-references', function () {
+    test('getReferencedSourceFiles() does not throw for builtin imports', function () {
+        fc.assert(
+            fc.property(builtinImportArbitrary, (moduleName) => {
+                const project = createProject({
+                    withFiles: [{ filePath: 'main.ts', content: `import value from "${moduleName}";` }]
+                });
 
-            assert.doesNotThrow(() => {
-                getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
-            });
-        })
-    );
-});
+                assert.doesNotThrow(() => {
+                    getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+                });
+            })
+        );
+    });
 
-test('getReferencedSourceFiles() throws for unresolved non-builtin imports', () => {
-    fc.assert(
-        fc.property(unresolvedImportArbitrary, (moduleName) => {
-            const project = createProject({
-                withFiles: [{ filePath: 'main.ts', content: `import value from "${moduleName}";` }]
-            });
+    test('getReferencedSourceFiles() throws for unresolved non-builtin imports', function () {
+        fc.assert(
+            fc.property(unresolvedImportArbitrary, (moduleName) => {
+                const project = createProject({
+                    withFiles: [{ filePath: 'main.ts', content: `import value from "${moduleName}";` }]
+                });
 
-            assert.throws(() => {
-                getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
-            }, Error);
-        })
-    );
+                assert.throws(() => {
+                    getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+                }, Error);
+            })
+        );
+    });
 });

--- a/source/dependency-scanner/source-file-references.test.ts
+++ b/source/dependency-scanner/source-file-references.test.ts
@@ -1,191 +1,195 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { ModuleKind } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { getReferencedSourceFiles, resolveSourceFileForLiteral } from './source-file-references.ts';
 
-test('returns an empty array when the given source file doesn’t has any imports', () => {
-    const files = [{ filePath: 'main.ts', content: '' }];
-    const project = createProject({ withFiles: files });
+suite('source-file-references', function () {
+    test('returns an empty array when the given source file doesn’t has any imports', function () {
+        const files = [{ filePath: 'main.ts', content: '' }];
+        const project = createProject({ withFiles: files });
 
-    const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+        const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('returns an empty array when the given source file has only imports to node-builtin modules', () => {
-    const files = [{ filePath: 'main.ts', content: 'import fs from "fs";' }];
-    const project = createProject({ withFiles: files });
+    test('returns an empty array when the given source file has only imports to node-builtin modules', function () {
+        const files = [{ filePath: 'main.ts', content: 'import fs from "fs";' }];
+        const project = createProject({ withFiles: files });
 
-    const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+        const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('returns an empty array when the given source file has only imports to node-builtin modules prefixed with node protocol', () => {
-    const files = [{ filePath: 'main.ts', content: 'import fs from "node:fs/promises";' }];
-    const project = createProject({ withFiles: files });
+    test('returns an empty array when the given source file has only imports to node-builtin modules prefixed with node protocol', function () {
+        const files = [{ filePath: 'main.ts', content: 'import fs from "node:fs/promises";' }];
+        const project = createProject({ withFiles: files });
 
-    const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+        const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
 
-    assert.deepStrictEqual(result, []);
-});
+        assert.deepStrictEqual(result, []);
+    });
 
-test('throws when the given source contains an import but it is not resolvable', () => {
-    const files = [{ filePath: 'main.ts', content: 'import {foo} from "foo.js"' }];
-    const project = createProject({ withFiles: files });
+    test('throws when the given source contains an import but it is not resolvable', function () {
+        const files = [{ filePath: 'main.ts', content: 'import {foo} from "foo.js"' }];
+        const project = createProject({ withFiles: files });
 
-    try {
-        getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
-        assert.fail('Expected getReferencedSourceFiles() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Failed to resolve import "foo.js" in file "/main.ts"');
+        try {
+            getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+            assert.fail('Expected getReferencedSourceFiles() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Failed to resolve import "foo.js" in file "/main.ts"');
+        }
+    });
+
+    test('throws when the given source contains an import to a node-builtin look-a-like module which is actually not a builtin', function () {
+        const files = [{ filePath: 'main.ts', content: 'import foo from "node:foo";' }];
+        const project = createProject({ withFiles: files });
+
+        try {
+            getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+            assert.fail('Expected getReferencedSourceFiles() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Failed to resolve import "node:foo" in file "/main.ts"');
+        }
+    });
+
+    function expectMainResolvesToFoo(
+        files: { readonly filePath: string; readonly content: string }[],
+        options: { readonly module?: ModuleKind } = {}
+    ): void {
+        const project = createProject({ withFiles: files, ...options });
+        const mainPath = files[0]?.filePath ?? '';
+        const fooPath = files[1]?.filePath ?? '';
+        const result = getReferencedSourceFiles(project.getSourceFileOrThrow(mainPath));
+
+        assert.deepStrictEqual(result, [project.getSourceFileOrThrow(fooPath)]);
     }
-});
 
-test('throws when the given source contains an import to a node-builtin look-a-like module which is actually not a builtin', () => {
-    const files = [{ filePath: 'main.ts', content: 'import foo from "node:foo";' }];
-    const project = createProject({ withFiles: files });
-
-    try {
-        getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
-        assert.fail('Expected getReferencedSourceFiles() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Failed to resolve import "node:foo" in file "/main.ts"');
-    }
-});
-
-function expectMainResolvesToFoo(
-    files: { readonly filePath: string; readonly content: string }[],
-    options: { readonly module?: ModuleKind } = {}
-): void {
-    const project = createProject({ withFiles: files, ...options });
-    const mainPath = files[0]?.filePath ?? '';
-    const fooPath = files[1]?.filePath ?? '';
-    const result = getReferencedSourceFiles(project.getSourceFileOrThrow(mainPath));
-
-    assert.deepStrictEqual(result, [project.getSourceFileOrThrow(fooPath)]);
-}
-
-test('returns array with the resolved source file using an import from statement', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.ts', content: 'import {foo} from "./foo"' },
-        { filePath: 'foo.ts', content: 'export const foo = "";' }
-    ]);
-});
-
-test('returns array with the resolved source file using an export from statement', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.ts', content: 'export {foo} from "./foo"' },
-        { filePath: 'foo.ts', content: 'export const foo = "";' }
-    ]);
-});
-
-test('returns array with the resolved source file using CommonJS', () => {
-    expectMainResolvesToFoo(
-        [
-            { filePath: 'main.js', content: 'const foo = require("./foo");' },
-            { filePath: 'foo.js', content: 'module.exports = {};' }
-        ],
-        { module: ModuleKind.CommonJS }
-    );
-});
-
-test('returns array with the resolved source file using import equals syntax', () => {
-    expectMainResolvesToFoo(
-        [
-            { filePath: 'main.ts', content: 'import foo = require("./foo");' },
+    test('returns array with the resolved source file using an import from statement', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.ts', content: 'import {foo} from "./foo"' },
             { filePath: 'foo.ts', content: 'export const foo = "";' }
-        ],
-        { module: ModuleKind.CommonJS }
-    );
-});
+        ]);
+    });
 
-test('returns array with the resolved source file using dynamic imports', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.ts', content: 'async function foo() { await import("./foo"); }' },
-        { filePath: 'foo.ts', content: '' }
-    ]);
-});
+    test('returns array with the resolved source file using an export from statement', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.ts', content: 'export {foo} from "./foo"' },
+            { filePath: 'foo.ts', content: 'export const foo = "";' }
+        ]);
+    });
 
-test('returns array with the resolved source file using type from import', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.ts', content: 'import type { Foo } from "./foo.ts"' },
-        { filePath: 'foo.ts', content: '' }
-    ]);
-});
+    test('returns array with the resolved source file using CommonJS', function () {
+        expectMainResolvesToFoo(
+            [
+                { filePath: 'main.js', content: 'const foo = require("./foo");' },
+                { filePath: 'foo.js', content: 'module.exports = {};' }
+            ],
+            { module: ModuleKind.CommonJS }
+        );
+    });
 
-test('returns array with the resolved source file using type import function', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.ts', content: 'type Foo = import("./foo").Foo' },
-        { filePath: 'foo.ts', content: '' }
-    ]);
-});
+    test('returns array with the resolved source file using import equals syntax', function () {
+        expectMainResolvesToFoo(
+            [
+                { filePath: 'main.ts', content: 'import foo = require("./foo");' },
+                { filePath: 'foo.ts', content: 'export const foo = "";' }
+            ],
+            { module: ModuleKind.CommonJS }
+        );
+    });
 
-test('returns array with the resolved source file using multiple import styles in one file', () => {
-    const files = [
-        {
-            filePath: 'main.ts',
-            content: [
-                'import { foo } from "./foo";',
-                'export { bar } from "./bar";',
-                'type Baz = import("./baz").Baz;',
-                'void foo;'
-            ].join('\n')
-        },
-        { filePath: 'foo.ts', content: 'export const foo = 1;' },
-        { filePath: 'bar.ts', content: 'export const bar = 2;' },
-        { filePath: 'baz.ts', content: 'export type Baz = string;' }
-    ];
-    const project = createProject({ withFiles: files });
+    test('returns array with the resolved source file using dynamic imports', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.ts', content: 'async function foo() { await import("./foo"); }' },
+            { filePath: 'foo.ts', content: '' }
+        ]);
+    });
 
-    const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
+    test('returns array with the resolved source file using type from import', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.ts', content: 'import type { Foo } from "./foo.ts"' },
+            { filePath: 'foo.ts', content: '' }
+        ]);
+    });
 
-    assert.deepStrictEqual(result, [
-        project.getSourceFileOrThrow('foo.ts'),
-        project.getSourceFileOrThrow('bar.ts'),
-        project.getSourceFileOrThrow('baz.ts')
-    ]);
-});
+    test('returns array with the resolved source file using type import function', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.ts', content: 'type Foo = import("./foo").Foo' },
+            { filePath: 'foo.ts', content: '' }
+        ]);
+    });
 
-test('returns array with the resolved source file using an import statement', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.ts', content: 'import {} from "./foo";' },
-        { filePath: 'foo.ts', content: 'parseInt("", 42)' }
-    ]);
-});
+    test('returns array with the resolved source file using multiple import styles in one file', function () {
+        const files = [
+            {
+                filePath: 'main.ts',
+                content: [
+                    'import { foo } from "./foo";',
+                    'export { bar } from "./bar";',
+                    'type Baz = import("./baz").Baz;',
+                    'void foo;'
+                ].join('\n')
+            },
+            { filePath: 'foo.ts', content: 'export const foo = 1;' },
+            { filePath: 'bar.ts', content: 'export const bar = 2;' },
+            { filePath: 'baz.ts', content: 'export type Baz = string;' }
+        ];
+        const project = createProject({ withFiles: files });
 
-test('works with JS files', () => {
-    expectMainResolvesToFoo([
-        { filePath: 'main.js', content: 'import {} from "./foo";' },
-        { filePath: 'foo.js', content: 'parseInt("", 42)' }
-    ]);
-});
+        const result = getReferencedSourceFiles(project.getSourceFileOrThrow('main.ts'));
 
-function resolveFirstImportLiteral(files: { readonly filePath: string; readonly content: string }[]): {
-    readonly project: ReturnType<typeof createProject>;
-    readonly result: ReturnType<typeof resolveSourceFileForLiteral>;
-} {
-    const project = createProject({ withFiles: files });
-    const sourceFile = project.getSourceFileOrThrow('main.ts');
-    const [literal] = sourceFile.getImportStringLiterals();
-    if (literal === undefined) {
-        assert.fail('Expected an import literal to exist');
+        assert.deepStrictEqual(result, [
+            project.getSourceFileOrThrow('foo.ts'),
+            project.getSourceFileOrThrow('bar.ts'),
+            project.getSourceFileOrThrow('baz.ts')
+        ]);
+    });
+
+    test('returns array with the resolved source file using an import statement', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.ts', content: 'import {} from "./foo";' },
+            { filePath: 'foo.ts', content: 'parseInt("", 42)' }
+        ]);
+    });
+
+    test('works with JS files', function () {
+        expectMainResolvesToFoo([
+            { filePath: 'main.js', content: 'import {} from "./foo";' },
+            { filePath: 'foo.js', content: 'parseInt("", 42)' }
+        ]);
+    });
+
+    function resolveFirstImportLiteral(files: { readonly filePath: string; readonly content: string }[]): {
+        readonly project: ReturnType<typeof createProject>;
+        readonly result: ReturnType<typeof resolveSourceFileForLiteral>;
+    } {
+        const project = createProject({ withFiles: files });
+        const sourceFile = project.getSourceFileOrThrow('main.ts');
+        const [literal] = sourceFile.getImportStringLiterals();
+        if (literal === undefined) {
+            assert.fail('Expected an import literal to exist');
+        }
+        return { project, result: resolveSourceFileForLiteral(literal, sourceFile) };
     }
-    return { project, result: resolveSourceFileForLiteral(literal, sourceFile) };
-}
 
-test('resolveSourceFileForLiteral() returns undefined when ts cannot resolve the module', () => {
-    const { result } = resolveFirstImportLiteral([{ filePath: 'main.ts', content: 'import {} from "not-resolved";' }]);
+    test('resolveSourceFileForLiteral() returns undefined when ts cannot resolve the module', function () {
+        const { result } = resolveFirstImportLiteral([
+            { filePath: 'main.ts', content: 'import {} from "not-resolved";' }
+        ]);
 
-    assert.strictEqual(result, undefined);
-});
+        assert.strictEqual(result, undefined);
+    });
 
-test('resolveSourceFileForLiteral() resolves dynamic import literals directly', () => {
-    const { project, result } = resolveFirstImportLiteral([
-        { filePath: 'main.ts', content: 'async function load() { return import("./foo"); }' },
-        { filePath: 'foo.ts', content: 'export const foo = 1;' }
-    ]);
+    test('resolveSourceFileForLiteral() resolves dynamic import literals directly', function () {
+        const { project, result } = resolveFirstImportLiteral([
+            { filePath: 'main.ts', content: 'async function load() { return import("./foo"); }' },
+            { filePath: 'foo.ts', content: 'export const foo = 1;' }
+        ]);
 
-    assert.strictEqual(result, project.getSourceFileOrThrow('foo.ts'));
+        assert.strictEqual(result, project.getSourceFileOrThrow('foo.ts'));
+    });
 });

--- a/source/dependency-scanner/source-map-file-locator.property.ts
+++ b/source/dependency-scanner/source-map-file-locator.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Maybe } from 'true-myth';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { createSourceMapFileLocator } from './source-map-file-locator.ts';
@@ -13,34 +13,36 @@ function createLocator(readFileContent: string, isReadable: boolean) {
     return createSourceMapFileLocator({ fileManager });
 }
 
-test('locate() returns Maybe.nothing() for malformed or missing source-map comments', async () => {
-    await fc.assert(
-        fc.asyncProperty(
-            fc.string().filter((value) => {
-                return !/^\/\/# sourceMappingURL=(?<url>.+)$/m.test(value);
-            }),
-            async (fileContent) => {
-                const result = await createLocator(fileContent, true).locate('/src/file.js');
+suite('source-map-file-locator', function () {
+    test('locate() returns Maybe.nothing() for malformed or missing source-map comments', async function () {
+        await fc.assert(
+            fc.asyncProperty(
+                fc.string().filter((value) => {
+                    return !/^\/\/# sourceMappingURL=(?<url>.+)$/m.test(value);
+                }),
+                async (fileContent) => {
+                    const result = await createLocator(fileContent, true).locate('/src/file.js');
+                    assert.deepStrictEqual(result, Maybe.nothing());
+                }
+            )
+        );
+    });
+
+    test('locate() returns Maybe.nothing() when the referenced source-map file is unreadable', async function () {
+        await fc.assert(
+            fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
+                const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, false).locate('/src/file.js');
                 assert.deepStrictEqual(result, Maybe.nothing());
-            }
-        )
-    );
-});
+            })
+        );
+    });
 
-test('locate() returns Maybe.nothing() when the referenced source-map file is unreadable', async () => {
-    await fc.assert(
-        fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
-            const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, false).locate('/src/file.js');
-            assert.deepStrictEqual(result, Maybe.nothing());
-        })
-    );
-});
-
-test('locate() returns Maybe.just() when the referenced source-map file is readable', async () => {
-    await fc.assert(
-        fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
-            const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, true).locate('/src/file.js');
-            assert.deepStrictEqual(result, Maybe.just(`/src/${mapFileName}`));
-        })
-    );
+    test('locate() returns Maybe.just() when the referenced source-map file is readable', async function () {
+        await fc.assert(
+            fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
+                const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, true).locate('/src/file.js');
+                assert.deepStrictEqual(result, Maybe.just(`/src/${mapFileName}`));
+            })
+        );
+    });
 });

--- a/source/dependency-scanner/source-map-file-locator.test.ts
+++ b/source/dependency-scanner/source-map-file-locator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Maybe } from 'true-myth';
 import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { createSourceMapFileLocator, type SourceMapFileLocator } from './source-map-file-locator.ts';
@@ -25,95 +25,97 @@ function sourceMapFileLocatorFactory(overrides: Overrides = {}): {
     };
 }
 
-test('reads the content of the given source file', async () => {
-    const { locator, fileManager } = sourceMapFileLocatorFactory();
+suite('source-map-file-locator', function () {
+    test('reads the content of the given source file', async function () {
+        const { locator, fileManager } = sourceMapFileLocatorFactory();
 
-    await locator.locate('/foo/bar.js');
+        await locator.locate('/foo/bar.js');
 
-    assert.strictEqual(fileManager.getReadFileCallCount(), 1);
-    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/foo/bar.js' });
-});
-
-async function expectLocateReturnsNothingWithoutCheckReadability(content: string): Promise<void> {
-    const { locator, fileManager } = sourceMapFileLocatorFactory({ readFileContent: content, isReadable: true });
-
-    const result = await locator.locate('/foo/bar.js');
-
-    assert.deepStrictEqual(result, Maybe.nothing());
-    assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 0);
-}
-
-test('returns nothing when there is no external source mapping URL referenced in the given file', async () => {
-    await expectLocateReturnsNothingWithoutCheckReadability('no sourceMappingURL comment');
-});
-
-test('returns nothing when the sourceMappingURL text is not at the start of a line comment', async () => {
-    await expectLocateReturnsNothingWithoutCheckReadability('const url = "//# sourceMappingURL=baz.map.js";');
-});
-
-test('returns nothing when the sourceMappingURL comment appears after code on a later line', async () => {
-    await expectLocateReturnsNothingWithoutCheckReadability(
-        'const x = 1;\nconst y = 2; //# sourceMappingURL=baz.map.js'
-    );
-});
-
-test('returns nothing when the sourceMappingURL comment does not contain a file name', async () => {
-    await expectLocateReturnsNothingWithoutCheckReadability('foo\n//# sourceMappingURL=');
-});
-
-test('reads the named capture group value as the source map file name', async () => {
-    const { locator, fileManager } = sourceMapFileLocatorFactory({
-        readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
-        isReadable: false
+        assert.strictEqual(fileManager.getReadFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/foo/bar.js' });
     });
 
-    const result = await locator.locate('/foo/bar.js');
+    async function expectLocateReturnsNothingWithoutCheckReadability(content: string): Promise<void> {
+        const { locator, fileManager } = sourceMapFileLocatorFactory({ readFileContent: content, isReadable: true });
 
-    assert.deepStrictEqual(result, Maybe.nothing());
-    assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js' });
-});
+        const result = await locator.locate('/foo/bar.js');
 
-test('uses the full sourceMappingURL capture up to the end of the line', async () => {
-    const { locator, fileManager } = sourceMapFileLocatorFactory({
-        readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js?hash=1',
-        isReadable: false
+        assert.deepStrictEqual(result, Maybe.nothing());
+        assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 0);
+    }
+
+    test('returns nothing when there is no external source mapping URL referenced in the given file', async function () {
+        await expectLocateReturnsNothingWithoutCheckReadability('no sourceMappingURL comment');
     });
 
-    await locator.locate('/foo/bar.js');
-
-    assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js?hash=1' });
-});
-
-test('checks if the referenced source mapping file is readable on the file system', async () => {
-    const { locator, fileManager } = sourceMapFileLocatorFactory({
-        readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
-        isReadable: false
+    test('returns nothing when the sourceMappingURL text is not at the start of a line comment', async function () {
+        await expectLocateReturnsNothingWithoutCheckReadability('const url = "//# sourceMappingURL=baz.map.js";');
     });
 
-    await locator.locate('/foo/bar.js');
-
-    assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
-    assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/foo/baz.map.js' });
-});
-
-test('returns the path to the referenced source map file when it is readable', async () => {
-    const { locator } = sourceMapFileLocatorFactory({
-        readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
-        isReadable: true
+    test('returns nothing when the sourceMappingURL comment appears after code on a later line', async function () {
+        await expectLocateReturnsNothingWithoutCheckReadability(
+            'const x = 1;\nconst y = 2; //# sourceMappingURL=baz.map.js'
+        );
     });
 
-    const result = await locator.locate('/foo/bar.js');
-
-    assert.deepStrictEqual(result, Maybe.just('/maps/baz.map.js'));
-});
-
-test('returns nothing when there is an external source mapping file referenced but it can’t be read', async () => {
-    const { locator } = sourceMapFileLocatorFactory({
-        readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
-        isReadable: false
+    test('returns nothing when the sourceMappingURL comment does not contain a file name', async function () {
+        await expectLocateReturnsNothingWithoutCheckReadability('foo\n//# sourceMappingURL=');
     });
 
-    const result = await locator.locate('/foo/bar.js');
+    test('reads the named capture group value as the source map file name', async function () {
+        const { locator, fileManager } = sourceMapFileLocatorFactory({
+            readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
+            isReadable: false
+        });
 
-    assert.deepStrictEqual(result, Maybe.nothing());
+        const result = await locator.locate('/foo/bar.js');
+
+        assert.deepStrictEqual(result, Maybe.nothing());
+        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js' });
+    });
+
+    test('uses the full sourceMappingURL capture up to the end of the line', async function () {
+        const { locator, fileManager } = sourceMapFileLocatorFactory({
+            readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js?hash=1',
+            isReadable: false
+        });
+
+        await locator.locate('/foo/bar.js');
+
+        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js?hash=1' });
+    });
+
+    test('checks if the referenced source mapping file is readable on the file system', async function () {
+        const { locator, fileManager } = sourceMapFileLocatorFactory({
+            readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
+            isReadable: false
+        });
+
+        await locator.locate('/foo/bar.js');
+
+        assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/foo/baz.map.js' });
+    });
+
+    test('returns the path to the referenced source map file when it is readable', async function () {
+        const { locator } = sourceMapFileLocatorFactory({
+            readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
+            isReadable: true
+        });
+
+        const result = await locator.locate('/foo/bar.js');
+
+        assert.deepStrictEqual(result, Maybe.just('/maps/baz.map.js'));
+    });
+
+    test('returns nothing when there is an external source mapping file referenced but it can’t be read', async function () {
+        const { locator } = sourceMapFileLocatorFactory({
+            readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
+            isReadable: false
+        });
+
+        const result = await locator.locate('/foo/bar.js');
+
+        assert.deepStrictEqual(result, Maybe.nothing());
+    });
 });

--- a/source/dependency-scanner/typescript-compiler-options.test.ts
+++ b/source/dependency-scanner/typescript-compiler-options.test.ts
@@ -1,50 +1,52 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { ModuleKind, ModuleResolutionKind } from 'ts-morph';
 import { analyzationOptionsToCompilerOptions } from './typescript-compiler-options.ts';
 
 const stubMainPackageJson = { name: 'pkg', version: '1.0.0', type: 'module' } as never;
 
-test('analyzationOptionsToCompilerOptions returns Node16 module resolution and module kinds', () => {
-    const options = analyzationOptionsToCompilerOptions({
-        resolveDeclarationFiles: true,
-        mainPackageJson: stubMainPackageJson
+suite('typescript-compiler-options', function () {
+    test('analyzationOptionsToCompilerOptions returns Node16 module resolution and module kinds', function () {
+        const options = analyzationOptionsToCompilerOptions({
+            resolveDeclarationFiles: true,
+            mainPackageJson: stubMainPackageJson
+        });
+
+        assert.strictEqual(options.moduleResolution, ModuleResolutionKind.Node16);
+        assert.strictEqual(options.module, ModuleKind.Node16);
     });
 
-    assert.strictEqual(options.moduleResolution, ModuleResolutionKind.Node16);
-    assert.strictEqual(options.module, ModuleKind.Node16);
-});
+    test('analyzationOptionsToCompilerOptions enables esModuleInterop, allowJs, noLib, skipLibCheck, and noEmit', function () {
+        const options = analyzationOptionsToCompilerOptions({
+            resolveDeclarationFiles: true,
+            mainPackageJson: stubMainPackageJson
+        });
 
-test('analyzationOptionsToCompilerOptions enables esModuleInterop, allowJs, noLib, skipLibCheck, and noEmit', () => {
-    const options = analyzationOptionsToCompilerOptions({
-        resolveDeclarationFiles: true,
-        mainPackageJson: stubMainPackageJson
+        assert.strictEqual(options.esModuleInterop, true);
+        assert.strictEqual(options.allowJs, true);
+        assert.strictEqual(options.noLib, true);
+        assert.strictEqual(options.skipLibCheck, true);
+        assert.strictEqual(options.noEmit, true);
     });
 
-    assert.strictEqual(options.esModuleInterop, true);
-    assert.strictEqual(options.allowJs, true);
-    assert.strictEqual(options.noLib, true);
-    assert.strictEqual(options.skipLibCheck, true);
-    assert.strictEqual(options.noEmit, true);
-});
+    test('analyzationOptionsToCompilerOptions clears types and typeRoots when declaration-file resolution is disabled', function () {
+        const options = analyzationOptionsToCompilerOptions({
+            resolveDeclarationFiles: false,
+            mainPackageJson: stubMainPackageJson
+        });
 
-test('analyzationOptionsToCompilerOptions clears types and typeRoots when declaration-file resolution is disabled', () => {
-    const options = analyzationOptionsToCompilerOptions({
-        resolveDeclarationFiles: false,
-        mainPackageJson: stubMainPackageJson
+        assert.deepStrictEqual(options.types, []);
+        assert.deepStrictEqual(options.typeRoots, []);
     });
 
-    assert.deepStrictEqual(options.types, []);
-    assert.deepStrictEqual(options.typeRoots, []);
-});
+    test('analyzationOptionsToCompilerOptions omits types and typeRoots when declaration-file resolution is enabled', function () {
+        const options = analyzationOptionsToCompilerOptions({
+            resolveDeclarationFiles: true,
+            mainPackageJson: stubMainPackageJson
+        });
 
-test('analyzationOptionsToCompilerOptions omits types and typeRoots when declaration-file resolution is enabled', () => {
-    const options = analyzationOptionsToCompilerOptions({
-        resolveDeclarationFiles: true,
-        mainPackageJson: stubMainPackageJson
+        assert.strictEqual(options.types, undefined);
+        assert.strictEqual(options.typeRoots, undefined);
     });
-
-    assert.strictEqual(options.types, undefined);
-    assert.strictEqual(options.typeRoots, undefined);
 });

--- a/source/dependency-scanner/typescript-file-host.test.ts
+++ b/source/dependency-scanner/typescript-file-host.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test, type AsyncFunc } from 'mocha';
+import { suite, test, type AsyncFunc } from 'mocha';
 import { type SinonSpy, fake } from 'sinon';
 import {
     createFileSystemAdapters,
@@ -57,420 +57,429 @@ function checkWrappedFileHostMethod(testCase: WrappedFileHostMethodCallTestCase)
     };
 }
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.ts',
-    checkWrappedFileHostMethod({
-        method: 'fileExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.d.ts',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+suite('typescript-file-host', function () {
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.ts',
+        checkWrappedFileHostMethod({
+            method: 'fileExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.d.ts',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.cts',
-    checkWrappedFileHostMethod({
-        method: 'fileExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.d.cts',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.cts',
+        checkWrappedFileHostMethod({
+            method: 'fileExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.d.cts',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.mts',
-    checkWrappedFileHostMethod({
-        method: 'fileExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.d.mts',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExists returns false when the file extension is .d.mts',
+        checkWrappedFileHostMethod({
+            method: 'fileExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.d.mts',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExists treats declaration file extensions case-insensitively',
-    checkWrappedFileHostMethod({
-        method: 'fileExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/BAR.D.TS',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExists treats declaration file extensions case-insensitively',
+        checkWrappedFileHostMethod({
+            method: 'fileExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/BAR.D.TS',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExists returns the same value from the wrapped fileSystemHost when it is not a declaration file',
-    checkWrappedFileHostMethod({
-        method: 'fileExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.txt',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/bar.txt']]
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExists returns the same value from the wrapped fileSystemHost when it is not a declaration file',
+        checkWrappedFileHostMethod({
+            method: 'fileExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.txt',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/bar.txt']]
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.ts',
-    checkWrappedFileHostMethod({
-        method: 'fileExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.d.ts',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.ts',
+        checkWrappedFileHostMethod({
+            method: 'fileExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.d.ts',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.cts',
-    checkWrappedFileHostMethod({
-        method: 'fileExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.d.cts',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.cts',
+        checkWrappedFileHostMethod({
+            method: 'fileExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.d.cts',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.mts',
-    checkWrappedFileHostMethod({
-        method: 'fileExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.d.mts',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns false when the file extension is .d.mts',
+        checkWrappedFileHostMethod({
+            method: 'fileExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.d.mts',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExistsSync treats declaration file extensions case-insensitively',
-    checkWrappedFileHostMethod({
-        method: 'fileExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/BAR.D.MTS',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExistsSync treats declaration file extensions case-insensitively',
+        checkWrappedFileHostMethod({
+            method: 'fileExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/BAR.D.MTS',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns the same value from the wrapped fileSystemHost when it is not a declaration file',
-    checkWrappedFileHostMethod({
-        method: 'fileExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/bar.txt',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/bar.txt']]
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.fileExistsSync returns the same value from the wrapped fileSystemHost when it is not a declaration file',
+        checkWrappedFileHostMethod({
+            method: 'fileExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/bar.txt',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/bar.txt']]
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExists returns false when the path contains the segments node_modules/@types/',
-    checkWrappedFileHostMethod({
-        method: 'directoryExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/node_modules/@types/bar',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExists returns false when the path contains the segments node_modules/@types/',
+        checkWrappedFileHostMethod({
+            method: 'directoryExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/node_modules/@types/bar',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExists returns the same value from the wrapped fileSystemHost when it doesn’t contain a type-roots path segment',
-    checkWrappedFileHostMethod({
-        method: 'directoryExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/node_modules/bar',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/node_modules/bar']]
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExists returns the same value from the wrapped fileSystemHost when it doesn’t contain a type-roots path segment',
+        checkWrappedFileHostMethod({
+            method: 'directoryExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/node_modules/bar',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/node_modules/bar']]
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns false when the path contains the segments node_modules/@types',
-    checkWrappedFileHostMethod({
-        method: 'directoryExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/node_modules/@types/bar',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns false when the path contains the segments node_modules/@types',
+        checkWrappedFileHostMethod({
+            method: 'directoryExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/node_modules/@types/bar',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
 
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns the same value from the wrapped fileSystemHost when it doesn’t contain a type-roots path segment',
-    checkWrappedFileHostMethod({
-        method: 'directoryExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/node_modules/bar',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/node_modules/bar']]
-    })
-);
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns the same value from the wrapped fileSystemHost when it doesn’t contain a type-roots path segment',
+        checkWrappedFileHostMethod({
+            method: 'directoryExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/node_modules/bar',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/node_modules/bar']]
+        })
+    );
 
-test(
-    'fileSystemHostWithoutFilter.fileExists returns the same value from the wrapped fileSystemHost even when a declaration file is given',
-    checkWrappedFileHostMethod({
-        method: 'fileExists',
-        adapter: 'fileSystemHostWithoutFilter',
-        pathToCheck: 'foo/bar.d.ts',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/bar.d.ts']]
-    })
-);
+    test(
+        'fileSystemHostWithoutFilter.fileExists returns the same value from the wrapped fileSystemHost even when a declaration file is given',
+        checkWrappedFileHostMethod({
+            method: 'fileExists',
+            adapter: 'fileSystemHostWithoutFilter',
+            pathToCheck: 'foo/bar.d.ts',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/bar.d.ts']]
+        })
+    );
 
-test(
-    'fileSystemHostWithoutFilter.fileExistsSync returns the same value from the wrapped fileSystemHost even when a declaration file is given',
-    checkWrappedFileHostMethod({
-        method: 'fileExistsSync',
-        adapter: 'fileSystemHostWithoutFilter',
-        pathToCheck: 'foo/bar.d.ts',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/bar.d.ts']]
-    })
-);
+    test(
+        'fileSystemHostWithoutFilter.fileExistsSync returns the same value from the wrapped fileSystemHost even when a declaration file is given',
+        checkWrappedFileHostMethod({
+            method: 'fileExistsSync',
+            adapter: 'fileSystemHostWithoutFilter',
+            pathToCheck: 'foo/bar.d.ts',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/bar.d.ts']]
+        })
+    );
 
-test('throws when fileExistsSync is not a function', () => {
-    try {
-        createFileSystemAdapters({
-            fileSystemHost: {
-                fileExists: fake(),
-                fileExistsSync: true,
-                directoryExists: fake(),
-                directoryExistsSync: fake()
-            } as unknown as FileSystemAdaptersDependencies['fileSystemHost']
+    test('throws when fileExistsSync is not a function', function () {
+        try {
+            createFileSystemAdapters({
+                fileSystemHost: {
+                    fileExists: fake(),
+                    fileExistsSync: true,
+                    directoryExists: fake(),
+                    directoryExistsSync: fake()
+                } as unknown as FileSystemAdaptersDependencies['fileSystemHost']
+            });
+            assert.fail('Expected createFileSystemAdapters() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Expected fileExistsSync to be a function');
+        }
+    });
+
+    test('throws when directoryExistsSync does not return a boolean', function () {
+        const fileSystemAdapters = fileSystemAdaptersFactory({
+            directoryExistsSync: fake.returns('invalid')
         });
-        assert.fail('Expected createFileSystemAdapters() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Expected fileExistsSync to be a function');
-    }
-});
 
-test('throws when directoryExistsSync does not return a boolean', () => {
-    const fileSystemAdapters = fileSystemAdaptersFactory({
-        directoryExistsSync: fake.returns('invalid')
+        try {
+            // eslint-disable-next-line node/no-sync -- this test intentionally exercises the synchronous ts-morph host contract
+            fileSystemAdapters.fileSystemHostFilteringDeclarationFiles.directoryExistsSync('foo/node_modules/bar');
+            assert.fail('Expected directoryExistsSync() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Expected directoryExistsSync to return a boolean');
+        }
     });
 
-    try {
-        // eslint-disable-next-line node/no-sync -- this test intentionally exercises the synchronous ts-morph host contract
-        fileSystemAdapters.fileSystemHostFilteringDeclarationFiles.directoryExistsSync('foo/node_modules/bar');
-        assert.fail('Expected directoryExistsSync() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Expected directoryExistsSync to return a boolean');
-    }
-});
+    test('throws when fileExistsSync does not return a boolean', function () {
+        const fileSystemAdapters = fileSystemAdaptersFactory({
+            fileExistsSync: fake.returns('invalid')
+        });
 
-test('throws when fileExistsSync does not return a boolean', () => {
-    const fileSystemAdapters = fileSystemAdaptersFactory({
-        fileExistsSync: fake.returns('invalid')
+        try {
+            // eslint-disable-next-line node/no-sync -- this test intentionally exercises the synchronous ts-morph host contract
+            fileSystemAdapters.fileSystemHostFilteringDeclarationFiles.fileExistsSync('foo/bar.txt');
+            assert.fail('Expected fileExistsSync() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Expected fileExistsSync to return a boolean');
+        }
     });
 
-    try {
-        // eslint-disable-next-line node/no-sync -- this test intentionally exercises the synchronous ts-morph host contract
-        fileSystemAdapters.fileSystemHostFilteringDeclarationFiles.fileExistsSync('foo/bar.txt');
-        assert.fail('Expected fileExistsSync() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Expected fileExistsSync to return a boolean');
-    }
-});
-
-test(
-    'fileSystemHostWithoutFilter.directoryExists returns the same value from the wrapped fileSystemHost even when a type-roots path is given',
-    checkWrappedFileHostMethod({
-        method: 'directoryExists',
-        adapter: 'fileSystemHostWithoutFilter',
-        pathToCheck: 'foo/node_modules/@types/bar',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/node_modules/@types/bar']]
-    })
-);
-
-test(
-    'fileSystemHostWithoutFilter.directoryExistsSync returns the same value from the wrapped fileSystemHost even when a type-roots path is given',
-    checkWrappedFileHostMethod({
-        method: 'directoryExistsSync',
-        adapter: 'fileSystemHostWithoutFilter',
-        pathToCheck: 'foo/node_modules/@types/bar',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-        expectedUpstreamCalls: [['foo/node_modules/@types/bar']]
-    })
-);
-
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExists returns false when the path ends with the segments node_modules/@types',
-    checkWrappedFileHostMethod({
-        method: 'directoryExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/node_modules/@types',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
-
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExists returns the same value from the wrapped fileSystemHost when the path contains node_modules/@types which is not the end of the segment',
-    checkWrappedFileHostMethod({
-        method: 'directoryExists',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-
-        pathToCheck: 'foo/node_modules/@typesomething/foo',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-
-        expectedUpstreamCalls: [['foo/node_modules/@typesomething/foo']]
-    })
-);
-
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns false when the path ends with the segments node_modules/@types',
-    checkWrappedFileHostMethod({
-        method: 'directoryExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-        pathToCheck: 'foo/node_modules/@types',
-        upstreamMethodReturnValue: true,
-        expectedResult: false,
-        expectedUpstreamCalls: []
-    })
-);
-
-test(
-    'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns the same value from the wrapped fileSystemHost when the path contains node_modules/@types which is not the end of the segment',
-    checkWrappedFileHostMethod({
-        method: 'directoryExistsSync',
-        adapter: 'fileSystemHostFilteringDeclarationFiles',
-
-        pathToCheck: 'foo/node_modules/@typesomething/foo',
-        upstreamMethodReturnValue: true,
-        expectedResult: true,
-
-        expectedUpstreamCalls: [['foo/node_modules/@typesomething/foo']]
-    })
-);
-
-test('withVirtualPackageJson() makes the configured package.json path exist even when the wrapped host says it does not', async () => {
-    const fileSystemAdapters = fileSystemAdaptersFactory({
-        fileExists: fake.resolves(false),
-        fileExistsSync: fake.returns(false)
-    });
-    const virtualHost = fileSystemAdapters.withVirtualPackageJson(
-        fileSystemAdapters.fileSystemHostWithoutFilter,
-        '/repo/src',
-        { type: 'module', imports: { '#foo': './foo.js' } }
+    test(
+        'fileSystemHostWithoutFilter.directoryExists returns the same value from the wrapped fileSystemHost even when a type-roots path is given',
+        checkWrappedFileHostMethod({
+            method: 'directoryExists',
+            adapter: 'fileSystemHostWithoutFilter',
+            pathToCheck: 'foo/node_modules/@types/bar',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/node_modules/@types/bar']]
+        })
     );
 
-    assert.strictEqual(await virtualHost.fileExists('/repo/src/package.json'), true);
-    // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
-    assert.strictEqual(virtualHost.fileExistsSync('/repo/src/package.json'), true);
-});
-
-test('withVirtualPackageJson() delegates existence checks for non-package.json paths to the wrapped host', async () => {
-    const fileExists = fake.resolves(false);
-    const fileExistsSync = fake.returns(true);
-    const fileSystemAdapters = fileSystemAdaptersFactory({ fileExists, fileExistsSync });
-    const virtualHost = fileSystemAdapters.withVirtualPackageJson(
-        fileSystemAdapters.fileSystemHostWithoutFilter,
-        '/repo/src',
-        { type: 'module' }
+    test(
+        'fileSystemHostWithoutFilter.directoryExistsSync returns the same value from the wrapped fileSystemHost even when a type-roots path is given',
+        checkWrappedFileHostMethod({
+            method: 'directoryExistsSync',
+            adapter: 'fileSystemHostWithoutFilter',
+            pathToCheck: 'foo/node_modules/@types/bar',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+            expectedUpstreamCalls: [['foo/node_modules/@types/bar']]
+        })
     );
 
-    assert.strictEqual(await virtualHost.fileExists('/repo/src/foo.js'), false);
-    // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
-    assert.strictEqual(virtualHost.fileExistsSync('/repo/src/foo.js'), true);
-    assert.deepStrictEqual(fileExists.args, [['/repo/src/foo.js']]);
-    assert.deepStrictEqual(fileExistsSync.args, [['/repo/src/foo.js']]);
-});
-
-test('withVirtualPackageJson() throws when the wrapped fileExistsSync does not return a boolean', () => {
-    const fileSystemAdapters = fileSystemAdaptersFactory({
-        fileExistsSync: fake.returns('invalid')
-    });
-    const virtualHost = fileSystemAdapters.withVirtualPackageJson(
-        fileSystemAdapters.fileSystemHostWithoutFilter,
-        '/repo/src',
-        { type: 'module' }
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExists returns false when the path ends with the segments node_modules/@types',
+        checkWrappedFileHostMethod({
+            method: 'directoryExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/node_modules/@types',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
     );
 
-    try {
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExists returns the same value from the wrapped fileSystemHost when the path contains node_modules/@types which is not the end of the segment',
+        checkWrappedFileHostMethod({
+            method: 'directoryExists',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+
+            pathToCheck: 'foo/node_modules/@typesomething/foo',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+
+            expectedUpstreamCalls: [['foo/node_modules/@typesomething/foo']]
+        })
+    );
+
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns false when the path ends with the segments node_modules/@types',
+        checkWrappedFileHostMethod({
+            method: 'directoryExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+            pathToCheck: 'foo/node_modules/@types',
+            upstreamMethodReturnValue: true,
+            expectedResult: false,
+            expectedUpstreamCalls: []
+        })
+    );
+
+    test(
+        'fileSystemHostFilteringDeclarationFiles.directoryExistsSync returns the same value from the wrapped fileSystemHost when the path contains node_modules/@types which is not the end of the segment',
+        checkWrappedFileHostMethod({
+            method: 'directoryExistsSync',
+            adapter: 'fileSystemHostFilteringDeclarationFiles',
+
+            pathToCheck: 'foo/node_modules/@typesomething/foo',
+            upstreamMethodReturnValue: true,
+            expectedResult: true,
+
+            expectedUpstreamCalls: [['foo/node_modules/@typesomething/foo']]
+        })
+    );
+
+    test('withVirtualPackageJson() makes the configured package.json path exist even when the wrapped host says it does not', async function () {
+        const fileSystemAdapters = fileSystemAdaptersFactory({
+            fileExists: fake.resolves(false),
+            fileExistsSync: fake.returns(false)
+        });
+        const virtualHost = fileSystemAdapters.withVirtualPackageJson(
+            fileSystemAdapters.fileSystemHostWithoutFilter,
+            '/repo/src',
+            { type: 'module', imports: { '#foo': './foo.js' } }
+        );
+
+        assert.strictEqual(await virtualHost.fileExists('/repo/src/package.json'), true);
         // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
-        virtualHost.fileExistsSync('/repo/src/foo.js');
-        assert.fail('Expected fileExistsSync() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Expected fileExistsSync to return a boolean');
-    }
-});
-
-test('withVirtualPackageJson() returns the serialized mainPackageJson for reads of the virtual manifest', async () => {
-    const readFile = fake.resolves('from-disk');
-    const readFileSync = fake.returns('from-disk-sync');
-    const fileSystemAdapters = fileSystemAdaptersFactory({ readFile, readFileSync });
-    const mainPackageJson = { type: 'module' as const, imports: { '#foo': './foo.js' } };
-    const virtualHost = fileSystemAdapters.withVirtualPackageJson(
-        fileSystemAdapters.fileSystemHostWithoutFilter,
-        '/repo/src',
-        mainPackageJson
-    );
-
-    assert.strictEqual(await virtualHost.readFile('/repo/src/package.json'), JSON.stringify(mainPackageJson, null, 2));
-    // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
-    assert.strictEqual(virtualHost.readFileSync('/repo/src/package.json'), JSON.stringify(mainPackageJson, null, 2));
-    assert.strictEqual(readFile.callCount, 0);
-    assert.strictEqual(readFileSync.callCount, 0);
-});
-
-test('withVirtualPackageJson() delegates reads for non-package.json paths to the wrapped host', async () => {
-    const readFile = fake.resolves('from-disk');
-    const readFileSync = fake.returns('from-disk-sync');
-    const fileSystemAdapters = fileSystemAdaptersFactory({ readFile, readFileSync });
-    const virtualHost = fileSystemAdapters.withVirtualPackageJson(
-        fileSystemAdapters.fileSystemHostWithoutFilter,
-        '/repo/src',
-        { type: 'module' }
-    );
-
-    assert.strictEqual(await virtualHost.readFile('/repo/src/foo.js'), 'from-disk');
-    // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
-    assert.strictEqual(virtualHost.readFileSync('/repo/src/foo.js'), 'from-disk-sync');
-    assert.deepStrictEqual(readFile.args, [['/repo/src/foo.js', undefined]]);
-    assert.deepStrictEqual(readFileSync.args, [['/repo/src/foo.js']]);
-});
-
-test('withVirtualPackageJson() throws when the wrapped readFileSync does not return a string', () => {
-    const fileSystemAdapters = fileSystemAdaptersFactory({
-        readFileSync: fake.returns(true)
+        assert.strictEqual(virtualHost.fileExistsSync('/repo/src/package.json'), true);
     });
-    const virtualHost = fileSystemAdapters.withVirtualPackageJson(
-        fileSystemAdapters.fileSystemHostWithoutFilter,
-        '/repo/src',
-        { type: 'module' }
-    );
 
-    try {
+    test('withVirtualPackageJson() delegates existence checks for non-package.json paths to the wrapped host', async function () {
+        const fileExists = fake.resolves(false);
+        const fileExistsSync = fake.returns(true);
+        const fileSystemAdapters = fileSystemAdaptersFactory({ fileExists, fileExistsSync });
+        const virtualHost = fileSystemAdapters.withVirtualPackageJson(
+            fileSystemAdapters.fileSystemHostWithoutFilter,
+            '/repo/src',
+            { type: 'module' }
+        );
+
+        assert.strictEqual(await virtualHost.fileExists('/repo/src/foo.js'), false);
         // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
-        virtualHost.readFileSync('/repo/src/foo.js');
-        assert.fail('Expected readFileSync() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Expected readFileSync to return a string');
-    }
+        assert.strictEqual(virtualHost.fileExistsSync('/repo/src/foo.js'), true);
+        assert.deepStrictEqual(fileExists.args, [['/repo/src/foo.js']]);
+        assert.deepStrictEqual(fileExistsSync.args, [['/repo/src/foo.js']]);
+    });
+
+    test('withVirtualPackageJson() throws when the wrapped fileExistsSync does not return a boolean', function () {
+        const fileSystemAdapters = fileSystemAdaptersFactory({
+            fileExistsSync: fake.returns('invalid')
+        });
+        const virtualHost = fileSystemAdapters.withVirtualPackageJson(
+            fileSystemAdapters.fileSystemHostWithoutFilter,
+            '/repo/src',
+            { type: 'module' }
+        );
+
+        try {
+            // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
+            virtualHost.fileExistsSync('/repo/src/foo.js');
+            assert.fail('Expected fileExistsSync() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Expected fileExistsSync to return a boolean');
+        }
+    });
+
+    test('withVirtualPackageJson() returns the serialized mainPackageJson for reads of the virtual manifest', async function () {
+        const readFile = fake.resolves('from-disk');
+        const readFileSync = fake.returns('from-disk-sync');
+        const fileSystemAdapters = fileSystemAdaptersFactory({ readFile, readFileSync });
+        const mainPackageJson = { type: 'module' as const, imports: { '#foo': './foo.js' } };
+        const virtualHost = fileSystemAdapters.withVirtualPackageJson(
+            fileSystemAdapters.fileSystemHostWithoutFilter,
+            '/repo/src',
+            mainPackageJson
+        );
+
+        assert.strictEqual(
+            await virtualHost.readFile('/repo/src/package.json'),
+            JSON.stringify(mainPackageJson, null, 2)
+        );
+
+        assert.strictEqual(
+            // eslint-disable-next-line node/no-sync -- exercising the sync branch of the virtual host under test
+            virtualHost.readFileSync('/repo/src/package.json'),
+            JSON.stringify(mainPackageJson, null, 2)
+        );
+        assert.strictEqual(readFile.callCount, 0);
+        assert.strictEqual(readFileSync.callCount, 0);
+    });
+
+    test('withVirtualPackageJson() delegates reads for non-package.json paths to the wrapped host', async function () {
+        const readFile = fake.resolves('from-disk');
+        const readFileSync = fake.returns('from-disk-sync');
+        const fileSystemAdapters = fileSystemAdaptersFactory({ readFile, readFileSync });
+        const virtualHost = fileSystemAdapters.withVirtualPackageJson(
+            fileSystemAdapters.fileSystemHostWithoutFilter,
+            '/repo/src',
+            { type: 'module' }
+        );
+
+        assert.strictEqual(await virtualHost.readFile('/repo/src/foo.js'), 'from-disk');
+        // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
+        assert.strictEqual(virtualHost.readFileSync('/repo/src/foo.js'), 'from-disk-sync');
+        assert.deepStrictEqual(readFile.args, [['/repo/src/foo.js', undefined]]);
+        assert.deepStrictEqual(readFileSync.args, [['/repo/src/foo.js']]);
+    });
+
+    test('withVirtualPackageJson() throws when the wrapped readFileSync does not return a string', function () {
+        const fileSystemAdapters = fileSystemAdaptersFactory({
+            readFileSync: fake.returns(true)
+        });
+        const virtualHost = fileSystemAdapters.withVirtualPackageJson(
+            fileSystemAdapters.fileSystemHostWithoutFilter,
+            '/repo/src',
+            { type: 'module' }
+        );
+
+        try {
+            // eslint-disable-next-line node/no-sync -- ts-morph hosts require sync methods
+            virtualHost.readFileSync('/repo/src/foo.js');
+            assert.fail('Expected readFileSync() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Expected readFileSync to return a string');
+        }
+    });
 });

--- a/source/dependency-scanner/typescript-project-analyzer.test.ts
+++ b/source/dependency-scanner/typescript-project-analyzer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { stub, fake, type SinonSpy, type SinonStub } from 'sinon';
 import {
     createTypescriptProjectAnalyzer,
@@ -117,94 +117,96 @@ function runAnalyzeProjectExpectingArgs(testArgs: {
     assert.deepStrictEqual(addSourceFilesAtPaths.firstCall.args, [[testArgs.expectedFilesGlob]]);
 }
 
-test('creates a project for all js files in the given folder with module resolution', () => {
-    const withVirtualPackageJson = fake.returns('virtualized-filtering-declaration-files');
-    runAnalyzeProjectExpectingArgs({
-        resolveDeclarationFiles: false,
-        fileSystemAdapters: {
-            fileSystemHostFilteringDeclarationFiles: 'filtering-declaration-files',
-            withVirtualPackageJson
-        },
-        expectedModule: 100,
-        expectedFileSystem: 'virtualized-filtering-declaration-files',
-        expectedFilesGlob: '/foo/**/*.js',
-        expectedExtra: { typeRoots: [], types: [] }
-    });
-});
-
-test('creates a project for all d.ts files in the given folder', () => {
-    const withVirtualPackageJson = fake.returns('virtualized-no-filtering');
-    runAnalyzeProjectExpectingArgs({
-        resolveDeclarationFiles: true,
-        fileSystemAdapters: {
-            fileSystemHostWithoutFilter: 'no-filtering',
-            withVirtualPackageJson
-        },
-        expectedModule: 100,
-        expectedFileSystem: 'virtualized-no-filtering',
-        expectedFilesGlob: '/foo/**/*.d.ts'
-    });
-});
-
-test('getReferencedSourceFilePaths() returns an empty array when the source file for given path doesn’t exist', () => {
-    const getSourceFile = fake.returns(undefined);
-    const TSMorphProject = createFakeTSMorphProject({ getSourceFile });
-    const analyzer = typescriptProjectAnalyzerFactory({ TSMorphProject });
-
-    const project = analyzer.analyzeProject('/foo', {
-        resolveDeclarationFiles: false,
-        mainPackageJson: { type: 'module' }
-    });
-    const result = project.getReferencedSourceFilePaths('/foo/bar.js');
-
-    assert.deepStrictEqual(result, []);
-});
-
-test('getProject() exposes the underlying ts-morph project instance', () => {
-    const TSMorphProject = createFakeTSMorphProject();
-    const analyzer = typescriptProjectAnalyzerFactory({ TSMorphProject });
-
-    const project = analyzer.analyzeProject('/foo', {
-        resolveDeclarationFiles: false,
-        mainPackageJson: { type: 'module' }
+suite('typescript-project-analyzer', function () {
+    test('creates a project for all js files in the given folder with module resolution', function () {
+        const withVirtualPackageJson = fake.returns('virtualized-filtering-declaration-files');
+        runAnalyzeProjectExpectingArgs({
+            resolveDeclarationFiles: false,
+            fileSystemAdapters: {
+                fileSystemHostFilteringDeclarationFiles: 'filtering-declaration-files',
+                withVirtualPackageJson
+            },
+            expectedModule: 100,
+            expectedFileSystem: 'virtualized-filtering-declaration-files',
+            expectedFilesGlob: '/foo/**/*.js',
+            expectedExtra: { typeRoots: [], types: [] }
+        });
     });
 
-    assert.strictEqual(project.getProject(), TSMorphProject.firstCall.returnValue);
-});
-
-test('getReferencedSourceFilePaths() returns the referenced source file paths', () => {
-    const getReferencedSourceFiles = fake.returns([
-        createFakeSourceFile({ filePath: '/foo/b.d.ts', isDeclarationFile: true }),
-        createFakeSourceFile({ filePath: '/foo/c.js', isDeclarationFile: false })
-    ]);
-    const getSourceFile = fake.returns(createFakeSourceFile({ filePath: '/foo/a.js' }));
-    const TSMorphProject = createFakeTSMorphProject({ getSourceFile });
-    const analyzer = typescriptProjectAnalyzerFactory({ TSMorphProject, getReferencedSourceFiles });
-
-    const project = analyzer.analyzeProject('/foo', {
-        resolveDeclarationFiles: false,
-        mainPackageJson: { type: 'module' }
-    });
-    const result = project.getReferencedSourceFilePaths('/foo/a.js');
-
-    assert.deepStrictEqual(result, ['/foo/b.d.ts', '/foo/c.js']);
-});
-
-test('passes the configured mainPackageJson into the virtual file-system overlay', () => {
-    const addSourceFilesAtPaths = fake();
-    const TSMorphProject = createFakeTSMorphProject({ addSourceFilesAtPaths });
-    const withVirtualPackageJson = fake.returns('virtualized-file-system');
-    const analyzer = typescriptProjectAnalyzerFactory({
-        TSMorphProject,
-        fileSystemAdapters: {
-            fileSystemHostFilteringDeclarationFiles: 'filtering-declaration-files',
-            withVirtualPackageJson
-        }
+    test('creates a project for all d.ts files in the given folder', function () {
+        const withVirtualPackageJson = fake.returns('virtualized-no-filtering');
+        runAnalyzeProjectExpectingArgs({
+            resolveDeclarationFiles: true,
+            fileSystemAdapters: {
+                fileSystemHostWithoutFilter: 'no-filtering',
+                withVirtualPackageJson
+            },
+            expectedModule: 100,
+            expectedFileSystem: 'virtualized-no-filtering',
+            expectedFilesGlob: '/foo/**/*.d.ts'
+        });
     });
 
-    const mainPackageJson = { type: 'module' as const, imports: { '#foo': './src/foo.js' } };
+    test('getReferencedSourceFilePaths() returns an empty array when the source file for given path doesn’t exist', function () {
+        const getSourceFile = fake.returns(undefined);
+        const TSMorphProject = createFakeTSMorphProject({ getSourceFile });
+        const analyzer = typescriptProjectAnalyzerFactory({ TSMorphProject });
 
-    analyzer.analyzeProject('/foo', { resolveDeclarationFiles: false, mainPackageJson });
+        const project = analyzer.analyzeProject('/foo', {
+            resolveDeclarationFiles: false,
+            mainPackageJson: { type: 'module' }
+        });
+        const result = project.getReferencedSourceFilePaths('/foo/bar.js');
 
-    assert.deepStrictEqual(withVirtualPackageJson.args, [['filtering-declaration-files', '/foo', mainPackageJson]]);
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('getProject() exposes the underlying ts-morph project instance', function () {
+        const TSMorphProject = createFakeTSMorphProject();
+        const analyzer = typescriptProjectAnalyzerFactory({ TSMorphProject });
+
+        const project = analyzer.analyzeProject('/foo', {
+            resolveDeclarationFiles: false,
+            mainPackageJson: { type: 'module' }
+        });
+
+        assert.strictEqual(project.getProject(), TSMorphProject.firstCall.returnValue);
+    });
+
+    test('getReferencedSourceFilePaths() returns the referenced source file paths', function () {
+        const getReferencedSourceFiles = fake.returns([
+            createFakeSourceFile({ filePath: '/foo/b.d.ts', isDeclarationFile: true }),
+            createFakeSourceFile({ filePath: '/foo/c.js', isDeclarationFile: false })
+        ]);
+        const getSourceFile = fake.returns(createFakeSourceFile({ filePath: '/foo/a.js' }));
+        const TSMorphProject = createFakeTSMorphProject({ getSourceFile });
+        const analyzer = typescriptProjectAnalyzerFactory({ TSMorphProject, getReferencedSourceFiles });
+
+        const project = analyzer.analyzeProject('/foo', {
+            resolveDeclarationFiles: false,
+            mainPackageJson: { type: 'module' }
+        });
+        const result = project.getReferencedSourceFilePaths('/foo/a.js');
+
+        assert.deepStrictEqual(result, ['/foo/b.d.ts', '/foo/c.js']);
+    });
+
+    test('passes the configured mainPackageJson into the virtual file-system overlay', function () {
+        const addSourceFilesAtPaths = fake();
+        const TSMorphProject = createFakeTSMorphProject({ addSourceFilesAtPaths });
+        const withVirtualPackageJson = fake.returns('virtualized-file-system');
+        const analyzer = typescriptProjectAnalyzerFactory({
+            TSMorphProject,
+            fileSystemAdapters: {
+                fileSystemHostFilteringDeclarationFiles: 'filtering-declaration-files',
+                withVirtualPackageJson
+            }
+        });
+
+        const mainPackageJson = { type: 'module' as const, imports: { '#foo': './src/foo.js' } };
+
+        analyzer.analyzeProject('/foo', { resolveDeclarationFiles: false, mainPackageJson });
+
+        assert.deepStrictEqual(withVirtualPackageJson.args, [['filtering-declaration-files', '/foo', mainPackageJson]]);
+    });
 });

--- a/source/dependency-scanner/virtual-package-json-host.test.ts
+++ b/source/dependency-scanner/virtual-package-json-host.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions, node/no-sync -- test stubs cast partial mocks of complex orchestrator types and exercise the ts-morph synchronous file-system interface */
 import assert from 'node:assert';
 import path from 'node:path';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { FileSystemHost } from 'ts-morph';
 import { createVirtualPackageJsonHost } from './virtual-package-json-host.ts';
 
@@ -16,35 +16,37 @@ function delegatingHost(records: Map<string, string>): FileSystemHost {
 
 const stubMainPackageJson = { name: 'pkg', version: '1.0.0', type: 'module' } as never;
 
-test('createVirtualPackageJsonHost reports the virtual package.json as existing', async () => {
-    const host = createVirtualPackageJsonHost(delegatingHost(new Map()), '/p', stubMainPackageJson);
-    const packageJsonPath = path.resolve('/p', 'package.json');
+suite('virtual-package-json-host', function () {
+    test('createVirtualPackageJsonHost reports the virtual package.json as existing', async function () {
+        const host = createVirtualPackageJsonHost(delegatingHost(new Map()), '/p', stubMainPackageJson);
+        const packageJsonPath = path.resolve('/p', 'package.json');
 
-    assert.strictEqual(host.fileExistsSync(packageJsonPath), true);
-    assert.strictEqual(await host.fileExists(packageJsonPath), true);
-});
+        assert.strictEqual(host.fileExistsSync(packageJsonPath), true);
+        assert.strictEqual(await host.fileExists(packageJsonPath), true);
+    });
 
-test('createVirtualPackageJsonHost serves the serialized main package.json content', async () => {
-    const host = createVirtualPackageJsonHost(delegatingHost(new Map()), '/p', stubMainPackageJson);
-    const packageJsonPath = path.resolve('/p', 'package.json');
+    test('createVirtualPackageJsonHost serves the serialized main package.json content', async function () {
+        const host = createVirtualPackageJsonHost(delegatingHost(new Map()), '/p', stubMainPackageJson);
+        const packageJsonPath = path.resolve('/p', 'package.json');
 
-    assert.deepStrictEqual(JSON.parse(host.readFileSync(packageJsonPath)), stubMainPackageJson);
-    assert.deepStrictEqual(JSON.parse(await host.readFile(packageJsonPath)), stubMainPackageJson);
-});
+        assert.deepStrictEqual(JSON.parse(host.readFileSync(packageJsonPath)), stubMainPackageJson);
+        assert.deepStrictEqual(JSON.parse(await host.readFile(packageJsonPath)), stubMainPackageJson);
+    });
 
-test('createVirtualPackageJsonHost delegates unrelated file reads to the wrapped host', async () => {
-    const records = new Map([['/other.txt', 'hello']]);
-    const host = createVirtualPackageJsonHost(delegatingHost(records), '/p', stubMainPackageJson);
+    test('createVirtualPackageJsonHost delegates unrelated file reads to the wrapped host', async function () {
+        const records = new Map([['/other.txt', 'hello']]);
+        const host = createVirtualPackageJsonHost(delegatingHost(records), '/p', stubMainPackageJson);
 
-    assert.strictEqual(host.readFileSync('/other.txt'), 'hello');
-    assert.strictEqual(await host.readFile('/other.txt'), 'hello');
-});
+        assert.strictEqual(host.readFileSync('/other.txt'), 'hello');
+        assert.strictEqual(await host.readFile('/other.txt'), 'hello');
+    });
 
-test('createVirtualPackageJsonHost delegates fileExists calls for unrelated paths to the wrapped host', async () => {
-    const records = new Map([['/other.txt', 'hello']]);
-    const host = createVirtualPackageJsonHost(delegatingHost(records), '/p', stubMainPackageJson);
+    test('createVirtualPackageJsonHost delegates fileExists calls for unrelated paths to the wrapped host', async function () {
+        const records = new Map([['/other.txt', 'hello']]);
+        const host = createVirtualPackageJsonHost(delegatingHost(records), '/p', stubMainPackageJson);
 
-    assert.strictEqual(host.fileExistsSync('/other.txt'), true);
-    assert.strictEqual(await host.fileExists('/other.txt'), true);
-    assert.strictEqual(host.fileExistsSync('/missing.txt'), false);
+        assert.strictEqual(host.fileExistsSync('/other.txt'), true);
+        assert.strictEqual(await host.fileExists('/other.txt'), true);
+        assert.strictEqual(host.fileExistsSync('/missing.txt'), false);
+    });
 });

--- a/source/directed-graph/graph.property.ts
+++ b/source/directed-graph/graph.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createDirectedGraph, type DirectedGraph } from './graph.ts';
 
 type GraphEdge<TId extends number | string> = Parameters<DirectedGraph<TId, unknown>['connect']>[0];
@@ -77,69 +77,74 @@ function createCyclicGraphArbitrary(): fc.Arbitrary<GraphShape> {
     });
 }
 
-test('reverse() preserves the edge set when applied twice and reverses all original edges', () => {
-    fc.assert(
-        fc.property(createDagArbitrary(), (shape) => {
-            const graph = createGraph(shape);
-            const reversedGraph = graph.reverse();
-            const reversedTwice = reversedGraph.reverse();
+suite('graph', function () {
+    test('reverse() preserves the edge set when applied twice and reverses all original edges', function () {
+        fc.assert(
+            fc.property(createDagArbitrary(), (shape) => {
+                const graph = createGraph(shape);
+                const reversedGraph = graph.reverse();
+                const reversedTwice = reversedGraph.reverse();
 
-            assert.deepStrictEqual(getSortedEdges(reversedTwice, shape.nodeIds), getSortedEdges(graph, shape.nodeIds));
+                assert.deepStrictEqual(
+                    getSortedEdges(reversedTwice, shape.nodeIds),
+                    getSortedEdges(graph, shape.nodeIds)
+                );
 
-            shape.edges.forEach((edge) => {
-                assert.strictEqual(reversedGraph.hasConnection({ from: edge.to, to: edge.from }), true);
-            });
-        }),
-        { numRuns: 8 }
-    );
-});
+                shape.edges.forEach((edge) => {
+                    assert.strictEqual(reversedGraph.hasConnection({ from: edge.to, to: edge.from }), true);
+                });
+            }),
+            { numRuns: 8 }
+        );
+    });
 
-test('getTopologicalGenerations() contains every node exactly once and respects edge order for DAGs', () => {
-    fc.assert(
-        fc.property(createDagArbitrary(), (shape) => {
-            const graph = createGraph(shape);
-            const generations = graph.getTopologicalGenerations();
-            const flattened = generations.flat();
+    test('getTopologicalGenerations() contains every node exactly once and respects edge order for DAGs', function () {
+        fc.assert(
+            fc.property(createDagArbitrary(), (shape) => {
+                const graph = createGraph(shape);
+                const generations = graph.getTopologicalGenerations();
+                const flattened = generations.flat();
 
-            assert.deepStrictEqual(Array.from(flattened).toSorted(), Array.from(shape.nodeIds).toSorted());
+                assert.deepStrictEqual(Array.from(flattened).toSorted(), Array.from(shape.nodeIds).toSorted());
 
-            const positions = new Map(
-                flattened.map((nodeId, index) => {
-                    return [nodeId, index];
-                })
-            );
-            shape.edges.forEach((edge) => {
-                assert.ok(positions.get(edge.from)! < positions.get(edge.to)!);
-            });
-        }),
-        { numRuns: 8 }
-    );
-});
+                const positions = new Map(
+                    flattened.map((nodeId, index) => {
+                        return [nodeId, index];
+                    })
+                );
+                shape.edges.forEach((edge) => {
+                    assert.ok(positions.get(edge.from)! < positions.get(edge.to)!);
+                });
+            }),
+            { numRuns: 8 }
+        );
+    });
 
-test('detectCycles() reports no cycles for generated DAGs', () => {
-    fc.assert(
-        fc.property(createDagArbitrary(), (shape) => {
-            const graph = createGraph(shape);
+    test('detectCycles() reports no cycles for generated DAGs', function () {
+        fc.assert(
+            fc.property(createDagArbitrary(), (shape) => {
+                const graph = createGraph(shape);
 
-            assert.deepStrictEqual(graph.detectCycles(), []);
-            assert.strictEqual(graph.isCyclic(), false);
-        }),
-        { numRuns: 8 }
-    );
-});
+                assert.deepStrictEqual(graph.detectCycles(), []);
+                assert.strictEqual(graph.isCyclic(), false);
+            }),
+            { numRuns: 8 }
+        );
+    });
 
-test('detectCycles() reports at least one cycle for generated cyclic graphs', () => {
-    fc.assert(
-        fc.property(createCyclicGraphArbitrary(), (shape) => {
-            const graph = createGraph(shape);
-            const cycles = graph.detectCycles();
+    test('detectCycles() reports at least one cycle for generated cyclic graphs', function () {
+        fc.assert(
+            fc.property(createCyclicGraphArbitrary(), (shape) => {
+                const graph = createGraph(shape);
+                const cycles = graph.detectCycles();
 
-            assert.ok(cycles.length > 0);
-            cycles.flat().forEach((nodeId) => {
-                assert.ok(shape.nodeIds.includes(nodeId));
-            });
-            assert.strictEqual(graph.isCyclic(), true);
-        }),
-        { numRuns: 8 }
-    );
+                assert.ok(cycles.length > 0);
+                cycles.flat().forEach((nodeId) => {
+                    assert.ok(shape.nodeIds.includes(nodeId));
+                });
+                assert.strictEqual(graph.isCyclic(), true);
+            }),
+            { numRuns: 8 }
+        );
+    });
 });

--- a/source/directed-graph/graph.test.ts
+++ b/source/directed-graph/graph.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test, type Func } from 'mocha';
+import { suite, test, type Func } from 'mocha';
 import { runNodeProbe } from '../test-libraries/run-node-probe.ts';
 import { createDirectedGraph, type DirectedGraph } from './graph.ts';
 
@@ -22,923 +22,925 @@ function expectGraphMethodToThrow(
     }
 }
 
-test('hasNode() returns false when there is no node for the given id', () => {
-    const graph = createDirectedGraph<string, string>();
-    assert.strictEqual(graph.hasNode('foo'), false);
-});
-
-test('hasNode() returns true when there is a node for the given id', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('foo', 'bar');
-
-    assert.strictEqual(graph.hasNode('foo'), true);
-});
-
-test('addNode() throws when adding a node with an id that already exist', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('foo', 'bar');
-
-    try {
-        graph.addNode('foo', 'baz');
-        assert.fail('Expected addNode() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "foo" already exists');
-    }
-});
-
-test('connect() throws when the from and to node don’t exist', () => {
-    expectGraphMethodToThrow('connect', undefined, 'Node with id "a" does not exist');
-});
-
-test('connect() throws when the from node doesn’t exist but the to node does', () => {
-    expectGraphMethodToThrow(
-        'connect',
-        (graph) => {
-            graph.addNode('b', 'bar');
-        },
-        'Node with id "a" does not exist'
-    );
-});
-
-test('connect() throws when the to node doesn’t exist but the from node does', () => {
-    expectGraphMethodToThrow(
-        'connect',
-        (graph) => {
-            graph.addNode('a', 'foo');
-        },
-        'Node with id "b" does not exist'
-    );
-});
-
-test('connect() throws when both nodes exist but there is already a connection', () => {
-    expectGraphMethodToThrow(
-        'connect',
-        (graph) => {
-            graph.addNode('a', 'foo');
-            graph.addNode('b', 'bar');
-            graph.connect({ from: 'a', to: 'b' });
-        },
-        'Edge from "a" to "b" already exists'
-    );
-});
-
-test('disconnect() throws when the from and to node don’t exist', () => {
-    expectGraphMethodToThrow('disconnect', undefined, 'Node with id "a" does not exist');
-});
-
-test('disconnect() throws when the from node doesn’t exist but the to node does', () => {
-    expectGraphMethodToThrow(
-        'disconnect',
-        (graph) => {
-            graph.addNode('b', 'bar');
-        },
-        'Node with id "a" does not exist'
-    );
-});
-
-test('disconnect() throws when the to node doesn’t exist but the from node does', () => {
-    expectGraphMethodToThrow(
-        'disconnect',
-        (graph) => {
-            graph.addNode('a', 'foo');
-        },
-        'Node with id "b" does not exist'
-    );
-});
-
-test('disconnect() throws when both nodes exist but there is no connection', () => {
-    expectGraphMethodToThrow(
-        'disconnect',
-        (graph) => {
-            graph.addNode('a', 'foo');
-            graph.addNode('b', 'bar');
-        },
-        'Edge from "a" to "b" does not exist'
-    );
-});
-
-test('hasConnection() returns false when there is no connection for the given ids', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-    graph.addNode('b', 'bar');
-
-    assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), false);
-});
-
-test('hasNode() returns true when there is a connection between the given nodes', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-    graph.addNode('b', 'bar');
-    graph.connect({ from: 'a', to: 'b' });
-
-    assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), true);
-});
-
-function collectFromGraph(graph: DirectedGraph<string, string>, startId: string): readonly string[] {
-    const collected: string[] = [];
-
-    graph.visitBreadthFirstSearch(startId, (node) => {
-        collected.push(node.id);
+suite('graph', function () {
+    test('hasNode() returns false when there is no node for the given id', function () {
+        const graph = createDirectedGraph<string, string>();
+        assert.strictEqual(graph.hasNode('foo'), false);
     });
 
-    return collected;
-}
+    test('hasNode() returns true when there is a node for the given id', function () {
+        const graph = createDirectedGraph<string, string>();
 
-test('throws when there is no node for the given start id', () => {
-    const graph = createDirectedGraph<string, string>();
+        graph.addNode('foo', 'bar');
 
-    try {
-        collectFromGraph(graph, 'foo');
-        assert.fail('Expected visitBreadthFirstSearch() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "foo" does not exist');
-    }
-});
-
-test('visits the start node first', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    graph.addNode('a', 'foo');
-
-    const collected = collectFromGraph(graph, 'a');
-
-    assert.deepStrictEqual(collected, ['a']);
-});
-
-type GraphWithNodesOptions = {
-    readonly nodes: readonly (readonly [id: string, data: string])[];
-    readonly connections: readonly GraphEdge<string>[];
-};
-
-function createGraphWithNodes(options: GraphWithNodesOptions): DirectedGraph<string, string> {
-    const { nodes, connections } = options;
-    const graph = createDirectedGraph<string, string>();
-
-    nodes.forEach(([id, data]) => {
-        graph.addNode(id, data);
+        assert.strictEqual(graph.hasNode('foo'), true);
     });
 
-    connections.forEach((edge) => {
-        graph.connect(edge);
+    test('addNode() throws when adding a node with an id that already exist', function () {
+        const graph = createDirectedGraph<string, string>();
+
+        graph.addNode('foo', 'bar');
+
+        try {
+            graph.addNode('foo', 'baz');
+            assert.fail('Expected addNode() to fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Node with id "foo" already exists');
+        }
     });
 
-    return graph;
-}
+    test('connect() throws when the from and to node don’t exist', function () {
+        expectGraphMethodToThrow('connect', undefined, 'Node with id "a" does not exist');
+    });
 
-type NodeVisitingTestCase = GraphWithNodesOptions & {
-    readonly disconnections?: GraphEdge<string>[];
-    readonly startId: string;
-    readonly expectedCollectedIds: string[];
-};
+    test('connect() throws when the from node doesn’t exist but the to node does', function () {
+        expectGraphMethodToThrow(
+            'connect',
+            (graph) => {
+                graph.addNode('b', 'bar');
+            },
+            'Node with id "a" does not exist'
+        );
+    });
 
-function checkNodeVisiting(testCase: Readonly<NodeVisitingTestCase>): Func {
-    return () => {
-        const { nodes, connections, disconnections = [], expectedCollectedIds, startId } = testCase;
-        const graph = createGraphWithNodes({ nodes, connections });
+    test('connect() throws when the to node doesn’t exist but the from node does', function () {
+        expectGraphMethodToThrow(
+            'connect',
+            (graph) => {
+                graph.addNode('a', 'foo');
+            },
+            'Node with id "b" does not exist'
+        );
+    });
 
-        disconnections.forEach((edge) => {
-            graph.disconnect(edge);
+    test('connect() throws when both nodes exist but there is already a connection', function () {
+        expectGraphMethodToThrow(
+            'connect',
+            (graph) => {
+                graph.addNode('a', 'foo');
+                graph.addNode('b', 'bar');
+                graph.connect({ from: 'a', to: 'b' });
+            },
+            'Edge from "a" to "b" already exists'
+        );
+    });
+
+    test('disconnect() throws when the from and to node don’t exist', function () {
+        expectGraphMethodToThrow('disconnect', undefined, 'Node with id "a" does not exist');
+    });
+
+    test('disconnect() throws when the from node doesn’t exist but the to node does', function () {
+        expectGraphMethodToThrow(
+            'disconnect',
+            (graph) => {
+                graph.addNode('b', 'bar');
+            },
+            'Node with id "a" does not exist'
+        );
+    });
+
+    test('disconnect() throws when the to node doesn’t exist but the from node does', function () {
+        expectGraphMethodToThrow(
+            'disconnect',
+            (graph) => {
+                graph.addNode('a', 'foo');
+            },
+            'Node with id "b" does not exist'
+        );
+    });
+
+    test('disconnect() throws when both nodes exist but there is no connection', function () {
+        expectGraphMethodToThrow(
+            'disconnect',
+            (graph) => {
+                graph.addNode('a', 'foo');
+                graph.addNode('b', 'bar');
+            },
+            'Edge from "a" to "b" does not exist'
+        );
+    });
+
+    test('hasConnection() returns false when there is no connection for the given ids', function () {
+        const graph = createDirectedGraph<string, string>();
+
+        graph.addNode('a', 'foo');
+        graph.addNode('b', 'bar');
+
+        assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), false);
+    });
+
+    test('hasNode() returns true when there is a connection between the given nodes', function () {
+        const graph = createDirectedGraph<string, string>();
+
+        graph.addNode('a', 'foo');
+        graph.addNode('b', 'bar');
+        graph.connect({ from: 'a', to: 'b' });
+
+        assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), true);
+    });
+
+    function collectFromGraph(graph: DirectedGraph<string, string>, startId: string): readonly string[] {
+        const collected: string[] = [];
+
+        graph.visitBreadthFirstSearch(startId, (node) => {
+            collected.push(node.id);
         });
 
-        const collected = collectFromGraph(graph, startId);
-
-        assert.deepStrictEqual(collected, expectedCollectedIds);
-    };
-}
-
-test(
-    'visits only the start node when there are multiple nodes but no connections',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar'],
-            ['c', 'baz']
-        ],
-        connections: [{ from: 'b', to: 'c' }],
-        startId: 'a',
-        expectedCollectedIds: ['a']
-    })
-);
-
-test(
-    'visits the start node and all connected nodes',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar']
-        ],
-        connections: [{ from: 'a', to: 'b' }],
-        startId: 'a',
-        expectedCollectedIds: ['a', 'b']
-    })
-);
-
-test(
-    'visits ONLY the start node when there are two nodes but the start node is not connected to other but the other is connected to the start node',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar']
-        ],
-        connections: [{ from: 'b', to: 'a' }],
-        startId: 'a',
-        expectedCollectedIds: ['a']
-    })
-);
-
-test(
-    'visits the start node and multiple connected nodes',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar'],
-            ['c', 'baz']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'a', to: 'c' }
-        ],
-        startId: 'a',
-        expectedCollectedIds: ['a', 'b', 'c']
-    })
-);
-
-const fiveNodes: readonly (readonly [string, string])[] = [
-    ['a', 'foo'],
-    ['b', 'bar'],
-    ['c', 'baz'],
-    ['d', 'qux'],
-    ['e', 'quux']
-];
-const fiveNodeConnections: readonly GraphEdge<string>[] = [
-    { from: 'a', to: 'b' },
-    { from: 'a', to: 'c' },
-    { from: 'b', to: 'd' },
-    { from: 'd', to: 'e' }
-];
-
-const fourEmptyNodes: readonly (readonly [string, string])[] = [
-    ['a', ''],
-    ['b', ''],
-    ['c', ''],
-    ['d', '']
-];
-
-test(
-    'visits the start node and multiple connected nodes and their subsequent nodes',
-    checkNodeVisiting({
-        nodes: fiveNodes,
-        connections: fiveNodeConnections,
-        startId: 'a',
-        expectedCollectedIds: ['a', 'b', 'c', 'd', 'e']
-    })
-);
-
-test(
-    'visits only the nodes that are still connected after disconnecting some',
-    checkNodeVisiting({
-        nodes: fiveNodes,
-        connections: fiveNodeConnections,
-        disconnections: [{ from: 'a', to: 'b' }],
-        startId: 'a',
-        expectedCollectedIds: ['a', 'c']
-    })
-);
-
-test(
-    'visits the two nodes that are connected to each other',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'a' }
-        ],
-        startId: 'a',
-        expectedCollectedIds: ['a', 'b']
-    })
-);
-
-test(
-    'visits the three nodes which have a cyclic connection',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar'],
-            ['c', 'baz']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'c' },
-            { from: 'c', to: 'a' }
-        ],
-        startId: 'a',
-        expectedCollectedIds: ['a', 'b', 'c']
-    })
-);
-
-test(
-    'visits ONLY the starting node when it is connected to itself',
-    checkNodeVisiting({
-        nodes: [['a', 'foo']],
-        connections: [{ from: 'a', to: 'a' }],
-        startId: 'a',
-        expectedCollectedIds: ['a']
-    })
-);
-
-test(
-    'visits only the nodes that are connected with the starting id',
-    checkNodeVisiting({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar'],
-            ['c', 'baz']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'c' }
-        ],
-        startId: 'b',
-        expectedCollectedIds: ['b', 'c']
-    })
-);
-
-test('detectCycles() returns an empty array for an empty graph', () => {
-    const graph = createDirectedGraph<string, string>();
-
-    assert.deepStrictEqual(graph.detectCycles(), []);
-});
-
-test('detectCycles() returns an empty array for a non-cyclic graph', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar']
-        ],
-        connections: [{ from: 'a', to: 'b' }]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), []);
-});
-
-test('detectCycles() returns the detected cycle when a node is referencing itself', () => {
-    const graph = createGraphWithNodes({
-        nodes: [['a', 'foo']],
-        connections: [{ from: 'a', to: 'a' }]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), [['a', 'a']]);
-});
-
-test('detectCycles() returns the detected cycle when a node is indirectly referencing itself', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'a' }
-        ]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), [['a', 'b', 'a']]);
-});
-
-test('detectCycles() detects multiple cycles in the same root node', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar'],
-            ['c', 'baz'],
-            ['d', 'qux']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'a' },
-            { from: 'b', to: 'c' },
-            { from: 'c', to: 'd' },
-            { from: 'd', to: 'c' }
-        ]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), [
-        ['a', 'b', 'a'],
-        ['a', 'b', 'c', 'd', 'c']
-    ]);
-});
-
-test('detectCycles() detects multiple cycles which are not connected', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar'],
-            ['c', 'baz']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'a' },
-            { from: 'c', to: 'c' }
-        ]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), [
-        ['a', 'b', 'a'],
-        ['c', 'c']
-    ]);
-});
-
-test('detectCycles() returns an empty array for a non-cyclic graph even when adjacent nodes of the base node reference a certain node multiple times within the graph', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', '']
-        ],
-        connections: [
-            { from: 'b', to: 'a' },
-            { from: 'c', to: 'a' },
-            { from: 'c', to: 'b' }
-        ]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), []);
-});
-
-test('detectCycles() returns all detected cycles when one base node has multiple cycles in its adjacent nodes', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', ''],
-            ['d', ''],
-            ['e', '']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'a', to: 'c' },
-            { from: 'b', to: 'd' },
-            { from: 'c', to: 'd' },
-            { from: 'd', to: 'e' },
-            { from: 'e', to: 'a' },
-            { from: 'e', to: 'c' }
-        ]
-    });
-
-    assert.deepStrictEqual(graph.detectCycles(), [
-        ['a', 'b', 'd', 'e', 'a'],
-        ['a', 'b', 'd', 'e', 'c', 'd'],
-        ['a', 'c', 'd', 'e', 'a'],
-        ['a', 'c', 'd', 'e', 'c']
-    ]);
-});
-
-test('isCyclic() returns true when there is one cycle in the graph', () => {
-    const graph = createGraphWithNodes({
-        nodes: [['a', '']],
-        connections: [{ from: 'a', to: 'a' }]
-    });
-
-    assert.strictEqual(graph.isCyclic(), true);
-});
-
-test('isCyclic() returns false when there is no cycle in the graph', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', '']
-        ],
-        connections: [{ from: 'a', to: 'b' }]
-    });
-
-    assert.strictEqual(graph.isCyclic(), false);
-});
-
-test('getTopologicalGenerations() throws when the graph is cyclic', () => {
-    const graph = createGraphWithNodes({
-        nodes: [['a', '']],
-        connections: [{ from: 'a', to: 'a' }]
-    });
-
-    try {
-        graph.getTopologicalGenerations();
-        assert.fail('Expected getTopologicalGenerations() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Failed to determine topological generations, current graph is cyclic'
-        );
+        return collected;
     }
-});
 
-test('getTopologicalGenerations() returns an empty array when the graph is empty', () => {
-    const graph = createDirectedGraph<string, string>();
-    const generations = graph.getTopologicalGenerations();
+    test('throws when there is no node for the given start id', function () {
+        const graph = createDirectedGraph<string, string>();
 
-    assert.deepStrictEqual(generations, []);
-});
-
-test('getTopologicalGenerations() returns one generation when there is only one node', () => {
-    const graph = createGraphWithNodes({
-        nodes: [['a', '']],
-        connections: []
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a']]);
-});
-
-test('getTopologicalGenerations() returns one generation when there are multiple non-connected nodes', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', '']
-        ],
-        connections: []
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a', 'b', 'c']]);
-});
-
-test('getTopologicalGenerations() returns two generations when there are two nodes which are connected', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', '']
-        ],
-        connections: [{ from: 'a', to: 'b' }]
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a'], ['b']]);
-});
-
-test('getTopologicalGenerations() returns two generations when there are three nodes which are connected with two roots', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', '']
-        ],
-        connections: [{ from: 'a', to: 'b' }]
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a', 'c'], ['b']]);
-});
-
-test('getTopologicalGenerations() returns two generations when there are three nodes which are connected with one root', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', '']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'a', to: 'c' }
-        ]
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a'], ['b', 'c']]);
-});
-
-test('getTopologicalGenerations() returns multiple generations of two independent paths', () => {
-    const graph = createGraphWithNodes({
-        nodes: fourEmptyNodes,
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'c', to: 'd' }
-        ]
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [
-        ['a', 'c'],
-        ['b', 'd']
-    ]);
-});
-
-test('getTopologicalGenerations() returns multiple generations of two dependent paths', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', ''],
-            ['d', ''],
-            ['e', ''],
-            ['f', '']
-        ],
-        connections: [
-            { from: 'a', to: 'e' },
-            { from: 'e', to: 'b' },
-            { from: 'c', to: 'd' },
-            { from: 'd', to: 'e' },
-            { from: 'e', to: 'f' }
-        ]
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a', 'c'], ['d'], ['e'], ['b', 'f']]);
-});
-
-test('getTopologicalGenerations() keeps a shared dependency in a later generation until all incoming edges are consumed', () => {
-    const graph = createGraphWithNodes({
-        nodes: fourEmptyNodes,
-        connections: [
-            { from: 'a', to: 'c' },
-            { from: 'b', to: 'c' },
-            { from: 'c', to: 'd' }
-        ]
-    });
-
-    const generations = graph.getTopologicalGenerations();
-
-    assert.deepStrictEqual(generations, [['a', 'b'], ['c'], ['d']]);
-});
-
-test('disconnect() updates incoming-edge counts used by topological generations', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', '']
-        ],
-        connections: [
-            { from: 'a', to: 'c' },
-            { from: 'b', to: 'c' }
-        ]
-    });
-
-    graph.disconnect({ from: 'b', to: 'c' });
-
-    assert.deepStrictEqual(graph.getTopologicalGenerations(), [['a', 'b'], ['c']]);
-
-    graph.disconnect({ from: 'a', to: 'c' });
-
-    assert.deepStrictEqual(graph.getTopologicalGenerations(), [['a', 'b', 'c']]);
-});
-
-test('traverse() visits each reachable node once across disconnected roots', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', 'first'],
-            ['b', 'second'],
-            ['c', 'third'],
-            ['d', 'fourth'],
-            ['e', 'fifth']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'b', to: 'c' },
-            { from: 'd', to: 'e' }
-        ]
-    });
-    const visited: string[] = [];
-
-    graph.traverse((node) => {
-        visited.push(`${node.id}:${node.incomingEdges}`);
-    });
-
-    assert.deepStrictEqual(visited, ['a:0', 'b:1', 'c:1', 'd:0', 'e:1']);
-});
-
-test('visitBreadthFirstSearch() visits shared descendants only once', () => {
-    const graph = createGraphWithNodes({
-        nodes: fourEmptyNodes,
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'a', to: 'c' },
-            { from: 'b', to: 'd' },
-            { from: 'c', to: 'd' }
-        ]
-    });
-
-    assert.deepStrictEqual(collectFromGraph(graph, 'a'), ['a', 'b', 'c', 'd']);
-});
-
-function buildSimpleAToBGraphWithReverse(): {
-    readonly graph: DirectedGraph<string, string>;
-    readonly reversedGraph: DirectedGraph<string, string>;
-} {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', 'foo'],
-            ['b', 'bar']
-        ],
-        connections: [{ from: 'a', to: 'b' }]
-    });
-    return { graph, reversedGraph: graph.reverse() };
-}
-
-test('reverse() returns a new graph with the edges reversed', () => {
-    const { graph, reversedGraph } = buildSimpleAToBGraphWithReverse();
-
-    assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), true);
-    assert.strictEqual(graph.hasConnection({ from: 'b', to: 'a' }), false);
-    assert.strictEqual(reversedGraph.hasConnection({ from: 'a', to: 'b' }), false);
-    assert.strictEqual(reversedGraph.hasConnection({ from: 'b', to: 'a' }), true);
-});
-
-test('reverse() copies all nodes with their data', () => {
-    const { reversedGraph } = buildSimpleAToBGraphWithReverse();
-    const collectedNodes: unknown[] = [];
-
-    reversedGraph.visitBreadthFirstSearch('b', (node) => {
-        collectedNodes.push(node);
-    });
-
-    assert.deepStrictEqual(collectedNodes, [
-        {
-            id: 'b',
-            data: 'bar',
-            adjacentNodeIds: new Set(['a']),
-            incomingEdges: 0
-        },
-        {
-            id: 'a',
-            data: 'foo',
-            adjacentNodeIds: new Set(),
-            incomingEdges: 1
+        try {
+            collectFromGraph(graph, 'foo');
+            assert.fail('Expected visitBreadthFirstSearch() to fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Node with id "foo" does not exist');
         }
-    ]);
-});
-
-test('getAdjacentIds() returns an empty Set if the requested node doesn’t have any connections', () => {
-    const graph = createGraphWithNodes({
-        nodes: [['a', '']],
-        connections: []
     });
 
-    const adjacentIds = graph.getAdjacentIds('a');
+    test('visits the start node first', function () {
+        const graph = createDirectedGraph<string, string>();
 
-    assert.deepStrictEqual(Array.from(adjacentIds.values()), []);
-});
+        graph.addNode('a', 'foo');
 
-test('getAdjacentIds() returns all connected ids for the requested node', () => {
-    const graph = createGraphWithNodes({
-        nodes: [
-            ['a', ''],
-            ['b', ''],
-            ['c', ''],
-            ['d', ''],
-            ['f', '']
-        ],
-        connections: [
-            { from: 'a', to: 'b' },
-            { from: 'a', to: 'c' },
-            { from: 'a', to: 'd' },
-            { from: 'b', to: 'f' }
-        ]
+        const collected = collectFromGraph(graph, 'a');
+
+        assert.deepStrictEqual(collected, ['a']);
     });
 
-    const adjacentIds = graph.getAdjacentIds('a');
+    type GraphWithNodesOptions = {
+        readonly nodes: readonly (readonly [id: string, data: string])[];
+        readonly connections: readonly GraphEdge<string>[];
+    };
 
-    assert.deepStrictEqual(Array.from(adjacentIds.values()), ['b', 'c', 'd']);
-});
+    function createGraphWithNodes(options: GraphWithNodesOptions): DirectedGraph<string, string> {
+        const { nodes, connections } = options;
+        const graph = createDirectedGraph<string, string>();
 
-test('getAdjacentIds() throws when the requested node doesn’t exist', () => {
-    const graph = createGraphWithNodes({
-        nodes: [],
-        connections: []
-    });
+        nodes.forEach(([id, data]) => {
+            graph.addNode(id, data);
+        });
 
-    try {
-        graph.getAdjacentIds('a');
-        assert.fail('Expected getAdjacentIds() to fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Node with id "a" does not exist');
+        connections.forEach((edge) => {
+            graph.connect(edge);
+        });
+
+        return graph;
     }
-});
 
-test('detectCycles() completes promptly for self-referential graphs', async () => {
-    const result = await runNodeProbe(
-        `
-            import { createDirectedGraph } from './source/directed-graph/graph.ts';
+    type NodeVisitingTestCase = GraphWithNodesOptions & {
+        readonly disconnections?: GraphEdge<string>[];
+        readonly startId: string;
+        readonly expectedCollectedIds: string[];
+    };
 
-            const graph = createDirectedGraph();
-            graph.addNode('a', 'value');
-            graph.connect({ from: 'a', to: 'a' });
+    function checkNodeVisiting(testCase: Readonly<NodeVisitingTestCase>): Func {
+        return () => {
+            const { nodes, connections, disconnections = [], expectedCollectedIds, startId } = testCase;
+            const graph = createGraphWithNodes({ nodes, connections });
 
-            console.log(JSON.stringify(graph.detectCycles()));
-        `,
-        { timeoutMs: 3000 }
-    );
-
-    assert.deepStrictEqual(result, [['a', 'a']]);
-}).timeout(probeTestTimeoutMs);
-
-test('visitBreadthFirstSearch() completes promptly for cyclic graphs', async () => {
-    const result = await runNodeProbe(
-        `
-            import { createDirectedGraph } from './source/directed-graph/graph.ts';
-
-            const graph = createDirectedGraph();
-            graph.addNode('a', 'first');
-            graph.addNode('b', 'second');
-            graph.connect({ from: 'a', to: 'b' });
-            graph.connect({ from: 'b', to: 'a' });
-
-            const visited = [];
-            graph.visitBreadthFirstSearch('a', (node) => {
-                visited.push(node.id);
+            disconnections.forEach((edge) => {
+                graph.disconnect(edge);
             });
 
-            console.log(JSON.stringify(visited));
-        `,
-        { timeoutMs: 3000 }
+            const collected = collectFromGraph(graph, startId);
+
+            assert.deepStrictEqual(collected, expectedCollectedIds);
+        };
+    }
+
+    test(
+        'visits only the start node when there are multiple nodes but no connections',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar'],
+                ['c', 'baz']
+            ],
+            connections: [{ from: 'b', to: 'c' }],
+            startId: 'a',
+            expectedCollectedIds: ['a']
+        })
     );
 
-    assert.deepStrictEqual(result, ['a', 'b']);
-}).timeout(probeTestTimeoutMs);
-
-test('getTopologicalGenerations() completes promptly for acyclic graphs', async () => {
-    const result = await runNodeProbe(
-        `
-            import { createDirectedGraph } from './source/directed-graph/graph.ts';
-
-            const graph = createDirectedGraph();
-            graph.addNode('a', 'first');
-            graph.addNode('b', 'second');
-            graph.connect({ from: 'a', to: 'b' });
-
-            console.log(JSON.stringify(graph.getTopologicalGenerations()));
-        `,
-        { timeoutMs: 3000 }
+    test(
+        'visits the start node and all connected nodes',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar']
+            ],
+            connections: [{ from: 'a', to: 'b' }],
+            startId: 'a',
+            expectedCollectedIds: ['a', 'b']
+        })
     );
 
-    assert.deepStrictEqual(result, [['a'], ['b']]);
-}).timeout(probeTestTimeoutMs);
+    test(
+        'visits ONLY the start node when there are two nodes but the start node is not connected to other but the other is connected to the start node',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar']
+            ],
+            connections: [{ from: 'b', to: 'a' }],
+            startId: 'a',
+            expectedCollectedIds: ['a']
+        })
+    );
 
-test('detectCycles() throws when cycle traversal exceeds the maximum depth', () => {
-    const graph = createDirectedGraph<string, string>({
-        cyclePathIncludes() {
-            return false;
-        }
+    test(
+        'visits the start node and multiple connected nodes',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar'],
+                ['c', 'baz']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'a', to: 'c' }
+            ],
+            startId: 'a',
+            expectedCollectedIds: ['a', 'b', 'c']
+        })
+    );
+
+    const fiveNodes: readonly (readonly [string, string])[] = [
+        ['a', 'foo'],
+        ['b', 'bar'],
+        ['c', 'baz'],
+        ['d', 'qux'],
+        ['e', 'quux']
+    ];
+    const fiveNodeConnections: readonly GraphEdge<string>[] = [
+        { from: 'a', to: 'b' },
+        { from: 'a', to: 'c' },
+        { from: 'b', to: 'd' },
+        { from: 'd', to: 'e' }
+    ];
+
+    const fourEmptyNodes: readonly (readonly [string, string])[] = [
+        ['a', ''],
+        ['b', ''],
+        ['c', ''],
+        ['d', '']
+    ];
+
+    test(
+        'visits the start node and multiple connected nodes and their subsequent nodes',
+        checkNodeVisiting({
+            nodes: fiveNodes,
+            connections: fiveNodeConnections,
+            startId: 'a',
+            expectedCollectedIds: ['a', 'b', 'c', 'd', 'e']
+        })
+    );
+
+    test(
+        'visits only the nodes that are still connected after disconnecting some',
+        checkNodeVisiting({
+            nodes: fiveNodes,
+            connections: fiveNodeConnections,
+            disconnections: [{ from: 'a', to: 'b' }],
+            startId: 'a',
+            expectedCollectedIds: ['a', 'c']
+        })
+    );
+
+    test(
+        'visits the two nodes that are connected to each other',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'a' }
+            ],
+            startId: 'a',
+            expectedCollectedIds: ['a', 'b']
+        })
+    );
+
+    test(
+        'visits the three nodes which have a cyclic connection',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar'],
+                ['c', 'baz']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'c' },
+                { from: 'c', to: 'a' }
+            ],
+            startId: 'a',
+            expectedCollectedIds: ['a', 'b', 'c']
+        })
+    );
+
+    test(
+        'visits ONLY the starting node when it is connected to itself',
+        checkNodeVisiting({
+            nodes: [['a', 'foo']],
+            connections: [{ from: 'a', to: 'a' }],
+            startId: 'a',
+            expectedCollectedIds: ['a']
+        })
+    );
+
+    test(
+        'visits only the nodes that are connected with the starting id',
+        checkNodeVisiting({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar'],
+                ['c', 'baz']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'c' }
+            ],
+            startId: 'b',
+            expectedCollectedIds: ['b', 'c']
+        })
+    );
+
+    test('detectCycles() returns an empty array for an empty graph', function () {
+        const graph = createDirectedGraph<string, string>();
+
+        assert.deepStrictEqual(graph.detectCycles(), []);
     });
-    graph.addNode('a', 'value');
-    graph.connect({ from: 'a', to: 'a' });
 
-    assert.throws(() => {
-        graph.detectCycles();
-    }, /^Error: Cycle detection exceeded the maximum traversal depth$/u);
-});
+    test('detectCycles() returns an empty array for a non-cyclic graph', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar']
+            ],
+            connections: [{ from: 'a', to: 'b' }]
+        });
 
-test('getTopologicalGenerations() throws when generation discovery stops making progress', () => {
-    const graph = createDirectedGraph<string, string>({
-        mergeDiscovered(_alreadyDiscovered, currentGeneration) {
-            return new Set(
-                currentGeneration.filter((id) => {
-                    return id !== 'a';
-                })
+        assert.deepStrictEqual(graph.detectCycles(), []);
+    });
+
+    test('detectCycles() returns the detected cycle when a node is referencing itself', function () {
+        const graph = createGraphWithNodes({
+            nodes: [['a', 'foo']],
+            connections: [{ from: 'a', to: 'a' }]
+        });
+
+        assert.deepStrictEqual(graph.detectCycles(), [['a', 'a']]);
+    });
+
+    test('detectCycles() returns the detected cycle when a node is indirectly referencing itself', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'a' }
+            ]
+        });
+
+        assert.deepStrictEqual(graph.detectCycles(), [['a', 'b', 'a']]);
+    });
+
+    test('detectCycles() detects multiple cycles in the same root node', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar'],
+                ['c', 'baz'],
+                ['d', 'qux']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'a' },
+                { from: 'b', to: 'c' },
+                { from: 'c', to: 'd' },
+                { from: 'd', to: 'c' }
+            ]
+        });
+
+        assert.deepStrictEqual(graph.detectCycles(), [
+            ['a', 'b', 'a'],
+            ['a', 'b', 'c', 'd', 'c']
+        ]);
+    });
+
+    test('detectCycles() detects multiple cycles which are not connected', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar'],
+                ['c', 'baz']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'a' },
+                { from: 'c', to: 'c' }
+            ]
+        });
+
+        assert.deepStrictEqual(graph.detectCycles(), [
+            ['a', 'b', 'a'],
+            ['c', 'c']
+        ]);
+    });
+
+    test('detectCycles() returns an empty array for a non-cyclic graph even when adjacent nodes of the base node reference a certain node multiple times within the graph', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', '']
+            ],
+            connections: [
+                { from: 'b', to: 'a' },
+                { from: 'c', to: 'a' },
+                { from: 'c', to: 'b' }
+            ]
+        });
+
+        assert.deepStrictEqual(graph.detectCycles(), []);
+    });
+
+    test('detectCycles() returns all detected cycles when one base node has multiple cycles in its adjacent nodes', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', ''],
+                ['d', ''],
+                ['e', '']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'a', to: 'c' },
+                { from: 'b', to: 'd' },
+                { from: 'c', to: 'd' },
+                { from: 'd', to: 'e' },
+                { from: 'e', to: 'a' },
+                { from: 'e', to: 'c' }
+            ]
+        });
+
+        assert.deepStrictEqual(graph.detectCycles(), [
+            ['a', 'b', 'd', 'e', 'a'],
+            ['a', 'b', 'd', 'e', 'c', 'd'],
+            ['a', 'c', 'd', 'e', 'a'],
+            ['a', 'c', 'd', 'e', 'c']
+        ]);
+    });
+
+    test('isCyclic() returns true when there is one cycle in the graph', function () {
+        const graph = createGraphWithNodes({
+            nodes: [['a', '']],
+            connections: [{ from: 'a', to: 'a' }]
+        });
+
+        assert.strictEqual(graph.isCyclic(), true);
+    });
+
+    test('isCyclic() returns false when there is no cycle in the graph', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', '']
+            ],
+            connections: [{ from: 'a', to: 'b' }]
+        });
+
+        assert.strictEqual(graph.isCyclic(), false);
+    });
+
+    test('getTopologicalGenerations() throws when the graph is cyclic', function () {
+        const graph = createGraphWithNodes({
+            nodes: [['a', '']],
+            connections: [{ from: 'a', to: 'a' }]
+        });
+
+        try {
+            graph.getTopologicalGenerations();
+            assert.fail('Expected getTopologicalGenerations() to fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Failed to determine topological generations, current graph is cyclic'
             );
         }
     });
-    graph.addNode('a', 'first');
-    graph.addNode('b', 'second');
-    graph.connect({ from: 'a', to: 'b' });
 
-    assert.throws(() => {
-        graph.getTopologicalGenerations();
-    }, /^Error: Topological generation discovery did not make progress after 3 attempts$/u);
-});
+    test('getTopologicalGenerations() returns an empty array when the graph is empty', function () {
+        const graph = createDirectedGraph<string, string>();
+        const generations = graph.getTopologicalGenerations();
 
-test('visitBreadthFirstSearch() throws when traversal exceeds the iteration budget', () => {
-    const graph = createDirectedGraph<string, string>({
-        visitedHas(visited, id) {
-            if (id === 'a' || id === 'b') {
-                return false;
+        assert.deepStrictEqual(generations, []);
+    });
+
+    test('getTopologicalGenerations() returns one generation when there is only one node', function () {
+        const graph = createGraphWithNodes({
+            nodes: [['a', '']],
+            connections: []
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a']]);
+    });
+
+    test('getTopologicalGenerations() returns one generation when there are multiple non-connected nodes', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', '']
+            ],
+            connections: []
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a', 'b', 'c']]);
+    });
+
+    test('getTopologicalGenerations() returns two generations when there are two nodes which are connected', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', '']
+            ],
+            connections: [{ from: 'a', to: 'b' }]
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a'], ['b']]);
+    });
+
+    test('getTopologicalGenerations() returns two generations when there are three nodes which are connected with two roots', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', '']
+            ],
+            connections: [{ from: 'a', to: 'b' }]
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a', 'c'], ['b']]);
+    });
+
+    test('getTopologicalGenerations() returns two generations when there are three nodes which are connected with one root', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', '']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'a', to: 'c' }
+            ]
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a'], ['b', 'c']]);
+    });
+
+    test('getTopologicalGenerations() returns multiple generations of two independent paths', function () {
+        const graph = createGraphWithNodes({
+            nodes: fourEmptyNodes,
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'c', to: 'd' }
+            ]
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [
+            ['a', 'c'],
+            ['b', 'd']
+        ]);
+    });
+
+    test('getTopologicalGenerations() returns multiple generations of two dependent paths', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', ''],
+                ['d', ''],
+                ['e', ''],
+                ['f', '']
+            ],
+            connections: [
+                { from: 'a', to: 'e' },
+                { from: 'e', to: 'b' },
+                { from: 'c', to: 'd' },
+                { from: 'd', to: 'e' },
+                { from: 'e', to: 'f' }
+            ]
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a', 'c'], ['d'], ['e'], ['b', 'f']]);
+    });
+
+    test('getTopologicalGenerations() keeps a shared dependency in a later generation until all incoming edges are consumed', function () {
+        const graph = createGraphWithNodes({
+            nodes: fourEmptyNodes,
+            connections: [
+                { from: 'a', to: 'c' },
+                { from: 'b', to: 'c' },
+                { from: 'c', to: 'd' }
+            ]
+        });
+
+        const generations = graph.getTopologicalGenerations();
+
+        assert.deepStrictEqual(generations, [['a', 'b'], ['c'], ['d']]);
+    });
+
+    test('disconnect() updates incoming-edge counts used by topological generations', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', '']
+            ],
+            connections: [
+                { from: 'a', to: 'c' },
+                { from: 'b', to: 'c' }
+            ]
+        });
+
+        graph.disconnect({ from: 'b', to: 'c' });
+
+        assert.deepStrictEqual(graph.getTopologicalGenerations(), [['a', 'b'], ['c']]);
+
+        graph.disconnect({ from: 'a', to: 'c' });
+
+        assert.deepStrictEqual(graph.getTopologicalGenerations(), [['a', 'b', 'c']]);
+    });
+
+    test('traverse() visits each reachable node once across disconnected roots', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', 'first'],
+                ['b', 'second'],
+                ['c', 'third'],
+                ['d', 'fourth'],
+                ['e', 'fifth']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'b', to: 'c' },
+                { from: 'd', to: 'e' }
+            ]
+        });
+        const visited: string[] = [];
+
+        graph.traverse((node) => {
+            visited.push(`${node.id}:${node.incomingEdges}`);
+        });
+
+        assert.deepStrictEqual(visited, ['a:0', 'b:1', 'c:1', 'd:0', 'e:1']);
+    });
+
+    test('visitBreadthFirstSearch() visits shared descendants only once', function () {
+        const graph = createGraphWithNodes({
+            nodes: fourEmptyNodes,
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'a', to: 'c' },
+                { from: 'b', to: 'd' },
+                { from: 'c', to: 'd' }
+            ]
+        });
+
+        assert.deepStrictEqual(collectFromGraph(graph, 'a'), ['a', 'b', 'c', 'd']);
+    });
+
+    function buildSimpleAToBGraphWithReverse(): {
+        readonly graph: DirectedGraph<string, string>;
+        readonly reversedGraph: DirectedGraph<string, string>;
+    } {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', 'foo'],
+                ['b', 'bar']
+            ],
+            connections: [{ from: 'a', to: 'b' }]
+        });
+        return { graph, reversedGraph: graph.reverse() };
+    }
+
+    test('reverse() returns a new graph with the edges reversed', function () {
+        const { graph, reversedGraph } = buildSimpleAToBGraphWithReverse();
+
+        assert.strictEqual(graph.hasConnection({ from: 'a', to: 'b' }), true);
+        assert.strictEqual(graph.hasConnection({ from: 'b', to: 'a' }), false);
+        assert.strictEqual(reversedGraph.hasConnection({ from: 'a', to: 'b' }), false);
+        assert.strictEqual(reversedGraph.hasConnection({ from: 'b', to: 'a' }), true);
+    });
+
+    test('reverse() copies all nodes with their data', function () {
+        const { reversedGraph } = buildSimpleAToBGraphWithReverse();
+        const collectedNodes: unknown[] = [];
+
+        reversedGraph.visitBreadthFirstSearch('b', (node) => {
+            collectedNodes.push(node);
+        });
+
+        assert.deepStrictEqual(collectedNodes, [
+            {
+                id: 'b',
+                data: 'bar',
+                adjacentNodeIds: new Set(['a']),
+                incomingEdges: 0
+            },
+            {
+                id: 'a',
+                data: 'foo',
+                adjacentNodeIds: new Set(),
+                incomingEdges: 1
             }
-            return visited.has(id);
+        ]);
+    });
+
+    test('getAdjacentIds() returns an empty Set if the requested node doesn’t have any connections', function () {
+        const graph = createGraphWithNodes({
+            nodes: [['a', '']],
+            connections: []
+        });
+
+        const adjacentIds = graph.getAdjacentIds('a');
+
+        assert.deepStrictEqual(Array.from(adjacentIds.values()), []);
+    });
+
+    test('getAdjacentIds() returns all connected ids for the requested node', function () {
+        const graph = createGraphWithNodes({
+            nodes: [
+                ['a', ''],
+                ['b', ''],
+                ['c', ''],
+                ['d', ''],
+                ['f', '']
+            ],
+            connections: [
+                { from: 'a', to: 'b' },
+                { from: 'a', to: 'c' },
+                { from: 'a', to: 'd' },
+                { from: 'b', to: 'f' }
+            ]
+        });
+
+        const adjacentIds = graph.getAdjacentIds('a');
+
+        assert.deepStrictEqual(Array.from(adjacentIds.values()), ['b', 'c', 'd']);
+    });
+
+    test('getAdjacentIds() throws when the requested node doesn’t exist', function () {
+        const graph = createGraphWithNodes({
+            nodes: [],
+            connections: []
+        });
+
+        try {
+            graph.getAdjacentIds('a');
+            assert.fail('Expected getAdjacentIds() to fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Node with id "a" does not exist');
         }
     });
-    graph.addNode('a', 'first');
-    graph.addNode('b', 'second');
-    graph.connect({ from: 'a', to: 'b' });
-    graph.connect({ from: 'b', to: 'a' });
-    let visitorCallCount = 0;
 
-    assert.throws(() => {
-        graph.visitBreadthFirstSearch('a', () => {
-            visitorCallCount += 1;
+    test('detectCycles() completes promptly for self-referential graphs', async function () {
+        const result = await runNodeProbe(
+            `
+                import { createDirectedGraph } from './source/directed-graph/graph.ts';
+
+                const graph = createDirectedGraph();
+                graph.addNode('a', 'value');
+                graph.connect({ from: 'a', to: 'a' });
+
+                console.log(JSON.stringify(graph.detectCycles()));
+            `,
+            { timeoutMs: 3000 }
+        );
+
+        assert.deepStrictEqual(result, [['a', 'a']]);
+    }).timeout(probeTestTimeoutMs);
+
+    test('visitBreadthFirstSearch() completes promptly for cyclic graphs', async function () {
+        const result = await runNodeProbe(
+            `
+                import { createDirectedGraph } from './source/directed-graph/graph.ts';
+
+                const graph = createDirectedGraph();
+                graph.addNode('a', 'first');
+                graph.addNode('b', 'second');
+                graph.connect({ from: 'a', to: 'b' });
+                graph.connect({ from: 'b', to: 'a' });
+
+                const visited = [];
+                graph.visitBreadthFirstSearch('a', (node) => {
+                    visited.push(node.id);
+                });
+
+                console.log(JSON.stringify(visited));
+            `,
+            { timeoutMs: 3000 }
+        );
+
+        assert.deepStrictEqual(result, ['a', 'b']);
+    }).timeout(probeTestTimeoutMs);
+
+    test('getTopologicalGenerations() completes promptly for acyclic graphs', async function () {
+        const result = await runNodeProbe(
+            `
+                import { createDirectedGraph } from './source/directed-graph/graph.ts';
+
+                const graph = createDirectedGraph();
+                graph.addNode('a', 'first');
+                graph.addNode('b', 'second');
+                graph.connect({ from: 'a', to: 'b' });
+
+                console.log(JSON.stringify(graph.getTopologicalGenerations()));
+            `,
+            { timeoutMs: 3000 }
+        );
+
+        assert.deepStrictEqual(result, [['a'], ['b']]);
+    }).timeout(probeTestTimeoutMs);
+
+    test('detectCycles() throws when cycle traversal exceeds the maximum depth', function () {
+        const graph = createDirectedGraph<string, string>({
+            cyclePathIncludes() {
+                return false;
+            }
         });
-    }, /^Error: Breadth-first traversal exceeded the maximum iteration budget$/u);
-    assert.strictEqual(visitorCallCount, 5);
+        graph.addNode('a', 'value');
+        graph.connect({ from: 'a', to: 'a' });
+
+        assert.throws(() => {
+            graph.detectCycles();
+        }, /^Error: Cycle detection exceeded the maximum traversal depth$/u);
+    });
+
+    test('getTopologicalGenerations() throws when generation discovery stops making progress', function () {
+        const graph = createDirectedGraph<string, string>({
+            mergeDiscovered(_alreadyDiscovered, currentGeneration) {
+                return new Set(
+                    currentGeneration.filter((id) => {
+                        return id !== 'a';
+                    })
+                );
+            }
+        });
+        graph.addNode('a', 'first');
+        graph.addNode('b', 'second');
+        graph.connect({ from: 'a', to: 'b' });
+
+        assert.throws(() => {
+            graph.getTopologicalGenerations();
+        }, /^Error: Topological generation discovery did not make progress after 3 attempts$/u);
+    });
+
+    test('visitBreadthFirstSearch() throws when traversal exceeds the iteration budget', function () {
+        const graph = createDirectedGraph<string, string>({
+            visitedHas(visited, id) {
+                if (id === 'a' || id === 'b') {
+                    return false;
+                }
+                return visited.has(id);
+            }
+        });
+        graph.addNode('a', 'first');
+        graph.addNode('b', 'second');
+        graph.connect({ from: 'a', to: 'b' });
+        graph.connect({ from: 'b', to: 'a' });
+        let visitorCallCount = 0;
+
+        assert.throws(() => {
+            graph.visitBreadthFirstSearch('a', () => {
+                visitorCallCount += 1;
+            });
+        }, /^Error: Breadth-first traversal exceeded the maximum iteration budget$/u);
+        assert.strictEqual(visitorCallCount, 5);
+    });
 });

--- a/source/file-manager/compare.property.ts
+++ b/source/file-manager/compare.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { FileDescription } from './file-description.ts';
 import { compareFileDescriptions } from './compare.ts';
 
@@ -10,39 +10,43 @@ const fileDescriptionArbitrary = fc.record<FileDescription>({
     isExecutable: fc.boolean()
 });
 
-test('compareFileDescriptions() is order-insensitive for equivalent file sets', () => {
-    fc.assert(
-        fc.property(
-            fc.uniqueArray(fileDescriptionArbitrary, {
-                selector: (fileDescription) => {
-                    return fileDescription.filePath;
-                },
-                maxLength: 20
-            }),
-            (fileDescriptions) => {
-                const permutation = Array.from(fileDescriptions).reverse();
+suite('compare', function () {
+    test('compareFileDescriptions() is order-insensitive for equivalent file sets', function () {
+        fc.assert(
+            fc.property(
+                fc.uniqueArray(fileDescriptionArbitrary, {
+                    selector: (fileDescription) => {
+                        return fileDescription.filePath;
+                    },
+                    maxLength: 20
+                }),
+                (fileDescriptions) => {
+                    const permutation = Array.from(fileDescriptions).reverse();
 
-                assert.deepStrictEqual(compareFileDescriptions(fileDescriptions, permutation), { status: 'equal' });
-            }
-        )
-    );
-});
+                    assert.deepStrictEqual(compareFileDescriptions(fileDescriptions, permutation), { status: 'equal' });
+                }
+            )
+        );
+    });
 
-test('compareFileDescriptions() reports non-equal when any file content changes', () => {
-    fc.assert(
-        fc.property(
-            fc.array(fileDescriptionArbitrary, { minLength: 1, maxLength: 20 }),
-            fc.string(),
-            (fileDescriptions, suffix) => {
-                const modified = Array.from(fileDescriptions);
-                const first = modified[0]!;
-                modified[0] = {
-                    ...first,
-                    content: `${first.content}${suffix}x`
-                };
+    test('compareFileDescriptions() reports non-equal when any file content changes', function () {
+        fc.assert(
+            fc.property(
+                fc.array(fileDescriptionArbitrary, { minLength: 1, maxLength: 20 }),
+                fc.string(),
+                (fileDescriptions, suffix) => {
+                    const modified = Array.from(fileDescriptions);
+                    const first = modified[0]!;
+                    modified[0] = {
+                        ...first,
+                        content: `${first.content}${suffix}x`
+                    };
 
-                assert.deepStrictEqual(compareFileDescriptions(fileDescriptions, modified), { status: 'not-equal' });
-            }
-        )
-    );
+                    assert.deepStrictEqual(compareFileDescriptions(fileDescriptions, modified), {
+                        status: 'not-equal'
+                    });
+                }
+            )
+        );
+    });
 });

--- a/source/file-manager/compare.test.ts
+++ b/source/file-manager/compare.test.ts
@@ -1,132 +1,134 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { compareFileDescriptions } from './compare.ts';
 
-test('returns equal when both file lists are empty', () => {
-    const result = compareFileDescriptions([], []);
-    assert.deepStrictEqual(result, { status: 'equal' });
-});
+suite('compare', function () {
+    test('returns equal when both file lists are empty', function () {
+        const result = compareFileDescriptions([], []);
+        assert.deepStrictEqual(result, { status: 'equal' });
+    });
 
-test('returns equal when both file lists have single element which is the same', () => {
-    const result = compareFileDescriptions(
-        [{ filePath: 'a', content: 'a', isExecutable: false }],
-        [{ filePath: 'a', content: 'a', isExecutable: false }]
-    );
-    assert.deepStrictEqual(result, { status: 'equal' });
-});
+    test('returns equal when both file lists have single element which is the same', function () {
+        const result = compareFileDescriptions(
+            [{ filePath: 'a', content: 'a', isExecutable: false }],
+            [{ filePath: 'a', content: 'a', isExecutable: false }]
+        );
+        assert.deepStrictEqual(result, { status: 'equal' });
+    });
 
-test('returns equal when both file lists have multiple elements which are the same and are in the same order', () => {
-    const result = compareFileDescriptions(
-        [
-            { filePath: 'a', content: 'a', isExecutable: true },
-            { filePath: 'b', content: 'b', isExecutable: false }
-        ],
-        [
-            { filePath: 'a', content: 'a', isExecutable: true },
-            { filePath: 'b', content: 'b', isExecutable: false }
-        ]
-    );
-    assert.deepStrictEqual(result, { status: 'equal' });
-});
+    test('returns equal when both file lists have multiple elements which are the same and are in the same order', function () {
+        const result = compareFileDescriptions(
+            [
+                { filePath: 'a', content: 'a', isExecutable: true },
+                { filePath: 'b', content: 'b', isExecutable: false }
+            ],
+            [
+                { filePath: 'a', content: 'a', isExecutable: true },
+                { filePath: 'b', content: 'b', isExecutable: false }
+            ]
+        );
+        assert.deepStrictEqual(result, { status: 'equal' });
+    });
 
-test('returns equal when both file lists have multiple elements which are the same and are in different order', () => {
-    const result = compareFileDescriptions(
-        [
-            { filePath: 'a', content: 'a', isExecutable: true },
-            { filePath: 'b', content: 'b', isExecutable: false }
-        ],
-        [
-            { filePath: 'b', content: 'b', isExecutable: false },
-            { filePath: 'a', content: 'a', isExecutable: true }
-        ]
-    );
-    assert.deepStrictEqual(result, { status: 'equal' });
-});
+    test('returns equal when both file lists have multiple elements which are the same and are in different order', function () {
+        const result = compareFileDescriptions(
+            [
+                { filePath: 'a', content: 'a', isExecutable: true },
+                { filePath: 'b', content: 'b', isExecutable: false }
+            ],
+            [
+                { filePath: 'b', content: 'b', isExecutable: false },
+                { filePath: 'a', content: 'a', isExecutable: true }
+            ]
+        );
+        assert.deepStrictEqual(result, { status: 'equal' });
+    });
 
-test('returns not-equal when one list is empty but the other not', () => {
-    const result = compareFileDescriptions([], [{ filePath: 'a', content: 'a', isExecutable: false }]);
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when one list is empty but the other not', function () {
+        const result = compareFileDescriptions([], [{ filePath: 'a', content: 'a', isExecutable: false }]);
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when one list is not empty but the other is', () => {
-    const result = compareFileDescriptions([{ filePath: 'a', content: 'a', isExecutable: true }], []);
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when one list is not empty but the other is', function () {
+        const result = compareFileDescriptions([{ filePath: 'a', content: 'a', isExecutable: true }], []);
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when both file lists have single element which is not the same', () => {
-    const result = compareFileDescriptions(
-        [{ filePath: 'a', content: 'a', isExecutable: true }],
-        [{ filePath: 'b', content: 'b', isExecutable: false }]
-    );
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when both file lists have single element which is not the same', function () {
+        const result = compareFileDescriptions(
+            [{ filePath: 'a', content: 'a', isExecutable: true }],
+            [{ filePath: 'b', content: 'b', isExecutable: false }]
+        );
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when both file lists have single element where only the filePath is different', () => {
-    const result = compareFileDescriptions(
-        [{ filePath: 'a', content: 'a', isExecutable: true }],
-        [{ filePath: 'b', content: 'a', isExecutable: true }]
-    );
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when both file lists have single element where only the filePath is different', function () {
+        const result = compareFileDescriptions(
+            [{ filePath: 'a', content: 'a', isExecutable: true }],
+            [{ filePath: 'b', content: 'a', isExecutable: true }]
+        );
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when both file lists have single element where only the content is different', () => {
-    const result = compareFileDescriptions(
-        [{ filePath: 'a', content: 'a', isExecutable: false }],
-        [{ filePath: 'a', content: 'b', isExecutable: false }]
-    );
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when both file lists have single element where only the content is different', function () {
+        const result = compareFileDescriptions(
+            [{ filePath: 'a', content: 'a', isExecutable: false }],
+            [{ filePath: 'a', content: 'b', isExecutable: false }]
+        );
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when both file lists have single element where only the isExecutable flag is different', () => {
-    const result = compareFileDescriptions(
-        [{ filePath: 'a', content: 'a', isExecutable: false }],
-        [{ filePath: 'a', content: 'a', isExecutable: true }]
-    );
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when both file lists have single element where only the isExecutable flag is different', function () {
+        const result = compareFileDescriptions(
+            [{ filePath: 'a', content: 'a', isExecutable: false }],
+            [{ filePath: 'a', content: 'a', isExecutable: true }]
+        );
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when both file lists have multiple elements where some are not the same', () => {
-    const result = compareFileDescriptions(
-        [
-            { filePath: 'a', content: 'a', isExecutable: true },
-            { filePath: 'b', content: 'b', isExecutable: true }
-        ],
-        [
-            { filePath: 'a', content: 'a', isExecutable: true },
-            { filePath: 'b', content: 'a', isExecutable: true }
-        ]
-    );
-    assert.deepStrictEqual(result, { status: 'not-equal' });
-});
+    test('returns not-equal when both file lists have multiple elements where some are not the same', function () {
+        const result = compareFileDescriptions(
+            [
+                { filePath: 'a', content: 'a', isExecutable: true },
+                { filePath: 'b', content: 'b', isExecutable: true }
+            ],
+            [
+                { filePath: 'a', content: 'a', isExecutable: true },
+                { filePath: 'b', content: 'a', isExecutable: true }
+            ]
+        );
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 
-test('returns not-equal when a file list reports a length that does not match its iterator output', () => {
-    const fileDescriptionsA = {
-        length: 1,
-        [Symbol.iterator](): Iterator<{ filePath: string; content: string; isExecutable: boolean }> {
-            return [
-                {
-                    filePath: 'a',
-                    content: 'a',
-                    isExecutable: false
-                }
-            ][Symbol.iterator]();
-        }
-    } as unknown as readonly {
-        readonly filePath: string;
-        readonly content: string;
-        readonly isExecutable: boolean;
-    }[];
-    const fileDescriptionsB = {
-        length: 1,
-        [Symbol.iterator](): Iterator<{ filePath: string; content: string; isExecutable: boolean }> {
-            return [][Symbol.iterator]();
-        }
-    } as unknown as readonly {
-        readonly filePath: string;
-        readonly content: string;
-        readonly isExecutable: boolean;
-    }[];
+    test('returns not-equal when a file list reports a length that does not match its iterator output', function () {
+        const fileDescriptionsA = {
+            length: 1,
+            [Symbol.iterator](): Iterator<{ filePath: string; content: string; isExecutable: boolean }> {
+                return [
+                    {
+                        filePath: 'a',
+                        content: 'a',
+                        isExecutable: false
+                    }
+                ][Symbol.iterator]();
+            }
+        } as unknown as readonly {
+            readonly filePath: string;
+            readonly content: string;
+            readonly isExecutable: boolean;
+        }[];
+        const fileDescriptionsB = {
+            length: 1,
+            [Symbol.iterator](): Iterator<{ filePath: string; content: string; isExecutable: boolean }> {
+                return [][Symbol.iterator]();
+            }
+        } as unknown as readonly {
+            readonly filePath: string;
+            readonly content: string;
+            readonly isExecutable: boolean;
+        }[];
 
-    const result = compareFileDescriptions(fileDescriptionsA, fileDescriptionsB);
-    assert.deepStrictEqual(result, { status: 'not-equal' });
+        const result = compareFileDescriptions(fileDescriptionsA, fileDescriptionsB);
+        assert.deepStrictEqual(result, { status: 'not-equal' });
+    });
 });

--- a/source/file-manager/equal.test.ts
+++ b/source/file-manager/equal.test.ts
@@ -1,32 +1,37 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { areFileDescriptionEqual } from './equal.ts';
 import { createFileDescription } from './file-description.ts';
 
-test('areFileDescriptionEqual returns true when filePath, content, and isExecutable all match', () => {
-    assert.strictEqual(
-        areFileDescriptionEqual(createFileDescription('a.js', 'x', true), createFileDescription('a.js', 'x', true)),
-        true
-    );
-});
+suite('equal', function () {
+    test('areFileDescriptionEqual returns true when filePath, content, and isExecutable all match', function () {
+        assert.strictEqual(
+            areFileDescriptionEqual(createFileDescription('a.js', 'x', true), createFileDescription('a.js', 'x', true)),
+            true
+        );
+    });
 
-test('areFileDescriptionEqual returns false when the filePath differs', () => {
-    assert.strictEqual(
-        areFileDescriptionEqual(createFileDescription('a.js', 'x'), createFileDescription('b.js', 'x')),
-        false
-    );
-});
+    test('areFileDescriptionEqual returns false when the filePath differs', function () {
+        assert.strictEqual(
+            areFileDescriptionEqual(createFileDescription('a.js', 'x'), createFileDescription('b.js', 'x')),
+            false
+        );
+    });
 
-test('areFileDescriptionEqual returns false when the content differs', () => {
-    assert.strictEqual(
-        areFileDescriptionEqual(createFileDescription('a.js', 'x'), createFileDescription('a.js', 'y')),
-        false
-    );
-});
+    test('areFileDescriptionEqual returns false when the content differs', function () {
+        assert.strictEqual(
+            areFileDescriptionEqual(createFileDescription('a.js', 'x'), createFileDescription('a.js', 'y')),
+            false
+        );
+    });
 
-test('areFileDescriptionEqual returns false when the executable flag differs', () => {
-    assert.strictEqual(
-        areFileDescriptionEqual(createFileDescription('a.js', 'x', true), createFileDescription('a.js', 'x', false)),
-        false
-    );
+    test('areFileDescriptionEqual returns false when the executable flag differs', function () {
+        assert.strictEqual(
+            areFileDescriptionEqual(
+                createFileDescription('a.js', 'x', true),
+                createFileDescription('a.js', 'x', false)
+            ),
+            false
+        );
+    });
 });

--- a/source/file-manager/file-description.test.ts
+++ b/source/file-manager/file-description.test.ts
@@ -1,19 +1,21 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFileDescription } from './file-description.ts';
 
-test('createFileDescription assembles a FileDescription with the given filePath, content, and executable flag', () => {
-    assert.deepStrictEqual(createFileDescription('a/index.js', 'export {};', true), {
-        filePath: 'a/index.js',
-        content: 'export {};',
-        isExecutable: true
+suite('file-description', function () {
+    test('createFileDescription assembles a FileDescription with the given filePath, content, and executable flag', function () {
+        assert.deepStrictEqual(createFileDescription('a/index.js', 'export {};', true), {
+            filePath: 'a/index.js',
+            content: 'export {};',
+            isExecutable: true
+        });
     });
-});
 
-test('createFileDescription defaults the content to an empty string', () => {
-    assert.strictEqual(createFileDescription('a.js').content, '');
-});
+    test('createFileDescription defaults the content to an empty string', function () {
+        assert.strictEqual(createFileDescription('a.js').content, '');
+    });
 
-test('createFileDescription defaults isExecutable to false', () => {
-    assert.strictEqual(createFileDescription('a.js').isExecutable, false);
+    test('createFileDescription defaults isExecutable to false', function () {
+        assert.strictEqual(createFileDescription('a.js').isExecutable, false);
+    });
 });

--- a/source/file-manager/file-manager.test.ts
+++ b/source/file-manager/file-manager.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { type FileManagerDependencies, createFileManager, type FileManager } from './file-manager.ts';
 
@@ -42,124 +42,126 @@ async function expectCheckReadability(access: SinonSpy, expectedReadable: boolea
     assert.deepStrictEqual(result, { isReadable: expectedReadable });
 }
 
-test('checkReadability() returns isReadable true when access() resolves', async () => {
-    await expectCheckReadability(fake.resolves(undefined), true);
-});
-
-test('checkReadability() returns isReadable false when access() rejects', async () => {
-    await expectCheckReadability(fake.rejects(undefined), false);
-});
-
-test('writeFile() writes the given content to the given file when the parent folder exists', async () => {
-    const access = fake.resolves(undefined);
-    const writeFile = fake.resolves(undefined);
-    const fileManager = fileManagerFactory({ access, writeFile });
-
-    await fileManager.writeFile('/foo/bar.txt', 'the-content');
-
-    assert.strictEqual(access.callCount, 1);
-    assert.deepStrictEqual(access.firstCall.args, ['/foo', fs.constants.R_OK]);
-    assert.strictEqual(writeFile.callCount, 1);
-    assert.deepStrictEqual(writeFile.firstCall.args, ['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]);
-});
-
-async function runWriteFile(access: SinonSpy): Promise<{ readonly writeFile: SinonSpy; readonly mkdir: SinonSpy }> {
-    const writeFile = fake.resolves(undefined);
-    const mkdir = fake.resolves(undefined);
-    const fileManager = fileManagerFactory({ access, writeFile, mkdir });
-
-    await fileManager.writeFile('/foo/bar.txt', 'the-content');
-    return { writeFile, mkdir };
-}
-
-test('writeFile() recursively creates the parent folder and then writes the given content to the given file when the parent folder does not exist', async () => {
-    const access = fake.rejects(undefined);
-    const { writeFile, mkdir } = await runWriteFile(access);
-
-    assert.deepStrictEqual(access.args, [['/foo', fs.constants.R_OK]]);
-    assert.deepStrictEqual(mkdir.args, [['/foo', { recursive: true }]]);
-    assert.deepStrictEqual(writeFile.args, [['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]]);
-});
-
-test('writeFile() does not create the parent folder when it is already readable', async () => {
-    const { writeFile, mkdir } = await runWriteFile(fake.resolves(undefined));
-
-    assert.strictEqual(mkdir.callCount, 0);
-    assert.deepStrictEqual(writeFile.args, [['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]]);
-});
-
-test('readFile() reads the given file and returns its content', async () => {
-    const readFile = fake.resolves('the-content');
-    const fileManager = fileManagerFactory({ readFile });
-
-    const result = await fileManager.readFile('/foo/bar.txt');
-
-    assert.strictEqual(readFile.callCount, 1);
-    assert.deepStrictEqual(readFile.firstCall.args, ['/foo/bar.txt', { encoding: 'utf8' }]);
-    assert.strictEqual(result, 'the-content');
-});
-
-test('copyFile() reads the content of the first file and writes that to the second file', async () => {
-    const readFile = fake.resolves('the-content');
-    const writeFile = fake.resolves(undefined);
-    const fileManager = fileManagerFactory({ readFile, writeFile });
-
-    await fileManager.copyFile('/foo/1.txt', '/foo/2.txt');
-
-    assert.strictEqual(readFile.callCount, 1);
-    assert.deepStrictEqual(readFile.firstCall.args, ['/foo/1.txt', { encoding: 'utf8' }]);
-    assert.strictEqual(writeFile.callCount, 1);
-    assert.deepStrictEqual(writeFile.firstCall.args, ['/foo/2.txt', 'the-content', { encoding: 'utf8' }]);
-});
-
-test('setExecutable() writes the executable file mode when enabled', async () => {
-    const chmod = fake.resolves(undefined);
-    const fileManager = fileManagerFactory({ chmod });
-
-    await fileManager.setExecutable('/foo/bar.txt', true);
-
-    assert.deepStrictEqual(chmod.firstCall.args, ['/foo/bar.txt', 0o755]);
-});
-
-test('setExecutable() writes the regular file mode when disabled', async () => {
-    const chmod = fake.resolves(undefined);
-    const fileManager = fileManagerFactory({ chmod });
-
-    await fileManager.setExecutable('/foo/bar.txt', false);
-
-    assert.deepStrictEqual(chmod.firstCall.args, ['/foo/bar.txt', 0o644]);
-});
-
-test('getTransferableFileDescriptionFromPath() returns the file description of the given file paths', async () => {
-    const stat = fake.resolves({ mode: 42 });
-    const readFile = fake.resolves('the-content');
-    const fileManager = fileManagerFactory({ stat, readFile });
-
-    const result = await fileManager.getTransferableFileDescriptionFromPath('/foo/bar.txt', '/target/path.txt');
-
-    assert.strictEqual(stat.callCount, 1);
-    assert.deepStrictEqual(stat.firstCall.args, ['/foo/bar.txt']);
-    assert.strictEqual(readFile.callCount, 1);
-    assert.deepStrictEqual(readFile.firstCall.args, ['/foo/bar.txt', { encoding: 'utf8' }]);
-    assert.deepStrictEqual(result, {
-        sourceFilePath: '/foo/bar.txt',
-        targetFilePath: '/target/path.txt',
-        content: 'the-content',
-        isExecutable: false
+suite('file-manager', function () {
+    test('checkReadability() returns isReadable true when access() resolves', async function () {
+        await expectCheckReadability(fake.resolves(undefined), true);
     });
-});
 
-test('getTransferableFileDescriptionFromPath() returns the file description with isExecutable set to true when the file mode indicates this', async () => {
-    const stat = fake.resolves({ mode: 493 });
-    const readFile = fake.resolves('the-content');
-    const fileManager = fileManagerFactory({ stat, readFile });
+    test('checkReadability() returns isReadable false when access() rejects', async function () {
+        await expectCheckReadability(fake.rejects(undefined), false);
+    });
 
-    const result = await fileManager.getTransferableFileDescriptionFromPath('/foo/bar.txt', '/target/path.txt');
+    test('writeFile() writes the given content to the given file when the parent folder exists', async function () {
+        const access = fake.resolves(undefined);
+        const writeFile = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ access, writeFile });
 
-    assert.deepStrictEqual(result, {
-        sourceFilePath: '/foo/bar.txt',
-        targetFilePath: '/target/path.txt',
-        content: 'the-content',
-        isExecutable: true
+        await fileManager.writeFile('/foo/bar.txt', 'the-content');
+
+        assert.strictEqual(access.callCount, 1);
+        assert.deepStrictEqual(access.firstCall.args, ['/foo', fs.constants.R_OK]);
+        assert.strictEqual(writeFile.callCount, 1);
+        assert.deepStrictEqual(writeFile.firstCall.args, ['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]);
+    });
+
+    async function runWriteFile(access: SinonSpy): Promise<{ readonly writeFile: SinonSpy; readonly mkdir: SinonSpy }> {
+        const writeFile = fake.resolves(undefined);
+        const mkdir = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ access, writeFile, mkdir });
+
+        await fileManager.writeFile('/foo/bar.txt', 'the-content');
+        return { writeFile, mkdir };
+    }
+
+    test('writeFile() recursively creates the parent folder and then writes the given content to the given file when the parent folder does not exist', async function () {
+        const access = fake.rejects(undefined);
+        const { writeFile, mkdir } = await runWriteFile(access);
+
+        assert.deepStrictEqual(access.args, [['/foo', fs.constants.R_OK]]);
+        assert.deepStrictEqual(mkdir.args, [['/foo', { recursive: true }]]);
+        assert.deepStrictEqual(writeFile.args, [['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]]);
+    });
+
+    test('writeFile() does not create the parent folder when it is already readable', async function () {
+        const { writeFile, mkdir } = await runWriteFile(fake.resolves(undefined));
+
+        assert.strictEqual(mkdir.callCount, 0);
+        assert.deepStrictEqual(writeFile.args, [['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]]);
+    });
+
+    test('readFile() reads the given file and returns its content', async function () {
+        const readFile = fake.resolves('the-content');
+        const fileManager = fileManagerFactory({ readFile });
+
+        const result = await fileManager.readFile('/foo/bar.txt');
+
+        assert.strictEqual(readFile.callCount, 1);
+        assert.deepStrictEqual(readFile.firstCall.args, ['/foo/bar.txt', { encoding: 'utf8' }]);
+        assert.strictEqual(result, 'the-content');
+    });
+
+    test('copyFile() reads the content of the first file and writes that to the second file', async function () {
+        const readFile = fake.resolves('the-content');
+        const writeFile = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ readFile, writeFile });
+
+        await fileManager.copyFile('/foo/1.txt', '/foo/2.txt');
+
+        assert.strictEqual(readFile.callCount, 1);
+        assert.deepStrictEqual(readFile.firstCall.args, ['/foo/1.txt', { encoding: 'utf8' }]);
+        assert.strictEqual(writeFile.callCount, 1);
+        assert.deepStrictEqual(writeFile.firstCall.args, ['/foo/2.txt', 'the-content', { encoding: 'utf8' }]);
+    });
+
+    test('setExecutable() writes the executable file mode when enabled', async function () {
+        const chmod = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ chmod });
+
+        await fileManager.setExecutable('/foo/bar.txt', true);
+
+        assert.deepStrictEqual(chmod.firstCall.args, ['/foo/bar.txt', 0o755]);
+    });
+
+    test('setExecutable() writes the regular file mode when disabled', async function () {
+        const chmod = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ chmod });
+
+        await fileManager.setExecutable('/foo/bar.txt', false);
+
+        assert.deepStrictEqual(chmod.firstCall.args, ['/foo/bar.txt', 0o644]);
+    });
+
+    test('getTransferableFileDescriptionFromPath() returns the file description of the given file paths', async function () {
+        const stat = fake.resolves({ mode: 42 });
+        const readFile = fake.resolves('the-content');
+        const fileManager = fileManagerFactory({ stat, readFile });
+
+        const result = await fileManager.getTransferableFileDescriptionFromPath('/foo/bar.txt', '/target/path.txt');
+
+        assert.strictEqual(stat.callCount, 1);
+        assert.deepStrictEqual(stat.firstCall.args, ['/foo/bar.txt']);
+        assert.strictEqual(readFile.callCount, 1);
+        assert.deepStrictEqual(readFile.firstCall.args, ['/foo/bar.txt', { encoding: 'utf8' }]);
+        assert.deepStrictEqual(result, {
+            sourceFilePath: '/foo/bar.txt',
+            targetFilePath: '/target/path.txt',
+            content: 'the-content',
+            isExecutable: false
+        });
+    });
+
+    test('getTransferableFileDescriptionFromPath() returns the file description with isExecutable set to true when the file mode indicates this', async function () {
+        const stat = fake.resolves({ mode: 493 });
+        const readFile = fake.resolves('the-content');
+        const fileManager = fileManagerFactory({ stat, readFile });
+
+        const result = await fileManager.getTransferableFileDescriptionFromPath('/foo/bar.txt', '/target/path.txt');
+
+        assert.deepStrictEqual(result, {
+            sourceFilePath: '/foo/bar.txt',
+            targetFilePath: '/target/path.txt',
+            content: 'the-content',
+            isExecutable: true
+        });
     });
 });

--- a/source/file-manager/permissions.test.ts
+++ b/source/file-manager/permissions.test.ts
@@ -1,62 +1,64 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { isExecutableFileMode } from './permissions.ts';
 
-test('returns false when the given mode is invalid', () => {
-    const result = isExecutableFileMode(-1);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is not executable at all', () => {
-    const result = isExecutableFileMode(420);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is only executable for the user', () => {
-    const result = isExecutableFileMode(484);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is only executable for the group', () => {
-    const result = isExecutableFileMode(428);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is only executable for others', () => {
-    const result = isExecutableFileMode(421);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is only executable for group and others', () => {
-    const result = isExecutableFileMode(429);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is only executable for user and others', () => {
-    const result = isExecutableFileMode(485);
-    assert.strictEqual(result, false);
-});
-
-test('returns false when the given mode is only executable for user and group', () => {
-    const result = isExecutableFileMode(492);
-    assert.strictEqual(result, false);
-});
-
-test('returns true when the given mode is executable for all user, group and others', () => {
-    const result = isExecutableFileMode(493);
-    assert.strictEqual(result, true);
-});
-
-test('returns true when the given mode is executable for all user, group and others, ignoring other permissions', () => {
-    const result = isExecutableFileMode(459);
-    assert.strictEqual(result, true);
-});
-
-test('returns false when converted permissions are missing entries', () => {
-    const result = isExecutableFileMode(493, {
-        convertObject: () => {
-            return { user: { execute: true } };
-        }
+suite('permissions', function () {
+    test('returns false when the given mode is invalid', function () {
+        const result = isExecutableFileMode(-1);
+        assert.strictEqual(result, false);
     });
-    assert.strictEqual(result, false);
+
+    test('returns false when the given mode is not executable at all', function () {
+        const result = isExecutableFileMode(420);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns false when the given mode is only executable for the user', function () {
+        const result = isExecutableFileMode(484);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns false when the given mode is only executable for the group', function () {
+        const result = isExecutableFileMode(428);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns false when the given mode is only executable for others', function () {
+        const result = isExecutableFileMode(421);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns false when the given mode is only executable for group and others', function () {
+        const result = isExecutableFileMode(429);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns false when the given mode is only executable for user and others', function () {
+        const result = isExecutableFileMode(485);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns false when the given mode is only executable for user and group', function () {
+        const result = isExecutableFileMode(492);
+        assert.strictEqual(result, false);
+    });
+
+    test('returns true when the given mode is executable for all user, group and others', function () {
+        const result = isExecutableFileMode(493);
+        assert.strictEqual(result, true);
+    });
+
+    test('returns true when the given mode is executable for all user, group and others, ignoring other permissions', function () {
+        const result = isExecutableFileMode(459);
+        assert.strictEqual(result, true);
+    });
+
+    test('returns false when converted permissions are missing entries', function () {
+        const result = isExecutableFileMode(493, {
+            convertObject: () => {
+                return { user: { execute: true } };
+            }
+        });
+        assert.strictEqual(result, false);
+    });
 });

--- a/source/linker/linked-bundle.test.ts
+++ b/source/linker/linked-bundle.test.ts
@@ -1,33 +1,35 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { getSubstitutedResources } from './linked-bundle.ts';
 
-test('getSubstitutedResources returns an empty array when no resource is substituted', () => {
-    const result = getSubstitutedResources({
-        contents: [
-            { isSubstituted: false, name: 'a' },
-            { isSubstituted: false, name: 'b' }
-        ]
+suite('linked-bundle', function () {
+    test('getSubstitutedResources returns an empty array when no resource is substituted', function () {
+        const result = getSubstitutedResources({
+            contents: [
+                { isSubstituted: false, name: 'a' },
+                { isSubstituted: false, name: 'b' }
+            ]
+        });
+
+        assert.deepStrictEqual(result, []);
     });
 
-    assert.deepStrictEqual(result, []);
-});
+    test('getSubstitutedResources keeps only the resources whose isSubstituted flag is true', function () {
+        const result = getSubstitutedResources({
+            contents: [
+                { isSubstituted: true, name: 'a' },
+                { isSubstituted: false, name: 'b' },
+                { isSubstituted: true, name: 'c' }
+            ]
+        });
 
-test('getSubstitutedResources keeps only the resources whose isSubstituted flag is true', () => {
-    const result = getSubstitutedResources({
-        contents: [
-            { isSubstituted: true, name: 'a' },
-            { isSubstituted: false, name: 'b' },
-            { isSubstituted: true, name: 'c' }
-        ]
+        assert.deepStrictEqual(
+            result.map((resource) => resource.name),
+            ['a', 'c']
+        );
     });
 
-    assert.deepStrictEqual(
-        result.map((resource) => resource.name),
-        ['a', 'c']
-    );
-});
-
-test('getSubstitutedResources returns an empty array for an empty contents array', () => {
-    assert.deepStrictEqual(getSubstitutedResources({ contents: [] }), []);
+    test('getSubstitutedResources returns an empty array for an empty contents array', function () {
+        assert.deepStrictEqual(getSubstitutedResources({ contents: [] }), []);
+    });
 });

--- a/source/linker/linker.test.ts
+++ b/source/linker/linker.test.ts
@@ -1,279 +1,281 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { createBundleLinker } from './linker.ts';
 
-test('linkBundle() keeps js-only roots when there are no bundle substitutions', async () => {
-    const linker = createBundleLinker();
-    const root = {
-        js: {
-            content: '',
-            isExecutable: false,
-            sourceFilePath: '/src/index.js',
-            targetFilePath: 'index.js'
-        }
-    } as const;
-
-    const result = await linker.linkBundle({
-        bundle: {
-            name: 'package-a',
-            exportPackageJson: true,
-            contents: [
-                {
-                    fileDescription: {
-                        content: 'import "./internal.js";',
-                        isExecutable: false,
-                        sourceFilePath: '/src/index.js',
-                        targetFilePath: 'index.js'
-                    },
-                    directDependencies: new Set(['/src/internal.js']),
-                    isExplicitlyIncluded: false,
-                    project: createProject({
-                        withFiles: [
-                            { filePath: '/src/index.js', content: 'import "./internal.js";' },
-                            { filePath: '/src/internal.js', content: 'export {};' }
-                        ]
-                    })
-                },
-                {
-                    fileDescription: {
-                        content: 'export {};',
-                        isExecutable: false,
-                        sourceFilePath: '/src/internal.js',
-                        targetFilePath: 'internal.js'
-                    },
-                    directDependencies: new Set(),
-                    isExplicitlyIncluded: false
-                }
-            ],
-            roots: { main: root },
-            surface: { mode: 'implicit', defaultModuleRoot: 'main' },
-            externalDependencies: new Map()
-        },
-        bundleDependencies: []
-    });
-
-    assert.strictEqual(result.name, 'package-a');
-    assert.strictEqual(result.exportPackageJson, true);
-    assert.deepStrictEqual(result.roots, {
-        main: {
+suite('linker', function () {
+    test('linkBundle() keeps js-only roots when there are no bundle substitutions', async function () {
+        const linker = createBundleLinker();
+        const root = {
             js: {
                 content: '',
                 isExecutable: false,
                 sourceFilePath: '/src/index.js',
                 targetFilePath: 'index.js'
             }
-        }
-    });
-    assert.strictEqual(result.contents.length, 2);
-});
+        } as const;
 
-test('linkBundle() flattens declaration roots and substitutes matching bundle dependencies', async () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/src/index.js', content: 'import "./dep.js";' },
-            { filePath: '/src/index.d.ts', content: 'export * from "./dep.d.ts";' }
-        ]
-    });
-    const linker = createBundleLinker();
-    const root = {
-        js: {
-            content: '',
-            isExecutable: false,
-            sourceFilePath: '/src/index.js',
-            targetFilePath: 'index.js'
-        },
-        declarationFile: {
-            content: '',
-            isExecutable: false,
-            sourceFilePath: '/src/index.d.ts',
-            targetFilePath: 'index.d.ts'
-        }
-    } as const;
-
-    const result = await linker.linkBundle({
-        bundle: {
-            name: 'package-a',
-            contents: [
-                {
-                    fileDescription: {
-                        content: 'import "./dep.js";',
-                        isExecutable: false,
-                        sourceFilePath: '/src/index.js',
-                        targetFilePath: 'index.js'
-                    },
-                    directDependencies: new Set(['/src/dep.js']),
-                    isExplicitlyIncluded: false,
-                    project
-                },
-                {
-                    fileDescription: {
-                        content: 'export * from "./dep.d.ts";',
-                        isExecutable: false,
-                        sourceFilePath: '/src/index.d.ts',
-                        targetFilePath: 'index.d.ts'
-                    },
-                    directDependencies: new Set(['/src/dep.d.ts']),
-                    isExplicitlyIncluded: false,
-                    project
-                },
-                {
-                    fileDescription: {
-                        content: 'export const dep = 1;',
-                        isExecutable: false,
-                        sourceFilePath: '/src/dep.js',
-                        targetFilePath: 'dep.js'
-                    },
-                    directDependencies: new Set(),
-                    isExplicitlyIncluded: false
-                },
-                {
-                    fileDescription: {
-                        content: 'export declare const dep: number;',
-                        isExecutable: false,
-                        sourceFilePath: '/src/dep.d.ts',
-                        targetFilePath: 'dep.d.ts'
-                    },
-                    directDependencies: new Set(),
-                    isExplicitlyIncluded: false
-                }
-            ],
-            roots: { main: root },
-            surface: { mode: 'implicit', defaultModuleRoot: 'main' },
-            externalDependencies: new Map()
-        },
-        bundleDependencies: [
-            {
-                name: 'bundle-dependency',
-                roots: {
-                    main: {
-                        js: {
-                            content: '',
-                            isExecutable: false,
-                            sourceFilePath: '/src/dep.js',
-                            targetFilePath: 'dep.js'
-                        }
-                    }
-                },
-                surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+        const result = await linker.linkBundle({
+            bundle: {
+                name: 'package-a',
+                exportPackageJson: true,
                 contents: [
                     {
                         fileDescription: {
-                            content: '',
+                            content: 'import "./internal.js";',
+                            isExecutable: false,
+                            sourceFilePath: '/src/index.js',
+                            targetFilePath: 'index.js'
+                        },
+                        directDependencies: new Set(['/src/internal.js']),
+                        isExplicitlyIncluded: false,
+                        project: createProject({
+                            withFiles: [
+                                { filePath: '/src/index.js', content: 'import "./internal.js";' },
+                                { filePath: '/src/internal.js', content: 'export {};' }
+                            ]
+                        })
+                    },
+                    {
+                        fileDescription: {
+                            content: 'export {};',
+                            isExecutable: false,
+                            sourceFilePath: '/src/internal.js',
+                            targetFilePath: 'internal.js'
+                        },
+                        directDependencies: new Set(),
+                        isExplicitlyIncluded: false
+                    }
+                ],
+                roots: { main: root },
+                surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+                externalDependencies: new Map()
+            },
+            bundleDependencies: []
+        });
+
+        assert.strictEqual(result.name, 'package-a');
+        assert.strictEqual(result.exportPackageJson, true);
+        assert.deepStrictEqual(result.roots, {
+            main: {
+                js: {
+                    content: '',
+                    isExecutable: false,
+                    sourceFilePath: '/src/index.js',
+                    targetFilePath: 'index.js'
+                }
+            }
+        });
+        assert.strictEqual(result.contents.length, 2);
+    });
+
+    test('linkBundle() flattens declaration roots and substitutes matching bundle dependencies', async function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/src/index.js', content: 'import "./dep.js";' },
+                { filePath: '/src/index.d.ts', content: 'export * from "./dep.d.ts";' }
+            ]
+        });
+        const linker = createBundleLinker();
+        const root = {
+            js: {
+                content: '',
+                isExecutable: false,
+                sourceFilePath: '/src/index.js',
+                targetFilePath: 'index.js'
+            },
+            declarationFile: {
+                content: '',
+                isExecutable: false,
+                sourceFilePath: '/src/index.d.ts',
+                targetFilePath: 'index.d.ts'
+            }
+        } as const;
+
+        const result = await linker.linkBundle({
+            bundle: {
+                name: 'package-a',
+                contents: [
+                    {
+                        fileDescription: {
+                            content: 'import "./dep.js";',
+                            isExecutable: false,
+                            sourceFilePath: '/src/index.js',
+                            targetFilePath: 'index.js'
+                        },
+                        directDependencies: new Set(['/src/dep.js']),
+                        isExplicitlyIncluded: false,
+                        project
+                    },
+                    {
+                        fileDescription: {
+                            content: 'export * from "./dep.d.ts";',
+                            isExecutable: false,
+                            sourceFilePath: '/src/index.d.ts',
+                            targetFilePath: 'index.d.ts'
+                        },
+                        directDependencies: new Set(['/src/dep.d.ts']),
+                        isExplicitlyIncluded: false,
+                        project
+                    },
+                    {
+                        fileDescription: {
+                            content: 'export const dep = 1;',
                             isExecutable: false,
                             sourceFilePath: '/src/dep.js',
                             targetFilePath: 'dep.js'
                         },
                         directDependencies: new Set(),
-                        isSubstituted: false,
                         isExplicitlyIncluded: false
                     },
                     {
                         fileDescription: {
-                            content: '',
+                            content: 'export declare const dep: number;',
                             isExecutable: false,
                             sourceFilePath: '/src/dep.d.ts',
                             targetFilePath: 'dep.d.ts'
                         },
                         directDependencies: new Set(),
-                        isSubstituted: false,
                         isExplicitlyIncluded: false
                     }
-                ]
-            }
-        ]
-    });
-
-    assert.strictEqual(result.contents.length, 2);
-    assert.strictEqual(result.contents[0]?.isSubstituted, true);
-    assert.deepStrictEqual(Array.from(result.linkedBundleDependencies.keys()), ['bundle-dependency']);
-});
-
-test('linkBundle() tolerates explicit roots that share transitive files', async () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/src/cli.js', content: 'import "./shared.js";' },
-            { filePath: '/src/worker.js', content: 'import "./shared.js";' },
-            { filePath: '/src/shared.js', content: 'export const shared = 1;' }
-        ]
-    });
-    const linker = createBundleLinker();
-
-    const result = await linker.linkBundle({
-        bundle: {
-            name: '@packtory/cli',
-            contents: [
+                ],
+                roots: { main: root },
+                surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+                externalDependencies: new Map()
+            },
+            bundleDependencies: [
                 {
-                    fileDescription: {
-                        content: 'import "./shared.js";',
-                        isExecutable: true,
-                        sourceFilePath: '/src/cli.js',
-                        targetFilePath: 'cli.js'
+                    name: 'bundle-dependency',
+                    roots: {
+                        main: {
+                            js: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/src/dep.js',
+                                targetFilePath: 'dep.js'
+                            }
+                        }
                     },
-                    directDependencies: new Set(['/src/shared.js']),
-                    isExplicitlyIncluded: false,
-                    project
-                },
-                {
-                    fileDescription: {
-                        content: 'import "./shared.js";',
-                        isExecutable: false,
-                        sourceFilePath: '/src/worker.js',
-                        targetFilePath: 'worker.js'
-                    },
-                    directDependencies: new Set(['/src/shared.js']),
-                    isExplicitlyIncluded: false,
-                    project
-                },
-                {
-                    fileDescription: {
-                        content: 'export const shared = 1;',
-                        isExecutable: false,
-                        sourceFilePath: '/src/shared.js',
-                        targetFilePath: 'shared.js'
-                    },
-                    directDependencies: new Set(),
-                    isExplicitlyIncluded: false,
-                    project
+                    surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+                    contents: [
+                        {
+                            fileDescription: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/src/dep.js',
+                                targetFilePath: 'dep.js'
+                            },
+                            directDependencies: new Set(),
+                            isSubstituted: false,
+                            isExplicitlyIncluded: false
+                        },
+                        {
+                            fileDescription: {
+                                content: '',
+                                isExecutable: false,
+                                sourceFilePath: '/src/dep.d.ts',
+                                targetFilePath: 'dep.d.ts'
+                            },
+                            directDependencies: new Set(),
+                            isSubstituted: false,
+                            isExplicitlyIncluded: false
+                        }
+                    ]
                 }
-            ],
-            roots: {
-                cli: {
-                    js: {
-                        content: '#!/usr/bin/env node\nimport "./shared.js";',
-                        isExecutable: true,
-                        sourceFilePath: '/src/cli.js',
-                        targetFilePath: 'cli.js'
+            ]
+        });
+
+        assert.strictEqual(result.contents.length, 2);
+        assert.strictEqual(result.contents[0]?.isSubstituted, true);
+        assert.deepStrictEqual(Array.from(result.linkedBundleDependencies.keys()), ['bundle-dependency']);
+    });
+
+    test('linkBundle() tolerates explicit roots that share transitive files', async function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/src/cli.js', content: 'import "./shared.js";' },
+                { filePath: '/src/worker.js', content: 'import "./shared.js";' },
+                { filePath: '/src/shared.js', content: 'export const shared = 1;' }
+            ]
+        });
+        const linker = createBundleLinker();
+
+        const result = await linker.linkBundle({
+            bundle: {
+                name: '@packtory/cli',
+                contents: [
+                    {
+                        fileDescription: {
+                            content: 'import "./shared.js";',
+                            isExecutable: true,
+                            sourceFilePath: '/src/cli.js',
+                            targetFilePath: 'cli.js'
+                        },
+                        directDependencies: new Set(['/src/shared.js']),
+                        isExplicitlyIncluded: false,
+                        project
+                    },
+                    {
+                        fileDescription: {
+                            content: 'import "./shared.js";',
+                            isExecutable: false,
+                            sourceFilePath: '/src/worker.js',
+                            targetFilePath: 'worker.js'
+                        },
+                        directDependencies: new Set(['/src/shared.js']),
+                        isExplicitlyIncluded: false,
+                        project
+                    },
+                    {
+                        fileDescription: {
+                            content: 'export const shared = 1;',
+                            isExecutable: false,
+                            sourceFilePath: '/src/shared.js',
+                            targetFilePath: 'shared.js'
+                        },
+                        directDependencies: new Set(),
+                        isExplicitlyIncluded: false,
+                        project
+                    }
+                ],
+                roots: {
+                    cli: {
+                        js: {
+                            content: '#!/usr/bin/env node\nimport "./shared.js";',
+                            isExecutable: true,
+                            sourceFilePath: '/src/cli.js',
+                            targetFilePath: 'cli.js'
+                        }
+                    },
+                    worker: {
+                        js: {
+                            content: 'import "./shared.js";',
+                            isExecutable: false,
+                            sourceFilePath: '/src/worker.js',
+                            targetFilePath: 'worker.js'
+                        }
                     }
                 },
-                worker: {
-                    js: {
-                        content: 'import "./shared.js";',
-                        isExecutable: false,
-                        sourceFilePath: '/src/worker.js',
-                        targetFilePath: 'worker.js'
+                surface: {
+                    mode: 'explicit',
+                    packageInterface: {
+                        bins: [{ root: 'cli', name: 'packtory' }],
+                        privateRoots: ['worker']
                     }
-                }
+                },
+                externalDependencies: new Map()
             },
-            surface: {
-                mode: 'explicit',
-                packageInterface: {
-                    bins: [{ root: 'cli', name: 'packtory' }],
-                    privateRoots: ['worker']
-                }
-            },
-            externalDependencies: new Map()
-        },
-        bundleDependencies: []
-    });
+            bundleDependencies: []
+        });
 
-    assert.strictEqual(result.contents.length, 3);
-    assert.deepStrictEqual(
-        result.contents
-            .map((entry) => {
-                return entry.fileDescription.sourceFilePath;
-            })
-            .toSorted(),
-        ['/src/cli.js', '/src/worker.js', '/src/shared.js'].toSorted()
-    );
+        assert.strictEqual(result.contents.length, 3);
+        assert.deepStrictEqual(
+            result.contents
+                .map((entry) => {
+                    return entry.fileDescription.sourceFilePath;
+                })
+                .toSorted(),
+            ['/src/cli.js', '/src/worker.js', '/src/shared.js'].toSorted()
+        );
+    });
 });

--- a/source/linker/replacement-lookup.test.ts
+++ b/source/linker/replacement-lookup.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { explicitPackageSurface } from '../package-surface/surface.ts';
 import { analyzedBundleResource, linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import type { BundleSubstitutionSource } from './linked-bundle.ts';
@@ -19,46 +19,48 @@ function exposingBundle(name: string, sourceFilePath: string, targetFilePath: st
     return bundle;
 }
 
-test('findAllPathReplacements returns no replacements when no bundle owns any of the files', () => {
-    const result = findAllPathReplacements(['/x/a.ts'], []);
+suite('replacement-lookup', function () {
+    test('findAllPathReplacements returns no replacements when no bundle owns any of the files', function () {
+        const result = findAllPathReplacements(['/x/a.ts'], []);
 
-    assert.strictEqual(result.importPathReplacements.size, 0);
-    assert.deepStrictEqual(result.bundleDependencies, []);
-});
-
-test('findAllPathReplacements maps each file to the public target path of the owning bundle', () => {
-    const bundle = exposingBundle('pkg-b', '/b/helpers.ts', 'helpers.ts');
-
-    const result = findAllPathReplacements(['/b/helpers.ts'], [bundle]);
-
-    assert.strictEqual(result.importPathReplacements.get('/b/helpers.ts'), 'pkg-b');
-    assert.deepStrictEqual(result.bundleDependencies, ['pkg-b']);
-});
-
-test('findAllPathReplacements throws when a bundle owns the file but does not expose it', () => {
-    const bundle = linkedBundle({
-        name: 'pkg-b',
-        contents: [analyzedBundleResource('/b/internal.ts', { targetFilePath: 'internal.ts' })],
-        surface: explicitPackageSurface({ modules: [{ root: 'main', export: '.' }] })
+        assert.strictEqual(result.importPathReplacements.size, 0);
+        assert.deepStrictEqual(result.bundleDependencies, []);
     });
 
-    try {
-        findAllPathReplacements(['/b/internal.ts'], [bundle]);
-        assert.fail('expected findAllPathReplacements to throw');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(
-            error.message,
-            'Package "pkg-b" does not expose "/b/internal.ts" for cross-package substitution'
-        );
-    }
-});
+    test('findAllPathReplacements maps each file to the public target path of the owning bundle', function () {
+        const bundle = exposingBundle('pkg-b', '/b/helpers.ts', 'helpers.ts');
 
-test('findAllPathReplacements returns one bundle dependency entry per matched file', () => {
-    const bundleB = exposingBundle('pkg-b', '/b/helpers.ts', 'helpers.ts');
-    const bundleC = exposingBundle('pkg-c', '/c/helpers.ts', 'helpers.ts');
+        const result = findAllPathReplacements(['/b/helpers.ts'], [bundle]);
 
-    const result = findAllPathReplacements(['/b/helpers.ts', '/c/helpers.ts'], [bundleB, bundleC]);
+        assert.strictEqual(result.importPathReplacements.get('/b/helpers.ts'), 'pkg-b');
+        assert.deepStrictEqual(result.bundleDependencies, ['pkg-b']);
+    });
 
-    assert.deepStrictEqual(result.bundleDependencies, ['pkg-b', 'pkg-c']);
+    test('findAllPathReplacements throws when a bundle owns the file but does not expose it', function () {
+        const bundle = linkedBundle({
+            name: 'pkg-b',
+            contents: [analyzedBundleResource('/b/internal.ts', { targetFilePath: 'internal.ts' })],
+            surface: explicitPackageSurface({ modules: [{ root: 'main', export: '.' }] })
+        });
+
+        try {
+            findAllPathReplacements(['/b/internal.ts'], [bundle]);
+            assert.fail('expected findAllPathReplacements to throw');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(
+                error.message,
+                'Package "pkg-b" does not expose "/b/internal.ts" for cross-package substitution'
+            );
+        }
+    });
+
+    test('findAllPathReplacements returns one bundle dependency entry per matched file', function () {
+        const bundleB = exposingBundle('pkg-b', '/b/helpers.ts', 'helpers.ts');
+        const bundleC = exposingBundle('pkg-c', '/c/helpers.ts', 'helpers.ts');
+
+        const result = findAllPathReplacements(['/b/helpers.ts', '/c/helpers.ts'], [bundleB, bundleC]);
+
+        assert.deepStrictEqual(result.bundleDependencies, ['pkg-b', 'pkg-c']);
+    });
 });

--- a/source/linker/resource-graph.test.ts
+++ b/source/linker/resource-graph.test.ts
@@ -1,55 +1,57 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createGraphFromResolvedBundle } from './resource-graph.ts';
 
-test('createGraphFromResolvedBundle() keeps only external dependencies referenced by each resource', () => {
-    const root = {
-        js: {
-            sourceFilePath: '/entry.js',
-            targetFilePath: 'entry.js',
-            content: '',
-            isExecutable: false
-        }
-    } as const;
-    const graph = createGraphFromResolvedBundle({
-        name: 'package-a',
-        contents: [
-            {
-                fileDescription: {
-                    sourceFilePath: '/entry.js',
-                    targetFilePath: 'entry.js',
-                    content: '',
-                    isExecutable: false
-                },
-                directDependencies: new Set(['/other.js']),
-                isExplicitlyIncluded: false
-            },
-            {
-                fileDescription: {
-                    sourceFilePath: '/other.js',
-                    targetFilePath: 'other.js',
-                    content: '',
-                    isExecutable: false
-                },
-                directDependencies: new Set(),
-                isExplicitlyIncluded: false
+suite('resource-graph', function () {
+    test('createGraphFromResolvedBundle() keeps only external dependencies referenced by each resource', function () {
+        const root = {
+            js: {
+                sourceFilePath: '/entry.js',
+                targetFilePath: 'entry.js',
+                content: '',
+                isExecutable: false
             }
-        ],
-        roots: { main: root },
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
-        externalDependencies: new Map([
-            ['left-pad', { name: 'left-pad', referencedFrom: ['/entry.js'] as const }],
-            ['unused', { name: 'unused', referencedFrom: ['/not-used.js'] as const }]
-        ])
-    });
-    const visited: { id: string; externalDependencies: readonly string[] }[] = [];
+        } as const;
+        const graph = createGraphFromResolvedBundle({
+            name: 'package-a',
+            contents: [
+                {
+                    fileDescription: {
+                        sourceFilePath: '/entry.js',
+                        targetFilePath: 'entry.js',
+                        content: '',
+                        isExecutable: false
+                    },
+                    directDependencies: new Set(['/other.js']),
+                    isExplicitlyIncluded: false
+                },
+                {
+                    fileDescription: {
+                        sourceFilePath: '/other.js',
+                        targetFilePath: 'other.js',
+                        content: '',
+                        isExecutable: false
+                    },
+                    directDependencies: new Set(),
+                    isExplicitlyIncluded: false
+                }
+            ],
+            roots: { main: root },
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
+            externalDependencies: new Map([
+                ['left-pad', { name: 'left-pad', referencedFrom: ['/entry.js'] as const }],
+                ['unused', { name: 'unused', referencedFrom: ['/not-used.js'] as const }]
+            ])
+        });
+        const visited: { id: string; externalDependencies: readonly string[] }[] = [];
 
-    graph.visitBreadthFirstSearch('/entry.js', (node) => {
-        visited.push({ id: node.id, externalDependencies: node.data.externalDependencies });
-    });
+        graph.visitBreadthFirstSearch('/entry.js', (node) => {
+            visited.push({ id: node.id, externalDependencies: node.data.externalDependencies });
+        });
 
-    assert.deepStrictEqual(visited, [
-        { id: '/entry.js', externalDependencies: ['left-pad'] },
-        { id: '/other.js', externalDependencies: [] }
-    ]);
+        assert.deepStrictEqual(visited, [
+            { id: '/entry.js', externalDependencies: ['left-pad'] },
+            { id: '/other.js', externalDependencies: [] }
+        ]);
+    });
 });

--- a/source/linker/source-modifier/import-paths.test.ts
+++ b/source/linker/source-modifier/import-paths.test.ts
@@ -1,113 +1,135 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { replaceImportPaths } from './import-paths.ts';
 
-test('returns source code unmodified when project is undefined', () => {
-    const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
+suite('import-paths', function () {
+    test('returns source code unmodified when project is undefined', function () {
+        const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(undefined, '/folder/foo.ts', 'const foo = "bar"; import "./bar";', replacements);
+        const result = replaceImportPaths(
+            undefined,
+            '/folder/foo.ts',
+            'const foo = "bar"; import "./bar";',
+            replacements
+        );
 
-    assert.strictEqual(result, 'const foo = "bar"; import "./bar";');
-});
-
-test('returns source code unmodified when there is no matching file in the given project', () => {
-    const project = createProject({
-        withFiles: [{ filePath: '/folder/bar.ts', content: 'const bar = "baz";' }]
+        assert.strictEqual(result, 'const foo = "bar"; import "./bar";');
     });
-    const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(project, '/folder/foo.ts', 'const foo = "bar"; import "./bar";', replacements);
+    test('returns source code unmodified when there is no matching file in the given project', function () {
+        const project = createProject({
+            withFiles: [{ filePath: '/folder/bar.ts', content: 'const bar = "baz";' }]
+        });
+        const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    assert.strictEqual(result, 'const foo = "bar"; import "./bar";');
-});
+        const result = replaceImportPaths(
+            project,
+            '/folder/foo.ts',
+            'const foo = "bar"; import "./bar";',
+            replacements
+        );
 
-test('returns source code unmodified when it doesn’t contain any import statement that needs to be replaced', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.ts', content: 'const foo = "bar";' },
-            { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
-        ]
+        assert.strictEqual(result, 'const foo = "bar"; import "./bar";');
     });
-    const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(project, '/folder/foo.ts', 'const foo = "bar";', replacements);
+    test('returns source code unmodified when it doesn’t contain any import statement that needs to be replaced', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/folder/foo.ts', content: 'const foo = "bar";' },
+                { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
+            ]
+        });
+        const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    assert.strictEqual(result, 'const foo = "bar";');
-});
+        const result = replaceImportPaths(project, '/folder/foo.ts', 'const foo = "bar";', replacements);
 
-test('returns the source code unmodified when there are no replacements', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.ts', content: 'const foo = "bar"; import "./bar";' },
-            { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
-        ]
+        assert.strictEqual(result, 'const foo = "bar";');
     });
-    const replacements = new Map<string, string>();
 
-    const result = replaceImportPaths(project, '/folder/foo.ts', 'const foo = "bar"; import "./bar";', replacements);
+    test('returns the source code unmodified when there are no replacements', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/folder/foo.ts', content: 'const foo = "bar"; import "./bar";' },
+                { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
+            ]
+        });
+        const replacements = new Map<string, string>();
 
-    assert.strictEqual(result, 'const foo = "bar"; import "./bar";');
-});
+        const result = replaceImportPaths(
+            project,
+            '/folder/foo.ts',
+            'const foo = "bar"; import "./bar";',
+            replacements
+        );
 
-test('returns the source code with the modified import statement', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.ts', content: 'const foo = "bar"; import "./bar";' },
-            { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
-        ]
+        assert.strictEqual(result, 'const foo = "bar"; import "./bar";');
     });
-    const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(project, '/folder/foo.ts', 'const foo = "bar"; import "./bar";', replacements);
+    test('returns the source code with the modified import statement', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/folder/foo.ts', content: 'const foo = "bar"; import "./bar";' },
+                { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
+            ]
+        });
+        const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    assert.strictEqual(result, 'const foo = "bar"; import "replacement";');
-});
+        const result = replaceImportPaths(
+            project,
+            '/folder/foo.ts',
+            'const foo = "bar"; import "./bar";',
+            replacements
+        );
 
-test('modifies only matching import statements and keeps non-matching statements unchanged', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.ts', content: 'import "./baz"; import "./bar";' },
-            { filePath: '/folder/bar.ts', content: 'const bar = "baz";' },
-            { filePath: '/folder/baz.ts', content: 'const baz = "qux";' }
-        ]
+        assert.strictEqual(result, 'const foo = "bar"; import "replacement";');
     });
-    const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(project, '/folder/foo.ts', 'import "./baz"; import "./bar";', replacements);
+    test('modifies only matching import statements and keeps non-matching statements unchanged', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/folder/foo.ts', content: 'import "./baz"; import "./bar";' },
+                { filePath: '/folder/bar.ts', content: 'const bar = "baz";' },
+                { filePath: '/folder/baz.ts', content: 'const baz = "qux";' }
+            ]
+        });
+        const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    assert.strictEqual(result, 'import "./baz"; import "replacement";');
-});
+        const result = replaceImportPaths(project, '/folder/foo.ts', 'import "./baz"; import "./bar";', replacements);
 
-test('modifies import statements correctly in d.ts files', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.d.ts', content: 'import "./bar.js";' },
-            { filePath: '/folder/bar.d.ts', content: 'const bar = "baz";' }
-        ]
+        assert.strictEqual(result, 'import "./baz"; import "replacement";');
     });
-    const replacements = new Map<string, string>([['/folder/bar.d.ts', 'replacement/bar.d.ts']]);
 
-    const result = replaceImportPaths(project, '/folder/foo.d.ts', 'import "./bar.js"', replacements);
+    test('modifies import statements correctly in d.ts files', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/folder/foo.d.ts', content: 'import "./bar.js";' },
+                { filePath: '/folder/bar.d.ts', content: 'const bar = "baz";' }
+            ]
+        });
+        const replacements = new Map<string, string>([['/folder/bar.d.ts', 'replacement/bar.d.ts']]);
 
-    assert.strictEqual(result, 'import "replacement/bar.d.ts";');
-});
+        const result = replaceImportPaths(project, '/folder/foo.d.ts', 'import "./bar.js"', replacements);
 
-test('keeps shebang line in the transformed output', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/folder/foo.ts', content: '#!/usr/bin/env node\nconst foo = "bar"; import "./bar";' },
-            { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
-        ]
+        assert.strictEqual(result, 'import "replacement/bar.d.ts";');
     });
-    const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    const result = replaceImportPaths(
-        project,
-        '/folder/foo.ts',
-        '#!/usr/bin/env node\nconst foo = "bar"; import "./bar";',
-        replacements
-    );
+    test('keeps shebang line in the transformed output', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/folder/foo.ts', content: '#!/usr/bin/env node\nconst foo = "bar"; import "./bar";' },
+                { filePath: '/folder/bar.ts', content: 'const bar = "baz";' }
+            ]
+        });
+        const replacements = new Map<string, string>([['/folder/bar.ts', 'replacement']]);
 
-    assert.strictEqual(result, '#!/usr/bin/env node\nconst foo = "bar"; import "replacement";');
+        const result = replaceImportPaths(
+            project,
+            '/folder/foo.ts',
+            '#!/usr/bin/env node\nconst foo = "bar"; import "./bar";',
+            replacements
+        );
+
+        assert.strictEqual(result, '#!/usr/bin/env node\nconst foo = "bar"; import "replacement";');
+    });
 });

--- a/source/linker/substitute-bundles.property.ts
+++ b/source/linker/substitute-bundles.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
 import { createGraphFromResolvedBundle } from './resource-graph.ts';
@@ -61,121 +61,123 @@ function createBundleDependency(index: number): VersionedBundleWithManifest {
     };
 }
 
-test('substituteDependencies() only rewrites matched imports and never invents unrelated files', () => {
-    fc.assert(
-        fc.property(
-            importCountArbitrary,
-            fc.array(fc.boolean(), { minLength: 0, maxLength: 4 }),
-            (importCount, replacementFlags) => {
-                const selectedFlags = replacementFlags.slice(0, importCount);
-                const importPaths = Array.from({ length: importCount }, (_, index) => {
-                    return `/dep-${index}.js`;
-                });
-                const project = createProject({
-                    withFiles: [
-                        {
-                            filePath: '/entry.js',
-                            content: importPaths
-                                .map((filePath) => {
-                                    return `import ".${filePath}";`;
-                                })
-                                .join('\n')
-                        },
-                        ...importPaths.map((filePath) => {
-                            return { filePath, content: `export const value = "${filePath}";` };
-                        })
-                    ]
-                });
-
-                const graph = createGraphFromResolvedBundle({
-                    roots: {
-                        main: {
-                            js: {
-                                content: '',
-                                isExecutable: false,
-                                sourceFilePath: '/entry.js',
-                                targetFilePath: 'entry.js'
-                            }
-                        }
-                    },
-                    contents: [
-                        {
-                            fileDescription: {
+suite('substitute-bundles', function () {
+    test('substituteDependencies() only rewrites matched imports and never invents unrelated files', function () {
+        fc.assert(
+            fc.property(
+                importCountArbitrary,
+                fc.array(fc.boolean(), { minLength: 0, maxLength: 4 }),
+                (importCount, replacementFlags) => {
+                    const selectedFlags = replacementFlags.slice(0, importCount);
+                    const importPaths = Array.from({ length: importCount }, (_, index) => {
+                        return `/dep-${index}.js`;
+                    });
+                    const project = createProject({
+                        withFiles: [
+                            {
+                                filePath: '/entry.js',
                                 content: importPaths
                                     .map((filePath) => {
                                         return `import ".${filePath}";`;
                                     })
-                                    .join('\n'),
-                                isExecutable: false,
-                                sourceFilePath: '/entry.js',
-                                targetFilePath: 'entry.js'
+                                    .join('\n')
                             },
-                            directDependencies: new Set(importPaths),
-                            project,
-                            isExplicitlyIncluded: false
-                        },
-                        ...importPaths.map((filePath) => {
-                            return {
-                                fileDescription: {
-                                    content: `export const value = "${filePath}";`,
+                            ...importPaths.map((filePath) => {
+                                return { filePath, content: `export const value = "${filePath}";` };
+                            })
+                        ]
+                    });
+
+                    const graph = createGraphFromResolvedBundle({
+                        roots: {
+                            main: {
+                                js: {
+                                    content: '',
                                     isExecutable: false,
-                                    sourceFilePath: filePath,
-                                    targetFilePath: filePath.slice(1)
+                                    sourceFilePath: '/entry.js',
+                                    targetFilePath: 'entry.js'
+                                }
+                            }
+                        },
+                        contents: [
+                            {
+                                fileDescription: {
+                                    content: importPaths
+                                        .map((filePath) => {
+                                            return `import ".${filePath}";`;
+                                        })
+                                        .join('\n'),
+                                    isExecutable: false,
+                                    sourceFilePath: '/entry.js',
+                                    targetFilePath: 'entry.js'
                                 },
-                                directDependencies: new Set<string>(),
+                                directDependencies: new Set(importPaths),
                                 project,
                                 isExplicitlyIncluded: false
-                            };
+                            },
+                            ...importPaths.map((filePath) => {
+                                return {
+                                    fileDescription: {
+                                        content: `export const value = "${filePath}";`,
+                                        isExecutable: false,
+                                        sourceFilePath: filePath,
+                                        targetFilePath: filePath.slice(1)
+                                    },
+                                    directDependencies: new Set<string>(),
+                                    project,
+                                    isExplicitlyIncluded: false
+                                };
+                            })
+                        ],
+                        surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+                        externalDependencies: new Map(),
+                        name: 'fixture'
+                    });
+
+                    const bundleDependencies = importPaths.flatMap((_, index) => {
+                        return (selectedFlags[index] ?? false) ? [createBundleDependency(index)] : [];
+                    });
+
+                    const substituted = substituteDependencies(graph, bundleDependencies);
+                    const result = substituted.flatten(['/entry.js']);
+                    const outputFiles = result.contents
+                        .map((entry) => {
+                            return entry.fileDescription.sourceFilePath;
                         })
-                    ],
-                    surface: { mode: 'implicit', defaultModuleRoot: 'main' },
-                    externalDependencies: new Map(),
-                    name: 'fixture'
-                });
+                        .toSorted();
 
-                const bundleDependencies = importPaths.flatMap((_, index) => {
-                    return (selectedFlags[index] ?? false) ? [createBundleDependency(index)] : [];
-                });
+                    outputFiles.forEach((filePath) => {
+                        assert.ok(filePath === '/entry.js' || importPaths.includes(filePath));
+                    });
 
-                const substituted = substituteDependencies(graph, bundleDependencies);
-                const result = substituted.flatten(['/entry.js']);
-                const outputFiles = result.contents
-                    .map((entry) => {
-                        return entry.fileDescription.sourceFilePath;
-                    })
-                    .toSorted();
-
-                outputFiles.forEach((filePath) => {
-                    assert.ok(filePath === '/entry.js' || importPaths.includes(filePath));
-                });
-
-                const entryFile = result.contents.find((entry) => {
-                    return entry.fileDescription.sourceFilePath === '/entry.js';
-                });
-                if (entryFile === undefined) {
-                    assert.fail('Expected entry file to exist');
-                }
-
-                importPaths.forEach((filePath, index) => {
-                    const isSubstituted = selectedFlags[index] ?? false;
-                    if (isSubstituted) {
-                        assert.ok(entryFile.fileDescription.content.includes(`package-${index}`));
-                        assert.strictEqual(outputFiles.includes(filePath), false);
-                    } else {
-                        assert.ok(entryFile.fileDescription.content.includes(`.${filePath}`));
-                        assert.strictEqual(outputFiles.includes(filePath), true);
+                    const entryFile = result.contents.find((entry) => {
+                        return entry.fileDescription.sourceFilePath === '/entry.js';
+                    });
+                    if (entryFile === undefined) {
+                        assert.fail('Expected entry file to exist');
                     }
-                });
 
-                const referencedBundleDependencies = Array.from(result.linkedBundleDependencies.keys()).toSorted();
-                const expectedBundleDependencies = importPaths
-                    .flatMap((_, index) => {
-                        return (selectedFlags[index] ?? false) ? [`package-${index}`] : [];
-                    })
-                    .toSorted();
-                assert.deepStrictEqual(referencedBundleDependencies, expectedBundleDependencies);
-            }
-        ),
-        { numRuns: 30 }
-    );
+                    importPaths.forEach((filePath, index) => {
+                        const isSubstituted = selectedFlags[index] ?? false;
+                        if (isSubstituted) {
+                            assert.ok(entryFile.fileDescription.content.includes(`package-${index}`));
+                            assert.strictEqual(outputFiles.includes(filePath), false);
+                        } else {
+                            assert.ok(entryFile.fileDescription.content.includes(`.${filePath}`));
+                            assert.strictEqual(outputFiles.includes(filePath), true);
+                        }
+                    });
+
+                    const referencedBundleDependencies = Array.from(result.linkedBundleDependencies.keys()).toSorted();
+                    const expectedBundleDependencies = importPaths
+                        .flatMap((_, index) => {
+                            return (selectedFlags[index] ?? false) ? [`package-${index}`] : [];
+                        })
+                        .toSorted();
+                    assert.deepStrictEqual(referencedBundleDependencies, expectedBundleDependencies);
+                }
+            ),
+            { numRuns: 30 }
+        );
+    });
 });

--- a/source/linker/substitute-bundles.test.ts
+++ b/source/linker/substitute-bundles.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { Project } from 'ts-morph';
 import { bundleResource, versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
@@ -128,154 +128,156 @@ const passthroughResult = {
     linkedBundleDependencies: new Map()
 } as const;
 
-test('doesn’t substitute anything when the given dependencies are empty', () => {
-    const inputGraph = buildInputGraph(entryFooSetup);
-    const substitutedGraph = substituteDependencies(inputGraph, []);
-    const result = substitutedGraph.flatten(['/entry.js']);
+suite('substitute-bundles', function () {
+    test('doesn’t substitute anything when the given dependencies are empty', function () {
+        const inputGraph = buildInputGraph(entryFooSetup);
+        const substitutedGraph = substituteDependencies(inputGraph, []);
+        const result = substitutedGraph.flatten(['/entry.js']);
 
-    assert.deepStrictEqual(result, passthroughResult);
-});
+        assert.deepStrictEqual(result, passthroughResult);
+    });
 
-test('doesn’t substitute anything when the given dependencies has only files that don’t match', () => {
-    const inputGraph = buildInputGraph(entryFooSetup);
-    const substitutedGraph = substituteDependencies(inputGraph, [bundleSource('first-package', '/bar.js')]);
-    const result = substitutedGraph.flatten(['/entry.js']);
+    test('doesn’t substitute anything when the given dependencies has only files that don’t match', function () {
+        const inputGraph = buildInputGraph(entryFooSetup);
+        const substitutedGraph = substituteDependencies(inputGraph, [bundleSource('first-package', '/bar.js')]);
+        const result = substitutedGraph.flatten(['/entry.js']);
 
-    assert.deepStrictEqual(result, passthroughResult);
-});
+        assert.deepStrictEqual(result, passthroughResult);
+    });
 
-test('throws when a dependency owns a referenced file but does not expose it publicly', () => {
-    const inputGraph = buildInputGraph(entryFooSetup);
+    test('throws when a dependency owns a referenced file but does not expose it publicly', function () {
+        const inputGraph = buildInputGraph(entryFooSetup);
 
-    assert.throws(() => {
-        substituteDependencies(inputGraph, [
-            versionedBundleWithManifest({
-                name: 'hidden-package',
-                version: '1.0.0',
-                roots: {
-                    main: {
-                        js: {
-                            sourceFilePath: '/bar.js',
-                            targetFilePath: 'bar.js',
-                            content: '',
-                            isExecutable: false
-                        }
-                    }
-                },
-                surface: {
-                    mode: 'explicit',
-                    packageInterface: {
-                        modules: [{ root: 'main', export: '.' }]
-                    }
-                },
-                contents: [
-                    {
-                        ...bundleResource('/foo.js', { targetFilePath: 'foo.js' }),
-                        isSubstituted: false,
-                        analysis: {
-                            survivingBindings: new Set<string>(),
-                            sideEffectStatements: [],
-                            sideEffectImports: new Set<string>()
+        assert.throws(() => {
+            substituteDependencies(inputGraph, [
+                versionedBundleWithManifest({
+                    name: 'hidden-package',
+                    version: '1.0.0',
+                    roots: {
+                        main: {
+                            js: {
+                                sourceFilePath: '/bar.js',
+                                targetFilePath: 'bar.js',
+                                content: '',
+                                isExecutable: false
+                            }
                         }
                     },
-                    {
-                        ...bundleResource('/unused.js', { targetFilePath: 'unused.js' }),
-                        isSubstituted: false,
-                        analysis: {
-                            survivingBindings: new Set<string>(),
-                            sideEffectStatements: [],
-                            sideEffectImports: new Set<string>()
+                    surface: {
+                        mode: 'explicit',
+                        packageInterface: {
+                            modules: [{ root: 'main', export: '.' }]
                         }
-                    }
-                ],
-                packageJson: { name: 'hidden-package', version: '1.0.0' },
-                exportsField: { '.': { import: './bar.js' } },
-                mainFile: { content: '', isExecutable: false, sourceFilePath: '/bar.js', targetFilePath: 'bar.js' },
-                manifestFile: { content: '', isExecutable: false, filePath: '/bar.js' }
-            })
-        ]);
-    }, /^Error: Package "hidden-package" does not expose "\/foo\.js" for cross-package substitution$/u);
-});
-
-test('substitutes a file that has imports statements matching the files in the given dependencies and returns a new graph eliminating unnecessary files', () => {
-    const project = buildEntryFooProject();
-    const inputGraph = buildInputGraph([
-        { source: '/entry.js', content: 'import "./foo.js";', directDependencies: ['/foo.js'], project },
-        { source: '/foo.js', content: 'true', project }
-    ]);
-    const substitutedGraph = substituteDependencies(inputGraph, [bundleSource('the-package', '/foo.js')]);
-    const result = substitutedGraph.flatten(['/entry.js']);
-
-    assert.deepStrictEqual(result, substitutedEntryResult('the-package'));
-});
-
-test('substitutes a file which matches an already substituted file from a dependency', () => {
-    const project = buildEntryFooProject();
-    const inputGraph = buildInputGraph([
-        { source: '/entry.js', content: 'import "./foo.js";', directDependencies: ['/foo.js'], project },
-        { source: '/foo.js', content: 'true', project }
-    ]);
-    const substitutedGraph = substituteDependencies(inputGraph, [bundleSource('first-package', '/foo.js', true)]);
-    const result = substitutedGraph.flatten(['/entry.js']);
-
-    assert.deepStrictEqual(result, substitutedEntryResult('first-package'));
-});
-
-test('substitutes multiple matching files in the given dependencies', () => {
-    const project = createProject({
-        withFiles: [
-            { filePath: '/entry.js', content: 'import "./foo.js";' },
-            { filePath: '/foo.js', content: 'import "./bar.js"; import "./baz.js";' },
-            { filePath: '/bar.js', content: 'true;' },
-            { filePath: '/baz.js', content: 'true;' }
-        ]
+                    },
+                    contents: [
+                        {
+                            ...bundleResource('/foo.js', { targetFilePath: 'foo.js' }),
+                            isSubstituted: false,
+                            analysis: {
+                                survivingBindings: new Set<string>(),
+                                sideEffectStatements: [],
+                                sideEffectImports: new Set<string>()
+                            }
+                        },
+                        {
+                            ...bundleResource('/unused.js', { targetFilePath: 'unused.js' }),
+                            isSubstituted: false,
+                            analysis: {
+                                survivingBindings: new Set<string>(),
+                                sideEffectStatements: [],
+                                sideEffectImports: new Set<string>()
+                            }
+                        }
+                    ],
+                    packageJson: { name: 'hidden-package', version: '1.0.0' },
+                    exportsField: { '.': { import: './bar.js' } },
+                    mainFile: { content: '', isExecutable: false, sourceFilePath: '/bar.js', targetFilePath: 'bar.js' },
+                    manifestFile: { content: '', isExecutable: false, filePath: '/bar.js' }
+                })
+            ]);
+        }, /^Error: Package "hidden-package" does not expose "\/foo\.js" for cross-package substitution$/u);
     });
-    const inputGraph = buildInputGraph([
-        { source: '/entry.js', content: 'import "./foo.js";', directDependencies: ['/foo.js'], project },
-        {
-            source: '/foo.js',
-            content: 'import "./bar.js"; import "./baz.js";',
-            directDependencies: ['/bar.js', '/baz.js'],
-            project
-        },
-        { source: '/bar.js', content: 'true;', project },
-        { source: '/baz.js', content: 'true;', project }
-    ]);
-    const substitutedGraph = substituteDependencies(inputGraph, [
-        bundleSource('first-package', '/bar.js'),
-        bundleSource('second-package', '/baz.js')
-    ]);
-    const result = substitutedGraph.flatten(['/entry.js']);
 
-    assert.deepStrictEqual(result, {
-        contents: [
+    test('substitutes a file that has imports statements matching the files in the given dependencies and returns a new graph eliminating unnecessary files', function () {
+        const project = buildEntryFooProject();
+        const inputGraph = buildInputGraph([
+            { source: '/entry.js', content: 'import "./foo.js";', directDependencies: ['/foo.js'], project },
+            { source: '/foo.js', content: 'true', project }
+        ]);
+        const substitutedGraph = substituteDependencies(inputGraph, [bundleSource('the-package', '/foo.js')]);
+        const result = substitutedGraph.flatten(['/entry.js']);
+
+        assert.deepStrictEqual(result, substitutedEntryResult('the-package'));
+    });
+
+    test('substitutes a file which matches an already substituted file from a dependency', function () {
+        const project = buildEntryFooProject();
+        const inputGraph = buildInputGraph([
+            { source: '/entry.js', content: 'import "./foo.js";', directDependencies: ['/foo.js'], project },
+            { source: '/foo.js', content: 'true', project }
+        ]);
+        const substitutedGraph = substituteDependencies(inputGraph, [bundleSource('first-package', '/foo.js', true)]);
+        const result = substitutedGraph.flatten(['/entry.js']);
+
+        assert.deepStrictEqual(result, substitutedEntryResult('first-package'));
+    });
+
+    test('substitutes multiple matching files in the given dependencies', function () {
+        const project = createProject({
+            withFiles: [
+                { filePath: '/entry.js', content: 'import "./foo.js";' },
+                { filePath: '/foo.js', content: 'import "./bar.js"; import "./baz.js";' },
+                { filePath: '/bar.js', content: 'true;' },
+                { filePath: '/baz.js', content: 'true;' }
+            ]
+        });
+        const inputGraph = buildInputGraph([
+            { source: '/entry.js', content: 'import "./foo.js";', directDependencies: ['/foo.js'], project },
             {
-                directDependencies: new Set(['/foo.js']),
-                fileDescription: {
-                    content: 'import "./foo.js";',
-                    isExecutable: false,
-                    sourceFilePath: '/entry.js',
-                    targetFilePath: 'entry.js'
-                },
-                isSubstituted: false,
-                isExplicitlyIncluded: false
+                source: '/foo.js',
+                content: 'import "./bar.js"; import "./baz.js";',
+                directDependencies: ['/bar.js', '/baz.js'],
+                project
             },
-            {
-                directDependencies: new Set(),
-                fileDescription: {
-                    content: 'import "first-package"; import "second-package";',
-                    isExecutable: false,
-                    sourceFilePath: '/foo.js',
-                    targetFilePath: 'foo.js'
+            { source: '/bar.js', content: 'true;', project },
+            { source: '/baz.js', content: 'true;', project }
+        ]);
+        const substitutedGraph = substituteDependencies(inputGraph, [
+            bundleSource('first-package', '/bar.js'),
+            bundleSource('second-package', '/baz.js')
+        ]);
+        const result = substitutedGraph.flatten(['/entry.js']);
+
+        assert.deepStrictEqual(result, {
+            contents: [
+                {
+                    directDependencies: new Set(['/foo.js']),
+                    fileDescription: {
+                        content: 'import "./foo.js";',
+                        isExecutable: false,
+                        sourceFilePath: '/entry.js',
+                        targetFilePath: 'entry.js'
+                    },
+                    isSubstituted: false,
+                    isExplicitlyIncluded: false
                 },
-                isSubstituted: true,
-                isExplicitlyIncluded: false
-            }
-        ],
-        externalDependencies: new Map(),
-        linkedBundleDependencies: new Map([
-            ['first-package', { name: 'first-package', referencedFrom: ['/foo.js'] }],
-            ['second-package', { name: 'second-package', referencedFrom: ['/foo.js'] }]
-        ])
+                {
+                    directDependencies: new Set(),
+                    fileDescription: {
+                        content: 'import "first-package"; import "second-package";',
+                        isExecutable: false,
+                        sourceFilePath: '/foo.js',
+                        targetFilePath: 'foo.js'
+                    },
+                    isSubstituted: true,
+                    isExplicitlyIncluded: false
+                }
+            ],
+            externalDependencies: new Map(),
+            linkedBundleDependencies: new Map([
+                ['first-package', { name: 'first-package', referencedFrom: ['/foo.js'] }],
+                ['second-package', { name: 'second-package', referencedFrom: ['/foo.js'] }]
+            ])
+        });
     });
 });

--- a/source/linker/substituted-resource-graph.test.ts
+++ b/source/linker/substituted-resource-graph.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { TransferableFileDescription } from '../file-manager/file-description.ts';
 import { createSubstitutedResourceGraph } from './substituted-resource-graph.ts';
 
@@ -15,50 +15,52 @@ function createFileDescription(
     };
 }
 
-test('flatten() deduplicates visited files, merges repeated dependency references, and keeps explicitly included files', () => {
-    const graph = createSubstitutedResourceGraph();
-    graph.add('/entry.js', {
-        fileDescription: createFileDescription('/entry.js', 'entry.js'),
-        externalDependencies: ['left-pad'],
-        bundleDependencies: ['bundle-dependency'],
-        isSubstituted: true,
-        isExplicitlyIncluded: false
-    });
-    graph.add('/shared.js', {
-        fileDescription: createFileDescription('/shared.js', 'shared.js'),
-        externalDependencies: ['left-pad'],
-        bundleDependencies: ['bundle-dependency'],
-        isSubstituted: false,
-        isExplicitlyIncluded: false
-    });
-    graph.add('/extra.txt', {
-        fileDescription: createFileDescription('/extra.txt', 'extra.txt'),
-        externalDependencies: [],
-        bundleDependencies: [],
-        isSubstituted: false,
-        isExplicitlyIncluded: true
-    });
-    graph.connect('/entry.js', '/shared.js');
-    graph.connect('/shared.js', '/entry.js');
+suite('substituted-resource-graph', function () {
+    test('flatten() deduplicates visited files, merges repeated dependency references, and keeps explicitly included files', function () {
+        const graph = createSubstitutedResourceGraph();
+        graph.add('/entry.js', {
+            fileDescription: createFileDescription('/entry.js', 'entry.js'),
+            externalDependencies: ['left-pad'],
+            bundleDependencies: ['bundle-dependency'],
+            isSubstituted: true,
+            isExplicitlyIncluded: false
+        });
+        graph.add('/shared.js', {
+            fileDescription: createFileDescription('/shared.js', 'shared.js'),
+            externalDependencies: ['left-pad'],
+            bundleDependencies: ['bundle-dependency'],
+            isSubstituted: false,
+            isExplicitlyIncluded: false
+        });
+        graph.add('/extra.txt', {
+            fileDescription: createFileDescription('/extra.txt', 'extra.txt'),
+            externalDependencies: [],
+            bundleDependencies: [],
+            isSubstituted: false,
+            isExplicitlyIncluded: true
+        });
+        graph.connect('/entry.js', '/shared.js');
+        graph.connect('/shared.js', '/entry.js');
 
-    const result = graph.flatten(['/entry.js', '/shared.js']);
+        const result = graph.flatten(['/entry.js', '/shared.js']);
 
-    assert.deepStrictEqual(
-        result.contents
-            .map((resource) => {
-                return resource.fileDescription.sourceFilePath;
-            })
-            .toSorted((left, right) => {
-                return left.localeCompare(right);
-            }),
-        ['/entry.js', '/extra.txt', '/shared.js']
-    );
-    assert.deepStrictEqual(
-        result.linkedBundleDependencies,
-        new Map([['bundle-dependency', { name: 'bundle-dependency', referencedFrom: ['/entry.js', '/shared.js'] }]])
-    );
-    assert.deepStrictEqual(
-        result.externalDependencies,
-        new Map([['left-pad', { name: 'left-pad', referencedFrom: ['/entry.js', '/shared.js'] }]])
-    );
+        assert.deepStrictEqual(
+            result.contents
+                .map((resource) => {
+                    return resource.fileDescription.sourceFilePath;
+                })
+                .toSorted((left, right) => {
+                    return left.localeCompare(right);
+                }),
+            ['/entry.js', '/extra.txt', '/shared.js']
+        );
+        assert.deepStrictEqual(
+            result.linkedBundleDependencies,
+            new Map([['bundle-dependency', { name: 'bundle-dependency', referencedFrom: ['/entry.js', '/shared.js'] }]])
+        );
+        assert.deepStrictEqual(
+            result.externalDependencies,
+            new Map([['left-pad', { name: 'left-pad', referencedFrom: ['/entry.js', '/shared.js'] }]])
+        );
+    });
 });

--- a/source/npm-oidc-id-token-resolver.test.ts
+++ b/source/npm-oidc-id-token-resolver.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { createNpmOidcIdTokenResolver } from './npm-oidc-id-token-resolver.ts';
 
@@ -68,160 +68,166 @@ async function expectFailure(action: () => Promise<unknown>, expectedError: RegE
     }
 }
 
-test('resolver uses the default environment variable when npm oidc provider is omitted', async () => {
-    const resolveIdToken = resolverFactory({
-        environmentVariables: {
-            GITHUB_ACTIONS: 'false',
-            NPM_ID_TOKEN: 'upstream-id-token'
-        }
-    });
-
-    const idToken = await resolveIdToken({ type: 'npm-oidc' });
-
-    assert.strictEqual(idToken, 'upstream-id-token');
-});
-
-test('resolver fetches a GitHub Actions id token when requested', async () => {
-    const fetchCalls: unknown[][] = [];
-    const resolveIdToken = createGitHubActionsResolver({
-        fetch: createGitHubActionsFetch(fetchCalls)
-    });
-
-    const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
-
-    assert.strictEqual(idToken, 'github-id-token');
-    assert.deepStrictEqual(fetchCalls, [
-        [
-            new URL('https://actions.example.test/id-token?audience=npm%3Aregistry.npmjs.org'),
-            {
-                headers: { Authorization: 'Bearer actions-request-token' }
-            }
-        ]
-    ]);
-});
-
-test('resolver auto-detects GitHub Actions when npm oidc provider is omitted', async () => {
-    const fetchCalls: unknown[][] = [];
-    const resolveIdToken = createGitHubActionsResolver({
-        fetch: createGitHubActionsFetch(fetchCalls),
-        environmentVariables: {
-            GITHUB_ACTIONS: 'true'
-        }
-    });
-
-    const idToken = await resolveIdToken({ type: 'npm-oidc' });
-
-    assert.strictEqual(idToken, 'github-id-token');
-    assert.strictEqual(fetchCalls.length, 1);
-});
-
-test('resolver uses the env provider even when GitHub Actions markers are present', async () => {
-    const fetchSpy = fake() as unknown as typeof globalThis.fetch;
-    const resolveIdToken = resolverFactory({
-        fetch: fetchSpy,
-        environmentVariables: {
-            GITHUB_ACTIONS: 'true',
-            NPM_ID_TOKEN: 'upstream-id-token'
-        }
-    });
-
-    const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'env' });
-
-    assert.strictEqual(idToken, 'upstream-id-token');
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 0);
-});
-
-test('resolver falls back to environment id tokens when auto-detection does not match GitHub Actions', async () => {
-    const fetchSpy = fake() as unknown as typeof globalThis.fetch;
-    const resolveIdToken = resolverFactory({
-        fetch: fetchSpy,
-        environmentVariables: {
-            GITHUB_ACTIONS: 'false',
-            NPM_ID_TOKEN: 'upstream-id-token'
-        }
-    });
-
-    const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'auto' });
-
-    assert.strictEqual(idToken, 'upstream-id-token');
-    assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 0);
-});
-
-test('resolver rejects GitHub Actions OIDC when required environment variables are missing', async () => {
-    const resolveIdToken = resolverFactory();
-
-    await expectFailure(async () => {
-        await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
-    }, /^Error: GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN$/u);
-});
-
-for (const [missingVariable, requestUrl, requestToken] of [
-    ['ACTIONS_ID_TOKEN_REQUEST_URL', undefined, 'actions-request-token'],
-    ['ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'https://actions.example.test/id-token', undefined]
-] as const) {
-    test(`resolver rejects GitHub Actions OIDC when ${missingVariable} is missing`, async () => {
-        const resolveIdToken = createGitHubActionsResolver({
+suite('npm-oidc-id-token-resolver', function () {
+    test('resolver uses the default environment variable when npm oidc provider is omitted', async function () {
+        const resolveIdToken = resolverFactory({
             environmentVariables: {
-                ACTIONS_ID_TOKEN_REQUEST_URL: requestUrl,
-                ACTIONS_ID_TOKEN_REQUEST_TOKEN: requestToken
+                GITHUB_ACTIONS: 'false',
+                NPM_ID_TOKEN: 'upstream-id-token'
             }
         });
+
+        const idToken = await resolveIdToken({ type: 'npm-oidc' });
+
+        assert.strictEqual(idToken, 'upstream-id-token');
+    });
+
+    test('resolver fetches a GitHub Actions id token when requested', async function () {
+        const fetchCalls: unknown[][] = [];
+        const resolveIdToken = createGitHubActionsResolver({
+            fetch: createGitHubActionsFetch(fetchCalls)
+        });
+
+        const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+
+        assert.strictEqual(idToken, 'github-id-token');
+        assert.deepStrictEqual(fetchCalls, [
+            [
+                new URL('https://actions.example.test/id-token?audience=npm%3Aregistry.npmjs.org'),
+                {
+                    headers: { Authorization: 'Bearer actions-request-token' }
+                }
+            ]
+        ]);
+    });
+
+    test('resolver auto-detects GitHub Actions when npm oidc provider is omitted', async function () {
+        const fetchCalls: unknown[][] = [];
+        const resolveIdToken = createGitHubActionsResolver({
+            fetch: createGitHubActionsFetch(fetchCalls),
+            environmentVariables: {
+                GITHUB_ACTIONS: 'true'
+            }
+        });
+
+        const idToken = await resolveIdToken({ type: 'npm-oidc' });
+
+        assert.strictEqual(idToken, 'github-id-token');
+        assert.strictEqual(fetchCalls.length, 1);
+    });
+
+    test('resolver uses the env provider even when GitHub Actions markers are present', async function () {
+        const fetchSpy = fake() as unknown as typeof globalThis.fetch;
+        const resolveIdToken = resolverFactory({
+            fetch: fetchSpy,
+            environmentVariables: {
+                GITHUB_ACTIONS: 'true',
+                NPM_ID_TOKEN: 'upstream-id-token'
+            }
+        });
+
+        const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'env' });
+
+        assert.strictEqual(idToken, 'upstream-id-token');
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 0);
+    });
+
+    test('resolver falls back to environment id tokens when auto-detection does not match GitHub Actions', async function () {
+        const fetchSpy = fake() as unknown as typeof globalThis.fetch;
+        const resolveIdToken = resolverFactory({
+            fetch: fetchSpy,
+            environmentVariables: {
+                GITHUB_ACTIONS: 'false',
+                NPM_ID_TOKEN: 'upstream-id-token'
+            }
+        });
+
+        const idToken = await resolveIdToken({ type: 'npm-oidc', provider: 'auto' });
+
+        assert.strictEqual(idToken, 'upstream-id-token');
+        assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 0);
+    });
+
+    test('resolver rejects GitHub Actions OIDC when required environment variables are missing', async function () {
+        const resolveIdToken = resolverFactory();
 
         await expectFailure(async () => {
             await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
         }, /^Error: GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN$/u);
     });
-}
 
-for (const [testName, response] of [
-    ['an unusable', {}],
-    ['a non-object', 'invalid-response'],
-    ['an array', Object.assign([], { value: 'github-id-token' })],
-    ['an empty', { value: '' }]
-] as const) {
-    test(`resolver rejects ${testName} GitHub Actions id token response`, async () => {
+    suite('GitHub Actions missing environment variables', function () {
+        for (const [missingVariable, requestUrl, requestToken] of [
+            ['ACTIONS_ID_TOKEN_REQUEST_URL', undefined, 'actions-request-token'],
+            ['ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'https://actions.example.test/id-token', undefined]
+        ] as const) {
+            test(`resolver rejects GitHub Actions OIDC when ${missingVariable} is missing`, async function () {
+                const resolveIdToken = createGitHubActionsResolver({
+                    environmentVariables: {
+                        ACTIONS_ID_TOKEN_REQUEST_URL: requestUrl,
+                        ACTIONS_ID_TOKEN_REQUEST_TOKEN: requestToken
+                    }
+                });
+
+                await expectFailure(async () => {
+                    await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+                }, /^Error: GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN$/u);
+            });
+        }
+    });
+
+    suite('GitHub Actions invalid id token responses', function () {
+        for (const [testName, response] of [
+            ['an unusable', {}],
+            ['a non-object', 'invalid-response'],
+            ['an array', Object.assign([], { value: 'github-id-token' })],
+            ['an empty', { value: '' }]
+        ] as const) {
+            test(`resolver rejects ${testName} GitHub Actions id token response`, async function () {
+                const resolveIdToken = createGitHubActionsResolver({
+                    fetch: fake.resolves({
+                        ok: true,
+                        status: 200,
+                        json: fake.resolves(response)
+                    }) as unknown as typeof globalThis.fetch
+                });
+
+                await expectFailure(async () => {
+                    await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+                }, /^Error: GitHub Actions OIDC token response did not contain a usable id_token$/u);
+            });
+        }
+    });
+
+    test('resolver rejects a failing GitHub Actions id token request', async function () {
         const resolveIdToken = createGitHubActionsResolver({
             fetch: fake.resolves({
-                ok: true,
-                status: 200,
-                json: fake.resolves(response)
+                ok: false,
+                status: 500,
+                json: fake.resolves({})
             }) as unknown as typeof globalThis.fetch
         });
 
         await expectFailure(async () => {
             await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
-        }, /^Error: GitHub Actions OIDC token response did not contain a usable id_token$/u);
-    });
-}
-
-test('resolver rejects a failing GitHub Actions id token request', async () => {
-    const resolveIdToken = createGitHubActionsResolver({
-        fetch: fake.resolves({
-            ok: false,
-            status: 500,
-            json: fake.resolves({})
-        }) as unknown as typeof globalThis.fetch
+        }, /^Error: GitHub Actions OIDC token request failed with status 500$/u);
     });
 
-    await expectFailure(async () => {
-        await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
-    }, /^Error: GitHub Actions OIDC token request failed with status 500$/u);
-});
+    test('resolver rejects a missing environment id token for env provider', async function () {
+        const resolveIdToken = resolverFactory();
 
-test('resolver rejects a missing environment id token for env provider', async () => {
-    const resolveIdToken = resolverFactory();
-
-    await expectFailure(async () => {
-        await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
-    }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
-});
-
-test('resolver rejects an empty environment id token for env provider', async () => {
-    const resolveIdToken = resolverFactory({
-        environmentVariables: { CUSTOM_ID_TOKEN: '' }
+        await expectFailure(async () => {
+            await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
+        }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
     });
 
-    await expectFailure(async () => {
-        await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
-    }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
+    test('resolver rejects an empty environment id token for env provider', async function () {
+        const resolveIdToken = resolverFactory({
+            environmentVariables: { CUSTOM_ID_TOKEN: '' }
+        });
+
+        await expectFailure(async () => {
+            await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
+        }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
+    });
 });

--- a/source/package-surface/bin-field.test.ts
+++ b/source/package-surface/bin-field.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { executableShebangRoot } from '../test-libraries/package-surface-fixtures.ts';
 import { buildBinField, type SurfaceBundleLike } from './bin-field.ts';
 
@@ -18,10 +18,12 @@ const implicitCliBundle: SurfaceBundleLike = {
     surface: { mode: 'implicit', defaultModuleRoot: 'cli' }
 };
 
-test('buildBinField dispatches to the explicit bin builder for an explicit surface', () => {
-    assert.deepStrictEqual(buildBinField(explicitCliBundle), { 'pkg-a-cli': './cli.js' });
-});
+suite('bin-field', function () {
+    test('buildBinField dispatches to the explicit bin builder for an explicit surface', function () {
+        assert.deepStrictEqual(buildBinField(explicitCliBundle), { 'pkg-a-cli': './cli.js' });
+    });
 
-test('buildBinField dispatches to the implicit bin builder for an implicit surface', () => {
-    assert.deepStrictEqual(buildBinField(implicitCliBundle), { 'package-a': './cli.js' });
+    test('buildBinField dispatches to the implicit bin builder for an implicit surface', function () {
+        assert.deepStrictEqual(buildBinField(implicitCliBundle), { 'package-a': './cli.js' });
+    });
 });

--- a/source/package-surface/explicit-bin.test.ts
+++ b/source/package-surface/explicit-bin.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { plainRoot, rootWithSource, shebangRoot } from '../test-libraries/package-surface-fixtures.ts';
 import { buildExplicitBinField } from './explicit-bin.ts';
 import type { ExplicitSurface } from './package-shape.ts';
@@ -9,63 +9,65 @@ const cliBin: ExplicitSurface = {
     packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
 };
 
-test('returns undefined when the explicit surface declares no bins', () => {
-    const modulesOnly: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { modules: [{ root: 'main', export: '.' }] }
-    };
+suite('explicit-bin', function () {
+    test('returns undefined when the explicit surface declares no bins', function () {
+        const modulesOnly: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { modules: [{ root: 'main', export: '.' }] }
+        };
 
-    assert.strictEqual(buildExplicitBinField({ name: 'package-a', roots: {} }, modulesOnly), undefined);
-});
+        assert.strictEqual(buildExplicitBinField({ name: 'package-a', roots: {} }, modulesOnly), undefined);
+    });
 
-test("maps a single bin to the root's import target", () => {
-    assert.deepStrictEqual(
-        buildExplicitBinField({ name: 'package-a', roots: { cli: shebangRoot('cli.js') } }, cliBin),
-        { 'package-a': './cli.js' }
-    );
-});
+    test("maps a single bin to the root's import target", function () {
+        assert.deepStrictEqual(
+            buildExplicitBinField({ name: 'package-a', roots: { cli: shebangRoot('cli.js') } }, cliBin),
+            { 'package-a': './cli.js' }
+        );
+    });
 
-test('maps multiple bins to their roots', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: {
-            bins: [
-                { root: 'a', name: 'tool-a' },
-                { root: 'b', name: 'tool-b' }
-            ]
-        }
-    };
+    test('maps multiple bins to their roots', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {
+                bins: [
+                    { root: 'a', name: 'tool-a' },
+                    { root: 'b', name: 'tool-b' }
+                ]
+            }
+        };
 
-    assert.deepStrictEqual(
-        buildExplicitBinField(
-            { name: 'package-a', roots: { a: shebangRoot('a.js'), b: shebangRoot('b.js') } },
-            surface
-        ),
-        { 'tool-a': './a.js', 'tool-b': './b.js' }
-    );
-});
+        assert.deepStrictEqual(
+            buildExplicitBinField(
+                { name: 'package-a', roots: { a: shebangRoot('a.js'), b: shebangRoot('b.js') } },
+                surface
+            ),
+            { 'tool-a': './a.js', 'tool-b': './b.js' }
+        );
+    });
 
-test('throws when a bin root has no shebang in its content', () => {
-    assert.throws(() => {
-        buildExplicitBinField({ name: 'package-a', roots: { cli: plainRoot('cli.js') } }, cliBin);
-    }, /^Error: Package "package-a" bin "package-a" must point to a root with a shebang$/u);
-});
+    test('throws when a bin root has no shebang in its content', function () {
+        assert.throws(() => {
+            buildExplicitBinField({ name: 'package-a', roots: { cli: plainRoot('cli.js') } }, cliBin);
+        }, /^Error: Package "package-a" bin "package-a" must point to a root with a shebang$/u);
+    });
 
-test('rejects executable-without-shebang roots as bin targets', () => {
-    const executableWithoutShebang = rootWithSource('', 'cli.js', { content: 'plain\n', isExecutable: true });
+    test('rejects executable-without-shebang roots as bin targets', function () {
+        const executableWithoutShebang = rootWithSource('', 'cli.js', { content: 'plain\n', isExecutable: true });
 
-    assert.throws(() => {
-        buildExplicitBinField({ name: 'package-a', roots: { cli: executableWithoutShebang } }, cliBin);
-    }, /^Error: Package "package-a" bin "package-a" must point to a root with a shebang$/u);
-});
+        assert.throws(() => {
+            buildExplicitBinField({ name: 'package-a', roots: { cli: executableWithoutShebang } }, cliBin);
+        }, /^Error: Package "package-a" bin "package-a" must point to a root with a shebang$/u);
+    });
 
-test('throws when a bin references an unknown root', () => {
-    const missingBin: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { bins: [{ root: 'missing', name: 'package-a' }] }
-    };
+    test('throws when a bin references an unknown root', function () {
+        const missingBin: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { bins: [{ root: 'missing', name: 'package-a' }] }
+        };
 
-    assert.throws(() => {
-        buildExplicitBinField({ name: 'package-a', roots: { cli: shebangRoot('cli.js') } }, missingBin);
-    }, /^Error: Package "package-a" references unknown root "missing"$/u);
+        assert.throws(() => {
+            buildExplicitBinField({ name: 'package-a', roots: { cli: shebangRoot('cli.js') } }, missingBin);
+        }, /^Error: Package "package-a" references unknown root "missing"$/u);
+    });
 });

--- a/source/package-surface/explicit-exports.test.ts
+++ b/source/package-surface/explicit-exports.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { plainRoot, rootWithDeclaration } from '../test-libraries/package-surface-fixtures.ts';
 import { buildExplicitExportsField } from './explicit-exports.ts';
 import type { ExplicitSurface } from './package-shape.ts';
@@ -10,60 +10,62 @@ const rootSurface: ExplicitSurface = {
     packageInterface: { modules: [{ root: 'main', export: '.' }] }
 };
 
-test('maps the "." export key to the root\'s import target without a types entry', () => {
-    assert.deepStrictEqual(buildExplicitExportsField(mainOnlyBundle, rootSurface)['.'], { import: './index.js' });
-});
-
-test('adds a types entry when the root has a declaration file', () => {
-    const bundle = {
-        name: 'package-a',
-        roots: { main: rootWithDeclaration('', 'index.js', '', 'index.d.ts') }
-    };
-
-    assert.deepStrictEqual(buildExplicitExportsField(bundle, rootSurface)['.'], {
-        import: './index.js',
-        types: './index.d.ts'
+suite('explicit-exports', function () {
+    test('maps the "." export key to the root\'s import target without a types entry', function () {
+        assert.deepStrictEqual(buildExplicitExportsField(mainOnlyBundle, rootSurface)['.'], { import: './index.js' });
     });
-});
 
-test("maps a subpath export to its root's import target", () => {
-    const bundle = { name: 'package-a', roots: { main: plainRoot('index.js'), cli: plainRoot('cli.js') } };
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: {
-            modules: [
-                { root: 'main', export: '.' },
-                { root: 'cli', export: './cli' }
-            ]
-        }
-    };
+    test('adds a types entry when the root has a declaration file', function () {
+        const bundle = {
+            name: 'package-a',
+            roots: { main: rootWithDeclaration('', 'index.js', '', 'index.d.ts') }
+        };
 
-    assert.deepStrictEqual(buildExplicitExportsField(bundle, surface)['./cli'], { import: './cli.js' });
-});
+        assert.deepStrictEqual(buildExplicitExportsField(bundle, rootSurface)['.'], {
+            import: './index.js',
+            types: './index.d.ts'
+        });
+    });
 
-test('returns an empty record when packageInterface declares only bins and no modules', () => {
-    const bundle = { name: 'package-a', roots: { cli: plainRoot('cli.js') } };
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
-    };
+    test("maps a subpath export to its root's import target", function () {
+        const bundle = { name: 'package-a', roots: { main: plainRoot('index.js'), cli: plainRoot('cli.js') } };
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {
+                modules: [
+                    { root: 'main', export: '.' },
+                    { root: 'cli', export: './cli' }
+                ]
+            }
+        };
 
-    assert.deepStrictEqual(buildExplicitExportsField(bundle, surface), {});
-});
+        assert.deepStrictEqual(buildExplicitExportsField(bundle, surface)['./cli'], { import: './cli.js' });
+    });
 
-test('includes the package.json export when exportPackageJson is true', () => {
-    const result = buildExplicitExportsField({ ...mainOnlyBundle, exportPackageJson: true }, rootSurface);
+    test('returns an empty record when packageInterface declares only bins and no modules', function () {
+        const bundle = { name: 'package-a', roots: { cli: plainRoot('cli.js') } };
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
+        };
 
-    assert.strictEqual(result['./package.json'], './package.json');
-});
+        assert.deepStrictEqual(buildExplicitExportsField(bundle, surface), {});
+    });
 
-test('throws when an export references an unknown root', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { modules: [{ root: 'missing', export: '.' }] }
-    };
+    test('includes the package.json export when exportPackageJson is true', function () {
+        const result = buildExplicitExportsField({ ...mainOnlyBundle, exportPackageJson: true }, rootSurface);
 
-    assert.throws(() => {
-        buildExplicitExportsField(mainOnlyBundle, surface);
-    }, /^Error: Package "package-a" references unknown root "missing"$/u);
+        assert.strictEqual(result['./package.json'], './package.json');
+    });
+
+    test('throws when an export references an unknown root', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { modules: [{ root: 'missing', export: '.' }] }
+        };
+
+        assert.throws(() => {
+            buildExplicitExportsField(mainOnlyBundle, surface);
+        }, /^Error: Package "package-a" references unknown root "missing"$/u);
+    });
 });

--- a/source/package-surface/explicit-specifier-build.test.ts
+++ b/source/package-surface/explicit-specifier-build.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { rootWithDeclaration, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import { getExplicitPublicModuleSpecifier } from './explicit-specifier-build.ts';
 import type { ExplicitSurface } from './package-shape.ts';
@@ -11,97 +11,99 @@ const rootSurface: ExplicitSurface = {
     packageInterface: { modules: [{ root: 'main', export: '.' }] }
 };
 
-test('returns the bare package name when the source path maps to the "." export key', () => {
-    assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, rootSurface, '/src/index.js'), 'package-a');
-});
+suite('explicit-specifier-build', function () {
+    test('returns the bare package name when the source path maps to the "." export key', function () {
+        assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, rootSurface, '/src/index.js'), 'package-a');
+    });
 
-test('returns "<name>/<subpath>" for a non-root explicit export', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { modules: [{ root: 'feature', export: './feature' }] }
-    };
+    test('returns "<name>/<subpath>" for a non-root explicit export', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { modules: [{ root: 'feature', export: './feature' }] }
+        };
 
-    assert.strictEqual(
-        getExplicitPublicModuleSpecifier(featureBundle, surface, '/src/feature.js'),
-        'package-a/feature'
-    );
-});
+        assert.strictEqual(
+            getExplicitPublicModuleSpecifier(featureBundle, surface, '/src/feature.js'),
+            'package-a/feature'
+        );
+    });
 
-test("matches a declaration source path against a root's declaration file", () => {
-    const bundle = {
-        name: 'package-a',
-        roots: { main: rootWithDeclaration('/src/index.js', 'index.js', '/src/index.d.ts', 'index.d.ts') }
-    };
+    test("matches a declaration source path against a root's declaration file", function () {
+        const bundle = {
+            name: 'package-a',
+            roots: { main: rootWithDeclaration('/src/index.js', 'index.js', '/src/index.d.ts', 'index.d.ts') }
+        };
 
-    assert.strictEqual(getExplicitPublicModuleSpecifier(bundle, rootSurface, '/src/index.d.ts'), 'package-a');
-});
+        assert.strictEqual(getExplicitPublicModuleSpecifier(bundle, rootSurface, '/src/index.d.ts'), 'package-a');
+    });
 
-test('returns undefined when no module entry references the source path', () => {
-    assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, rootSurface, '/src/other.js'), undefined);
-});
+    test('returns undefined when no module entry references the source path', function () {
+        assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, rootSurface, '/src/other.js'), undefined);
+    });
 
-test('returns undefined for explicit packages without any module exports', () => {
-    const bundle = { name: 'package-a', roots: { cli: rootWithSource('/src/cli.js', 'cli.js') } };
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
-    };
+    test('returns undefined for explicit packages without any module exports', function () {
+        const bundle = { name: 'package-a', roots: { cli: rootWithSource('/src/cli.js', 'cli.js') } };
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
+        };
 
-    assert.strictEqual(getExplicitPublicModuleSpecifier(bundle, surface, '/src/cli.js'), undefined);
-});
+        assert.strictEqual(getExplicitPublicModuleSpecifier(bundle, surface, '/src/cli.js'), undefined);
+    });
 
-test('prefers the shortest matching export key when several modules reference the same root', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: {
-            modules: [
-                { root: 'feature', export: './feature-long' },
-                { root: 'feature', export: './a' }
-            ]
-        }
-    };
+    test('prefers the shortest matching export key when several modules reference the same root', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {
+                modules: [
+                    { root: 'feature', export: './feature-long' },
+                    { root: 'feature', export: './a' }
+                ]
+            }
+        };
 
-    assert.strictEqual(getExplicitPublicModuleSpecifier(featureBundle, surface, '/src/feature.js'), 'package-a/a');
-});
+        assert.strictEqual(getExplicitPublicModuleSpecifier(featureBundle, surface, '/src/feature.js'), 'package-a/a');
+    });
 
-test('keeps the first match when later entries are not shorter', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: {
-            modules: [
-                { root: 'feature', export: './aa' },
-                { root: 'feature', export: './bb' }
-            ]
-        }
-    };
+    test('keeps the first match when later entries are not shorter', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {
+                modules: [
+                    { root: 'feature', export: './aa' },
+                    { root: 'feature', export: './bb' }
+                ]
+            }
+        };
 
-    assert.strictEqual(getExplicitPublicModuleSpecifier(featureBundle, surface, '/src/feature.js'), 'package-a/aa');
-});
+        assert.strictEqual(getExplicitPublicModuleSpecifier(featureBundle, surface, '/src/feature.js'), 'package-a/aa');
+    });
 
-test('promotes "." ahead of an earlier non-dot export referencing the same root', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: {
-            modules: [
-                { root: 'main', export: './index' },
-                { root: 'main', export: '.' }
-            ]
-        }
-    };
+    test('promotes "." ahead of an earlier non-dot export referencing the same root', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {
+                modules: [
+                    { root: 'main', export: './index' },
+                    { root: 'main', export: '.' }
+                ]
+            }
+        };
 
-    assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, surface, '/src/index.js'), 'package-a');
-});
+        assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, surface, '/src/index.js'), 'package-a');
+    });
 
-test('keeps "." selected when a later entry references the same root with a longer key', () => {
-    const surface: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: {
-            modules: [
-                { root: 'main', export: '.' },
-                { root: 'main', export: './later' }
-            ]
-        }
-    };
+    test('keeps "." selected when a later entry references the same root with a longer key', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {
+                modules: [
+                    { root: 'main', export: '.' },
+                    { root: 'main', export: './later' }
+                ]
+            }
+        };
 
-    assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, surface, '/src/index.js'), 'package-a');
+        assert.strictEqual(getExplicitPublicModuleSpecifier(mainOnlyBundle, surface, '/src/index.js'), 'package-a');
+    });
 });

--- a/source/package-surface/explicit-specifier-resolve.test.ts
+++ b/source/package-surface/explicit-specifier-resolve.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import type { ExplicitSurface } from './package-shape.ts';
 import { resolveExplicitPublicModuleSourceFilePath } from './explicit-specifier-resolve.ts';
@@ -16,48 +16,53 @@ const featureSurface: ExplicitSurface = {
     packageInterface: { modules: [{ root: 'feature', export: './feature' }] }
 };
 
-test('resolves the package name to its "." module\'s js source path', () => {
-    assert.strictEqual(
-        resolveExplicitPublicModuleSourceFilePath(mainOnlyBundle, rootSurface, 'package-a'),
-        '/src/index.js'
-    );
-});
+suite('explicit-specifier-resolve', function () {
+    test('resolves the package name to its "." module\'s js source path', function () {
+        assert.strictEqual(
+            resolveExplicitPublicModuleSourceFilePath(mainOnlyBundle, rootSurface, 'package-a'),
+            '/src/index.js'
+        );
+    });
 
-test('resolves a "<name>/<subpath>" specifier to the matching module\'s js source path', () => {
-    assert.strictEqual(
-        resolveExplicitPublicModuleSourceFilePath(featureBundle, featureSurface, 'package-a/feature'),
-        '/src/feature.js'
-    );
-});
+    test('resolves a "<name>/<subpath>" specifier to the matching module\'s js source path', function () {
+        assert.strictEqual(
+            resolveExplicitPublicModuleSourceFilePath(featureBundle, featureSurface, 'package-a/feature'),
+            '/src/feature.js'
+        );
+    });
 
-test('returns undefined for a foreign package specifier', () => {
-    assert.strictEqual(
-        resolveExplicitPublicModuleSourceFilePath(featureBundle, featureSurface, 'other-package/feature'),
-        undefined
-    );
-});
+    test('returns undefined for a foreign package specifier', function () {
+        assert.strictEqual(
+            resolveExplicitPublicModuleSourceFilePath(featureBundle, featureSurface, 'other-package/feature'),
+            undefined
+        );
+    });
 
-test('returns undefined when the export key does not match any module', () => {
-    assert.strictEqual(
-        resolveExplicitPublicModuleSourceFilePath(mainOnlyBundle, rootSurface, 'package-a/missing'),
-        undefined
-    );
-});
+    test('returns undefined when the export key does not match any module', function () {
+        assert.strictEqual(
+            resolveExplicitPublicModuleSourceFilePath(mainOnlyBundle, rootSurface, 'package-a/missing'),
+            undefined
+        );
+    });
 
-test('returns undefined when the packageInterface has no modules at all', () => {
-    const binOnly: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
-    };
+    test('returns undefined when the packageInterface has no modules at all', function () {
+        const binOnly: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] }
+        };
 
-    assert.strictEqual(resolveExplicitPublicModuleSourceFilePath(cliBundle, binOnly, 'package-a'), undefined);
-});
+        assert.strictEqual(resolveExplicitPublicModuleSourceFilePath(cliBundle, binOnly, 'package-a'), undefined);
+    });
 
-test('ignores malformed module entries when the specifier is for another package', () => {
-    const malformed: ExplicitSurface = {
-        mode: 'explicit',
-        packageInterface: { modules: [{ root: 'feature', export: undefined as never }] }
-    };
+    test('ignores malformed module entries when the specifier is for another package', function () {
+        const malformed: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { modules: [{ root: 'feature', export: undefined as never }] }
+        };
 
-    assert.strictEqual(resolveExplicitPublicModuleSourceFilePath(featureBundle, malformed, 'other-package'), undefined);
+        assert.strictEqual(
+            resolveExplicitPublicModuleSourceFilePath(featureBundle, malformed, 'other-package'),
+            undefined
+        );
+    });
 });

--- a/source/package-surface/export-map.test.ts
+++ b/source/package-surface/export-map.test.ts
@@ -1,26 +1,28 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import { buildExportsField } from './export-map.ts';
 import { explicitPackageSurface, implicitPackageSurface } from './surface.ts';
 
-test('buildExportsField uses the explicit-mode builder when the bundle surface is explicit', () => {
-    const bundle = linkedBundle({
-        surface: explicitPackageSurface({ modules: [{ root: 'main', export: '.' }] })
+suite('export-map', function () {
+    test('buildExportsField uses the explicit-mode builder when the bundle surface is explicit', function () {
+        const bundle = linkedBundle({
+            surface: explicitPackageSurface({ modules: [{ root: 'main', export: '.' }] })
+        });
+
+        const exportsField = buildExportsField(bundle, new Set());
+
+        assert.ok(exportsField !== undefined);
+        assert.ok('.' in (exportsField as Record<string, unknown>));
     });
 
-    const exportsField = buildExportsField(bundle, new Set());
+    test('buildExportsField uses the implicit-mode builder when the bundle surface is implicit', function () {
+        const bundle = linkedBundle({ surface: implicitPackageSurface('main') });
 
-    assert.ok(exportsField !== undefined);
-    assert.ok('.' in (exportsField as Record<string, unknown>));
-});
+        const exportsField = buildExportsField(bundle, new Set());
 
-test('buildExportsField uses the implicit-mode builder when the bundle surface is implicit', () => {
-    const bundle = linkedBundle({ surface: implicitPackageSurface('main') });
-
-    const exportsField = buildExportsField(bundle, new Set());
-
-    assert.ok(exportsField !== undefined);
-    assert.ok('.' in (exportsField as Record<string, unknown>));
+        assert.ok(exportsField !== undefined);
+        assert.ok('.' in (exportsField as Record<string, unknown>));
+    });
 });

--- a/source/package-surface/implicit-bin.test.ts
+++ b/source/package-surface/implicit-bin.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     executableShebangRoot,
     plainRoot,
@@ -8,69 +8,74 @@ import {
 } from '../test-libraries/package-surface-fixtures.ts';
 import { buildImplicitBinField } from './implicit-bin.ts';
 
-test('returns undefined when no roots are executable shebang scripts', () => {
-    const result = buildImplicitBinField({ name: 'package-a', roots: { main: plainRoot('index.js') } });
+suite('implicit-bin', function () {
+    test('returns undefined when no roots are executable shebang scripts', function () {
+        const result = buildImplicitBinField({ name: 'package-a', roots: { main: plainRoot('index.js') } });
 
-    assert.strictEqual(result, undefined);
-});
-
-test('returns undefined when a shebang root is not marked executable', () => {
-    assert.strictEqual(buildImplicitBinField({ name: 'package-a', roots: { cli: shebangRoot('cli.js') } }), undefined);
-});
-
-test('returns undefined when an executable root lacks a shebang in its content', () => {
-    const executableWithoutShebang = rootWithSource('', 'cli.js', { content: 'plain\n', isExecutable: true });
-
-    assert.strictEqual(
-        buildImplicitBinField({ name: 'package-a', roots: { cli: executableWithoutShebang } }),
-        undefined
-    );
-});
-
-test('maps a single executable shebang root to the unscoped package name', () => {
-    const result = buildImplicitBinField({
-        name: '@scope/package-a',
-        roots: { cli: executableShebangRoot('cli.js') }
+        assert.strictEqual(result, undefined);
     });
 
-    assert.deepStrictEqual(result, { 'package-a': './cli.js' });
-});
-
-test('uses the full name for an unscoped package', () => {
-    const result = buildImplicitBinField({
-        name: 'package-a',
-        roots: { cli: executableShebangRoot('cli.js') }
+    test('returns undefined when a shebang root is not marked executable', function () {
+        assert.strictEqual(
+            buildImplicitBinField({ name: 'package-a', roots: { cli: shebangRoot('cli.js') } }),
+            undefined
+        );
     });
 
-    assert.deepStrictEqual(result, { 'package-a': './cli.js' });
-});
+    test('returns undefined when an executable root lacks a shebang in its content', function () {
+        const executableWithoutShebang = rootWithSource('', 'cli.js', { content: 'plain\n', isExecutable: true });
 
-test('treats names like "@scope" without a slash as their own bin name', () => {
-    const result = buildImplicitBinField({
-        name: '@scope',
-        roots: { cli: executableShebangRoot('cli.js') }
+        assert.strictEqual(
+            buildImplicitBinField({ name: 'package-a', roots: { cli: executableWithoutShebang } }),
+            undefined
+        );
     });
 
-    assert.deepStrictEqual(result, { '@scope': './cli.js' });
-});
-
-test('preserves an @scope-like substring that does not start the package name', () => {
-    const result = buildImplicitBinField({
-        name: 'prefix@scope/package-a',
-        roots: { cli: executableShebangRoot('cli.js') }
-    });
-
-    assert.deepStrictEqual(result, { 'prefix@scope/package-a': './cli.js' });
-});
-
-test('throws when more than one root qualifies as an implicit bin', () => {
-    assert.throws(() => {
-        buildImplicitBinField({
-            name: 'package-a',
-            roots: {
-                cli: executableShebangRoot('cli.js'),
-                worker: executableShebangRoot('worker.js')
-            }
+    test('maps a single executable shebang root to the unscoped package name', function () {
+        const result = buildImplicitBinField({
+            name: '@scope/package-a',
+            roots: { cli: executableShebangRoot('cli.js') }
         });
-    }, /^Error: Package "package-a" has multiple executable shebang roots; declare packageInterface\.bins explicitly$/u);
+
+        assert.deepStrictEqual(result, { 'package-a': './cli.js' });
+    });
+
+    test('uses the full name for an unscoped package', function () {
+        const result = buildImplicitBinField({
+            name: 'package-a',
+            roots: { cli: executableShebangRoot('cli.js') }
+        });
+
+        assert.deepStrictEqual(result, { 'package-a': './cli.js' });
+    });
+
+    test('treats names like "@scope" without a slash as their own bin name', function () {
+        const result = buildImplicitBinField({
+            name: '@scope',
+            roots: { cli: executableShebangRoot('cli.js') }
+        });
+
+        assert.deepStrictEqual(result, { '@scope': './cli.js' });
+    });
+
+    test('preserves an @scope-like substring that does not start the package name', function () {
+        const result = buildImplicitBinField({
+            name: 'prefix@scope/package-a',
+            roots: { cli: executableShebangRoot('cli.js') }
+        });
+
+        assert.deepStrictEqual(result, { 'prefix@scope/package-a': './cli.js' });
+    });
+
+    test('throws when more than one root qualifies as an implicit bin', function () {
+        assert.throws(() => {
+            buildImplicitBinField({
+                name: 'package-a',
+                roots: {
+                    cli: executableShebangRoot('cli.js'),
+                    worker: executableShebangRoot('worker.js')
+                }
+            });
+        }, /^Error: Package "package-a" has multiple executable shebang roots; declare packageInterface\.bins explicitly$/u);
+    });
 });

--- a/source/package-surface/implicit-exports.test.ts
+++ b/source/package-surface/implicit-exports.test.ts
@@ -1,36 +1,38 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { content, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import { buildImplicitExportsField } from './implicit-exports.ts';
 
-test('combines root exports and substitution exports for the implicit branch', () => {
-    const result = buildImplicitExportsField(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/index.js', 'index.js'), content('/src/public.js', 'public.js')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        new Set(['/src/public.js'])
-    );
+suite('implicit-exports', function () {
+    test('combines root exports and substitution exports for the implicit branch', function () {
+        const result = buildImplicitExportsField(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/index.js', 'index.js'), content('/src/public.js', 'public.js')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            new Set(['/src/public.js'])
+        );
 
-    assert.deepStrictEqual(result, {
-        '.': { import: './index.js' },
-        './public.js': { import: './public.js' }
+        assert.deepStrictEqual(result, {
+            '.': { import: './index.js' },
+            './public.js': { import: './public.js' }
+        });
     });
-});
 
-test('appends the package.json export when exportPackageJson is true', () => {
-    const result = buildImplicitExportsField(
-        {
-            name: 'package-a',
-            exportPackageJson: true,
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: []
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        new Set()
-    );
+    test('appends the package.json export when exportPackageJson is true', function () {
+        const result = buildImplicitExportsField(
+            {
+                name: 'package-a',
+                exportPackageJson: true,
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: []
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            new Set()
+        );
 
-    assert.strictEqual(result['./package.json'], './package.json');
+        assert.strictEqual(result['./package.json'], './package.json');
+    });
 });

--- a/source/package-surface/implicit-root-exports.test.ts
+++ b/source/package-surface/implicit-root-exports.test.ts
@@ -1,49 +1,51 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { plainRoot, rootWithDeclaration } from '../test-libraries/package-surface-fixtures.ts';
 import { buildImplicitRootExports } from './implicit-root-exports.ts';
 
-test('maps the default root to "."', () => {
-    const result = buildImplicitRootExports(
-        { name: 'package-a', roots: { main: plainRoot('index.js') } },
-        { mode: 'implicit', defaultModuleRoot: 'main' }
-    );
-
-    assert.deepStrictEqual(result['.'], { import: './index.js' });
-});
-
-test('includes types alongside the import when the default root has a declaration', () => {
-    const result = buildImplicitRootExports(
-        { name: 'package-a', roots: { main: rootWithDeclaration('', 'index.js', '', 'index.d.ts') } },
-        { mode: 'implicit', defaultModuleRoot: 'main' }
-    );
-
-    assert.deepStrictEqual(result['.'], { import: './index.js', types: './index.d.ts' });
-});
-
-test('maps a non-default root to "./<targetFilePath>"', () => {
-    const result = buildImplicitRootExports(
-        { name: 'package-a', roots: { main: plainRoot('index.js'), helper: plainRoot('helper.js') } },
-        { mode: 'implicit', defaultModuleRoot: 'main' }
-    );
-
-    assert.deepStrictEqual(result['./helper.js'], { import: './helper.js' });
-});
-
-test('does not duplicate the default root under its target file path', () => {
-    const result = buildImplicitRootExports(
-        { name: 'package-a', roots: { main: plainRoot('index.js') } },
-        { mode: 'implicit', defaultModuleRoot: 'main' }
-    );
-
-    assert.strictEqual(Object.hasOwn(result, './index.js'), false);
-});
-
-test('throws when the default root id does not exist', () => {
-    assert.throws(() => {
-        buildImplicitRootExports(
+suite('implicit-root-exports', function () {
+    test('maps the default root to "."', function () {
+        const result = buildImplicitRootExports(
             { name: 'package-a', roots: { main: plainRoot('index.js') } },
-            { mode: 'implicit', defaultModuleRoot: 'missing' }
+            { mode: 'implicit', defaultModuleRoot: 'main' }
         );
-    }, /^Error: Package "package-a" references unknown root "missing"$/u);
+
+        assert.deepStrictEqual(result['.'], { import: './index.js' });
+    });
+
+    test('includes types alongside the import when the default root has a declaration', function () {
+        const result = buildImplicitRootExports(
+            { name: 'package-a', roots: { main: rootWithDeclaration('', 'index.js', '', 'index.d.ts') } },
+            { mode: 'implicit', defaultModuleRoot: 'main' }
+        );
+
+        assert.deepStrictEqual(result['.'], { import: './index.js', types: './index.d.ts' });
+    });
+
+    test('maps a non-default root to "./<targetFilePath>"', function () {
+        const result = buildImplicitRootExports(
+            { name: 'package-a', roots: { main: plainRoot('index.js'), helper: plainRoot('helper.js') } },
+            { mode: 'implicit', defaultModuleRoot: 'main' }
+        );
+
+        assert.deepStrictEqual(result['./helper.js'], { import: './helper.js' });
+    });
+
+    test('does not duplicate the default root under its target file path', function () {
+        const result = buildImplicitRootExports(
+            { name: 'package-a', roots: { main: plainRoot('index.js') } },
+            { mode: 'implicit', defaultModuleRoot: 'main' }
+        );
+
+        assert.strictEqual(Object.hasOwn(result, './index.js'), false);
+    });
+
+    test('throws when the default root id does not exist', function () {
+        assert.throws(() => {
+            buildImplicitRootExports(
+                { name: 'package-a', roots: { main: plainRoot('index.js') } },
+                { mode: 'implicit', defaultModuleRoot: 'missing' }
+            );
+        }, /^Error: Package "package-a" references unknown root "missing"$/u);
+    });
 });

--- a/source/package-surface/implicit-specifier-build.test.ts
+++ b/source/package-surface/implicit-specifier-build.test.ts
@@ -1,142 +1,144 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { content, rootWithDeclaration, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import { getImplicitPublicModuleSpecifier } from './implicit-specifier-build.ts';
 
-test("returns the bare package name for the default root's js source path", () => {
-    const result = getImplicitPublicModuleSpecifier(
-        { name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') }, contents: [] },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/index.js'
-    );
+suite('implicit-specifier-build', function () {
+    test("returns the bare package name for the default root's js source path", function () {
+        const result = getImplicitPublicModuleSpecifier(
+            { name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') }, contents: [] },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/index.js'
+        );
 
-    assert.strictEqual(result, 'package-a');
-});
+        assert.strictEqual(result, 'package-a');
+    });
 
-test("returns the bare package name for the default root's declaration source path", () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: { main: rootWithDeclaration('/src/index.js', 'index.js', '/src/index.d.ts', 'index.d.ts') },
-            contents: []
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/index.d.ts'
-    );
-
-    assert.strictEqual(result, 'package-a');
-});
-
-test('returns "<name>/<jsTargetFilePath>" for a non-default declaration source path', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: {
-                main: rootWithSource('/src/index.js', 'index.js'),
-                helper: rootWithDeclaration('/src/helper.js', 'helper.js', '/src/helper.d.ts', 'helper.d.ts')
+    test("returns the bare package name for the default root's declaration source path", function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: { main: rootWithDeclaration('/src/index.js', 'index.js', '/src/index.d.ts', 'index.d.ts') },
+                contents: []
             },
-            contents: []
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/helper.d.ts'
-    );
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/index.d.ts'
+        );
 
-    assert.strictEqual(result, 'package-a/helper.js');
-});
+        assert.strictEqual(result, 'package-a');
+    });
 
-test('returns "<name>/<targetFilePath>" for a content source path not bound to any root', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/feature.js', 'feature.js')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/feature.js'
-    );
-
-    assert.strictEqual(result, 'package-a/feature.js');
-});
-
-test('returns undefined for a source path that is neither a root nor content', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        { name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') }, contents: [] },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/missing.js'
-    );
-
-    assert.strictEqual(result, undefined);
-});
-
-test('uses content lookup when an .mts declaration cannot be matched to a root', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/module.d.mts', 'module.d.mts')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/module.d.mts'
-    );
-
-    assert.strictEqual(result, 'package-a/module.d.mts');
-});
-
-test('uses content lookup when an .cts declaration cannot be matched to a root', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/common.d.cts', 'common.d.cts')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/common.d.cts'
-    );
-
-    assert.strictEqual(result, 'package-a/common.d.cts');
-});
-
-test('exposes a declaration-only file via its content target path', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/foo.d.ts', 'foo.d.ts')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/foo.d.ts'
-    );
-
-    assert.strictEqual(result, 'package-a/foo.d.ts');
-});
-
-test('does not reinterpret unsupported file types as declaration companions', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/notes.txt', 'notes.txt')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/notes.txt'
-    );
-
-    assert.strictEqual(result, 'package-a/notes.txt');
-});
-
-test('prefers a declaration-root match over a content match for the same source path', () => {
-    const result = getImplicitPublicModuleSpecifier(
-        {
-            name: 'package-a',
-            roots: {
-                main: rootWithSource('/src/index.js', 'index.js'),
-                helper: rootWithDeclaration('/src/helper.js', 'helper.js', '/src/helper.d.ts', 'helper.d.ts')
+    test('returns "<name>/<jsTargetFilePath>" for a non-default declaration source path', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: {
+                    main: rootWithSource('/src/index.js', 'index.js'),
+                    helper: rootWithDeclaration('/src/helper.js', 'helper.js', '/src/helper.d.ts', 'helper.d.ts')
+                },
+                contents: []
             },
-            contents: [content('/src/helper.d.ts', 'helper.d.ts')]
-        },
-        { mode: 'implicit', defaultModuleRoot: 'main' },
-        '/src/helper.d.ts'
-    );
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/helper.d.ts'
+        );
 
-    assert.strictEqual(result, 'package-a/helper.js');
+        assert.strictEqual(result, 'package-a/helper.js');
+    });
+
+    test('returns "<name>/<targetFilePath>" for a content source path not bound to any root', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/feature.js', 'feature.js')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/feature.js'
+        );
+
+        assert.strictEqual(result, 'package-a/feature.js');
+    });
+
+    test('returns undefined for a source path that is neither a root nor content', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            { name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') }, contents: [] },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/missing.js'
+        );
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test('uses content lookup when an .mts declaration cannot be matched to a root', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/module.d.mts', 'module.d.mts')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/module.d.mts'
+        );
+
+        assert.strictEqual(result, 'package-a/module.d.mts');
+    });
+
+    test('uses content lookup when an .cts declaration cannot be matched to a root', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/common.d.cts', 'common.d.cts')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/common.d.cts'
+        );
+
+        assert.strictEqual(result, 'package-a/common.d.cts');
+    });
+
+    test('exposes a declaration-only file via its content target path', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/foo.d.ts', 'foo.d.ts')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/foo.d.ts'
+        );
+
+        assert.strictEqual(result, 'package-a/foo.d.ts');
+    });
+
+    test('does not reinterpret unsupported file types as declaration companions', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/notes.txt', 'notes.txt')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/notes.txt'
+        );
+
+        assert.strictEqual(result, 'package-a/notes.txt');
+    });
+
+    test('prefers a declaration-root match over a content match for the same source path', function () {
+        const result = getImplicitPublicModuleSpecifier(
+            {
+                name: 'package-a',
+                roots: {
+                    main: rootWithSource('/src/index.js', 'index.js'),
+                    helper: rootWithDeclaration('/src/helper.js', 'helper.js', '/src/helper.d.ts', 'helper.d.ts')
+                },
+                contents: [content('/src/helper.d.ts', 'helper.d.ts')]
+            },
+            { mode: 'implicit', defaultModuleRoot: 'main' },
+            '/src/helper.d.ts'
+        );
+
+        assert.strictEqual(result, 'package-a/helper.js');
+    });
 });

--- a/source/package-surface/implicit-specifier-resolve.test.ts
+++ b/source/package-surface/implicit-specifier-resolve.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { content, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import type { ImplicitSurface } from './package-shape.ts';
 import { resolveImplicitPublicModuleSourceFilePath } from './implicit-specifier-resolve.ts';
@@ -16,30 +16,32 @@ const emptyContentBundle = {
     contents: []
 };
 
-test("resolves the package name to the default root's js source path", () => {
-    assert.strictEqual(
-        resolveImplicitPublicModuleSourceFilePath(emptyContentBundle, surface, 'package-a'),
-        '/src/index.js'
-    );
-});
+suite('implicit-specifier-resolve', function () {
+    test("resolves the package name to the default root's js source path", function () {
+        assert.strictEqual(
+            resolveImplicitPublicModuleSourceFilePath(emptyContentBundle, surface, 'package-a'),
+            '/src/index.js'
+        );
+    });
 
-test('resolves "<name>/<targetFilePath>" to the content\'s source path', () => {
-    assert.strictEqual(
-        resolveImplicitPublicModuleSourceFilePath(bundleWithPrivateContent, surface, 'package-a/private.js'),
-        '/src/private.js'
-    );
-});
+    test('resolves "<name>/<targetFilePath>" to the content\'s source path', function () {
+        assert.strictEqual(
+            resolveImplicitPublicModuleSourceFilePath(bundleWithPrivateContent, surface, 'package-a/private.js'),
+            '/src/private.js'
+        );
+    });
 
-test('returns undefined for a foreign package specifier', () => {
-    assert.strictEqual(
-        resolveImplicitPublicModuleSourceFilePath(bundleWithPrivateContent, surface, 'other-package/private.js'),
-        undefined
-    );
-});
+    test('returns undefined for a foreign package specifier', function () {
+        assert.strictEqual(
+            resolveImplicitPublicModuleSourceFilePath(bundleWithPrivateContent, surface, 'other-package/private.js'),
+            undefined
+        );
+    });
 
-test('returns undefined for a subpath specifier whose target is not in contents', () => {
-    assert.strictEqual(
-        resolveImplicitPublicModuleSourceFilePath(emptyContentBundle, surface, 'package-a/missing.js'),
-        undefined
-    );
+    test('returns undefined for a subpath specifier whose target is not in contents', function () {
+        assert.strictEqual(
+            resolveImplicitPublicModuleSourceFilePath(emptyContentBundle, surface, 'package-a/missing.js'),
+            undefined
+        );
+    });
 });

--- a/source/package-surface/package-json-export.test.ts
+++ b/source/package-surface/package-json-export.test.ts
@@ -1,34 +1,36 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { decorateWithPackageJsonExport } from './package-json-export.ts';
 
-test('returns the input unchanged when exportPackageJson is undefined', () => {
-    assert.deepStrictEqual(decorateWithPackageJsonExport({}, { '.': { import: './index.js' } }), {
-        '.': { import: './index.js' }
+suite('package-json-export', function () {
+    test('returns the input unchanged when exportPackageJson is undefined', function () {
+        assert.deepStrictEqual(decorateWithPackageJsonExport({}, { '.': { import: './index.js' } }), {
+            '.': { import: './index.js' }
+        });
     });
-});
 
-test('returns the input unchanged when exportPackageJson is missing on the bundle', () => {
-    assert.deepStrictEqual(
-        decorateWithPackageJsonExport({ exportPackageJson: undefined }, { '.': { import: './index.js' } }),
-        { '.': { import: './index.js' } }
-    );
-});
-
-test('adds a "./package.json" entry when exportPackageJson is true', () => {
-    const result = decorateWithPackageJsonExport({ exportPackageJson: true }, { '.': { import: './index.js' } });
-
-    assert.deepStrictEqual(result, {
-        '.': { import: './index.js' },
-        './package.json': './package.json'
+    test('returns the input unchanged when exportPackageJson is missing on the bundle', function () {
+        assert.deepStrictEqual(
+            decorateWithPackageJsonExport({ exportPackageJson: undefined }, { '.': { import: './index.js' } }),
+            { '.': { import: './index.js' } }
+        );
     });
-});
 
-test('preserves existing entries alongside the package.json export', () => {
-    const result = decorateWithPackageJsonExport(
-        { exportPackageJson: true },
-        { '.': { import: './a.js' }, './b': { import: './b.js' } }
-    );
+    test('adds a "./package.json" entry when exportPackageJson is true', function () {
+        const result = decorateWithPackageJsonExport({ exportPackageJson: true }, { '.': { import: './index.js' } });
 
-    assert.deepStrictEqual(result['./b'], { import: './b.js' });
+        assert.deepStrictEqual(result, {
+            '.': { import: './index.js' },
+            './package.json': './package.json'
+        });
+    });
+
+    test('preserves existing entries alongside the package.json export', function () {
+        const result = decorateWithPackageJsonExport(
+            { exportPackageJson: true },
+            { '.': { import: './a.js' }, './b': { import: './b.js' } }
+        );
+
+        assert.deepStrictEqual(result['./b'], { import: './b.js' });
+    });
 });

--- a/source/package-surface/package-shape.test.ts
+++ b/source/package-surface/package-shape.test.ts
@@ -1,25 +1,27 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { buildExportEntry, toImportTarget, type RootFileDescription } from './package-shape.ts';
 
 const baseRoot: RootFileDescription = {
     js: { sourceFilePath: '/src/index.ts', targetFilePath: 'index.js', isExecutable: false, content: '' }
 };
 
-test('toImportTarget prepends "./" to relative target file paths', () => {
-    assert.strictEqual(toImportTarget('index.js'), './index.js');
-    assert.strictEqual(toImportTarget('nested/lib.js'), './nested/lib.js');
-});
+suite('package-shape', function () {
+    test('toImportTarget prepends "./" to relative target file paths', function () {
+        assert.strictEqual(toImportTarget('index.js'), './index.js');
+        assert.strictEqual(toImportTarget('nested/lib.js'), './nested/lib.js');
+    });
 
-test('buildExportEntry returns an entry with just an "import" target when no declaration file is attached', () => {
-    assert.deepStrictEqual(buildExportEntry(baseRoot), { import: './index.js' });
-});
+    test('buildExportEntry returns an entry with just an "import" target when no declaration file is attached', function () {
+        assert.deepStrictEqual(buildExportEntry(baseRoot), { import: './index.js' });
+    });
 
-test('buildExportEntry includes a "types" target when the root has an attached declaration file', () => {
-    const root: RootFileDescription = {
-        ...baseRoot,
-        declarationFile: { sourceFilePath: '/src/index.d.ts', targetFilePath: 'index.d.ts' }
-    };
+    test('buildExportEntry includes a "types" target when the root has an attached declaration file', function () {
+        const root: RootFileDescription = {
+            ...baseRoot,
+            declarationFile: { sourceFilePath: '/src/index.d.ts', targetFilePath: 'index.d.ts' }
+        };
 
-    assert.deepStrictEqual(buildExportEntry(root), { import: './index.js', types: './index.d.ts' });
+        assert.deepStrictEqual(buildExportEntry(root), { import: './index.js', types: './index.d.ts' });
+    });
 });

--- a/source/package-surface/public-module-usage.test.ts
+++ b/source/package-surface/public-module-usage.test.ts
@@ -1,99 +1,111 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { analyzedBundle, analyzedBundleResource } from '../test-libraries/bundle-fixtures.ts';
 import { collectPublicModuleUsage } from './public-module-usage.ts';
 
-test('collectPublicModuleUsage() collects imported and re-exported public modules across bundles', () => {
-    const packageBundle = analyzedBundle({
-        name: 'package-a',
-        roots: {
-            main: {
-                js: { sourceFilePath: '/pkg/index.js', targetFilePath: 'index.js', content: '', isExecutable: false }
-            },
-            feature: {
-                js: {
-                    sourceFilePath: '/pkg/feature.js',
-                    targetFilePath: 'feature.js',
-                    content: '',
-                    isExecutable: false
+suite('public-module-usage', function () {
+    test('collectPublicModuleUsage() collects imported and re-exported public modules across bundles', function () {
+        const packageBundle = analyzedBundle({
+            name: 'package-a',
+            roots: {
+                main: {
+                    js: {
+                        sourceFilePath: '/pkg/index.js',
+                        targetFilePath: 'index.js',
+                        content: '',
+                        isExecutable: false
+                    }
+                },
+                feature: {
+                    js: {
+                        sourceFilePath: '/pkg/feature.js',
+                        targetFilePath: 'feature.js',
+                        content: '',
+                        isExecutable: false
+                    }
+                },
+                ignored: {
+                    js: {
+                        sourceFilePath: '/pkg/ignored.js',
+                        targetFilePath: 'ignored.js',
+                        content: '',
+                        isExecutable: false
+                    }
                 }
             },
-            ignored: {
-                js: {
-                    sourceFilePath: '/pkg/ignored.js',
-                    targetFilePath: 'ignored.js',
-                    content: '',
-                    isExecutable: false
+            contents: [
+                analyzedBundleResource('/pkg/index.js', { targetFilePath: 'index.js' }),
+                analyzedBundleResource('/pkg/feature.js', { targetFilePath: 'feature.js' }),
+                analyzedBundleResource('/pkg/ignored.js', { targetFilePath: 'ignored.js' })
+            ],
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        });
+        const extraBundle = analyzedBundle({
+            name: 'Stryker was here',
+            roots: {
+                main: {
+                    js: {
+                        sourceFilePath: '/extra/index.js',
+                        targetFilePath: 'index.js',
+                        content: '',
+                        isExecutable: false
+                    }
                 }
-            }
-        },
-        contents: [
-            analyzedBundleResource('/pkg/index.js', { targetFilePath: 'index.js' }),
-            analyzedBundleResource('/pkg/feature.js', { targetFilePath: 'feature.js' }),
-            analyzedBundleResource('/pkg/ignored.js', { targetFilePath: 'ignored.js' })
-        ],
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+            },
+            contents: [analyzedBundleResource('/extra/index.js', { targetFilePath: 'index.js' })],
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        });
+        const consumer = analyzedBundle({
+            name: 'consumer',
+            contents: [
+                analyzedBundleResource('/consumer/index.js', {
+                    content: [
+                        'import packageA from "package-a";',
+                        'export { feature } from "package-a/feature.js";',
+                        'const requiredFeature = require("package-a/feature.js");',
+                        'import "./local.js";'
+                    ].join('\n')
+                }),
+                analyzedBundleResource('/consumer/extra.js', {
+                    content: 'import "package-a";\nexport * from "package-a/feature.js";\n'
+                }),
+                analyzedBundleResource('/consumer/readme.md', {
+                    targetFilePath: 'README.md',
+                    content: 'import "package-a/ignored.js";'
+                })
+            ]
+        });
+
+        const result = collectPublicModuleUsage([consumer, packageBundle, extraBundle]);
+
+        assert.deepStrictEqual(result.get('package-a'), new Set(['/pkg/index.js', '/pkg/feature.js']));
+        assert.strictEqual(result.has('Stryker was here'), false);
     });
-    const extraBundle = analyzedBundle({
-        name: 'Stryker was here',
-        roots: {
-            main: {
-                js: {
-                    sourceFilePath: '/extra/index.js',
-                    targetFilePath: 'index.js',
-                    content: '',
-                    isExecutable: false
+
+    test('collectPublicModuleUsage() ignores self-imports and unresolved package specifiers', function () {
+        const selfBundle = analyzedBundle({
+            name: 'package-a',
+            roots: {
+                main: {
+                    js: {
+                        sourceFilePath: '/pkg/index.js',
+                        targetFilePath: 'index.js',
+                        content: '',
+                        isExecutable: false
+                    }
                 }
-            }
-        },
-        contents: [analyzedBundleResource('/extra/index.js', { targetFilePath: 'index.js' })],
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+            },
+            contents: [
+                analyzedBundleResource('/pkg/index.js', {
+                    content: 'import "package-a";\nimport "missing-package";\n',
+                    targetFilePath: 'index.js'
+                })
+            ],
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        });
+
+        const result = collectPublicModuleUsage([selfBundle]);
+
+        assert.deepStrictEqual(result, new Map());
     });
-    const consumer = analyzedBundle({
-        name: 'consumer',
-        contents: [
-            analyzedBundleResource('/consumer/index.js', {
-                content: [
-                    'import packageA from "package-a";',
-                    'export { feature } from "package-a/feature.js";',
-                    'const requiredFeature = require("package-a/feature.js");',
-                    'import "./local.js";'
-                ].join('\n')
-            }),
-            analyzedBundleResource('/consumer/extra.js', {
-                content: 'import "package-a";\nexport * from "package-a/feature.js";\n'
-            }),
-            analyzedBundleResource('/consumer/readme.md', {
-                targetFilePath: 'README.md',
-                content: 'import "package-a/ignored.js";'
-            })
-        ]
-    });
-
-    const result = collectPublicModuleUsage([consumer, packageBundle, extraBundle]);
-
-    assert.deepStrictEqual(result.get('package-a'), new Set(['/pkg/index.js', '/pkg/feature.js']));
-    assert.strictEqual(result.has('Stryker was here'), false);
-});
-
-test('collectPublicModuleUsage() ignores self-imports and unresolved package specifiers', () => {
-    const selfBundle = analyzedBundle({
-        name: 'package-a',
-        roots: {
-            main: {
-                js: { sourceFilePath: '/pkg/index.js', targetFilePath: 'index.js', content: '', isExecutable: false }
-            }
-        },
-        contents: [
-            analyzedBundleResource('/pkg/index.js', {
-                content: 'import "package-a";\nimport "missing-package";\n',
-                targetFilePath: 'index.js'
-            })
-        ],
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
-    });
-
-    const result = collectPublicModuleUsage([selfBundle]);
-
-    assert.deepStrictEqual(result, new Map());
 });

--- a/source/package-surface/public-specifiers.test.ts
+++ b/source/package-surface/public-specifiers.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import type { BundleLike } from './package-shape.ts';
 import { getPublicModuleSpecifierForSourcePath, resolvePublicModuleSourceFilePath } from './public-specifiers.ts';
@@ -23,18 +23,20 @@ const implicitBundle: BundleLike = {
     surface: { mode: 'implicit', defaultModuleRoot: 'main' }
 };
 
-test('getPublicModuleSpecifierForSourcePath dispatches to the explicit builder for explicit surfaces', () => {
-    assert.strictEqual(getPublicModuleSpecifierForSourcePath(explicitBundle, '/src/index.js'), 'package-a');
-});
+suite('public-specifiers', function () {
+    test('getPublicModuleSpecifierForSourcePath dispatches to the explicit builder for explicit surfaces', function () {
+        assert.strictEqual(getPublicModuleSpecifierForSourcePath(explicitBundle, '/src/index.js'), 'package-a');
+    });
 
-test('getPublicModuleSpecifierForSourcePath dispatches to the implicit builder for implicit surfaces', () => {
-    assert.strictEqual(getPublicModuleSpecifierForSourcePath(implicitBundle, '/src/index.js'), 'package-a');
-});
+    test('getPublicModuleSpecifierForSourcePath dispatches to the implicit builder for implicit surfaces', function () {
+        assert.strictEqual(getPublicModuleSpecifierForSourcePath(implicitBundle, '/src/index.js'), 'package-a');
+    });
 
-test('resolvePublicModuleSourceFilePath dispatches to the explicit resolver for explicit surfaces', () => {
-    assert.strictEqual(resolvePublicModuleSourceFilePath(explicitBundle, 'package-a'), '/src/index.js');
-});
+    test('resolvePublicModuleSourceFilePath dispatches to the explicit resolver for explicit surfaces', function () {
+        assert.strictEqual(resolvePublicModuleSourceFilePath(explicitBundle, 'package-a'), '/src/index.js');
+    });
 
-test('resolvePublicModuleSourceFilePath dispatches to the implicit resolver for implicit surfaces', () => {
-    assert.strictEqual(resolvePublicModuleSourceFilePath(implicitBundle, 'package-a'), '/src/index.js');
+    test('resolvePublicModuleSourceFilePath dispatches to the implicit resolver for implicit surfaces', function () {
+        assert.strictEqual(resolvePublicModuleSourceFilePath(implicitBundle, 'package-a'), '/src/index.js');
+    });
 });

--- a/source/package-surface/root-registry.test.ts
+++ b/source/package-surface/root-registry.test.ts
@@ -1,91 +1,93 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { plainRoot, rootWithDeclaration, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import { getEntryRootIds, getRoot, isMatchingRootSourcePath } from './root-registry.ts';
 
-test('getRoot returns the root for a known id', () => {
-    const root = rootWithSource('/src/index.js', 'index.js');
+suite('root-registry', function () {
+    test('getRoot returns the root for a known id', function () {
+        const root = rootWithSource('/src/index.js', 'index.js');
 
-    assert.strictEqual(getRoot({ name: 'package-a', roots: { main: root } }, 'main'), root);
-});
-
-test('getRoot throws when the id is not present', () => {
-    assert.throws(() => {
-        getRoot({ name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') } }, 'missing');
-    }, /^Error: Package "package-a" references unknown root "missing"$/u);
-});
-
-test('isMatchingRootSourcePath matches the js source path', () => {
-    const root = rootWithSource('/src/index.js', 'index.js');
-
-    assert.strictEqual(isMatchingRootSourcePath(root, '/src/index.js'), true);
-});
-
-test('isMatchingRootSourcePath matches the declaration file source path', () => {
-    const root = rootWithDeclaration('/src/index.js', 'index.js', '/src/index.d.ts', 'index.d.ts');
-
-    assert.strictEqual(isMatchingRootSourcePath(root, '/src/index.d.ts'), true);
-});
-
-test('isMatchingRootSourcePath returns false for an unrelated source path', () => {
-    const root = rootWithSource('/src/index.js', 'index.js');
-
-    assert.strictEqual(isMatchingRootSourcePath(root, '/src/other.js'), false);
-});
-
-test('getEntryRootIds returns every root id in implicit mode', () => {
-    const result = getEntryRootIds({
-        roots: { main: plainRoot('index.js'), worker: plainRoot('worker.js') },
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        assert.strictEqual(getRoot({ name: 'package-a', roots: { main: root } }, 'main'), root);
     });
 
-    assert.deepStrictEqual(result, new Set(['main', 'worker']));
-});
-
-test('getEntryRootIds includes explicit module roots', () => {
-    const result = getEntryRootIds({
-        roots: { main: plainRoot('index.js') },
-        surface: { mode: 'explicit', packageInterface: { modules: [{ root: 'main', export: '.' }] } }
+    test('getRoot throws when the id is not present', function () {
+        assert.throws(() => {
+            getRoot({ name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') } }, 'missing');
+        }, /^Error: Package "package-a" references unknown root "missing"$/u);
     });
 
-    assert.deepStrictEqual(result, new Set(['main']));
-});
+    test('isMatchingRootSourcePath matches the js source path', function () {
+        const root = rootWithSource('/src/index.js', 'index.js');
 
-test('getEntryRootIds includes explicit bin roots', () => {
-    const result = getEntryRootIds({
-        roots: { cli: plainRoot('cli.js') },
-        surface: { mode: 'explicit', packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] } }
+        assert.strictEqual(isMatchingRootSourcePath(root, '/src/index.js'), true);
     });
 
-    assert.deepStrictEqual(result, new Set(['cli']));
-});
+    test('isMatchingRootSourcePath matches the declaration file source path', function () {
+        const root = rootWithDeclaration('/src/index.js', 'index.js', '/src/index.d.ts', 'index.d.ts');
 
-test('getEntryRootIds includes explicit privateRoots alongside public roots', () => {
-    const result = getEntryRootIds({
-        roots: { main: plainRoot('index.js'), worker: plainRoot('worker.js') },
-        surface: {
-            mode: 'explicit',
-            packageInterface: {
-                modules: [{ root: 'main', export: '.' }],
-                privateRoots: ['worker']
+        assert.strictEqual(isMatchingRootSourcePath(root, '/src/index.d.ts'), true);
+    });
+
+    test('isMatchingRootSourcePath returns false for an unrelated source path', function () {
+        const root = rootWithSource('/src/index.js', 'index.js');
+
+        assert.strictEqual(isMatchingRootSourcePath(root, '/src/other.js'), false);
+    });
+
+    test('getEntryRootIds returns every root id in implicit mode', function () {
+        const result = getEntryRootIds({
+            roots: { main: plainRoot('index.js'), worker: plainRoot('worker.js') },
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+        });
+
+        assert.deepStrictEqual(result, new Set(['main', 'worker']));
+    });
+
+    test('getEntryRootIds includes explicit module roots', function () {
+        const result = getEntryRootIds({
+            roots: { main: plainRoot('index.js') },
+            surface: { mode: 'explicit', packageInterface: { modules: [{ root: 'main', export: '.' }] } }
+        });
+
+        assert.deepStrictEqual(result, new Set(['main']));
+    });
+
+    test('getEntryRootIds includes explicit bin roots', function () {
+        const result = getEntryRootIds({
+            roots: { cli: plainRoot('cli.js') },
+            surface: { mode: 'explicit', packageInterface: { bins: [{ root: 'cli', name: 'package-a' }] } }
+        });
+
+        assert.deepStrictEqual(result, new Set(['cli']));
+    });
+
+    test('getEntryRootIds includes explicit privateRoots alongside public roots', function () {
+        const result = getEntryRootIds({
+            roots: { main: plainRoot('index.js'), worker: plainRoot('worker.js') },
+            surface: {
+                mode: 'explicit',
+                packageInterface: {
+                    modules: [{ root: 'main', export: '.' }],
+                    privateRoots: ['worker']
+                }
             }
-        }
+        });
+
+        assert.deepStrictEqual(result, new Set(['main', 'worker']));
     });
 
-    assert.deepStrictEqual(result, new Set(['main', 'worker']));
-});
-
-test('getEntryRootIds dedupes a root referenced by both modules and bins', () => {
-    const result = getEntryRootIds({
-        roots: { shared: plainRoot('shared.js') },
-        surface: {
-            mode: 'explicit',
-            packageInterface: {
-                modules: [{ root: 'shared', export: '.' }],
-                bins: [{ root: 'shared', name: 'package-a' }]
+    test('getEntryRootIds dedupes a root referenced by both modules and bins', function () {
+        const result = getEntryRootIds({
+            roots: { shared: plainRoot('shared.js') },
+            surface: {
+                mode: 'explicit',
+                packageInterface: {
+                    modules: [{ root: 'shared', export: '.' }],
+                    bins: [{ root: 'shared', name: 'package-a' }]
+                }
             }
-        }
-    });
+        });
 
-    assert.deepStrictEqual(result, new Set(['shared']));
+        assert.deepStrictEqual(result, new Set(['shared']));
+    });
 });

--- a/source/package-surface/specifier-syntax.test.ts
+++ b/source/package-surface/specifier-syntax.test.ts
@@ -1,39 +1,44 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { resolveExplicitExportKey, resolveImplicitSpecifier, toPackageSpecifier } from './specifier-syntax.ts';
 
-test('toPackageSpecifier returns the bare package name for the "." export key', () => {
-    assert.strictEqual(toPackageSpecifier('package-a', '.'), 'package-a');
-});
+suite('specifier-syntax', function () {
+    test('toPackageSpecifier returns the bare package name for the "." export key', function () {
+        assert.strictEqual(toPackageSpecifier('package-a', '.'), 'package-a');
+    });
 
-test('toPackageSpecifier joins a non-root export key as a subpath of the package name', () => {
-    assert.strictEqual(toPackageSpecifier('package-a', './feature'), 'package-a/feature');
-});
+    test('toPackageSpecifier joins a non-root export key as a subpath of the package name', function () {
+        assert.strictEqual(toPackageSpecifier('package-a', './feature'), 'package-a/feature');
+    });
 
-test('resolveExplicitExportKey returns "." for a specifier equal to the package name', () => {
-    assert.strictEqual(resolveExplicitExportKey('package-a', 'package-a'), '.');
-});
+    test('resolveExplicitExportKey returns "." for a specifier equal to the package name', function () {
+        assert.strictEqual(resolveExplicitExportKey('package-a', 'package-a'), '.');
+    });
 
-test('resolveExplicitExportKey returns the subpath as a "./..." key for a prefixed specifier', () => {
-    assert.strictEqual(resolveExplicitExportKey('package-a', 'package-a/feature'), './feature');
-});
+    test('resolveExplicitExportKey returns the subpath as a "./..." key for a prefixed specifier', function () {
+        assert.strictEqual(resolveExplicitExportKey('package-a', 'package-a/feature'), './feature');
+    });
 
-test('resolveExplicitExportKey returns undefined for a foreign specifier', () => {
-    assert.strictEqual(resolveExplicitExportKey('package-a', 'other-package'), undefined);
-});
+    test('resolveExplicitExportKey returns undefined for a foreign specifier', function () {
+        assert.strictEqual(resolveExplicitExportKey('package-a', 'other-package'), undefined);
+    });
 
-test('resolveExplicitExportKey returns undefined for a name-prefix that is not a subpath', () => {
-    assert.strictEqual(resolveExplicitExportKey('package-a', 'package-anything'), undefined);
-});
+    test('resolveExplicitExportKey returns undefined for a name-prefix that is not a subpath', function () {
+        assert.strictEqual(resolveExplicitExportKey('package-a', 'package-anything'), undefined);
+    });
 
-test('resolveImplicitSpecifier returns ["root"] for a specifier equal to the bundle name', () => {
-    assert.deepStrictEqual(resolveImplicitSpecifier('package-a', 'package-a'), ['root']);
-});
+    test('resolveImplicitSpecifier returns ["root"] for a specifier equal to the bundle name', function () {
+        assert.deepStrictEqual(resolveImplicitSpecifier('package-a', 'package-a'), ['root']);
+    });
 
-test('resolveImplicitSpecifier returns ["content", path] for a subpath specifier', () => {
-    assert.deepStrictEqual(resolveImplicitSpecifier('package-a', 'package-a/feature.js'), ['content', 'feature.js']);
-});
+    test('resolveImplicitSpecifier returns ["content", path] for a subpath specifier', function () {
+        assert.deepStrictEqual(resolveImplicitSpecifier('package-a', 'package-a/feature.js'), [
+            'content',
+            'feature.js'
+        ]);
+    });
 
-test('resolveImplicitSpecifier returns ["private"] for a foreign specifier', () => {
-    assert.deepStrictEqual(resolveImplicitSpecifier('package-a', 'other-package/feature.js'), ['private']);
+    test('resolveImplicitSpecifier returns ["private"] for a foreign specifier', function () {
+        assert.deepStrictEqual(resolveImplicitSpecifier('package-a', 'other-package/feature.js'), ['private']);
+    });
 });

--- a/source/package-surface/substitution-exports.test.ts
+++ b/source/package-surface/substitution-exports.test.ts
@@ -1,172 +1,174 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { content, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import { collectSubstitutionExports } from './substitution-exports.ts';
 
-test('returns an empty record when no substitution paths are provided', () => {
-    const result = collectSubstitutionExports(
-        { name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') }, contents: [] },
-        new Set()
-    );
+suite('substitution-exports', function () {
+    test('returns an empty record when no substitution paths are provided', function () {
+        const result = collectSubstitutionExports(
+            { name: 'package-a', roots: { main: rootWithSource('/src/index.js', 'index.js') }, contents: [] },
+            new Set()
+        );
 
-    assert.deepStrictEqual(result, {});
-});
+        assert.deepStrictEqual(result, {});
+    });
 
-test('skips a substitution path that matches a root js source path', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/index.js', 'index.js')]
-        },
-        new Set(['/src/index.js'])
-    );
-
-    assert.deepStrictEqual(result, {});
-});
-
-test('exposes a non-root content path as "./<targetFilePath>"', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/public.js', 'public.js')]
-        },
-        new Set(['/src/public.js'])
-    );
-
-    assert.deepStrictEqual(result['./public.js'], { import: './public.js' });
-});
-
-test('pairs a .js substitution with its .d.ts companion when present in contents', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/feature.js', 'feature.js'), content('/src/feature.d.ts', 'feature.d.ts')]
-        },
-        new Set(['/src/feature.js'])
-    );
-
-    assert.deepStrictEqual(result['./feature.js'], { import: './feature.js', types: './feature.d.ts' });
-});
-
-test('pairs a .mjs substitution with its .d.mts companion when present', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/module.mjs', 'module.mjs'), content('/src/module.d.mts', 'module.d.mts')]
-        },
-        new Set(['/src/module.mjs'])
-    );
-
-    assert.deepStrictEqual(result['./module.mjs'], { import: './module.mjs', types: './module.d.mts' });
-});
-
-test('pairs a .cjs substitution with its .d.cts companion when present', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/common.cjs', 'common.cjs'), content('/src/common.d.cts', 'common.d.cts')]
-        },
-        new Set(['/src/common.cjs'])
-    );
-
-    assert.deepStrictEqual(result['./common.cjs'], { import: './common.cjs', types: './common.d.cts' });
-});
-
-test('omits the types entry when no declaration companion exists for a .js substitution', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/feature.js', 'feature.js')]
-        },
-        new Set(['/src/feature.js'])
-    );
-
-    assert.deepStrictEqual(result['./feature.js'], { import: './feature.js' });
-});
-
-test('exposes a non-code substitution target without searching for a declaration companion', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/data.json', 'data.json')]
-        },
-        new Set(['/src/data.json'])
-    );
-
-    assert.deepStrictEqual(result['./data.json'], { import: './data.json' });
-});
-
-test('omits a substitution whose target is a .d.ts declaration', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/types.d.ts', 'types.d.ts')]
-        },
-        new Set(['/src/types.d.ts'])
-    );
-
-    assert.deepStrictEqual(result, {});
-});
-
-test('omits a substitution whose target is a .d.mts declaration', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/types.d.mts', 'types.d.mts')]
-        },
-        new Set(['/src/types.d.mts'])
-    );
-
-    assert.deepStrictEqual(result, {});
-});
-
-test('omits a substitution whose target is a .d.cts declaration', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: { main: rootWithSource('/src/index.js', 'index.js') },
-            contents: [content('/src/types.d.cts', 'types.d.cts')]
-        },
-        new Set(['/src/types.d.cts'])
-    );
-
-    assert.deepStrictEqual(result, {});
-});
-
-test('skips a substitution path that matches one root js source path among multiple roots', () => {
-    const result = collectSubstitutionExports(
-        {
-            name: 'package-a',
-            roots: {
-                main: rootWithSource('/src/index.js', 'index.js'),
-                feature: rootWithSource('/src/feature.js', 'feature.js')
-            },
-            contents: [content('/src/index.js', 'index.js'), content('/src/feature.js', 'feature.js')]
-        },
-        new Set(['/src/index.js'])
-    );
-
-    assert.deepStrictEqual(result, {});
-});
-
-test('throws when a substitution source path is not present in contents', () => {
-    assert.throws(() => {
-        collectSubstitutionExports(
+    test('skips a substitution path that matches a root js source path', function () {
+        const result = collectSubstitutionExports(
             {
                 name: 'package-a',
                 roots: { main: rootWithSource('/src/index.js', 'index.js') },
                 contents: [content('/src/index.js', 'index.js')]
             },
-            new Set(['/src/missing.js'])
+            new Set(['/src/index.js'])
         );
-    }, /^Error: Package "package-a" is missing content for "\/src\/missing\.js"$/u);
+
+        assert.deepStrictEqual(result, {});
+    });
+
+    test('exposes a non-root content path as "./<targetFilePath>"', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/public.js', 'public.js')]
+            },
+            new Set(['/src/public.js'])
+        );
+
+        assert.deepStrictEqual(result['./public.js'], { import: './public.js' });
+    });
+
+    test('pairs a .js substitution with its .d.ts companion when present in contents', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/feature.js', 'feature.js'), content('/src/feature.d.ts', 'feature.d.ts')]
+            },
+            new Set(['/src/feature.js'])
+        );
+
+        assert.deepStrictEqual(result['./feature.js'], { import: './feature.js', types: './feature.d.ts' });
+    });
+
+    test('pairs a .mjs substitution with its .d.mts companion when present', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/module.mjs', 'module.mjs'), content('/src/module.d.mts', 'module.d.mts')]
+            },
+            new Set(['/src/module.mjs'])
+        );
+
+        assert.deepStrictEqual(result['./module.mjs'], { import: './module.mjs', types: './module.d.mts' });
+    });
+
+    test('pairs a .cjs substitution with its .d.cts companion when present', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/common.cjs', 'common.cjs'), content('/src/common.d.cts', 'common.d.cts')]
+            },
+            new Set(['/src/common.cjs'])
+        );
+
+        assert.deepStrictEqual(result['./common.cjs'], { import: './common.cjs', types: './common.d.cts' });
+    });
+
+    test('omits the types entry when no declaration companion exists for a .js substitution', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/feature.js', 'feature.js')]
+            },
+            new Set(['/src/feature.js'])
+        );
+
+        assert.deepStrictEqual(result['./feature.js'], { import: './feature.js' });
+    });
+
+    test('exposes a non-code substitution target without searching for a declaration companion', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/data.json', 'data.json')]
+            },
+            new Set(['/src/data.json'])
+        );
+
+        assert.deepStrictEqual(result['./data.json'], { import: './data.json' });
+    });
+
+    test('omits a substitution whose target is a .d.ts declaration', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/types.d.ts', 'types.d.ts')]
+            },
+            new Set(['/src/types.d.ts'])
+        );
+
+        assert.deepStrictEqual(result, {});
+    });
+
+    test('omits a substitution whose target is a .d.mts declaration', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/types.d.mts', 'types.d.mts')]
+            },
+            new Set(['/src/types.d.mts'])
+        );
+
+        assert.deepStrictEqual(result, {});
+    });
+
+    test('omits a substitution whose target is a .d.cts declaration', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [content('/src/types.d.cts', 'types.d.cts')]
+            },
+            new Set(['/src/types.d.cts'])
+        );
+
+        assert.deepStrictEqual(result, {});
+    });
+
+    test('skips a substitution path that matches one root js source path among multiple roots', function () {
+        const result = collectSubstitutionExports(
+            {
+                name: 'package-a',
+                roots: {
+                    main: rootWithSource('/src/index.js', 'index.js'),
+                    feature: rootWithSource('/src/feature.js', 'feature.js')
+                },
+                contents: [content('/src/index.js', 'index.js'), content('/src/feature.js', 'feature.js')]
+            },
+            new Set(['/src/index.js'])
+        );
+
+        assert.deepStrictEqual(result, {});
+    });
+
+    test('throws when a substitution source path is not present in contents', function () {
+        assert.throws(() => {
+            collectSubstitutionExports(
+                {
+                    name: 'package-a',
+                    roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                    contents: [content('/src/index.js', 'index.js')]
+                },
+                new Set(['/src/missing.js'])
+            );
+        }, /^Error: Package "package-a" is missing content for "\/src\/missing\.js"$/u);
+    });
 });

--- a/source/package-surface/surface.test.ts
+++ b/source/package-surface/surface.test.ts
@@ -1,29 +1,31 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { explicitPackageSurface, implicitPackageSurface, isImplicitPackageSurface } from './surface.ts';
 
-test('implicitPackageSurface() creates an implicit runtime surface', () => {
-    const packageSurface = implicitPackageSurface('main');
+suite('surface', function () {
+    test('implicitPackageSurface() creates an implicit runtime surface', function () {
+        const packageSurface = implicitPackageSurface('main');
 
-    assert.deepStrictEqual(packageSurface, {
-        mode: 'implicit',
-        defaultModuleRoot: 'main'
-    });
-    assert.strictEqual(isImplicitPackageSurface(packageSurface), true);
-});
-
-test('explicitPackageSurface() creates an explicit runtime surface', () => {
-    const packageSurface = explicitPackageSurface({
-        bins: [{ name: 'cli', root: 'main' }],
-        modules: [{ export: '.', root: 'main' }]
+        assert.deepStrictEqual(packageSurface, {
+            mode: 'implicit',
+            defaultModuleRoot: 'main'
+        });
+        assert.strictEqual(isImplicitPackageSurface(packageSurface), true);
     });
 
-    assert.deepStrictEqual(packageSurface, {
-        mode: 'explicit',
-        packageInterface: {
+    test('explicitPackageSurface() creates an explicit runtime surface', function () {
+        const packageSurface = explicitPackageSurface({
             bins: [{ name: 'cli', root: 'main' }],
             modules: [{ export: '.', root: 'main' }]
-        }
+        });
+
+        assert.deepStrictEqual(packageSurface, {
+            mode: 'explicit',
+            packageInterface: {
+                bins: [{ name: 'cli', root: 'main' }],
+                modules: [{ export: '.', root: 'main' }]
+            }
+        });
+        assert.strictEqual(isImplicitPackageSurface(packageSurface), false);
     });
-    assert.strictEqual(isImplicitPackageSurface(packageSurface), false);
 });

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { fooPackageConfigFactory } from '../test-libraries/config-fixtures.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
@@ -68,451 +68,453 @@ function runMapConfigExpectingError(
     }
 }
 
-test('throws when the given packageName doesn’t exist in the configs', () => {
-    try {
-        configToBuildAndPublishOptions(
-            'foo',
-            {},
-            {
-                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-                packages: [
-                    {
-                        name: '',
-                        sourcesFolder: '',
-                        roots: { main: { js: '' } },
-                        mainPackageJson: { type: 'module' }
-                    }
-                ]
-            },
-            []
-        );
-        assert.fail('Expected configToBuildAndPublishOptions() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Config for package "foo" is missing');
-    }
-});
-
-test('throws when the sourcesFolder is missing after config merging', () => {
-    runMapConfigExpectingError(
-        {
-            name: 'foo',
-            roots: { main: { js: '' } },
-            mainPackageJson: { type: 'module' }
-        } as unknown as PackageConfigInput,
-        'Config for package "foo" is missing the sources folder'
-    );
-});
-
-test('throws when the main package.json settings are missing after config merging', () => {
-    runMapConfigExpectingError(
-        { name: 'foo', sourcesFolder: '/src', roots: { main: { js: '' } } } as unknown as PackageConfigInput,
-        'Config for package "foo" is missing the main package.json settings'
-    );
-});
-
-test('doesn’t change js roots when they are already absolute paths', () => {
-    const packageConfig = fooPackageConfigFactory.build({ roots: { main: { js: '/the-entry-file' } } });
-
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
-
-    assert.deepStrictEqual(result.roots, { main: { js: '/the-entry-file' } });
-});
-
-test('merges deadCodeElimination settings into the prepared shared options', () => {
-    const packageConfig = {
-        ...fooPackageConfigFactory.build(),
-        deadCodeElimination: { enabled: false, pureConstructors: ['Map'] }
-    } as unknown as PackageConfigInput;
-
-    const result = runMapConfig(packageConfig, {
-        commonPackageSettings: {
-            publishSettings: { access: 'public' },
-            deadCodeElimination: { enabled: true, pureImports: [{ from: 'zod/mini' }], pureConstructors: ['Set'] }
+suite('map-config', function () {
+    test('throws when the given packageName doesn’t exist in the configs', function () {
+        try {
+            configToBuildAndPublishOptions(
+                'foo',
+                {},
+                {
+                    registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                    packages: [
+                        {
+                            name: '',
+                            sourcesFolder: '',
+                            roots: { main: { js: '' } },
+                            mainPackageJson: { type: 'module' }
+                        }
+                    ]
+                },
+                []
+            );
+            assert.fail('Expected configToBuildAndPublishOptions() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Config for package "foo" is missing');
         }
     });
 
-    assert.deepStrictEqual(result.deadCodeElimination, {
-        enabled: false,
-        pureImports: [{ from: 'zod/mini' }],
-        pureConstructors: ['Map']
-    });
-});
-
-test('adds the sourcesFolder as a prefix to a js root when it is a relative path', () => {
-    const packageConfig = fooPackageConfigFactory.build({ roots: { main: { js: 'the-entry-file' } } });
-
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
-
-    assert.deepStrictEqual(result.roots, { main: { js: 'the-source/the-entry-file' } });
-});
-
-test('throws when a package has no roots after config lookup', () => {
-    runMapConfigExpectingError(
-        {
-            name: 'foo',
-            sourcesFolder: 'the-source',
-            roots: {},
-            mainPackageJson: { type: 'module' }
-        } as unknown as PackageConfigInput,
-        'Package "foo" must define at least one root'
-    );
-});
-
-test('normalizes every configured root', () => {
-    const packageConfig = fooPackageConfigFactory.build({
-        roots: {
-            main: { js: 'first.js' },
-            secondary: { js: 'second.js', declarationFile: 'second.d.ts' }
-        },
-        defaultModuleRoot: 'main'
+    test('throws when the sourcesFolder is missing after config merging', function () {
+        runMapConfigExpectingError(
+            {
+                name: 'foo',
+                roots: { main: { js: '' } },
+                mainPackageJson: { type: 'module' }
+            } as unknown as PackageConfigInput,
+            'Config for package "foo" is missing the sources folder'
+        );
     });
 
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
-
-    assert.deepStrictEqual(result.roots, {
-        main: { js: 'the-source/first.js' },
-        secondary: { js: 'the-source/second.js', declarationFile: 'the-source/second.d.ts' }
+    test('throws when the main package.json settings are missing after config merging', function () {
+        runMapConfigExpectingError(
+            { name: 'foo', sourcesFolder: '/src', roots: { main: { js: '' } } } as unknown as PackageConfigInput,
+            'Config for package "foo" is missing the main package.json settings'
+        );
     });
-});
 
-test('throws when multiple implicit roots are configured without defaultModuleRoot', () => {
-    runMapConfigExpectingError(
-        fooPackageConfigFactory.build({
+    test('doesn’t change js roots when they are already absolute paths', function () {
+        const packageConfig = fooPackageConfigFactory.build({ roots: { main: { js: '/the-entry-file' } } });
+
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
+
+        assert.deepStrictEqual(result.roots, { main: { js: '/the-entry-file' } });
+    });
+
+    test('merges deadCodeElimination settings into the prepared shared options', function () {
+        const packageConfig = {
+            ...fooPackageConfigFactory.build(),
+            deadCodeElimination: { enabled: false, pureConstructors: ['Map'] }
+        } as unknown as PackageConfigInput;
+
+        const result = runMapConfig(packageConfig, {
+            commonPackageSettings: {
+                publishSettings: { access: 'public' },
+                deadCodeElimination: { enabled: true, pureImports: [{ from: 'zod/mini' }], pureConstructors: ['Set'] }
+            }
+        });
+
+        assert.deepStrictEqual(result.deadCodeElimination, {
+            enabled: false,
+            pureImports: [{ from: 'zod/mini' }],
+            pureConstructors: ['Map']
+        });
+    });
+
+    test('adds the sourcesFolder as a prefix to a js root when it is a relative path', function () {
+        const packageConfig = fooPackageConfigFactory.build({ roots: { main: { js: 'the-entry-file' } } });
+
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
+
+        assert.deepStrictEqual(result.roots, { main: { js: 'the-source/the-entry-file' } });
+    });
+
+    test('throws when a package has no roots after config lookup', function () {
+        runMapConfigExpectingError(
+            {
+                name: 'foo',
+                sourcesFolder: 'the-source',
+                roots: {},
+                mainPackageJson: { type: 'module' }
+            } as unknown as PackageConfigInput,
+            'Package "foo" must define at least one root'
+        );
+    });
+
+    test('normalizes every configured root', function () {
+        const packageConfig = fooPackageConfigFactory.build({
             roots: {
                 main: { js: 'first.js' },
-                secondary: { js: 'second.js' }
+                secondary: { js: 'second.js', declarationFile: 'second.d.ts' }
             },
-            defaultModuleRoot: undefined
-        }),
-        'Config for package "foo" is missing defaultModuleRoot',
-        { extraPackages: [] }
-    );
-});
+            defaultModuleRoot: 'main'
+        });
 
-test('uses the configured defaultModuleRoot when multiple implicit roots exist', () => {
-    const result = runMapConfig(
-        fooPackageConfigFactory.build({
-            roots: {
-                main: { js: 'first.js' },
-                secondary: { js: 'second.js' }
-            },
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
+
+        assert.deepStrictEqual(result.roots, {
+            main: { js: 'the-source/first.js' },
+            secondary: { js: 'the-source/second.js', declarationFile: 'the-source/second.d.ts' }
+        });
+    });
+
+    test('throws when multiple implicit roots are configured without defaultModuleRoot', function () {
+        runMapConfigExpectingError(
+            fooPackageConfigFactory.build({
+                roots: {
+                    main: { js: 'first.js' },
+                    secondary: { js: 'second.js' }
+                },
+                defaultModuleRoot: undefined
+            }),
+            'Config for package "foo" is missing defaultModuleRoot',
+            { extraPackages: [] }
+        );
+    });
+
+    test('uses the configured defaultModuleRoot when multiple implicit roots exist', function () {
+        const result = runMapConfig(
+            fooPackageConfigFactory.build({
+                roots: {
+                    main: { js: 'first.js' },
+                    secondary: { js: 'second.js' }
+                },
+                defaultModuleRoot: 'secondary'
+            }),
+            { extraPackages: [] }
+        );
+
+        assert.deepStrictEqual(result.surface, {
+            mode: 'implicit',
             defaultModuleRoot: 'secondary'
-        }),
-        { extraPackages: [] }
-    );
-
-    assert.deepStrictEqual(result.surface, {
-        mode: 'implicit',
-        defaultModuleRoot: 'secondary'
+        });
     });
-});
 
-test('builds an implicit surface when packageInterface is not configured', () => {
-    const result = runMapConfig(
-        {
-            name: 'foo',
-            sourcesFolder: 'the-source',
-            roots: {
-                main: { js: 'index.js' }
-            },
-            mainPackageJson: { type: 'module' }
-        } as unknown as PackageConfigInput,
-        { extraPackages: [] }
-    );
+    test('builds an implicit surface when packageInterface is not configured', function () {
+        const result = runMapConfig(
+            {
+                name: 'foo',
+                sourcesFolder: 'the-source',
+                roots: {
+                    main: { js: 'index.js' }
+                },
+                mainPackageJson: { type: 'module' }
+            } as unknown as PackageConfigInput,
+            { extraPackages: [] }
+        );
 
-    assert.deepStrictEqual(result.surface, {
-        mode: 'implicit',
-        defaultModuleRoot: 'main'
+        assert.deepStrictEqual(result.surface, {
+            mode: 'implicit',
+            defaultModuleRoot: 'main'
+        });
     });
-});
 
-test('preserves an explicit package surface when packageInterface is configured', () => {
-    const result = runMapConfig(
-        {
-            name: 'foo',
-            sourcesFolder: 'the-source',
-            roots: {
-                main: { js: 'index.js' },
-                cli: { js: 'cli.js' }
-            },
-            mainPackageJson: { type: 'module' },
+    test('preserves an explicit package surface when packageInterface is configured', function () {
+        const result = runMapConfig(
+            {
+                name: 'foo',
+                sourcesFolder: 'the-source',
+                roots: {
+                    main: { js: 'index.js' },
+                    cli: { js: 'cli.js' }
+                },
+                mainPackageJson: { type: 'module' },
+                packageInterface: {
+                    modules: [{ root: 'main', export: '.' }],
+                    bins: [{ root: 'cli', name: 'foo' }]
+                }
+            } as unknown as PackageConfigInput,
+            { extraPackages: [] }
+        );
+
+        assert.deepStrictEqual(result.surface, {
+            mode: 'explicit',
             packageInterface: {
                 modules: [{ root: 'main', export: '.' }],
                 bins: [{ root: 'cli', name: 'foo' }]
             }
-        } as unknown as PackageConfigInput,
-        { extraPackages: [] }
-    );
-
-    assert.deepStrictEqual(result.surface, {
-        mode: 'explicit',
-        packageInterface: {
-            modules: [{ root: 'main', export: '.' }],
-            bins: [{ root: 'cli', name: 'foo' }]
-        }
-    });
-});
-
-test('doesn’t change declarationFile root paths when they are already absolute', () => {
-    const packageConfig = fooPackageConfigFactory.build({
-        roots: { main: { js: '/js-file', declarationFile: '/declaration-file' } }
+        });
     });
 
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
+    test('doesn’t change declarationFile root paths when they are already absolute', function () {
+        const packageConfig = fooPackageConfigFactory.build({
+            roots: { main: { js: '/js-file', declarationFile: '/declaration-file' } }
+        });
 
-    assert.deepStrictEqual(result.roots, { main: { js: '/js-file', declarationFile: '/declaration-file' } });
-});
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
 
-test('adds the sourcesFolder as a prefix to a declarationFile root path when it is relative', () => {
-    const packageConfig = fooPackageConfigFactory.build({
-        roots: { main: { js: '/js-file', declarationFile: 'declaration-file' } }
+        assert.deepStrictEqual(result.roots, { main: { js: '/js-file', declarationFile: '/declaration-file' } });
     });
 
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
+    test('adds the sourcesFolder as a prefix to a declarationFile root path when it is relative', function () {
+        const packageConfig = fooPackageConfigFactory.build({
+            roots: { main: { js: '/js-file', declarationFile: 'declaration-file' } }
+        });
 
-    assert.deepStrictEqual(result.roots, {
-        main: { js: '/js-file', declarationFile: 'the-source/declaration-file' }
-    });
-});
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
 
-test('doesn’t change an additionalFile sourcePathFile when it is already an absolute path', () => {
-    const packageConfig = fooPackageWithAdditionalFiles([{ sourceFilePath: '/foo', targetFilePath: 'bar' }]);
-
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
-
-    assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: '/foo', targetFilePath: 'bar' }]);
-});
-
-test('adds the sourceFolder as prefix to an additionalFile sourcePathFile when it is a relative path', () => {
-    const packageConfig = fooPackageWithAdditionalFiles([{ sourceFilePath: 'foo', targetFilePath: 'bar' }]);
-
-    const result = runMapConfig(packageConfig, { extraPackages: [] });
-
-    assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/foo', targetFilePath: 'bar' }]);
-});
-
-test('throws an error when a bundle dependency does not exist', () => {
-    runMapConfigExpectingError(
-        { ...fooPackageConfigFactory.build(), bundleDependencies: ['bar'] },
-        'Dependent bundle "bar" not found'
-    );
-});
-
-test('maps the bundle dependency names correctly to the VersionedBundleWithManifest objects when it exists', () => {
-    const bundleDependency = versionedBundleWithManifest({
-        name: 'bar',
-        packageJson: { name: 'bar', version: '' }
-    });
-    const options = runMapConfig(
-        { ...fooPackageConfigFactory.build(), bundleDependencies: ['bar'] },
-        { bundleDependencies: [bundleDependency] }
-    );
-
-    assert.deepStrictEqual(options.bundleDependencies, [bundleDependency]);
-});
-
-test('defaults the includeSourceMapFiles option to false when it is not in the package config nor in common settings', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build());
-
-    assert.strictEqual(result.includeSourceMapFiles, false);
-});
-
-test('sets the includeSourceMapFiles option to true when it is true in the per package config and not set in common settings', () => {
-    const result = runMapConfig({ ...fooPackageConfigFactory.build(), includeSourceMapFiles: true });
-
-    assert.strictEqual(result.includeSourceMapFiles, true);
-});
-
-test('sets the includeSourceMapFiles option to true when it is not set in the per package config but set in common settings', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), {
-        commonPackageSettings: { includeSourceMapFiles: true }
+        assert.deepStrictEqual(result.roots, {
+            main: { js: '/js-file', declarationFile: 'the-source/declaration-file' }
+        });
     });
 
-    assert.strictEqual(result.includeSourceMapFiles, true);
-});
+    test('doesn’t change an additionalFile sourcePathFile when it is already an absolute path', function () {
+        const packageConfig = fooPackageWithAdditionalFiles([{ sourceFilePath: '/foo', targetFilePath: 'bar' }]);
 
-test('sets the includeSourceMapFiles option to false when it is set to false the per package config and set to true in the common settings', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), includeSourceMapFiles: false },
-        { commonPackageSettings: { includeSourceMapFiles: true } }
-    );
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
 
-    assert.strictEqual(result.includeSourceMapFiles, false);
-});
-
-test('merges the additional files if they are set both in common settings and per package settings', () => {
-    const result = runMapConfig(fooPackageWithAdditionalFiles([{ sourceFilePath: 'foo', targetFilePath: 'bar' }]), {
-        commonPackageSettings: { additionalFiles: [{ sourceFilePath: 'baz', targetFilePath: 'qux' }] },
-        extraPackages: []
+        assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: '/foo', targetFilePath: 'bar' }]);
     });
 
-    assert.deepStrictEqual(result.additionalFiles, [
-        { sourceFilePath: 'the-source/baz', targetFilePath: 'qux' },
-        { sourceFilePath: 'the-source/foo', targetFilePath: 'bar' }
-    ]);
-});
+    test('adds the sourceFolder as prefix to an additionalFile sourcePathFile when it is a relative path', function () {
+        const packageConfig = fooPackageWithAdditionalFiles([{ sourceFilePath: 'foo', targetFilePath: 'bar' }]);
 
-test('overwrites the additional files from common settings when a per package setting defines a file with the same target', () => {
-    const result = runMapConfig(fooPackageWithAdditionalFiles([{ sourceFilePath: 'foo', targetFilePath: 'bar' }]), {
-        commonPackageSettings: { additionalFiles: [{ sourceFilePath: 'baz', targetFilePath: 'bar' }] },
-        extraPackages: []
+        const result = runMapConfig(packageConfig, { extraPackages: [] });
+
+        assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/foo', targetFilePath: 'bar' }]);
     });
 
-    assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/foo', targetFilePath: 'bar' }]);
-});
-
-test('uses only the additionalFiles from common settings when the per package settings don’t have additional files specified', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), {
-        commonPackageSettings: { additionalFiles: [{ sourceFilePath: 'baz', targetFilePath: 'bar' }] },
-        extraPackages: []
+    test('throws an error when a bundle dependency does not exist', function () {
+        runMapConfigExpectingError(
+            { ...fooPackageConfigFactory.build(), bundleDependencies: ['bar'] },
+            'Dependent bundle "bar" not found'
+        );
     });
 
-    assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/baz', targetFilePath: 'bar' }]);
-});
+    test('maps the bundle dependency names correctly to the VersionedBundleWithManifest objects when it exists', function () {
+        const bundleDependency = versionedBundleWithManifest({
+            name: 'bar',
+            packageJson: { name: 'bar', version: '' }
+        });
+        const options = runMapConfig(
+            { ...fooPackageConfigFactory.build(), bundleDependencies: ['bar'] },
+            { bundleDependencies: [bundleDependency] }
+        );
 
-test('removes additional files which are duplicated by picking the last one', () => {
-    const result = runMapConfig(
-        fooPackageWithAdditionalFiles([
-            { sourceFilePath: 'foo', targetFilePath: 'bar' },
-            { sourceFilePath: 'baz', targetFilePath: 'bar' }
-        ]),
-        { extraPackages: [] }
-    );
-
-    assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/baz', targetFilePath: 'bar' }]);
-});
-
-test('sets additionalPackageJsonAttributes to an empty object when they are not defined at all', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), { extraPackages: [] });
-
-    assert.deepStrictEqual(result.additionalPackageJsonAttributes, {});
-});
-
-test('sets additionalPackageJsonAttributes to the value of the per package settings', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), additionalPackageJsonAttributes: { foo: 'bar' } },
-        { extraPackages: [] }
-    );
-
-    assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'bar' });
-});
-
-test('sets additionalPackageJsonAttributes to the value of the common settings', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), {
-        commonPackageSettings: { additionalPackageJsonAttributes: { foo: 'bar' } },
-        extraPackages: []
+        assert.deepStrictEqual(options.bundleDependencies, [bundleDependency]);
     });
 
-    assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'bar' });
-});
+    test('defaults the includeSourceMapFiles option to false when it is not in the package config nor in common settings', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build());
 
-test('defaults versioning to automatic when the package config does not specify it', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), { extraPackages: [] });
+        assert.strictEqual(result.includeSourceMapFiles, false);
+    });
 
-    assert.deepStrictEqual(result.versioning, { automatic: true });
-});
+    test('sets the includeSourceMapFiles option to true when it is true in the per package config and not set in common settings', function () {
+        const result = runMapConfig({ ...fooPackageConfigFactory.build(), includeSourceMapFiles: true });
 
-test('preserves explicit package versioning settings', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), versioning: { automatic: false, version: '2.3.4' } },
-        { extraPackages: [] }
-    );
+        assert.strictEqual(result.includeSourceMapFiles, true);
+    });
 
-    assert.deepStrictEqual(result.versioning, { automatic: false, version: '2.3.4' });
-});
+    test('sets the includeSourceMapFiles option to true when it is not set in the per package config but set in common settings', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), {
+            commonPackageSettings: { includeSourceMapFiles: true }
+        });
 
-test('merges additionalPackageJsonAttributes from per package and common settings', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), additionalPackageJsonAttributes: { baz: 'qux' } },
-        {
+        assert.strictEqual(result.includeSourceMapFiles, true);
+    });
+
+    test('sets the includeSourceMapFiles option to false when it is set to false the per package config and set to true in the common settings', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), includeSourceMapFiles: false },
+            { commonPackageSettings: { includeSourceMapFiles: true } }
+        );
+
+        assert.strictEqual(result.includeSourceMapFiles, false);
+    });
+
+    test('merges the additional files if they are set both in common settings and per package settings', function () {
+        const result = runMapConfig(fooPackageWithAdditionalFiles([{ sourceFilePath: 'foo', targetFilePath: 'bar' }]), {
+            commonPackageSettings: { additionalFiles: [{ sourceFilePath: 'baz', targetFilePath: 'qux' }] },
+            extraPackages: []
+        });
+
+        assert.deepStrictEqual(result.additionalFiles, [
+            { sourceFilePath: 'the-source/baz', targetFilePath: 'qux' },
+            { sourceFilePath: 'the-source/foo', targetFilePath: 'bar' }
+        ]);
+    });
+
+    test('overwrites the additional files from common settings when a per package setting defines a file with the same target', function () {
+        const result = runMapConfig(fooPackageWithAdditionalFiles([{ sourceFilePath: 'foo', targetFilePath: 'bar' }]), {
+            commonPackageSettings: { additionalFiles: [{ sourceFilePath: 'baz', targetFilePath: 'bar' }] },
+            extraPackages: []
+        });
+
+        assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/foo', targetFilePath: 'bar' }]);
+    });
+
+    test('uses only the additionalFiles from common settings when the per package settings don’t have additional files specified', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), {
+            commonPackageSettings: { additionalFiles: [{ sourceFilePath: 'baz', targetFilePath: 'bar' }] },
+            extraPackages: []
+        });
+
+        assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/baz', targetFilePath: 'bar' }]);
+    });
+
+    test('removes additional files which are duplicated by picking the last one', function () {
+        const result = runMapConfig(
+            fooPackageWithAdditionalFiles([
+                { sourceFilePath: 'foo', targetFilePath: 'bar' },
+                { sourceFilePath: 'baz', targetFilePath: 'bar' }
+            ]),
+            { extraPackages: [] }
+        );
+
+        assert.deepStrictEqual(result.additionalFiles, [{ sourceFilePath: 'the-source/baz', targetFilePath: 'bar' }]);
+    });
+
+    test('sets additionalPackageJsonAttributes to an empty object when they are not defined at all', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), { extraPackages: [] });
+
+        assert.deepStrictEqual(result.additionalPackageJsonAttributes, {});
+    });
+
+    test('sets additionalPackageJsonAttributes to the value of the per package settings', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), additionalPackageJsonAttributes: { foo: 'bar' } },
+            { extraPackages: [] }
+        );
+
+        assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'bar' });
+    });
+
+    test('sets additionalPackageJsonAttributes to the value of the common settings', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), {
             commonPackageSettings: { additionalPackageJsonAttributes: { foo: 'bar' } },
             extraPackages: []
-        }
-    );
+        });
 
-    assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'bar', baz: 'qux' });
-});
-
-test('overwrites additionalPackageJsonAttributes from common settings when there are also defined in per package settings', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), additionalPackageJsonAttributes: { foo: 'qux' } },
-        {
-            commonPackageSettings: { additionalPackageJsonAttributes: { foo: 'bar' } },
-            extraPackages: []
-        }
-    );
-
-    assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'qux' });
-});
-
-test('uses the common publishSettings when the package config does not override it', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), {
-        commonPackageSettings: { publishSettings: { access: 'public', provenance: { type: 'auto' } } },
-        extraPackages: []
+        assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'bar' });
     });
 
-    assert.deepStrictEqual(result.publishSettings, { access: 'public', provenance: { type: 'auto' } });
-});
+    test('defaults versioning to automatic when the package config does not specify it', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), { extraPackages: [] });
 
-test('prefers the per-package publishSettings over the common default', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), publishSettings: { access: 'restricted' } },
-        {
-            commonPackageSettings: { publishSettings: { access: 'public' } },
-            extraPackages: []
-        }
-    );
-
-    assert.deepStrictEqual(result.publishSettings, { access: 'restricted' });
-});
-
-test('defaults allowMutableSpecifiers to an empty array when no dependencyPolicy is configured', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), { extraPackages: [] });
-
-    assert.deepStrictEqual(result.allowMutableSpecifiers, []);
-});
-
-test('uses the per-package dependencyPolicy.allowMutableSpecifiers when set', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), dependencyPolicy: { allowMutableSpecifiers: ['react'] } },
-        { extraPackages: [] }
-    );
-
-    assert.deepStrictEqual(result.allowMutableSpecifiers, ['react']);
-});
-
-test('falls back to the common dependencyPolicy.allowMutableSpecifiers when the package does not set it', () => {
-    const result = runMapConfig(fooPackageConfigFactory.build(), {
-        commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: ['shared-fork'] } },
-        extraPackages: []
+        assert.deepStrictEqual(result.versioning, { automatic: true });
     });
 
-    assert.deepStrictEqual(result.allowMutableSpecifiers, ['shared-fork']);
-});
+    test('preserves explicit package versioning settings', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), versioning: { automatic: false, version: '2.3.4' } },
+            { extraPackages: [] }
+        );
 
-test('per-package dependencyPolicy fully replaces the common dependencyPolicy', () => {
-    const result = runMapConfig(
-        { ...fooPackageConfigFactory.build(), dependencyPolicy: { allowMutableSpecifiers: ['only-this'] } },
-        {
-            commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: ['common-only'] } },
+        assert.deepStrictEqual(result.versioning, { automatic: false, version: '2.3.4' });
+    });
+
+    test('merges additionalPackageJsonAttributes from per package and common settings', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), additionalPackageJsonAttributes: { baz: 'qux' } },
+            {
+                commonPackageSettings: { additionalPackageJsonAttributes: { foo: 'bar' } },
+                extraPackages: []
+            }
+        );
+
+        assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'bar', baz: 'qux' });
+    });
+
+    test('overwrites additionalPackageJsonAttributes from common settings when there are also defined in per package settings', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), additionalPackageJsonAttributes: { foo: 'qux' } },
+            {
+                commonPackageSettings: { additionalPackageJsonAttributes: { foo: 'bar' } },
+                extraPackages: []
+            }
+        );
+
+        assert.deepStrictEqual(result.additionalPackageJsonAttributes, { foo: 'qux' });
+    });
+
+    test('uses the common publishSettings when the package config does not override it', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), {
+            commonPackageSettings: { publishSettings: { access: 'public', provenance: { type: 'auto' } } },
             extraPackages: []
-        }
-    );
+        });
 
-    assert.deepStrictEqual(result.allowMutableSpecifiers, ['only-this']);
-});
+        assert.deepStrictEqual(result.publishSettings, { access: 'public', provenance: { type: 'auto' } });
+    });
 
-test('throws a "missing publish settings" error when neither commonPackageSettings nor the package supplies one', () => {
-    const packageWithoutPublishSettings = fooPackageConfigFactory.build();
-    const config = {
-        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-        packages: [packageWithoutPublishSettings]
-    } as unknown as PacktoryConfigInput;
+    test('prefers the per-package publishSettings over the common default', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), publishSettings: { access: 'restricted' } },
+            {
+                commonPackageSettings: { publishSettings: { access: 'public' } },
+                extraPackages: []
+            }
+        );
 
-    assert.throws(
-        () => {
-            configToBuildAndPublishOptions('foo', { foo: packageWithoutPublishSettings }, config, []);
-        },
-        { message: 'Config for package "foo" is missing publish settings' }
-    );
+        assert.deepStrictEqual(result.publishSettings, { access: 'restricted' });
+    });
+
+    test('defaults allowMutableSpecifiers to an empty array when no dependencyPolicy is configured', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), { extraPackages: [] });
+
+        assert.deepStrictEqual(result.allowMutableSpecifiers, []);
+    });
+
+    test('uses the per-package dependencyPolicy.allowMutableSpecifiers when set', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), dependencyPolicy: { allowMutableSpecifiers: ['react'] } },
+            { extraPackages: [] }
+        );
+
+        assert.deepStrictEqual(result.allowMutableSpecifiers, ['react']);
+    });
+
+    test('falls back to the common dependencyPolicy.allowMutableSpecifiers when the package does not set it', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), {
+            commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: ['shared-fork'] } },
+            extraPackages: []
+        });
+
+        assert.deepStrictEqual(result.allowMutableSpecifiers, ['shared-fork']);
+    });
+
+    test('per-package dependencyPolicy fully replaces the common dependencyPolicy', function () {
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), dependencyPolicy: { allowMutableSpecifiers: ['only-this'] } },
+            {
+                commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: ['common-only'] } },
+                extraPackages: []
+            }
+        );
+
+        assert.deepStrictEqual(result.allowMutableSpecifiers, ['only-this']);
+    });
+
+    test('throws a "missing publish settings" error when neither commonPackageSettings nor the package supplies one', function () {
+        const packageWithoutPublishSettings = fooPackageConfigFactory.build();
+        const config = {
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            packages: [packageWithoutPublishSettings]
+        } as unknown as PacktoryConfigInput;
+
+        assert.throws(
+            () => {
+                configToBuildAndPublishOptions('foo', { foo: packageWithoutPublishSettings }, config, []);
+            },
+            { message: 'Config for package "foo" is missing publish settings' }
+        );
+    });
 });

--- a/source/packtory/normalize-paths.property.ts
+++ b/source/packtory/normalize-paths.property.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import path from 'node:path';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { normalizeAdditionalFile, normalizeRoot } from './normalize-paths.ts';
 
 const pathSegmentArbitrary = fc.stringMatching(/^[\w.-]+$/);
@@ -19,104 +19,106 @@ const absolutePathArbitrary = fc.tuple(relativePathArbitrary, relativePathArbitr
     return path.join(path.sep, folder, filePath);
 });
 
-test('normalizeRoot() keeps absolute paths unchanged and resolves relative paths against the source folder', () => {
-    fc.assert(
-        fc.property(
-            relativePathArbitrary,
-            relativePathArbitrary,
-            fc.option(relativePathArbitrary, { nil: undefined }),
-            (sourceFolder, js, declarationFile) => {
-                const relativeRoot = declarationFile === undefined ? { js } : { js, declarationFile };
-                const normalizedRelativeRoot = normalizeRoot(relativeRoot, sourceFolder);
+suite('normalize-paths', function () {
+    test('normalizeRoot() keeps absolute paths unchanged and resolves relative paths against the source folder', function () {
+        fc.assert(
+            fc.property(
+                relativePathArbitrary,
+                relativePathArbitrary,
+                fc.option(relativePathArbitrary, { nil: undefined }),
+                (sourceFolder, js, declarationFile) => {
+                    const relativeRoot = declarationFile === undefined ? { js } : { js, declarationFile };
+                    const normalizedRelativeRoot = normalizeRoot(relativeRoot, sourceFolder);
 
-                assert.strictEqual(normalizedRelativeRoot.js, path.join(sourceFolder, js));
-                assert.strictEqual(
-                    normalizedRelativeRoot.declarationFile,
-                    declarationFile === undefined ? undefined : path.join(sourceFolder, declarationFile)
-                );
-            }
-        )
-    );
+                    assert.strictEqual(normalizedRelativeRoot.js, path.join(sourceFolder, js));
+                    assert.strictEqual(
+                        normalizedRelativeRoot.declarationFile,
+                        declarationFile === undefined ? undefined : path.join(sourceFolder, declarationFile)
+                    );
+                }
+            )
+        );
 
-    fc.assert(
-        fc.property(
-            absolutePathArbitrary,
-            relativePathArbitrary,
-            fc.option(absolutePathArbitrary, { nil: undefined }),
-            (js, sourceFolder, declarationFile) => {
-                const absoluteRoot = declarationFile === undefined ? { js } : { js, declarationFile };
-                const normalizedAbsoluteRoot = normalizeRoot(absoluteRoot, sourceFolder);
+        fc.assert(
+            fc.property(
+                absolutePathArbitrary,
+                relativePathArbitrary,
+                fc.option(absolutePathArbitrary, { nil: undefined }),
+                (js, sourceFolder, declarationFile) => {
+                    const absoluteRoot = declarationFile === undefined ? { js } : { js, declarationFile };
+                    const normalizedAbsoluteRoot = normalizeRoot(absoluteRoot, sourceFolder);
 
-                assert.strictEqual(normalizedAbsoluteRoot.js, js);
-                assert.strictEqual(normalizedAbsoluteRoot.declarationFile, declarationFile);
-            }
-        )
-    );
-});
+                    assert.strictEqual(normalizedAbsoluteRoot.js, js);
+                    assert.strictEqual(normalizedAbsoluteRoot.declarationFile, declarationFile);
+                }
+            )
+        );
+    });
 
-test('normalizeAdditionalFile() keeps the target path and resolves only the source path', () => {
-    fc.assert(
-        fc.property(
-            relativePathArbitrary,
-            relativePathArbitrary,
-            relativePathArbitrary,
-            (sourceFolder, sourceFilePath, targetFilePath) => {
-                const normalized = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
+    test('normalizeAdditionalFile() keeps the target path and resolves only the source path', function () {
+        fc.assert(
+            fc.property(
+                relativePathArbitrary,
+                relativePathArbitrary,
+                relativePathArbitrary,
+                (sourceFolder, sourceFilePath, targetFilePath) => {
+                    const normalized = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
 
-                assert.deepStrictEqual(normalized, {
-                    sourceFilePath: path.join(sourceFolder, sourceFilePath),
-                    targetFilePath
-                });
-            }
-        )
-    );
+                    assert.deepStrictEqual(normalized, {
+                        sourceFilePath: path.join(sourceFolder, sourceFilePath),
+                        targetFilePath
+                    });
+                }
+            )
+        );
 
-    fc.assert(
-        fc.property(
-            relativePathArbitrary,
-            absolutePathArbitrary,
-            relativePathArbitrary,
-            (sourceFolder, sourceFilePath, targetFilePath) => {
-                const normalized = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
+        fc.assert(
+            fc.property(
+                relativePathArbitrary,
+                absolutePathArbitrary,
+                relativePathArbitrary,
+                (sourceFolder, sourceFilePath, targetFilePath) => {
+                    const normalized = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
 
-                assert.deepStrictEqual(normalized, {
-                    sourceFilePath,
-                    targetFilePath
-                });
-            }
-        )
-    );
-});
+                    assert.deepStrictEqual(normalized, {
+                        sourceFilePath,
+                        targetFilePath
+                    });
+                }
+            )
+        );
+    });
 
-test('normalizeRoot() is idempotent once all paths are normalized', () => {
-    fc.assert(
-        fc.property(
-            absolutePathArbitrary,
-            relativePathArbitrary,
-            fc.option(relativePathArbitrary, { nil: undefined }),
-            (sourceFolder, js, declarationFile) => {
-                const root = declarationFile === undefined ? { js } : { js, declarationFile };
-                const normalizedOnce = normalizeRoot(root, sourceFolder);
-                const normalizedTwice = normalizeRoot(normalizedOnce, sourceFolder);
+    test('normalizeRoot() is idempotent once all paths are normalized', function () {
+        fc.assert(
+            fc.property(
+                absolutePathArbitrary,
+                relativePathArbitrary,
+                fc.option(relativePathArbitrary, { nil: undefined }),
+                (sourceFolder, js, declarationFile) => {
+                    const root = declarationFile === undefined ? { js } : { js, declarationFile };
+                    const normalizedOnce = normalizeRoot(root, sourceFolder);
+                    const normalizedTwice = normalizeRoot(normalizedOnce, sourceFolder);
 
-                assert.deepStrictEqual(normalizedTwice, normalizedOnce);
-            }
-        )
-    );
-});
+                    assert.deepStrictEqual(normalizedTwice, normalizedOnce);
+                }
+            )
+        );
+    });
 
-test('normalizeAdditionalFile() is idempotent once the source path is normalized', () => {
-    fc.assert(
-        fc.property(
-            absolutePathArbitrary,
-            relativePathArbitrary,
-            relativePathArbitrary,
-            (sourceFolder, sourceFilePath, targetFilePath) => {
-                const normalizedOnce = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
-                const normalizedTwice = normalizeAdditionalFile(normalizedOnce, sourceFolder);
+    test('normalizeAdditionalFile() is idempotent once the source path is normalized', function () {
+        fc.assert(
+            fc.property(
+                absolutePathArbitrary,
+                relativePathArbitrary,
+                relativePathArbitrary,
+                (sourceFolder, sourceFilePath, targetFilePath) => {
+                    const normalizedOnce = normalizeAdditionalFile({ sourceFilePath, targetFilePath }, sourceFolder);
+                    const normalizedTwice = normalizeAdditionalFile(normalizedOnce, sourceFolder);
 
-                assert.deepStrictEqual(normalizedTwice, normalizedOnce);
-            }
-        )
-    );
+                    assert.deepStrictEqual(normalizedTwice, normalizedOnce);
+                }
+            )
+        );
+    });
 });

--- a/source/packtory/normalize-paths.test.ts
+++ b/source/packtory/normalize-paths.test.ts
@@ -1,44 +1,46 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { normalizeAdditionalFile, normalizeRoot } from './normalize-paths.ts';
 
-test('normalizeRoot leaves absolute js paths unchanged', () => {
-    assert.deepStrictEqual(normalizeRoot({ js: '/abs/index.js' }, '/src'), { js: '/abs/index.js' });
-});
-
-test('normalizeRoot prefixes relative js paths with the source folder', () => {
-    assert.deepStrictEqual(normalizeRoot({ js: 'index.js' }, '/src'), { js: '/src/index.js' });
-});
-
-test('normalizeRoot also normalizes the declaration file path when present', () => {
-    assert.deepStrictEqual(normalizeRoot({ js: 'index.js', declarationFile: 'index.d.ts' }, '/src'), {
-        js: '/src/index.js',
-        declarationFile: '/src/index.d.ts'
+suite('normalize-paths', function () {
+    test('normalizeRoot leaves absolute js paths unchanged', function () {
+        assert.deepStrictEqual(normalizeRoot({ js: '/abs/index.js' }, '/src'), { js: '/abs/index.js' });
     });
-});
 
-test('normalizeRoot omits the declaration file from the output when none is provided', () => {
-    const result = normalizeRoot({ js: 'index.js' }, '/src');
-    assert.strictEqual('declarationFile' in result, false);
-});
+    test('normalizeRoot prefixes relative js paths with the source folder', function () {
+        assert.deepStrictEqual(normalizeRoot({ js: 'index.js' }, '/src'), { js: '/src/index.js' });
+    });
 
-test('normalizeAdditionalFile resolves the sourceFilePath relative to the source folder', () => {
-    assert.deepStrictEqual(
-        normalizeAdditionalFile({ sourceFilePath: 'README.md', targetFilePath: 'README.md' }, '/src'),
-        { sourceFilePath: '/src/README.md', targetFilePath: 'README.md' }
-    );
-});
+    test('normalizeRoot also normalizes the declaration file path when present', function () {
+        assert.deepStrictEqual(normalizeRoot({ js: 'index.js', declarationFile: 'index.d.ts' }, '/src'), {
+            js: '/src/index.js',
+            declarationFile: '/src/index.d.ts'
+        });
+    });
 
-test('normalizeAdditionalFile keeps an absolute sourceFilePath unchanged', () => {
-    assert.deepStrictEqual(
-        normalizeAdditionalFile({ sourceFilePath: '/abs/README.md', targetFilePath: 'README.md' }, '/src'),
-        { sourceFilePath: '/abs/README.md', targetFilePath: 'README.md' }
-    );
-});
+    test('normalizeRoot omits the declaration file from the output when none is provided', function () {
+        const result = normalizeRoot({ js: 'index.js' }, '/src');
+        assert.strictEqual('declarationFile' in result, false);
+    });
 
-test('normalizeAdditionalFile keeps the targetFilePath untouched', () => {
-    assert.strictEqual(
-        normalizeAdditionalFile({ sourceFilePath: 'a.md', targetFilePath: 'docs/a.md' }, '/src').targetFilePath,
-        'docs/a.md'
-    );
+    test('normalizeAdditionalFile resolves the sourceFilePath relative to the source folder', function () {
+        assert.deepStrictEqual(
+            normalizeAdditionalFile({ sourceFilePath: 'README.md', targetFilePath: 'README.md' }, '/src'),
+            { sourceFilePath: '/src/README.md', targetFilePath: 'README.md' }
+        );
+    });
+
+    test('normalizeAdditionalFile keeps an absolute sourceFilePath unchanged', function () {
+        assert.deepStrictEqual(
+            normalizeAdditionalFile({ sourceFilePath: '/abs/README.md', targetFilePath: 'README.md' }, '/src'),
+            { sourceFilePath: '/abs/README.md', targetFilePath: 'README.md' }
+        );
+    });
+
+    test('normalizeAdditionalFile keeps the targetFilePath untouched', function () {
+        assert.strictEqual(
+            normalizeAdditionalFile({ sourceFilePath: 'a.md', targetFilePath: 'docs/a.md' }, '/src').targetFilePath,
+            'docs/a.md'
+        );
+    });
 });

--- a/source/packtory/options/bundle-dependency-resolution.test.ts
+++ b/source/packtory/options/bundle-dependency-resolution.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfig } from '../../config/config.ts';
 import { resolveBundleDependencies } from './bundle-dependency-resolution.ts';
 
@@ -7,35 +7,37 @@ function pkg(overrides: Partial<PackageConfig>): PackageConfig {
     return { name: 'pkg-a', ...overrides } as unknown as PackageConfig;
 }
 
-test('resolveBundleDependencies returns empty lists when the package has no declared dependencies', () => {
-    assert.deepStrictEqual(resolveBundleDependencies(pkg({}), []), {
-        bundleDependencies: [],
-        bundlePeerDependencies: []
+suite('bundle-dependency-resolution', function () {
+    test('resolveBundleDependencies returns empty lists when the package has no declared dependencies', function () {
+        assert.deepStrictEqual(resolveBundleDependencies(pkg({}), []), {
+            bundleDependencies: [],
+            bundlePeerDependencies: []
+        });
     });
-});
 
-test('resolveBundleDependencies maps each declared dependency name to the matching bundle', () => {
-    const bundleA = { name: 'pkg-b', payload: 'b' };
-    const bundleB = { name: 'pkg-c', payload: 'c' };
+    test('resolveBundleDependencies maps each declared dependency name to the matching bundle', function () {
+        const bundleA = { name: 'pkg-b', payload: 'b' };
+        const bundleB = { name: 'pkg-c', payload: 'c' };
 
-    const result = resolveBundleDependencies(pkg({ bundleDependencies: ['pkg-b', 'pkg-c'] }), [bundleA, bundleB]);
+        const result = resolveBundleDependencies(pkg({ bundleDependencies: ['pkg-b', 'pkg-c'] }), [bundleA, bundleB]);
 
-    assert.deepStrictEqual(result.bundleDependencies, [bundleA, bundleB]);
-});
+        assert.deepStrictEqual(result.bundleDependencies, [bundleA, bundleB]);
+    });
 
-test('resolveBundleDependencies maps each declared peer dependency name to the matching bundle', () => {
-    const peer = { name: 'pkg-peer', payload: 'p' };
+    test('resolveBundleDependencies maps each declared peer dependency name to the matching bundle', function () {
+        const peer = { name: 'pkg-peer', payload: 'p' };
 
-    const result = resolveBundleDependencies(pkg({ bundlePeerDependencies: ['pkg-peer'] }), [peer]);
+        const result = resolveBundleDependencies(pkg({ bundlePeerDependencies: ['pkg-peer'] }), [peer]);
 
-    assert.deepStrictEqual(result.bundlePeerDependencies, [peer]);
-});
+        assert.deepStrictEqual(result.bundlePeerDependencies, [peer]);
+    });
 
-test('resolveBundleDependencies throws when a declared dependency has no matching bundle', () => {
-    try {
-        resolveBundleDependencies(pkg({ bundleDependencies: ['missing'] }), []);
-        assert.fail('Expected resolveBundleDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Dependent bundle "missing" not found');
-    }
+    test('resolveBundleDependencies throws when a declared dependency has no matching bundle', function () {
+        try {
+            resolveBundleDependencies(pkg({ bundleDependencies: ['missing'] }), []);
+            assert.fail('Expected resolveBundleDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Dependent bundle "missing" not found');
+        }
+    });
 });

--- a/source/packtory/options/dead-code-elimination-resolution.test.ts
+++ b/source/packtory/options/dead-code-elimination-resolution.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ValidConfigWithoutRegistryResult } from '../../config/validation.ts';
 import { resolveDeadCodeEliminationByName } from './dead-code-elimination-resolution.ts';
 
@@ -18,22 +18,24 @@ function validated(
     } as unknown as ValidConfigWithoutRegistryResult;
 }
 
-test('resolveDeadCodeEliminationByName produces one entry per declared package', () => {
-    const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a' }, { name: 'pkg-b' }]));
-    assert.deepStrictEqual(Array.from(map.keys()), ['pkg-a', 'pkg-b']);
-});
+suite('dead-code-elimination-resolution', function () {
+    test('resolveDeadCodeEliminationByName produces one entry per declared package', function () {
+        const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a' }, { name: 'pkg-b' }]));
+        assert.deepStrictEqual(Array.from(map.keys()), ['pkg-a', 'pkg-b']);
+    });
 
-test('resolveDeadCodeEliminationByName uses the package-level enabled flag when one is provided', () => {
-    const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a', enabled: false }]));
-    assert.strictEqual(map.get('pkg-a')?.enabled, false);
-});
+    test('resolveDeadCodeEliminationByName uses the package-level enabled flag when one is provided', function () {
+        const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a', enabled: false }]));
+        assert.strictEqual(map.get('pkg-a')?.enabled, false);
+    });
 
-test('resolveDeadCodeEliminationByName falls back to the common enabled flag when the package has no override', () => {
-    const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a' }], { enabled: false }));
-    assert.strictEqual(map.get('pkg-a')?.enabled, false);
-});
+    test('resolveDeadCodeEliminationByName falls back to the common enabled flag when the package has no override', function () {
+        const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a' }], { enabled: false }));
+        assert.strictEqual(map.get('pkg-a')?.enabled, false);
+    });
 
-test('resolveDeadCodeEliminationByName returns undefined when neither the package nor the common settings define the setting', () => {
-    const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a' }]));
-    assert.strictEqual(map.get('pkg-a'), undefined);
+    test('resolveDeadCodeEliminationByName returns undefined when neither the package nor the common settings define the setting', function () {
+        const map = resolveDeadCodeEliminationByName(validated([{ name: 'pkg-a' }]));
+        assert.strictEqual(map.get('pkg-a'), undefined);
+    });
 });

--- a/source/packtory/options/prepare-package-options.test.ts
+++ b/source/packtory/options/prepare-package-options.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfigsByName, PacktoryConfigWithoutRegistry } from '../../config/config.ts';
 import { preparePackageOptions } from './prepare-package-options.ts';
 
@@ -19,31 +19,33 @@ function minimalPacktoryConfig(): PacktoryConfigWithoutRegistry {
     return { packages: [] } as unknown as PacktoryConfigWithoutRegistry;
 }
 
-test('preparePackageOptions throws when the requested package is missing from the config map', () => {
-    try {
-        preparePackageOptions('missing', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
-        assert.fail('expected preparePackageOptions to throw');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'Config for package "missing" is missing');
-    }
-});
+suite('prepare-package-options', function () {
+    test('preparePackageOptions throws when the requested package is missing from the config map', function () {
+        try {
+            preparePackageOptions('missing', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
+            assert.fail('expected preparePackageOptions to throw');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'Config for package "missing" is missing');
+        }
+    });
 
-test('preparePackageOptions returns the selected package config along with shared options', () => {
-    const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
+    test('preparePackageOptions returns the selected package config along with shared options', function () {
+        const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
 
-    assert.strictEqual(prepared.packageConfig.name, 'pkg-a');
-    assert.strictEqual(prepared.sharedOptions.name, 'pkg-a');
-});
+        assert.strictEqual(prepared.packageConfig.name, 'pkg-a');
+        assert.strictEqual(prepared.sharedOptions.name, 'pkg-a');
+    });
 
-test('preparePackageOptions defaults versioning to automatic when not configured', () => {
-    const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
+    test('preparePackageOptions defaults versioning to automatic when not configured', function () {
+        const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
 
-    assert.deepStrictEqual(prepared.versioning, { automatic: true });
-});
+        assert.deepStrictEqual(prepared.versioning, { automatic: true });
+    });
 
-test('preparePackageOptions normalizes root paths against the sources folder', () => {
-    const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
+    test('preparePackageOptions normalizes root paths against the sources folder', function () {
+        const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
 
-    assert.strictEqual(prepared.sharedOptions.roots.main?.js, '/src/index.js');
+        assert.strictEqual(prepared.sharedOptions.roots.main?.js, '/src/index.js');
+    });
 });

--- a/source/packtory/options/required-value-helpers.test.ts
+++ b/source/packtory/options/required-value-helpers.test.ts
@@ -1,36 +1,38 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { getRequiredArrayValue, getRequiredValue, mapRequiredArrayValue } from './required-value-helpers.ts';
 
-test('getRequiredValue returns the value when it is defined', () => {
-    assert.strictEqual(getRequiredValue('abc', 'msg'), 'abc');
-});
+suite('required-value-helpers', function () {
+    test('getRequiredValue returns the value when it is defined', function () {
+        assert.strictEqual(getRequiredValue('abc', 'msg'), 'abc');
+    });
 
-test('getRequiredValue throws with the given message when the value is undefined', () => {
-    try {
-        getRequiredValue(undefined, 'value missing');
-        assert.fail('Expected getRequiredValue() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'value missing');
-    }
-});
+    test('getRequiredValue throws with the given message when the value is undefined', function () {
+        try {
+            getRequiredValue(undefined, 'value missing');
+            assert.fail('Expected getRequiredValue() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'value missing');
+        }
+    });
 
-test('getRequiredArrayValue returns the array unchanged when it has at least one element', () => {
-    assert.deepStrictEqual(getRequiredArrayValue(['a', 'b'], 'msg'), ['a', 'b']);
-});
+    test('getRequiredArrayValue returns the array unchanged when it has at least one element', function () {
+        assert.deepStrictEqual(getRequiredArrayValue(['a', 'b'], 'msg'), ['a', 'b']);
+    });
 
-test('getRequiredArrayValue throws with the given message when the array is empty', () => {
-    try {
-        getRequiredArrayValue([], 'array required');
-        assert.fail('Expected getRequiredArrayValue() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'array required');
-    }
-});
+    test('getRequiredArrayValue throws with the given message when the array is empty', function () {
+        try {
+            getRequiredArrayValue([], 'array required');
+            assert.fail('Expected getRequiredArrayValue() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'array required');
+        }
+    });
 
-test('mapRequiredArrayValue maps every element with the supplied mapper while preserving the non-empty signature', () => {
-    assert.deepStrictEqual(
-        mapRequiredArrayValue([1, 2, 3], (value) => value * 2),
-        [2, 4, 6]
-    );
+    test('mapRequiredArrayValue maps every element with the supplied mapper while preserving the non-empty signature', function () {
+        assert.deepStrictEqual(
+            mapRequiredArrayValue([1, 2, 3], (value) => value * 2),
+            [2, 4, 6]
+        );
+    });
 });

--- a/source/packtory/options/setting-resolvers.test.ts
+++ b/source/packtory/options/setting-resolvers.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- tests narrow PackageConfig / PacktoryConfigWithoutRegistry to the fields each resolver actually reads */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from '../../config/config.ts';
 import type { MainPackageJson } from '../../config/package-json.ts';
 import {
@@ -22,86 +22,88 @@ function config(overrides: Partial<PacktoryConfigWithoutRegistry> = {}): Packtor
 
 const baseMain: MainPackageJson = { type: 'module' };
 
-test('resolveSourcesFolder prefers the package-level sourcesFolder over commonPackageSettings', () => {
-    const result = resolveSourcesFolder(
-        pkg({ sourcesFolder: 'pkg-src' }),
-        config({ commonPackageSettings: { sourcesFolder: 'common-src' } as never })
-    );
-    assert.strictEqual(result, 'pkg-src');
-});
-
-test('resolveSourcesFolder falls back to commonPackageSettings when the package omits sourcesFolder', () => {
-    const result = resolveSourcesFolder(
-        pkg({}),
-        config({ commonPackageSettings: { sourcesFolder: 'common-src' } as never })
-    );
-    assert.strictEqual(result, 'common-src');
-});
-
-test('resolveSourcesFolder throws when no source folder is configured anywhere', () => {
-    try {
-        resolveSourcesFolder(pkg({}), config());
-        assert.fail('Expected resolveSourcesFolder() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing the sources folder');
-    }
-});
-
-test('resolveMainPackageJson returns the package-level mainPackageJson when defined', () => {
-    const result = resolveMainPackageJson(pkg({ mainPackageJson: baseMain }), config());
-    assert.deepStrictEqual(result, baseMain);
-});
-
-test('resolveMainPackageJson throws when no main package.json is configured anywhere', () => {
-    try {
-        resolveMainPackageJson(pkg({}), config());
-        assert.fail('Expected resolveMainPackageJson() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Config for package "pkg-a" is missing the main package.json settings'
+suite('setting-resolvers', function () {
+    test('resolveSourcesFolder prefers the package-level sourcesFolder over commonPackageSettings', function () {
+        const result = resolveSourcesFolder(
+            pkg({ sourcesFolder: 'pkg-src' }),
+            config({ commonPackageSettings: { sourcesFolder: 'common-src' } as never })
         );
-    }
-});
+        assert.strictEqual(result, 'pkg-src');
+    });
 
-test('resolvePublishSettings throws when no publish settings are configured', () => {
-    try {
-        resolvePublishSettings(pkg({}), config());
-        assert.fail('Expected resolvePublishSettings() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing publish settings');
-    }
-});
+    test('resolveSourcesFolder falls back to commonPackageSettings when the package omits sourcesFolder', function () {
+        const result = resolveSourcesFolder(
+            pkg({}),
+            config({ commonPackageSettings: { sourcesFolder: 'common-src' } as never })
+        );
+        assert.strictEqual(result, 'common-src');
+    });
 
-test('resolveAllowMutableSpecifiers returns an empty array when no dependency policy is configured', () => {
-    assert.deepStrictEqual(resolveAllowMutableSpecifiers(pkg({}), config()), []);
-});
+    test('resolveSourcesFolder throws when no source folder is configured anywhere', function () {
+        try {
+            resolveSourcesFolder(pkg({}), config());
+            assert.fail('Expected resolveSourcesFolder() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing the sources folder');
+        }
+    });
 
-test('resolveAllowMutableSpecifiers prefers package-level dependency policy over commonPackageSettings', () => {
-    const result = resolveAllowMutableSpecifiers(
-        pkg({ dependencyPolicy: { allowMutableSpecifiers: ['react'] } as never }),
-        config({ commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: ['lodash'] } } as never })
-    );
-    assert.deepStrictEqual(result, ['react']);
-});
+    test('resolveMainPackageJson returns the package-level mainPackageJson when defined', function () {
+        const result = resolveMainPackageJson(pkg({ mainPackageJson: baseMain }), config());
+        assert.deepStrictEqual(result, baseMain);
+    });
 
-test('buildAdditionalPackageJsonAttributes merges common attributes with package-level overrides', () => {
-    const result = buildAdditionalPackageJsonAttributes(
-        pkg({ additionalPackageJsonAttributes: { keywords: ['custom'], scripts: { build: 'tsc' } } as never }),
-        config({ commonPackageSettings: { additionalPackageJsonAttributes: { keywords: ['shared'] } } as never })
-    );
+    test('resolveMainPackageJson throws when no main package.json is configured anywhere', function () {
+        try {
+            resolveMainPackageJson(pkg({}), config());
+            assert.fail('Expected resolveMainPackageJson() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Config for package "pkg-a" is missing the main package.json settings'
+            );
+        }
+    });
 
-    assert.deepStrictEqual(result, { keywords: ['custom'], scripts: { build: 'tsc' } });
-});
+    test('resolvePublishSettings throws when no publish settings are configured', function () {
+        try {
+            resolvePublishSettings(pkg({}), config());
+            assert.fail('Expected resolvePublishSettings() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing publish settings');
+        }
+    });
 
-test('resolveIncludeSourceMapFiles defaults to false when neither level configures it', () => {
-    assert.strictEqual(resolveIncludeSourceMapFiles(pkg({}), config()), false);
-});
+    test('resolveAllowMutableSpecifiers returns an empty array when no dependency policy is configured', function () {
+        assert.deepStrictEqual(resolveAllowMutableSpecifiers(pkg({}), config()), []);
+    });
 
-test('resolveIncludeSourceMapFiles prefers the package-level setting over commonPackageSettings', () => {
-    const result = resolveIncludeSourceMapFiles(
-        pkg({ includeSourceMapFiles: true }),
-        config({ commonPackageSettings: { includeSourceMapFiles: false } as never })
-    );
-    assert.strictEqual(result, true);
+    test('resolveAllowMutableSpecifiers prefers package-level dependency policy over commonPackageSettings', function () {
+        const result = resolveAllowMutableSpecifiers(
+            pkg({ dependencyPolicy: { allowMutableSpecifiers: ['react'] } as never }),
+            config({ commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: ['lodash'] } } as never })
+        );
+        assert.deepStrictEqual(result, ['react']);
+    });
+
+    test('buildAdditionalPackageJsonAttributes merges common attributes with package-level overrides', function () {
+        const result = buildAdditionalPackageJsonAttributes(
+            pkg({ additionalPackageJsonAttributes: { keywords: ['custom'], scripts: { build: 'tsc' } } as never }),
+            config({ commonPackageSettings: { additionalPackageJsonAttributes: { keywords: ['shared'] } } as never })
+        );
+
+        assert.deepStrictEqual(result, { keywords: ['custom'], scripts: { build: 'tsc' } });
+    });
+
+    test('resolveIncludeSourceMapFiles defaults to false when neither level configures it', function () {
+        assert.strictEqual(resolveIncludeSourceMapFiles(pkg({}), config()), false);
+    });
+
+    test('resolveIncludeSourceMapFiles prefers the package-level setting over commonPackageSettings', function () {
+        const result = resolveIncludeSourceMapFiles(
+            pkg({ includeSourceMapFiles: true }),
+            config({ commonPackageSettings: { includeSourceMapFiles: false } as never })
+        );
+        assert.strictEqual(result, true);
+    });
 });

--- a/source/packtory/options/surface-resolution.test.ts
+++ b/source/packtory/options/surface-resolution.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- tests narrow PackageConfig to the fields resolveSurface actually reads */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageConfig } from '../../config/config.ts';
 import { resolveSurface } from './surface-resolution.ts';
 
@@ -8,38 +8,40 @@ function pkg(overrides: Partial<PackageConfig>): PackageConfig {
     return { name: 'pkg-a', ...overrides } as unknown as PackageConfig;
 }
 
-test('resolveSurface returns an implicit surface using the only root when there is a single root', () => {
-    const surface = resolveSurface(['main'], pkg({}));
+suite('surface-resolution', function () {
+    test('resolveSurface returns an implicit surface using the only root when there is a single root', function () {
+        const surface = resolveSurface(['main'], pkg({}));
 
-    if (surface.mode !== 'implicit') {
-        assert.fail('expected implicit surface');
-    }
-    assert.strictEqual(surface.defaultModuleRoot, 'main');
-});
+        if (surface.mode !== 'implicit') {
+            assert.fail('expected implicit surface');
+        }
+        assert.strictEqual(surface.defaultModuleRoot, 'main');
+    });
 
-test('resolveSurface returns an implicit surface honouring defaultModuleRoot when multiple roots exist', () => {
-    const surface = resolveSurface(['main', 'feature'], pkg({ defaultModuleRoot: 'feature' }));
+    test('resolveSurface returns an implicit surface honouring defaultModuleRoot when multiple roots exist', function () {
+        const surface = resolveSurface(['main', 'feature'], pkg({ defaultModuleRoot: 'feature' }));
 
-    if (surface.mode !== 'implicit') {
-        assert.fail('expected implicit surface');
-    }
-    assert.strictEqual(surface.defaultModuleRoot, 'feature');
-});
+        if (surface.mode !== 'implicit') {
+            assert.fail('expected implicit surface');
+        }
+        assert.strictEqual(surface.defaultModuleRoot, 'feature');
+    });
 
-test('resolveSurface throws when multiple roots exist without a defaultModuleRoot', () => {
-    try {
-        resolveSurface(['main', 'feature'], pkg({}));
-        assert.fail('Expected resolveSurface() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing defaultModuleRoot');
-    }
-});
+    test('resolveSurface throws when multiple roots exist without a defaultModuleRoot', function () {
+        try {
+            resolveSurface(['main', 'feature'], pkg({}));
+            assert.fail('Expected resolveSurface() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing defaultModuleRoot');
+        }
+    });
 
-test('resolveSurface returns an explicit surface when packageInterface is provided', () => {
-    const surface = resolveSurface(
-        ['main'],
-        pkg({ packageInterface: { modules: [{ root: 'main', export: '.' }] } as never })
-    );
+    test('resolveSurface returns an explicit surface when packageInterface is provided', function () {
+        const surface = resolveSurface(
+            ['main'],
+            pkg({ packageInterface: { modules: [{ root: 'main', export: '.' }] } as never })
+        );
 
-    assert.strictEqual(surface.mode, 'explicit');
+        assert.strictEqual(surface.mode, 'explicit');
+    });
 });

--- a/source/packtory/options/version-trigger.test.ts
+++ b/source/packtory/options/version-trigger.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Maybe } from 'true-myth';
 import type { BuildAndPublishOptions } from '../map-config.ts';
 import { determineBuildVersion, inferVersionTrigger, shouldIncreaseVersion } from './version-trigger.ts';
@@ -12,54 +12,56 @@ function pinnedOptions(version: string): BuildAndPublishOptions {
     return { versioning: { automatic: false, version } } as unknown as BuildAndPublishOptions;
 }
 
-test('determineBuildVersion returns the current version when the registry already has one', () => {
-    assert.strictEqual(determineBuildVersion(Maybe.just('1.0.0'), automaticOptions()), '1.0.0');
-});
+suite('version-trigger', function () {
+    test('determineBuildVersion returns the current version when the registry already has one', function () {
+        assert.strictEqual(determineBuildVersion(Maybe.just('1.0.0'), automaticOptions()), '1.0.0');
+    });
 
-test('determineBuildVersion returns the pinned version when automatic is disabled and no current version exists', () => {
-    assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), pinnedOptions('2.0.0')), '2.0.0');
-});
+    test('determineBuildVersion returns the pinned version when automatic is disabled and no current version exists', function () {
+        assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), pinnedOptions('2.0.0')), '2.0.0');
+    });
 
-test('determineBuildVersion returns the minimum version when automatic is enabled and no current version exists', () => {
-    assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), automaticOptions('0.1.0')), '0.1.0');
-});
+    test('determineBuildVersion returns the minimum version when automatic is enabled and no current version exists', function () {
+        assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), automaticOptions('0.1.0')), '0.1.0');
+    });
 
-test('determineBuildVersion defaults to "0.0.0" when automatic and no minimum version is set', () => {
-    assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), automaticOptions()), '0.0.0');
-});
+    test('determineBuildVersion defaults to "0.0.0" when automatic and no minimum version is set', function () {
+        assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), automaticOptions()), '0.0.0');
+    });
 
-test('shouldIncreaseVersion returns false when automatic versioning is disabled', () => {
-    assert.strictEqual(shouldIncreaseVersion(Maybe.just('1.0.0'), pinnedOptions('2.0.0')), false);
-});
+    test('shouldIncreaseVersion returns false when automatic versioning is disabled', function () {
+        assert.strictEqual(shouldIncreaseVersion(Maybe.just('1.0.0'), pinnedOptions('2.0.0')), false);
+    });
 
-test('shouldIncreaseVersion returns true when automatic and the current version is known', () => {
-    assert.strictEqual(shouldIncreaseVersion(Maybe.just('1.0.0'), automaticOptions()), true);
-});
+    test('shouldIncreaseVersion returns true when automatic and the current version is known', function () {
+        assert.strictEqual(shouldIncreaseVersion(Maybe.just('1.0.0'), automaticOptions()), true);
+    });
 
-test('shouldIncreaseVersion returns false when automatic and no current version exists but a minimum is set', () => {
-    assert.strictEqual(shouldIncreaseVersion(Maybe.nothing<string>(), automaticOptions('0.1.0')), false);
-});
+    test('shouldIncreaseVersion returns false when automatic and no current version exists but a minimum is set', function () {
+        assert.strictEqual(shouldIncreaseVersion(Maybe.nothing<string>(), automaticOptions('0.1.0')), false);
+    });
 
-test('shouldIncreaseVersion returns true when automatic and no current version and no minimum is set', () => {
-    assert.strictEqual(shouldIncreaseVersion(Maybe.nothing<string>(), automaticOptions()), true);
-});
+    test('shouldIncreaseVersion returns true when automatic and no current version and no minimum is set', function () {
+        assert.strictEqual(shouldIncreaseVersion(Maybe.nothing<string>(), automaticOptions()), true);
+    });
 
-test('inferVersionTrigger returns auto-patch-bump when the version was bumped', () => {
-    assert.strictEqual(inferVersionTrigger(Maybe.just('1.0.0'), automaticOptions(), true), 'auto-patch-bump');
-});
+    test('inferVersionTrigger returns auto-patch-bump when the version was bumped', function () {
+        assert.strictEqual(inferVersionTrigger(Maybe.just('1.0.0'), automaticOptions(), true), 'auto-patch-bump');
+    });
 
-test('inferVersionTrigger returns pinned when automatic versioning is disabled and no bump occurred', () => {
-    assert.strictEqual(inferVersionTrigger(Maybe.just('1.0.0'), pinnedOptions('2.0.0'), false), 'pinned');
-});
+    test('inferVersionTrigger returns pinned when automatic versioning is disabled and no bump occurred', function () {
+        assert.strictEqual(inferVersionTrigger(Maybe.just('1.0.0'), pinnedOptions('2.0.0'), false), 'pinned');
+    });
 
-test('inferVersionTrigger returns auto-patch-bump when the current version exists but no bump occurred', () => {
-    assert.strictEqual(inferVersionTrigger(Maybe.just('1.0.0'), automaticOptions(), false), 'auto-patch-bump');
-});
+    test('inferVersionTrigger returns auto-patch-bump when the current version exists but no bump occurred', function () {
+        assert.strictEqual(inferVersionTrigger(Maybe.just('1.0.0'), automaticOptions(), false), 'auto-patch-bump');
+    });
 
-test('inferVersionTrigger returns minimum when automatic, no current version, and a minimum is configured', () => {
-    assert.strictEqual(inferVersionTrigger(Maybe.nothing<string>(), automaticOptions('0.1.0'), false), 'minimum');
-});
+    test('inferVersionTrigger returns minimum when automatic, no current version, and a minimum is configured', function () {
+        assert.strictEqual(inferVersionTrigger(Maybe.nothing<string>(), automaticOptions('0.1.0'), false), 'minimum');
+    });
 
-test('inferVersionTrigger returns initial when automatic and no current version and no minimum is configured', () => {
-    assert.strictEqual(inferVersionTrigger(Maybe.nothing<string>(), automaticOptions(), false), 'initial');
+    test('inferVersionTrigger returns initial when automatic and no current version and no minimum is configured', function () {
+        assert.strictEqual(inferVersionTrigger(Maybe.nothing<string>(), automaticOptions(), false), 'initial');
+    });
 });

--- a/source/packtory/package-processor-build.test.ts
+++ b/source/packtory/package-processor-build.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { BundleLinker } from '../linker/linker.ts';
 import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
@@ -21,33 +21,35 @@ function stubDependencies() {
     };
 }
 
-test('createResolveAndBuildOperations exposes the build and resolveAndLink operations', () => {
-    const operations = createResolveAndBuildOperations(stubDependencies());
+suite('package-processor-build', function () {
+    test('createResolveAndBuildOperations exposes the build and resolveAndLink operations', function () {
+        const operations = createResolveAndBuildOperations(stubDependencies());
 
-    assert.strictEqual(typeof operations.build, 'function');
-    assert.strictEqual(typeof operations.resolveAndLink, 'function');
-});
+        assert.strictEqual(typeof operations.build, 'function');
+        assert.strictEqual(typeof operations.resolveAndLink, 'function');
+    });
 
-test('resolveAndLink rejects a non-ESM mainPackageJson at the operations layer', async () => {
-    const operations = createResolveAndBuildOperations(stubDependencies());
+    test('resolveAndLink rejects a non-ESM mainPackageJson at the operations layer', async function () {
+        const operations = createResolveAndBuildOperations(stubDependencies());
 
-    try {
-        await operations.resolveAndLink({ mainPackageJson: { type: 'commonjs' } } as never);
-        assert.fail('expected resolveAndLink to reject the non-ESM main package json');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'mainPackageJson.type must be "module"');
-    }
-});
+        try {
+            await operations.resolveAndLink({ mainPackageJson: { type: 'commonjs' } } as never);
+            assert.fail('expected resolveAndLink to reject the non-ESM main package json');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'mainPackageJson.type must be "module"');
+        }
+    });
 
-test('build rejects a non-ESM mainPackageJson at the operations layer', async () => {
-    const operations = createResolveAndBuildOperations(stubDependencies());
+    test('build rejects a non-ESM mainPackageJson at the operations layer', async function () {
+        const operations = createResolveAndBuildOperations(stubDependencies());
 
-    try {
-        await operations.build({ mainPackageJson: { type: 'commonjs' } } as never);
-        assert.fail('expected build to reject the non-ESM main package json');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'mainPackageJson.type must be "module"');
-    }
+        try {
+            await operations.build({ mainPackageJson: { type: 'commonjs' } } as never);
+            assert.fail('expected build to reject the non-ESM main package json');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'mainPackageJson.type must be "module"');
+        }
+    });
 });

--- a/source/packtory/package-processor-publish.test.ts
+++ b/source/packtory/package-processor-publish.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { BundleEmitter } from '../bundle-emitter/emitter.ts';
 import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
 import type { SbomFileBuilder } from '../sbom/sbom-file.ts';
@@ -16,24 +16,26 @@ function stubDependencies() {
     };
 }
 
-test('createPublishOperations exposes both buildAndPublish and tryBuildAndPublish operations', () => {
-    const operations = createPublishOperations(stubDependencies());
+suite('package-processor-publish', function () {
+    test('createPublishOperations exposes both buildAndPublish and tryBuildAndPublish operations', function () {
+        const operations = createPublishOperations(stubDependencies());
 
-    assert.strictEqual(typeof operations.buildAndPublish, 'function');
-    assert.strictEqual(typeof operations.tryBuildAndPublish, 'function');
-});
+        assert.strictEqual(typeof operations.buildAndPublish, 'function');
+        assert.strictEqual(typeof operations.tryBuildAndPublish, 'function');
+    });
 
-test('tryBuildAndPublish rejects a non-ESM mainPackageJson at the operations layer', async () => {
-    const operations = createPublishOperations(stubDependencies());
+    test('tryBuildAndPublish rejects a non-ESM mainPackageJson at the operations layer', async function () {
+        const operations = createPublishOperations(stubDependencies());
 
-    try {
-        await operations.tryBuildAndPublish({
-            analyzedBundle: { name: 'pkg-a' } as never,
-            buildOptions: { mainPackageJson: { type: 'commonjs' } } as never
-        });
-        assert.fail('expected tryBuildAndPublish to reject the non-ESM main package json');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'mainPackageJson.type must be "module"');
-    }
+        try {
+            await operations.tryBuildAndPublish({
+                analyzedBundle: { name: 'pkg-a' } as never,
+                buildOptions: { mainPackageJson: { type: 'commonjs' } } as never
+            });
+            assert.fail('expected tryBuildAndPublish to reject the non-ESM main package json');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'mainPackageJson.type must be "module"');
+        }
+    });
 });

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
@@ -206,675 +206,677 @@ function getCallArgs(spy: SinonSpy): unknown[][] {
     });
 }
 
-test('resolveAndLink() emits progress events and links the resolved bundle with all dependency bundles', async () => {
-    const linkedBundle = createLinkedBundle();
-    const resolve = fake.resolves({
-        name: 'package-a',
-        contents: [],
-        roots: { main: { js: createTransferableFile('/entry.js') } } as const,
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
-        externalDependencies: new Map()
-    });
-    const linkBundle = fake.resolves(linkedBundle);
-    const { processor, emit } = createProcessor({ resolve, linkBundle });
-
-    const options = createResolveOptions();
-    const result = await processor.resolveAndLink(options);
-
-    assert.strictEqual(result, linkedBundle);
-    assert.deepStrictEqual(resolve.firstCall.args, [options]);
-    assert.deepStrictEqual(linkBundle.firstCall.args, [
-        {
-            bundle: {
-                name: 'package-a',
-                contents: [],
-                roots: { main: { js: createTransferableFile('/entry.js') } },
-                surface: { mode: 'implicit', defaultModuleRoot: 'main' },
-                externalDependencies: new Map()
-            },
-            bundleDependencies: [...options.bundleDependencies, ...options.bundlePeerDependencies]
-        }
-    ]);
-    assert.deepStrictEqual(getCallArgs(emit), [
-        ['resolving', { packageName: 'package-a' }],
-        ['linking', { packageName: 'package-a' }]
-    ]);
-});
-
-test('build() resolves, links, runs the dead-code eliminator, and forwards to versionManager.addVersion()', async () => {
-    const linkedBundle = createLinkedBundle();
-    const linkBundle = fake.resolves(linkedBundle);
-    const addVersion = fake.returns(createVersionedBundle());
-    const { processor, addVersion: addVersionSpy } = createProcessor({ linkBundle, addVersion });
-
-    const result = await processor.build({
-        ...createBuildAndPublishOptions(),
-        version: '3.4.5'
-    });
-
-    assert.strictEqual(result.packageJson.version, '1.2.3');
-    assert.deepStrictEqual(addVersionSpy.firstCall.args, [
-        {
-            bundle: { ...linkedBundle, contents: [], sideEffectsField: undefined },
-            version: '3.4.5',
-            mainPackageJson: { type: 'module', dependencies: { dep: '^1.0.0' } },
-            bundleDependencies: [createVersionedBundle('bundle-dependency', '1.0.0')],
-            bundlePeerDependencies: [createVersionedBundle('peer-dependency', '2.0.0')],
-            additionalPackageJsonAttributes: { publishConfig: { access: 'public' } },
-            allowMutableSpecifiers: []
-        }
-    ]);
-});
-
-test('build() forwards deadCodeElimination settings to the eliminator', async () => {
-    const eliminate = fake(
-        async (inputs: readonly { transformationsEnabled: boolean; deadCodeElimination?: unknown }[]) => {
-            return inputs.map((entry) => {
-                return {
-                    ...createLinkedBundle(),
-                    contents: [],
-                    sideEffectsField: undefined,
-                    transformationsEnabledFlag: entry.transformationsEnabled
-                };
-            });
-        }
-    );
-    const { processor } = createProcessor({ eliminate });
-    const deadCodeElimination = { enabled: false, pureConstructors: ['Set'] } as const;
-
-    await processor.build({
-        ...createBuildAndPublishOptions(),
-        version: '1.0.0',
-        deadCodeElimination
-    });
-
-    const eliminationInputs = eliminate.firstCall.args[0] as readonly {
-        readonly transformationsEnabled: boolean;
-        readonly deadCodeElimination?: typeof deadCodeElimination;
-    }[];
-    const firstInput = eliminationInputs[0];
-    assert.ok(firstInput);
-    assert.strictEqual(firstInput.transformationsEnabled, false);
-    assert.deepStrictEqual(firstInput.deadCodeElimination, deadCodeElimination);
-});
-
-test('build() defaults transformationsEnabled to true when deadCodeElimination is not configured', async () => {
-    const eliminate = fake(async (inputs: readonly { transformationsEnabled: boolean }[]) => {
-        return inputs.map(() => {
-            return { ...createLinkedBundle(), contents: [], sideEffectsField: undefined };
+suite('package-processor', function () {
+    test('resolveAndLink() emits progress events and links the resolved bundle with all dependency bundles', async function () {
+        const linkedBundle = createLinkedBundle();
+        const resolve = fake.resolves({
+            name: 'package-a',
+            contents: [],
+            roots: { main: { js: createTransferableFile('/entry.js') } } as const,
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
+            externalDependencies: new Map()
         });
+        const linkBundle = fake.resolves(linkedBundle);
+        const { processor, emit } = createProcessor({ resolve, linkBundle });
+
+        const options = createResolveOptions();
+        const result = await processor.resolveAndLink(options);
+
+        assert.strictEqual(result, linkedBundle);
+        assert.deepStrictEqual(resolve.firstCall.args, [options]);
+        assert.deepStrictEqual(linkBundle.firstCall.args, [
+            {
+                bundle: {
+                    name: 'package-a',
+                    contents: [],
+                    roots: { main: { js: createTransferableFile('/entry.js') } },
+                    surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+                    externalDependencies: new Map()
+                },
+                bundleDependencies: [...options.bundleDependencies, ...options.bundlePeerDependencies]
+            }
+        ]);
+        assert.deepStrictEqual(getCallArgs(emit), [
+            ['resolving', { packageName: 'package-a' }],
+            ['linking', { packageName: 'package-a' }]
+        ]);
     });
-    const { processor } = createProcessor({ eliminate });
 
-    await processor.build({ ...createBuildAndPublishOptions(), version: '1.0.0' });
+    test('build() resolves, links, runs the dead-code eliminator, and forwards to versionManager.addVersion()', async function () {
+        const linkedBundle = createLinkedBundle();
+        const linkBundle = fake.resolves(linkedBundle);
+        const addVersion = fake.returns(createVersionedBundle());
+        const { processor, addVersion: addVersionSpy } = createProcessor({ linkBundle, addVersion });
 
-    const eliminationInputs = eliminate.firstCall.args[0] as readonly { transformationsEnabled: boolean }[];
-    const firstInput = eliminationInputs[0];
-    assert.ok(firstInput);
-    assert.strictEqual(firstInput.transformationsEnabled, true);
-});
-
-test('build() throws when the dead-code eliminator returns no bundle', async () => {
-    const eliminate = fake.resolves([]);
-    const { processor } = createProcessor({ eliminate });
-
-    try {
-        await processor.build({
+        const result = await processor.build({
             ...createBuildAndPublishOptions(),
             version: '3.4.5'
         });
-        assert.fail('Expected processor.build() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Dead code eliminator returned no bundle for "package-a"');
-    }
-});
 
-test('tryBuildAndPublish() returns already-published when the emitted bundle already matches the latest version', async () => {
-    const versionedBundle = createVersionedBundle('package-a', '0.0.0');
-    const checkBundleAlreadyPublished = fake.resolves({ alreadyPublishedAsLatest: true });
-    const { processor, increaseVersion, emit } = createProcessor({
-        addVersion: fake.returns(versionedBundle),
-        checkBundleAlreadyPublished
+        assert.strictEqual(result.packageJson.version, '1.2.3');
+        assert.deepStrictEqual(addVersionSpy.firstCall.args, [
+            {
+                bundle: { ...linkedBundle, contents: [], sideEffectsField: undefined },
+                version: '3.4.5',
+                mainPackageJson: { type: 'module', dependencies: { dep: '^1.0.0' } },
+                bundleDependencies: [createVersionedBundle('bundle-dependency', '1.0.0')],
+                bundlePeerDependencies: [createVersionedBundle('peer-dependency', '2.0.0')],
+                additionalPackageJsonAttributes: { publishConfig: { access: 'public' } },
+                allowMutableSpecifiers: []
+            }
+        ]);
     });
 
-    const result = await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: createBuildAndPublishOptions()
-    });
+    test('build() forwards deadCodeElimination settings to the eliminator', async function () {
+        const eliminate = fake(
+            async (inputs: readonly { transformationsEnabled: boolean; deadCodeElimination?: unknown }[]) => {
+                return inputs.map((entry) => {
+                    return {
+                        ...createLinkedBundle(),
+                        contents: [],
+                        sideEffectsField: undefined,
+                        transformationsEnabledFlag: entry.transformationsEnabled
+                    };
+                });
+            }
+        );
+        const { processor } = createProcessor({ eliminate });
+        const deadCodeElimination = { enabled: false, pureConstructors: ['Set'] } as const;
 
-    assert.deepStrictEqual(result, { bundle: versionedBundle, status: 'already-published' });
-    assert.strictEqual(increaseVersion.callCount, 0);
-    assert.deepStrictEqual(checkBundleAlreadyPublished.firstCall.args, [
-        {
-            bundle: versionedBundle,
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } }
-        }
-    ]);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '0.0.0' }]]);
-});
-
-test('tryBuildAndPublish() rebuilds with an increased version for the first publish', async () => {
-    const initialBundle = createVersionedBundle('package-a', '0.0.0');
-    const rebuiltBundle = createVersionedBundle('package-a', '0.0.1');
-    const determineCurrentVersion = fake.resolves(Maybe.nothing());
-    const { processor, emit } = createProcessor({
-        determineCurrentVersion,
-        addVersion: fake.returns(initialBundle),
-        increaseVersion: fake.returns(rebuiltBundle)
-    });
-
-    const result = await tryBuildAndPublishDefault(processor);
-
-    assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'initial-version' });
-    assert.deepStrictEqual(determineCurrentVersion.firstCall.args, [
-        {
-            name: 'package-a',
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            versioning: { automatic: true }
-        }
-    ]);
-    assert.deepStrictEqual(getCallArgs(emit), [
-        ['building', { packageName: 'package-a', version: '0.0.0' }],
-        ['rebuilding', { packageName: 'package-a', version: '0.0.0' }]
-    ]);
-});
-
-test('tryBuildAndPublish() returns new-version when the package already has a published version', async () => {
-    const initialBundle = createVersionedBundle('package-a', '2.0.0');
-    const rebuiltBundle = createVersionedBundle('package-a', '2.0.1');
-    const { processor } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
-        addVersion: fake.returns(initialBundle),
-        increaseVersion: fake.returns(rebuiltBundle)
-    });
-
-    const result = await tryBuildAndPublishDefault(processor);
-
-    assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'new-version' });
-});
-
-test('tryBuildAndPublish() keeps the configured manual version without rebuilding on the initial publish', async () => {
-    const manualBundle = createVersionedBundle('package-a', '4.5.6');
-    const { processor, increaseVersion, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.nothing()),
-        addVersion: fake.returns(manualBundle)
-    });
-
-    const buildOptions: BuildAndPublishOptions = {
-        ...createBuildAndPublishOptions(),
-        versioning: { automatic: false, version: '4.5.6' }
-    };
-    const result = await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions
-    });
-
-    assert.deepStrictEqual(result, { bundle: manualBundle, status: 'initial-version' });
-    assert.strictEqual(increaseVersion.callCount, 0);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '4.5.6' }]]);
-});
-
-test('tryBuildAndPublish() keeps the current published version without rebuilding when automatic versioning is disabled', async () => {
-    const currentBundle = createVersionedBundle('package-a', '2.0.0');
-    const { processor, increaseVersion, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
-        addVersion: fake.returns(currentBundle)
-    });
-
-    const buildOptions: BuildAndPublishOptions = {
-        ...createBuildAndPublishOptions(),
-        versioning: { automatic: false, version: '9.9.9' }
-    };
-    const result = await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions
-    });
-
-    assert.deepStrictEqual(result, { bundle: currentBundle, status: 'new-version' });
-    assert.strictEqual(increaseVersion.callCount, 0);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '2.0.0' }]]);
-});
-
-test('tryBuildAndPublish() uses minimumVersion for the first automatic publish without rebuilding', async () => {
-    const minimumVersionBundle = createVersionedBundle('package-a', '1.2.3');
-    const { processor, increaseVersion, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.nothing()),
-        addVersion: fake.returns(minimumVersionBundle)
-    });
-
-    const buildOptions: BuildAndPublishOptions = {
-        ...createBuildAndPublishOptions(),
-        versioning: { automatic: true, minimumVersion: '1.2.3' }
-    };
-    const result = await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions
-    });
-
-    assert.deepStrictEqual(result, { bundle: minimumVersionBundle, status: 'initial-version' });
-    assert.strictEqual(increaseVersion.callCount, 0);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '1.2.3' }]]);
-});
-
-test('tryBuildAndPublish() forwards the fully built addVersion payload before publication checks', async () => {
-    const addVersion = fake.returns(createVersionedBundle('package-a', '1.2.3'));
-    const checkBundleAlreadyPublished = fake.resolves({ alreadyPublishedAsLatest: false });
-    const { processor } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
-        addVersion,
-        checkBundleAlreadyPublished
-    });
-
-    const analyzedBundle = createAnalyzedBundle();
-    const buildOptions = createBuildAndPublishOptions();
-    await processor.tryBuildAndPublish({ analyzedBundle, buildOptions });
-
-    assert.deepStrictEqual(addVersion.firstCall.args, [
-        {
-            bundle: analyzedBundle,
-            ...buildOptions,
-            version: '1.2.3',
-            substitutionPublicModuleSourcePaths: undefined
-        }
-    ]);
-});
-
-test('tryBuildAndPublish() keeps the configured manual version without rebuilding on a rerun', async () => {
-    const manualBundle = createVersionedBundle('package-a', '3.2.1');
-    const { processor, increaseVersion, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('3.2.1')),
-        addVersion: fake.returns(manualBundle)
-    });
-
-    const result = await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: {
+        await processor.build({
             ...createBuildAndPublishOptions(),
-            versioning: { automatic: false, version: '3.2.1' }
+            version: '1.0.0',
+            deadCodeElimination
+        });
+
+        const eliminationInputs = eliminate.firstCall.args[0] as readonly {
+            readonly transformationsEnabled: boolean;
+            readonly deadCodeElimination?: typeof deadCodeElimination;
+        }[];
+        const firstInput = eliminationInputs[0];
+        assert.ok(firstInput);
+        assert.strictEqual(firstInput.transformationsEnabled, false);
+        assert.deepStrictEqual(firstInput.deadCodeElimination, deadCodeElimination);
+    });
+
+    test('build() defaults transformationsEnabled to true when deadCodeElimination is not configured', async function () {
+        const eliminate = fake(async (inputs: readonly { transformationsEnabled: boolean }[]) => {
+            return inputs.map(() => {
+                return { ...createLinkedBundle(), contents: [], sideEffectsField: undefined };
+            });
+        });
+        const { processor } = createProcessor({ eliminate });
+
+        await processor.build({ ...createBuildAndPublishOptions(), version: '1.0.0' });
+
+        const eliminationInputs = eliminate.firstCall.args[0] as readonly { transformationsEnabled: boolean }[];
+        const firstInput = eliminationInputs[0];
+        assert.ok(firstInput);
+        assert.strictEqual(firstInput.transformationsEnabled, true);
+    });
+
+    test('build() throws when the dead-code eliminator returns no bundle', async function () {
+        const eliminate = fake.resolves([]);
+        const { processor } = createProcessor({ eliminate });
+
+        try {
+            await processor.build({
+                ...createBuildAndPublishOptions(),
+                version: '3.4.5'
+            });
+            assert.fail('Expected processor.build() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Dead code eliminator returned no bundle for "package-a"');
         }
     });
 
-    assert.deepStrictEqual(result, { bundle: manualBundle, status: 'new-version' });
-    assert.strictEqual(increaseVersion.callCount, 0);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '3.2.1' }]]);
-});
+    test('tryBuildAndPublish() returns already-published when the emitted bundle already matches the latest version', async function () {
+        const versionedBundle = createVersionedBundle('package-a', '0.0.0');
+        const checkBundleAlreadyPublished = fake.resolves({ alreadyPublishedAsLatest: true });
+        const { processor, increaseVersion, emit } = createProcessor({
+            addVersion: fake.returns(versionedBundle),
+            checkBundleAlreadyPublished
+        });
 
-test('buildAndPublish() returns immediately when the package is already published', async () => {
-    const publish = fake.resolves(undefined);
-    const alreadyPublishedResult: BuildAndPublishResult = {
-        bundle: createVersionedBundle(),
-        status: 'already-published'
-    };
-    const { processor, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
-        addVersion: fake.returns(createVersionedBundle()),
-        checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true }),
-        publish
+        const result = await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: createBuildAndPublishOptions()
+        });
+
+        assert.deepStrictEqual(result, { bundle: versionedBundle, status: 'already-published' });
+        assert.strictEqual(increaseVersion.callCount, 0);
+        assert.deepStrictEqual(checkBundleAlreadyPublished.firstCall.args, [
+            {
+                bundle: versionedBundle,
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } }
+            }
+        ]);
+        assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '0.0.0' }]]);
     });
 
-    const result = await processor.buildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: createBuildAndPublishOptions()
+    test('tryBuildAndPublish() rebuilds with an increased version for the first publish', async function () {
+        const initialBundle = createVersionedBundle('package-a', '0.0.0');
+        const rebuiltBundle = createVersionedBundle('package-a', '0.0.1');
+        const determineCurrentVersion = fake.resolves(Maybe.nothing());
+        const { processor, emit } = createProcessor({
+            determineCurrentVersion,
+            addVersion: fake.returns(initialBundle),
+            increaseVersion: fake.returns(rebuiltBundle)
+        });
+
+        const result = await tryBuildAndPublishDefault(processor);
+
+        assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'initial-version' });
+        assert.deepStrictEqual(determineCurrentVersion.firstCall.args, [
+            {
+                name: 'package-a',
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                versioning: { automatic: true }
+            }
+        ]);
+        assert.deepStrictEqual(getCallArgs(emit), [
+            ['building', { packageName: 'package-a', version: '0.0.0' }],
+            ['rebuilding', { packageName: 'package-a', version: '0.0.0' }]
+        ]);
     });
 
-    assert.deepStrictEqual(result, alreadyPublishedResult);
-    assert.strictEqual(publish.callCount, 0);
-    assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '1.2.3' }]]);
-});
+    test('tryBuildAndPublish() returns new-version when the package already has a published version', async function () {
+        const initialBundle = createVersionedBundle('package-a', '2.0.0');
+        const rebuiltBundle = createVersionedBundle('package-a', '2.0.1');
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
+            addVersion: fake.returns(initialBundle),
+            increaseVersion: fake.returns(rebuiltBundle)
+        });
 
-test('buildAndPublish() publishes the rebuilt bundle and emits publishing progress', async () => {
-    const rebuiltBundle = createVersionedBundle('package-a', '1.2.4');
-    const publish = fake.resolves(undefined);
-    const { processor, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
-        addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
-        increaseVersion: fake.returns(rebuiltBundle),
-        publish
+        const result = await tryBuildAndPublishDefault(processor);
+
+        assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'new-version' });
     });
 
-    const options: DetermineVersionAndPublishOptions = {
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: createBuildAndPublishOptions()
-    };
-    const result = await processor.buildAndPublish(options);
+    test('tryBuildAndPublish() keeps the configured manual version without rebuilding on the initial publish', async function () {
+        const manualBundle = createVersionedBundle('package-a', '4.5.6');
+        const { processor, increaseVersion, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.nothing()),
+            addVersion: fake.returns(manualBundle)
+        });
 
-    assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'new-version' });
-    assert.deepStrictEqual(publish.firstCall.args, [
-        {
-            bundle: rebuiltBundle,
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            publishSettings: { access: 'public', sbom: { enabled: false } }
-        }
-    ]);
-    assert.deepStrictEqual(getCallArgs(emit), [
-        ['building', { packageName: 'package-a', version: '1.2.3' }],
-        ['rebuilding', { packageName: 'package-a', version: '1.2.3' }],
-        ['publishing', { packageName: 'package-a', version: '1.2.4' }]
-    ]);
-});
+        const buildOptions: BuildAndPublishOptions = {
+            ...createBuildAndPublishOptions(),
+            versioning: { automatic: false, version: '4.5.6' }
+        };
+        const result = await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions
+        });
 
-function setupSbomScenario(
-    sbomResult: readonly { filePath: string; content: string; isExecutable: boolean }[] | undefined
-): {
-    readonly bundle: VersionedBundleWithManifest;
-    readonly analyzedBundle: AnalyzedBundle;
-    readonly generateSbom: SinonSpy;
-    readonly checkBundleAlreadyPublished: SinonSpy;
-    readonly processor: ReturnType<typeof createPackageProcessor>;
-} {
-    const bundle = createVersionedBundle('package-a', '1.2.3');
-    const analyzedBundle = createAnalyzedBundle();
-    const generateSbom = fake.resolves(sbomResult);
-    const checkBundleAlreadyPublished = fake.resolves({ alreadyPublishedAsLatest: false });
-    const { processor } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
-        addVersion: fake.returns(bundle),
-        checkBundleAlreadyPublished,
-        generateSbom
-    });
-    return { bundle, analyzedBundle, generateSbom, checkBundleAlreadyPublished, processor };
-}
-
-test('tryBuildAndPublish() invokes the sbomFileBuilder with the resolved bundle, siblings, and publish settings', async () => {
-    const sbomFile = { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false };
-    const { bundle, analyzedBundle, generateSbom, checkBundleAlreadyPublished, processor } = setupSbomScenario([
-        sbomFile
-    ]);
-
-    const buildOptions: BuildAndPublishOptions = {
-        ...createBuildAndPublishOptions(),
-        publishSettings: { access: 'public', sbom: { enabled: true } }
-    };
-    await processor.tryBuildAndPublish({ analyzedBundle, buildOptions });
-
-    assert.strictEqual(generateSbom.callCount, 1);
-    const expectedSiblings = [...buildOptions.bundleDependencies, ...buildOptions.bundlePeerDependencies];
-    assert.deepStrictEqual(generateSbom.firstCall.args, [
-        bundle,
-        expectedSiblings,
-        { access: 'public', sbom: { enabled: true } }
-    ]);
-    const checkArgs = checkBundleAlreadyPublished.firstCall.args[0] as { extraFiles: readonly unknown[] };
-    assert.deepStrictEqual(checkArgs.extraFiles, [sbomFile]);
-});
-
-test('tryBuildAndPublish() omits extraFiles when sbomFileBuilder returns undefined', async () => {
-    const { analyzedBundle, checkBundleAlreadyPublished, processor } = setupSbomScenario(undefined);
-
-    await processor.tryBuildAndPublish({ analyzedBundle, buildOptions: createBuildAndPublishOptions() });
-
-    const checkArgs = checkBundleAlreadyPublished.firstCall.args[0] as Record<string, unknown>;
-    assert.strictEqual('extraFiles' in checkArgs, false);
-});
-
-test('resolveAndLink() emits scanCompleted with the resolved bundle scan results when subscribed', async () => {
-    const hasSubscribers = fake((eventName: string) => {
-        return eventName === 'scanCompleted';
-    });
-    const resolve = fake.resolves({
-        name: 'package-a',
-        contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' } }],
-        roots: { main: { js: createTransferableFile('/entry.js') } } as const,
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
-        externalDependencies: new Map([['lodash', { version: '^4' }]])
-    });
-    const { processor, emit } = createProcessor({ hasSubscribers, resolve });
-
-    await processor.resolveAndLink(createResolveOptions());
-
-    const scanCalls = getCallArgs(emit).filter((args) => {
-        return args[0] === 'scanCompleted';
-    });
-    assert.strictEqual(scanCalls.length, 1);
-    assert.deepStrictEqual(scanCalls[0], [
-        'scanCompleted',
-        {
-            packageName: 'package-a',
-            included: [{ path: '/src/a.ts', reason: 'reachable-from-entry' }],
-            excluded: [{ specifier: 'lodash', reason: 'external-module' }]
-        }
-    ]);
-});
-
-test('resolveAndLink() does NOT emit scanCompleted when no subscriber is registered', async () => {
-    const { processor, emit } = createProcessor();
-
-    await processor.resolveAndLink(createResolveOptions());
-
-    const scanCalls = getCallArgs(emit).filter((args) => {
-        return args[0] === 'scanCompleted';
-    });
-    assert.strictEqual(scanCalls.length, 0);
-});
-
-test('resolveAndLink() emits linkingCompleted with the linker rewrites when subscribed', async () => {
-    const hasSubscribers = fake((eventName: string) => {
-        return eventName === 'linkingCompleted';
-    });
-    const linkBundle = fake.resolves({
-        name: 'package-a',
-        contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true }],
-        roots: { main: { js: createTransferableFile('/entry.js') } } as const,
-        surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
-        linkedBundleDependencies: new Map([['pkg-b', {}]]),
-        externalDependencies: new Map()
-    });
-    const { processor, emit } = createProcessor({ hasSubscribers, linkBundle });
-
-    await processor.resolveAndLink(createResolveOptions());
-
-    const linkingCalls = getCallArgs(emit).filter((args) => {
-        return args[0] === 'linkingCompleted';
-    });
-    assert.strictEqual(linkingCalls.length, 1);
-    assert.deepStrictEqual(linkingCalls[0], [
-        'linkingCompleted',
-        {
-            packageName: 'package-a',
-            rewrites: [
-                {
-                    file: '/src/a.ts',
-                    fromSpecifier: '/src/a.ts',
-                    toSpecifier: 'pkg-b',
-                    targetBundle: 'pkg-b'
-                }
-            ]
-        }
-    ]);
-});
-
-test('resolveAndLink() does NOT emit linkingCompleted when no subscriber is registered', async () => {
-    const { processor, emit } = createProcessor();
-
-    await processor.resolveAndLink(createResolveOptions());
-
-    const linkingCalls = getCallArgs(emit).filter((args) => {
-        return args[0] === 'linkingCompleted';
-    });
-    assert.strictEqual(linkingCalls.length, 0);
-});
-
-function onlyVersionDeterminedSubscriber(): SinonSpy {
-    return fake((eventName: string) => {
-        return eventName === 'versionDetermined';
-    });
-}
-
-function filterVersionDetermined(emit: SinonSpy): unknown[][] {
-    return getCallArgs(emit).filter((args) => {
-        return args[0] === 'versionDetermined';
-    });
-}
-
-function expectSingleVersionDetermined(
-    emit: SinonSpy,
-    payload: {
-        packageName: string;
-        previousVersion: string | undefined;
-        chosenVersion: string;
-        trigger: 'auto-patch-bump' | 'initial' | 'minimum' | 'pinned';
-    }
-): void {
-    assert.deepStrictEqual(filterVersionDetermined(emit), [['versionDetermined', payload]]);
-}
-
-test('tryBuildAndPublish() emits versionDetermined trigger "pinned" when first publish keeps the manual version', async () => {
-    const manualBundle = createVersionedBundle('package-a', '4.5.6');
-    const { processor, emit } = createProcessor({
-        hasSubscribers: onlyVersionDeterminedSubscriber(),
-        determineCurrentVersion: fake.resolves(Maybe.nothing()),
-        addVersion: fake.returns(manualBundle)
+        assert.deepStrictEqual(result, { bundle: manualBundle, status: 'initial-version' });
+        assert.strictEqual(increaseVersion.callCount, 0);
+        assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '4.5.6' }]]);
     });
 
-    await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: { ...createBuildAndPublishOptions(), versioning: { automatic: false, version: '4.5.6' } }
+    test('tryBuildAndPublish() keeps the current published version without rebuilding when automatic versioning is disabled', async function () {
+        const currentBundle = createVersionedBundle('package-a', '2.0.0');
+        const { processor, increaseVersion, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
+            addVersion: fake.returns(currentBundle)
+        });
+
+        const buildOptions: BuildAndPublishOptions = {
+            ...createBuildAndPublishOptions(),
+            versioning: { automatic: false, version: '9.9.9' }
+        };
+        const result = await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions
+        });
+
+        assert.deepStrictEqual(result, { bundle: currentBundle, status: 'new-version' });
+        assert.strictEqual(increaseVersion.callCount, 0);
+        assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '2.0.0' }]]);
     });
 
-    expectSingleVersionDetermined(emit, {
-        packageName: 'package-a',
-        previousVersion: undefined,
-        chosenVersion: '4.5.6',
-        trigger: 'pinned'
-    });
-});
+    test('tryBuildAndPublish() uses minimumVersion for the first automatic publish without rebuilding', async function () {
+        const minimumVersionBundle = createVersionedBundle('package-a', '1.2.3');
+        const { processor, increaseVersion, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.nothing()),
+            addVersion: fake.returns(minimumVersionBundle)
+        });
 
-test('tryBuildAndPublish() emits versionDetermined trigger "auto-patch-bump" on first auto publish without minimum', async () => {
-    const initialBundle = createVersionedBundle('package-a', '0.0.0');
-    const rebuiltBundle = createVersionedBundle('package-a', '0.0.1');
-    const { processor, emit } = createProcessor({
-        hasSubscribers: onlyVersionDeterminedSubscriber(),
-        determineCurrentVersion: fake.resolves(Maybe.nothing()),
-        addVersion: fake.returns(initialBundle),
-        increaseVersion: fake.returns(rebuiltBundle)
-    });
-
-    await tryBuildAndPublishDefault(processor);
-
-    expectSingleVersionDetermined(emit, {
-        packageName: 'package-a',
-        previousVersion: undefined,
-        chosenVersion: '0.0.1',
-        trigger: 'auto-patch-bump'
-    });
-});
-
-test('tryBuildAndPublish() emits versionDetermined trigger "minimum" when minimumVersion is used as-is', async () => {
-    const minimumVersionBundle = createVersionedBundle('package-a', '1.2.3');
-    const { processor, emit } = createProcessor({
-        hasSubscribers: onlyVersionDeterminedSubscriber(),
-        determineCurrentVersion: fake.resolves(Maybe.nothing()),
-        addVersion: fake.returns(minimumVersionBundle)
-    });
-
-    await processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: {
+        const buildOptions: BuildAndPublishOptions = {
             ...createBuildAndPublishOptions(),
             versioning: { automatic: true, minimumVersion: '1.2.3' }
+        };
+        const result = await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions
+        });
+
+        assert.deepStrictEqual(result, { bundle: minimumVersionBundle, status: 'initial-version' });
+        assert.strictEqual(increaseVersion.callCount, 0);
+        assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '1.2.3' }]]);
+    });
+
+    test('tryBuildAndPublish() forwards the fully built addVersion payload before publication checks', async function () {
+        const addVersion = fake.returns(createVersionedBundle('package-a', '1.2.3'));
+        const checkBundleAlreadyPublished = fake.resolves({ alreadyPublishedAsLatest: false });
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion,
+            checkBundleAlreadyPublished
+        });
+
+        const analyzedBundle = createAnalyzedBundle();
+        const buildOptions = createBuildAndPublishOptions();
+        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions });
+
+        assert.deepStrictEqual(addVersion.firstCall.args, [
+            {
+                bundle: analyzedBundle,
+                ...buildOptions,
+                version: '1.2.3',
+                substitutionPublicModuleSourcePaths: undefined
+            }
+        ]);
+    });
+
+    test('tryBuildAndPublish() keeps the configured manual version without rebuilding on a rerun', async function () {
+        const manualBundle = createVersionedBundle('package-a', '3.2.1');
+        const { processor, increaseVersion, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('3.2.1')),
+            addVersion: fake.returns(manualBundle)
+        });
+
+        const result = await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: {
+                ...createBuildAndPublishOptions(),
+                versioning: { automatic: false, version: '3.2.1' }
+            }
+        });
+
+        assert.deepStrictEqual(result, { bundle: manualBundle, status: 'new-version' });
+        assert.strictEqual(increaseVersion.callCount, 0);
+        assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '3.2.1' }]]);
+    });
+
+    test('buildAndPublish() returns immediately when the package is already published', async function () {
+        const publish = fake.resolves(undefined);
+        const alreadyPublishedResult: BuildAndPublishResult = {
+            bundle: createVersionedBundle(),
+            status: 'already-published'
+        };
+        const { processor, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion: fake.returns(createVersionedBundle()),
+            checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true }),
+            publish
+        });
+
+        const result = await processor.buildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: createBuildAndPublishOptions()
+        });
+
+        assert.deepStrictEqual(result, alreadyPublishedResult);
+        assert.strictEqual(publish.callCount, 0);
+        assert.deepStrictEqual(getCallArgs(emit), [['building', { packageName: 'package-a', version: '1.2.3' }]]);
+    });
+
+    test('buildAndPublish() publishes the rebuilt bundle and emits publishing progress', async function () {
+        const rebuiltBundle = createVersionedBundle('package-a', '1.2.4');
+        const publish = fake.resolves(undefined);
+        const { processor, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
+            increaseVersion: fake.returns(rebuiltBundle),
+            publish
+        });
+
+        const options: DetermineVersionAndPublishOptions = {
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: createBuildAndPublishOptions()
+        };
+        const result = await processor.buildAndPublish(options);
+
+        assert.deepStrictEqual(result, { bundle: rebuiltBundle, status: 'new-version' });
+        assert.deepStrictEqual(publish.firstCall.args, [
+            {
+                bundle: rebuiltBundle,
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                publishSettings: { access: 'public', sbom: { enabled: false } }
+            }
+        ]);
+        assert.deepStrictEqual(getCallArgs(emit), [
+            ['building', { packageName: 'package-a', version: '1.2.3' }],
+            ['rebuilding', { packageName: 'package-a', version: '1.2.3' }],
+            ['publishing', { packageName: 'package-a', version: '1.2.4' }]
+        ]);
+    });
+
+    function setupSbomScenario(
+        sbomResult: readonly { filePath: string; content: string; isExecutable: boolean }[] | undefined
+    ): {
+        readonly bundle: VersionedBundleWithManifest;
+        readonly analyzedBundle: AnalyzedBundle;
+        readonly generateSbom: SinonSpy;
+        readonly checkBundleAlreadyPublished: SinonSpy;
+        readonly processor: ReturnType<typeof createPackageProcessor>;
+    } {
+        const bundle = createVersionedBundle('package-a', '1.2.3');
+        const analyzedBundle = createAnalyzedBundle();
+        const generateSbom = fake.resolves(sbomResult);
+        const checkBundleAlreadyPublished = fake.resolves({ alreadyPublishedAsLatest: false });
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion: fake.returns(bundle),
+            checkBundleAlreadyPublished,
+            generateSbom
+        });
+        return { bundle, analyzedBundle, generateSbom, checkBundleAlreadyPublished, processor };
+    }
+
+    test('tryBuildAndPublish() invokes the sbomFileBuilder with the resolved bundle, siblings, and publish settings', async function () {
+        const sbomFile = { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false };
+        const { bundle, analyzedBundle, generateSbom, checkBundleAlreadyPublished, processor } = setupSbomScenario([
+            sbomFile
+        ]);
+
+        const buildOptions: BuildAndPublishOptions = {
+            ...createBuildAndPublishOptions(),
+            publishSettings: { access: 'public', sbom: { enabled: true } }
+        };
+        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions });
+
+        assert.strictEqual(generateSbom.callCount, 1);
+        const expectedSiblings = [...buildOptions.bundleDependencies, ...buildOptions.bundlePeerDependencies];
+        assert.deepStrictEqual(generateSbom.firstCall.args, [
+            bundle,
+            expectedSiblings,
+            { access: 'public', sbom: { enabled: true } }
+        ]);
+        const checkArgs = checkBundleAlreadyPublished.firstCall.args[0] as { extraFiles: readonly unknown[] };
+        assert.deepStrictEqual(checkArgs.extraFiles, [sbomFile]);
+    });
+
+    test('tryBuildAndPublish() omits extraFiles when sbomFileBuilder returns undefined', async function () {
+        const { analyzedBundle, checkBundleAlreadyPublished, processor } = setupSbomScenario(undefined);
+
+        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions: createBuildAndPublishOptions() });
+
+        const checkArgs = checkBundleAlreadyPublished.firstCall.args[0] as Record<string, unknown>;
+        assert.strictEqual('extraFiles' in checkArgs, false);
+    });
+
+    test('resolveAndLink() emits scanCompleted with the resolved bundle scan results when subscribed', async function () {
+        const hasSubscribers = fake((eventName: string) => {
+            return eventName === 'scanCompleted';
+        });
+        const resolve = fake.resolves({
+            name: 'package-a',
+            contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' } }],
+            roots: { main: { js: createTransferableFile('/entry.js') } } as const,
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
+            externalDependencies: new Map([['lodash', { version: '^4' }]])
+        });
+        const { processor, emit } = createProcessor({ hasSubscribers, resolve });
+
+        await processor.resolveAndLink(createResolveOptions());
+
+        const scanCalls = getCallArgs(emit).filter((args) => {
+            return args[0] === 'scanCompleted';
+        });
+        assert.strictEqual(scanCalls.length, 1);
+        assert.deepStrictEqual(scanCalls[0], [
+            'scanCompleted',
+            {
+                packageName: 'package-a',
+                included: [{ path: '/src/a.ts', reason: 'reachable-from-entry' }],
+                excluded: [{ specifier: 'lodash', reason: 'external-module' }]
+            }
+        ]);
+    });
+
+    test('resolveAndLink() does NOT emit scanCompleted when no subscriber is registered', async function () {
+        const { processor, emit } = createProcessor();
+
+        await processor.resolveAndLink(createResolveOptions());
+
+        const scanCalls = getCallArgs(emit).filter((args) => {
+            return args[0] === 'scanCompleted';
+        });
+        assert.strictEqual(scanCalls.length, 0);
+    });
+
+    test('resolveAndLink() emits linkingCompleted with the linker rewrites when subscribed', async function () {
+        const hasSubscribers = fake((eventName: string) => {
+            return eventName === 'linkingCompleted';
+        });
+        const linkBundle = fake.resolves({
+            name: 'package-a',
+            contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true }],
+            roots: { main: { js: createTransferableFile('/entry.js') } } as const,
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' } as const,
+            linkedBundleDependencies: new Map([['pkg-b', {}]]),
+            externalDependencies: new Map()
+        });
+        const { processor, emit } = createProcessor({ hasSubscribers, linkBundle });
+
+        await processor.resolveAndLink(createResolveOptions());
+
+        const linkingCalls = getCallArgs(emit).filter((args) => {
+            return args[0] === 'linkingCompleted';
+        });
+        assert.strictEqual(linkingCalls.length, 1);
+        assert.deepStrictEqual(linkingCalls[0], [
+            'linkingCompleted',
+            {
+                packageName: 'package-a',
+                rewrites: [
+                    {
+                        file: '/src/a.ts',
+                        fromSpecifier: '/src/a.ts',
+                        toSpecifier: 'pkg-b',
+                        targetBundle: 'pkg-b'
+                    }
+                ]
+            }
+        ]);
+    });
+
+    test('resolveAndLink() does NOT emit linkingCompleted when no subscriber is registered', async function () {
+        const { processor, emit } = createProcessor();
+
+        await processor.resolveAndLink(createResolveOptions());
+
+        const linkingCalls = getCallArgs(emit).filter((args) => {
+            return args[0] === 'linkingCompleted';
+        });
+        assert.strictEqual(linkingCalls.length, 0);
+    });
+
+    function onlyVersionDeterminedSubscriber(): SinonSpy {
+        return fake((eventName: string) => {
+            return eventName === 'versionDetermined';
+        });
+    }
+
+    function filterVersionDetermined(emit: SinonSpy): unknown[][] {
+        return getCallArgs(emit).filter((args) => {
+            return args[0] === 'versionDetermined';
+        });
+    }
+
+    function expectSingleVersionDetermined(
+        emit: SinonSpy,
+        payload: {
+            packageName: string;
+            previousVersion: string | undefined;
+            chosenVersion: string;
+            trigger: 'auto-patch-bump' | 'initial' | 'minimum' | 'pinned';
         }
+    ): void {
+        assert.deepStrictEqual(filterVersionDetermined(emit), [['versionDetermined', payload]]);
+    }
+
+    test('tryBuildAndPublish() emits versionDetermined trigger "pinned" when first publish keeps the manual version', async function () {
+        const manualBundle = createVersionedBundle('package-a', '4.5.6');
+        const { processor, emit } = createProcessor({
+            hasSubscribers: onlyVersionDeterminedSubscriber(),
+            determineCurrentVersion: fake.resolves(Maybe.nothing()),
+            addVersion: fake.returns(manualBundle)
+        });
+
+        await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: { ...createBuildAndPublishOptions(), versioning: { automatic: false, version: '4.5.6' } }
+        });
+
+        expectSingleVersionDetermined(emit, {
+            packageName: 'package-a',
+            previousVersion: undefined,
+            chosenVersion: '4.5.6',
+            trigger: 'pinned'
+        });
     });
 
-    expectSingleVersionDetermined(emit, {
-        packageName: 'package-a',
-        previousVersion: undefined,
-        chosenVersion: '1.2.3',
-        trigger: 'minimum'
-    });
-});
+    test('tryBuildAndPublish() emits versionDetermined trigger "auto-patch-bump" on first auto publish without minimum', async function () {
+        const initialBundle = createVersionedBundle('package-a', '0.0.0');
+        const rebuiltBundle = createVersionedBundle('package-a', '0.0.1');
+        const { processor, emit } = createProcessor({
+            hasSubscribers: onlyVersionDeterminedSubscriber(),
+            determineCurrentVersion: fake.resolves(Maybe.nothing()),
+            addVersion: fake.returns(initialBundle),
+            increaseVersion: fake.returns(rebuiltBundle)
+        });
 
-test('tryBuildAndPublish() emits versionDetermined with the previousVersion for a rebuild on existing publication', async () => {
-    const currentBundle = createVersionedBundle('package-a', '2.0.0');
-    const rebuilt = createVersionedBundle('package-a', '2.0.1');
-    const { processor, emit } = createProcessor({
-        hasSubscribers: onlyVersionDeterminedSubscriber(),
-        determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
-        addVersion: fake.returns(currentBundle),
-        increaseVersion: fake.returns(rebuilt)
-    });
+        await tryBuildAndPublishDefault(processor);
 
-    await tryBuildAndPublishDefault(processor);
-
-    expectSingleVersionDetermined(emit, {
-        packageName: 'package-a',
-        previousVersion: '2.0.0',
-        chosenVersion: '2.0.1',
-        trigger: 'auto-patch-bump'
-    });
-});
-
-test('tryBuildAndPublish() emits versionDetermined trigger "auto-patch-bump" without bump when current matches an automatic build', async () => {
-    const initialBundle = createVersionedBundle('package-a', '2.0.0');
-    const { processor, emit } = createProcessor({
-        hasSubscribers: onlyVersionDeterminedSubscriber(),
-        determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
-        addVersion: fake.returns(initialBundle),
-        checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true })
+        expectSingleVersionDetermined(emit, {
+            packageName: 'package-a',
+            previousVersion: undefined,
+            chosenVersion: '0.0.1',
+            trigger: 'auto-patch-bump'
+        });
     });
 
-    await tryBuildAndPublishDefault(processor);
+    test('tryBuildAndPublish() emits versionDetermined trigger "minimum" when minimumVersion is used as-is', async function () {
+        const minimumVersionBundle = createVersionedBundle('package-a', '1.2.3');
+        const { processor, emit } = createProcessor({
+            hasSubscribers: onlyVersionDeterminedSubscriber(),
+            determineCurrentVersion: fake.resolves(Maybe.nothing()),
+            addVersion: fake.returns(minimumVersionBundle)
+        });
 
-    expectSingleVersionDetermined(emit, {
-        packageName: 'package-a',
-        previousVersion: '2.0.0',
-        chosenVersion: '2.0.0',
-        trigger: 'auto-patch-bump'
-    });
-});
+        await processor.tryBuildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: {
+                ...createBuildAndPublishOptions(),
+                versioning: { automatic: true, minimumVersion: '1.2.3' }
+            }
+        });
 
-test('tryBuildAndPublish() emits versionDetermined trigger "initial" when nothing is published and the bundle already matches', async () => {
-    const initialBundle = createVersionedBundle('package-a', '0.0.0');
-    const { processor, emit } = createProcessor({
-        hasSubscribers: onlyVersionDeterminedSubscriber(),
-        determineCurrentVersion: fake.resolves(Maybe.nothing()),
-        addVersion: fake.returns(initialBundle),
-        checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true })
-    });
-
-    await tryBuildAndPublishDefault(processor);
-
-    expectSingleVersionDetermined(emit, {
-        packageName: 'package-a',
-        previousVersion: undefined,
-        chosenVersion: '0.0.0',
-        trigger: 'initial'
-    });
-});
-
-test('tryBuildAndPublish() does NOT emit versionDetermined when no subscriber is registered', async () => {
-    const { processor, emit } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
-        addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
-        checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true })
+        expectSingleVersionDetermined(emit, {
+            packageName: 'package-a',
+            previousVersion: undefined,
+            chosenVersion: '1.2.3',
+            trigger: 'minimum'
+        });
     });
 
-    await tryBuildAndPublishDefault(processor);
+    test('tryBuildAndPublish() emits versionDetermined with the previousVersion for a rebuild on existing publication', async function () {
+        const currentBundle = createVersionedBundle('package-a', '2.0.0');
+        const rebuilt = createVersionedBundle('package-a', '2.0.1');
+        const { processor, emit } = createProcessor({
+            hasSubscribers: onlyVersionDeterminedSubscriber(),
+            determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
+            addVersion: fake.returns(currentBundle),
+            increaseVersion: fake.returns(rebuilt)
+        });
 
-    assert.strictEqual(filterVersionDetermined(emit).length, 0);
-});
+        await tryBuildAndPublishDefault(processor);
 
-test('buildAndPublish() forwards extraFiles from sbomFileBuilder to publish', async () => {
-    const rebuiltBundle = createVersionedBundle('package-a', '1.2.4');
-    const publish = fake.resolves(undefined);
-    const generateSbom = fake.resolves([
-        { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false }
-    ]);
-    const { processor } = createProcessor({
-        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
-        addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
-        increaseVersion: fake.returns(rebuiltBundle),
-        publish,
-        generateSbom
+        expectSingleVersionDetermined(emit, {
+            packageName: 'package-a',
+            previousVersion: '2.0.0',
+            chosenVersion: '2.0.1',
+            trigger: 'auto-patch-bump'
+        });
     });
 
-    const options: DetermineVersionAndPublishOptions = {
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: { ...createBuildAndPublishOptions(), publishSettings: { access: 'public' } }
-    };
-    await processor.buildAndPublish(options);
+    test('tryBuildAndPublish() emits versionDetermined trigger "auto-patch-bump" without bump when current matches an automatic build', async function () {
+        const initialBundle = createVersionedBundle('package-a', '2.0.0');
+        const { processor, emit } = createProcessor({
+            hasSubscribers: onlyVersionDeterminedSubscriber(),
+            determineCurrentVersion: fake.resolves(Maybe.just('2.0.0')),
+            addVersion: fake.returns(initialBundle),
+            checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true })
+        });
 
-    const publishArgs = publish.firstCall.args[0] as { extraFiles: readonly unknown[] };
-    assert.deepStrictEqual(publishArgs.extraFiles, [
-        { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false }
-    ]);
+        await tryBuildAndPublishDefault(processor);
+
+        expectSingleVersionDetermined(emit, {
+            packageName: 'package-a',
+            previousVersion: '2.0.0',
+            chosenVersion: '2.0.0',
+            trigger: 'auto-patch-bump'
+        });
+    });
+
+    test('tryBuildAndPublish() emits versionDetermined trigger "initial" when nothing is published and the bundle already matches', async function () {
+        const initialBundle = createVersionedBundle('package-a', '0.0.0');
+        const { processor, emit } = createProcessor({
+            hasSubscribers: onlyVersionDeterminedSubscriber(),
+            determineCurrentVersion: fake.resolves(Maybe.nothing()),
+            addVersion: fake.returns(initialBundle),
+            checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true })
+        });
+
+        await tryBuildAndPublishDefault(processor);
+
+        expectSingleVersionDetermined(emit, {
+            packageName: 'package-a',
+            previousVersion: undefined,
+            chosenVersion: '0.0.0',
+            trigger: 'initial'
+        });
+    });
+
+    test('tryBuildAndPublish() does NOT emit versionDetermined when no subscriber is registered', async function () {
+        const { processor, emit } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
+            checkBundleAlreadyPublished: fake.resolves({ alreadyPublishedAsLatest: true })
+        });
+
+        await tryBuildAndPublishDefault(processor);
+
+        assert.strictEqual(filterVersionDetermined(emit).length, 0);
+    });
+
+    test('buildAndPublish() forwards extraFiles from sbomFileBuilder to publish', async function () {
+        const rebuiltBundle = createVersionedBundle('package-a', '1.2.4');
+        const publish = fake.resolves(undefined);
+        const generateSbom = fake.resolves([
+            { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false }
+        ]);
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
+            increaseVersion: fake.returns(rebuiltBundle),
+            publish,
+            generateSbom
+        });
+
+        const options: DetermineVersionAndPublishOptions = {
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: { ...createBuildAndPublishOptions(), publishSettings: { access: 'public' } }
+        };
+        await processor.buildAndPublish(options);
+
+        const publishArgs = publish.firstCall.args[0] as { extraFiles: readonly unknown[] };
+        assert.deepStrictEqual(publishArgs.extraFiles, [
+            { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false }
+        ]);
+    });
 });

--- a/source/packtory/packtory-publish.test.ts
+++ b/source/packtory/packtory-publish.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
 import {
     emptyScheduler,
@@ -17,49 +17,51 @@ function happyDependencies() {
     };
 }
 
-test('createRunBuildAndPublishValidated returns Ok([]) when resolve and publish both succeed with no packages', async () => {
-    const run = createRunBuildAndPublishValidated(happyDependencies());
+suite('packtory-publish', function () {
+    test('createRunBuildAndPublishValidated returns Ok([]) when resolve and publish both succeed with no packages', async function () {
+        const run = createRunBuildAndPublishValidated(happyDependencies());
 
-    const result = await run(
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-        { dryRun: false },
-        async () => Result.ok([])
-    );
+        const result = await run(
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
+            { dryRun: false },
+            async () => Result.ok([])
+        );
 
-    assert.strictEqual(result.isOk, true);
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-test('createRunBuildAndPublishValidated maps resolve failures into publish failures via the mapping helper', async () => {
-    const run = createRunBuildAndPublishValidated(happyDependencies());
+    test('createRunBuildAndPublishValidated maps resolve failures into publish failures via the mapping helper', async function () {
+        const run = createRunBuildAndPublishValidated(happyDependencies());
 
-    const result = await run(
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-        { dryRun: false },
-        async () => Result.err({ type: 'config', issues: ['bad'] })
-    );
+        const result = await run(
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
+            { dryRun: false },
+            async () => Result.err({ type: 'config', issues: ['bad'] })
+        );
 
-    if (!result.isErr) {
-        assert.fail('expected the result to be an error');
-    }
-    assert.deepStrictEqual(result.error, { type: 'config', issues: ['bad'] });
-});
+        if (!result.isErr) {
+            assert.fail('expected the result to be an error');
+        }
+        assert.deepStrictEqual(result.error, { type: 'config', issues: ['bad'] });
+    });
 
-test('createRunBuildAndPublishValidated wraps publish-stage partial failures into the publish-partial variant', async () => {
-    const dependencies = {
-        ...happyDependencies(),
-        scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] })
-    };
+    test('createRunBuildAndPublishValidated wraps publish-stage partial failures into the publish-partial variant', async function () {
+        const dependencies = {
+            ...happyDependencies(),
+            scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] })
+        };
 
-    const run = createRunBuildAndPublishValidated(dependencies);
+        const run = createRunBuildAndPublishValidated(dependencies);
 
-    const result = await run(
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-        { dryRun: false },
-        async () => Result.ok([])
-    );
+        const result = await run(
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
+            { dryRun: false },
+            async () => Result.ok([])
+        );
 
-    if (!result.isErr) {
-        assert.fail('expected the result to be an error');
-    }
-    assert.strictEqual(result.error.type, 'partial');
+        if (!result.isErr) {
+            assert.fail('expected the result to be an error');
+        }
+        assert.strictEqual(result.error.type, 'partial');
+    });
 });

--- a/source/packtory/packtory-resolve.test.ts
+++ b/source/packtory/packtory-resolve.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     emptyDeadCodeEliminator,
     emptyScheduler,
@@ -18,27 +18,29 @@ function happyDependencies() {
     };
 }
 
-test('createResolveAndLinkAllValidated returns Ok([]) when no packages are configured', async () => {
-    const resolve = createResolveAndLinkAllValidated(happyDependencies());
+suite('packtory-resolve', function () {
+    test('createResolveAndLinkAllValidated returns Ok([]) when no packages are configured', async function () {
+        const resolve = createResolveAndLinkAllValidated(happyDependencies());
 
-    const result = await resolve({ packageConfigs: {}, packtoryConfig: { packages: [] } } as never);
+        const result = await resolve({ packageConfigs: {}, packtoryConfig: { packages: [] } } as never);
 
-    assert.strictEqual(result.isOk, true);
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-test('createResolveAndLinkAllValidated wraps scheduler failures into a resolve-partial failure', async () => {
-    const dependencies = {
-        ...happyDependencies(),
-        scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] })
-    };
-    const resolve = createResolveAndLinkAllValidated(dependencies);
+    test('createResolveAndLinkAllValidated wraps scheduler failures into a resolve-partial failure', async function () {
+        const dependencies = {
+            ...happyDependencies(),
+            scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] })
+        };
+        const resolve = createResolveAndLinkAllValidated(dependencies);
 
-    const result = await resolve({ packageConfigs: {}, packtoryConfig: { packages: [] } } as never);
+        const result = await resolve({ packageConfigs: {}, packtoryConfig: { packages: [] } } as never);
 
-    if (!result.isErr || result.error.type !== 'partial') {
-        assert.fail('expected a partial failure');
-    }
-    assert.deepStrictEqual(result.error.error.succeeded, []);
-    assert.strictEqual(result.error.error.failures.length, 1);
-    assert.strictEqual(result.error.error.failures[0]?.message, 'boom');
+        if (!result.isErr || result.error.type !== 'partial') {
+            assert.fail('expected a partial failure');
+        }
+        assert.deepStrictEqual(result.error.error.succeeded, []);
+        assert.strictEqual(result.error.error.failures.length, 1);
+        assert.strictEqual(result.error.error.failures[0]?.message, 'boom');
+    });
 });

--- a/source/packtory/packtory-results.test.ts
+++ b/source/packtory/packtory-results.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
 import type { BuildAndPublishResult } from './package-processor.ts';
 import {
@@ -14,43 +14,45 @@ import {
     type ResolveAndLinkAllResult
 } from './packtory-results.ts';
 
-test('configError wraps the given issues in a discriminated config-failure variant', () => {
-    assert.deepStrictEqual(configError(['a', 'b']), { type: 'config', issues: ['a', 'b'] });
-});
-
-test('publishPartialFailure tags a PartialError as a publish-partial failure', () => {
-    const failure = publishPartialFailure({
-        succeeded: [] as readonly BuildAndPublishResult[],
-        failures: [{ message: 'boom' } as never]
+suite('packtory-results', function () {
+    test('configError wraps the given issues in a discriminated config-failure variant', function () {
+        assert.deepStrictEqual(configError(['a', 'b']), { type: 'config', issues: ['a', 'b'] });
     });
-    assert.strictEqual(failure.type, 'partial');
-    assert.deepStrictEqual(failure.failures, [{ message: 'boom' }]);
-});
 
-test('resolvePartialFailure wraps a PartialError under the partial discriminator', () => {
-    const partial = resolvePartialFailure({ succeeded: [], failures: [] });
-    assert.strictEqual(partial.type, 'partial');
-    assert.deepStrictEqual(partial.error, { succeeded: [], failures: [] });
-});
+    test('publishPartialFailure tags a PartialError as a publish-partial failure', function () {
+        const failure = publishPartialFailure({
+            succeeded: [] as readonly BuildAndPublishResult[],
+            failures: [{ message: 'boom' } as never]
+        });
+        assert.strictEqual(failure.type, 'partial');
+        assert.deepStrictEqual(failure.failures, [{ message: 'boom' }]);
+    });
 
-test('createPublishAllOutcome captures the result and the report getter', () => {
-    const result = Result.err({ type: 'config', issues: [] }) as PublishAllResult;
-    const report: BuildReport = {
-        schemaVersion: 1,
-        generatedAt: 'x',
-        packages: {},
-        aggregate: { crossBundleLinks: [] }
-    };
-    const outcome = createPublishAllOutcome(result, () => report);
+    test('resolvePartialFailure wraps a PartialError under the partial discriminator', function () {
+        const partial = resolvePartialFailure({ succeeded: [], failures: [] });
+        assert.strictEqual(partial.type, 'partial');
+        assert.deepStrictEqual(partial.error, { succeeded: [], failures: [] });
+    });
 
-    assert.strictEqual(outcome.result, result);
-    assert.strictEqual(outcome.getReport(), report);
-});
+    test('createPublishAllOutcome captures the result and the report getter', function () {
+        const result = Result.err({ type: 'config', issues: [] }) as PublishAllResult;
+        const report: BuildReport = {
+            schemaVersion: 1,
+            generatedAt: 'x',
+            packages: {},
+            aggregate: { crossBundleLinks: [] }
+        };
+        const outcome = createPublishAllOutcome(result, () => report);
 
-test('createResolveAndLinkAllOutcome captures the result and the report getter', () => {
-    const result = Result.err({ type: 'config', issues: [] }) as ResolveAndLinkAllResult;
-    const outcome = createResolveAndLinkAllOutcome(result, () => undefined);
+        assert.strictEqual(outcome.result, result);
+        assert.strictEqual(outcome.getReport(), report);
+    });
 
-    assert.strictEqual(outcome.result, result);
-    assert.strictEqual(outcome.getReport(), undefined);
+    test('createResolveAndLinkAllOutcome captures the result and the report getter', function () {
+        const result = Result.err({ type: 'config', issues: [] }) as ResolveAndLinkAllResult;
+        const outcome = createResolveAndLinkAllOutcome(result, () => undefined);
+
+        assert.strictEqual(outcome.result, result);
+        assert.strictEqual(outcome.getReport(), undefined);
+    });
 });

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
 import type { PacktoryConfig, PacktoryConfigWithoutRegistry } from '../config/config.ts';
@@ -221,264 +221,269 @@ function createPacktoryUnderTest(
     };
 }
 
-test('resolveAndLinkAll() returns config issues when the config without registry is invalid', async () => {
-    const { packtory } = createPacktoryUnderTest();
+suite('packtory', function () {
+    test('resolveAndLinkAll() returns config issues when the config without registry is invalid', async function () {
+        const { packtory } = createPacktoryUnderTest();
 
-    const { result } = await packtory.resolveAndLinkAll({ invalid: true });
+        const { result } = await packtory.resolveAndLinkAll({ invalid: true });
 
-    const error = getErrResult(result, 'Expected resolveAndLinkAll() should fail but it did not');
-    assert.strictEqual(error.type, 'config');
-});
-
-function createPacktoryThatSharesSourceFile(): ReturnType<typeof createPacktoryUnderTest> {
-    return createPacktoryUnderTest({
-        resolveAndLink: fake(async (options: { name: string }) => {
-            return createLinkedBundle(options.name, '/shared.js');
-        })
-    });
-}
-
-test('resolveAndLinkAll() returns check failures after the linked bundles were built', async () => {
-    const { packtory } = createPacktoryThatSharesSourceFile();
-
-    const { result } = await packtory.resolveAndLinkAll(
-        createConfigWithoutRegistry({
-            checks: { noDuplicatedFiles: { enabled: true } },
-            packages: twoPackageEntries
-        })
-    );
-
-    assert.deepStrictEqual(
-        result,
-        Result.err({
-            type: 'checks',
-            issues: ['File "/shared.js" is included in multiple packages: package-a, package-b']
-        })
-    );
-});
-
-test('resolveAndLinkAll() returns all resolved packages on success', async () => {
-    const { packtory, resolveAndLink, scheduler } = createPacktoryUnderTest();
-
-    const { result } = await packtory.resolveAndLinkAll(
-        createConfigWithoutRegistry({
-            packages: [
-                { name: 'dependency', roots: { main: { js: 'dependency/index.js' } } },
-                {
-                    name: 'package-a',
-                    roots: { main: { js: 'package-a/index.js' } },
-                    bundleDependencies: ['dependency']
-                }
-            ]
-        })
-    );
-
-    const resolvedPackages = getOkResult(result, 'Expected resolveAndLinkAll() should succeed');
-    assert.strictEqual(resolveAndLink.callCount, 2);
-    assert.strictEqual(scheduler.runForEachScheduledPackage.callCount, 1);
-    assert.deepStrictEqual(
-        resolvedPackages.map((entry) => {
-            return entry.name;
-        }),
-        ['dependency', 'package-a']
-    );
-});
-
-test('buildAndPublishAll() returns config issues when the config with registry is invalid', async () => {
-    const { packtory } = createPacktoryUnderTest();
-
-    const { result } = await packtory.buildAndPublishAll({ invalid: true }, { dryRun: true });
-
-    assert.deepStrictEqual(
-        result,
-        Result.err({
-            type: 'config',
-            issues: ['at registrySettings: missing property', 'invalid value doesn’t match expected union']
-        })
-    );
-});
-
-test('buildAndPublishAll() returns check failures without entering publish mode', async () => {
-    const buildAndPublish = fake();
-    const tryBuildAndPublish = fake();
-    const { packtory } = createPacktoryUnderTest({
-        resolveAndLink: fake(async (options: { name: string }) => {
-            return createLinkedBundle(options.name, '/shared.js');
-        }),
-        buildAndPublish,
-        tryBuildAndPublish
+        const error = getErrResult(result, 'Expected resolveAndLinkAll() should fail but it did not');
+        assert.strictEqual(error.type, 'config');
     });
 
-    const { result } = await packtory.buildAndPublishAll(
-        createConfig({
-            checks: { noDuplicatedFiles: { enabled: true } },
-            packages: twoPackageEntries
-        }),
-        { dryRun: false }
-    );
+    function createPacktoryThatSharesSourceFile(): ReturnType<typeof createPacktoryUnderTest> {
+        return createPacktoryUnderTest({
+            resolveAndLink: fake(async (options: { name: string }) => {
+                return createLinkedBundle(options.name, '/shared.js');
+            })
+        });
+    }
 
-    assert.deepStrictEqual(
-        result,
-        Result.err({
-            type: 'checks',
-            issues: ['File "/shared.js" is included in multiple packages: package-a, package-b']
-        })
-    );
-    assert.strictEqual(tryBuildAndPublish.callCount, 0);
-    assert.strictEqual(buildAndPublish.callCount, 0);
-});
+    test('resolveAndLinkAll() returns check failures after the linked bundles were built', async function () {
+        const { packtory } = createPacktoryThatSharesSourceFile();
 
-test('buildAndPublishAll() uses tryBuildAndPublish() in dry-run mode and returns successful publish results', async () => {
-    const { packtory, tryBuildAndPublish, buildAndPublish, scheduler } = createPacktoryUnderTest();
+        const { result } = await packtory.resolveAndLinkAll(
+            createConfigWithoutRegistry({
+                checks: { noDuplicatedFiles: { enabled: true } },
+                packages: twoPackageEntries
+            })
+        );
 
-    const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
-
-    assert.deepStrictEqual(
-        result,
-        Result.ok([{ bundle: createVersionedBundle('package-a'), status: 'initial-version' }])
-    );
-    assert.strictEqual(tryBuildAndPublish.callCount, 1);
-    assert.strictEqual(buildAndPublish.callCount, 0);
-    assert.strictEqual(scheduler.runForEachScheduledPackage.callCount, 2);
-});
-
-test('buildAndPublishAll() uses buildAndPublish() outside dry-run mode', async () => {
-    const { packtory, tryBuildAndPublish, buildAndPublish } = createPacktoryUnderTest();
-
-    const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: false });
-
-    assert.deepStrictEqual(result, Result.ok([{ bundle: createVersionedBundle('package-a'), status: 'new-version' }]));
-    assert.strictEqual(tryBuildAndPublish.callCount, 0);
-    assert.strictEqual(buildAndPublish.callCount, 1);
-});
-
-function subscribeToPackageFailed(
-    progressBroadcaster: PacktoryUnderTest['progressBroadcaster']
-): { packageName: string; stage: string; message: string }[] {
-    const received: { packageName: string; stage: string; message: string }[] = [];
-    progressBroadcaster.consumer.on('packageFailed', (payload) => {
-        received.push({ packageName: payload.packageName, stage: payload.stage, message: payload.message });
-    });
-    return received;
-}
-
-test('resolveAndLinkAll() emits packageFailed with stage "resolveAndLink" when the resolve step throws', async () => {
-    const resolveAndLink = fake(async () => {
-        throw new Error('resolve crashed');
-    });
-    const { packtory, progressBroadcaster } = createPacktoryUnderTest({
-        resolveAndLink,
-        resolveStage: runPublishStageUntilFailure
-    });
-    const received = subscribeToPackageFailed(progressBroadcaster);
-
-    await packtory.resolveAndLinkAll(createConfigWithoutRegistry());
-
-    assert.deepStrictEqual(received, [
-        { packageName: 'package-a', stage: 'resolveAndLink', message: 'resolve crashed' }
-    ]);
-});
-
-test('buildAndPublishAll() emits packageFailed with stage "publish" when the publish step throws', async () => {
-    const buildAndPublish = fake(async () => {
-        throw new Error('publish crashed');
-    });
-    const tryBuildAndPublish = fake(async () => {
-        throw new Error('publish crashed');
-    });
-    const { packtory, progressBroadcaster } = createPacktoryUnderTest({
-        buildAndPublish,
-        tryBuildAndPublish,
-        publishStage: runPublishStageUntilFailure
-    });
-    const received = subscribeToPackageFailed(progressBroadcaster);
-
-    await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
-
-    const publishFailures = received.filter((entry) => {
-        return entry.stage === 'publish';
-    });
-    assert.deepStrictEqual(publishFailures, [
-        { packageName: 'package-a', stage: 'publish', message: 'publish crashed' }
-    ]);
-});
-
-test('resolveAndLinkAll() disposes the report aggregator after the call completes', async () => {
-    const { packtory, progressBroadcaster } = createPacktoryUnderTest();
-
-    await packtory.resolveAndLinkAll(createConfigWithoutRegistry(), { collectReport: true });
-
-    assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
-});
-
-test('resolveAndLinkAll() disposes the report aggregator even when the call throws', async () => {
-    const resolveAndLink = fake(async () => {
-        throw new Error('boom');
-    });
-    const { packtory, progressBroadcaster } = createPacktoryUnderTest({
-        resolveAndLink,
-        resolveStage: runPublishStageUntilFailure
+        assert.deepStrictEqual(
+            result,
+            Result.err({
+                type: 'checks',
+                issues: ['File "/shared.js" is included in multiple packages: package-a, package-b']
+            })
+        );
     });
 
-    await packtory.resolveAndLinkAll(createConfigWithoutRegistry(), { collectReport: true });
+    test('resolveAndLinkAll() returns all resolved packages on success', async function () {
+        const { packtory, resolveAndLink, scheduler } = createPacktoryUnderTest();
 
-    assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
-});
+        const { result } = await packtory.resolveAndLinkAll(
+            createConfigWithoutRegistry({
+                packages: [
+                    { name: 'dependency', roots: { main: { js: 'dependency/index.js' } } },
+                    {
+                        name: 'package-a',
+                        roots: { main: { js: 'package-a/index.js' } },
+                        bundleDependencies: ['dependency']
+                    }
+                ]
+            })
+        );
 
-test('buildAndPublishAll() disposes the report aggregator after the call completes', async () => {
-    const { packtory, progressBroadcaster } = createPacktoryUnderTest();
-
-    await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
-
-    assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
-});
-
-test('buildAndPublishAll() disposes the report aggregator even when the call throws', async () => {
-    const buildAndPublish = fake(async () => {
-        throw new Error('boom');
+        const resolvedPackages = getOkResult(result, 'Expected resolveAndLinkAll() should succeed');
+        assert.strictEqual(resolveAndLink.callCount, 2);
+        assert.strictEqual(scheduler.runForEachScheduledPackage.callCount, 1);
+        assert.deepStrictEqual(
+            resolvedPackages.map((entry) => {
+                return entry.name;
+            }),
+            ['dependency', 'package-a']
+        );
     });
-    const tryBuildAndPublish = fake(async () => {
-        throw new Error('boom');
+
+    test('buildAndPublishAll() returns config issues when the config with registry is invalid', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const { result } = await packtory.buildAndPublishAll({ invalid: true }, { dryRun: true });
+
+        assert.deepStrictEqual(
+            result,
+            Result.err({
+                type: 'config',
+                issues: ['at registrySettings: missing property', 'invalid value doesn’t match expected union']
+            })
+        );
     });
-    const { packtory, progressBroadcaster } = createPacktoryUnderTest({
-        buildAndPublish,
-        tryBuildAndPublish,
-        publishStage: runPublishStageUntilFailure
+
+    test('buildAndPublishAll() returns check failures without entering publish mode', async function () {
+        const buildAndPublish = fake();
+        const tryBuildAndPublish = fake();
+        const { packtory } = createPacktoryUnderTest({
+            resolveAndLink: fake(async (options: { name: string }) => {
+                return createLinkedBundle(options.name, '/shared.js');
+            }),
+            buildAndPublish,
+            tryBuildAndPublish
+        });
+
+        const { result } = await packtory.buildAndPublishAll(
+            createConfig({
+                checks: { noDuplicatedFiles: { enabled: true } },
+                packages: twoPackageEntries
+            }),
+            { dryRun: false }
+        );
+
+        assert.deepStrictEqual(
+            result,
+            Result.err({
+                type: 'checks',
+                issues: ['File "/shared.js" is included in multiple packages: package-a, package-b']
+            })
+        );
+        assert.strictEqual(tryBuildAndPublish.callCount, 0);
+        assert.strictEqual(buildAndPublish.callCount, 0);
     });
 
-    await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+    test('buildAndPublishAll() uses tryBuildAndPublish() in dry-run mode and returns successful publish results', async function () {
+        const { packtory, tryBuildAndPublish, buildAndPublish, scheduler } = createPacktoryUnderTest();
 
-    assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
-});
+        const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
 
-test('resolveAndLinkAll() with collectReport=true returns a non-undefined getReport', async () => {
-    const { packtory } = createPacktoryUnderTest();
+        assert.deepStrictEqual(
+            result,
+            Result.ok([{ bundle: createVersionedBundle('package-a'), status: 'initial-version' }])
+        );
+        assert.strictEqual(tryBuildAndPublish.callCount, 1);
+        assert.strictEqual(buildAndPublish.callCount, 0);
+        assert.strictEqual(scheduler.runForEachScheduledPackage.callCount, 2);
+    });
 
-    const outcome = await packtory.resolveAndLinkAll(createConfigWithoutRegistry(), { collectReport: true });
+    test('buildAndPublishAll() uses buildAndPublish() outside dry-run mode', async function () {
+        const { packtory, tryBuildAndPublish, buildAndPublish } = createPacktoryUnderTest();
 
-    assert.notStrictEqual(outcome.getReport(), undefined);
-});
+        const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: false });
 
-test('resolveAndLinkAll() without collectReport returns a getReport that yields undefined', async () => {
-    const { packtory } = createPacktoryUnderTest();
+        assert.deepStrictEqual(
+            result,
+            Result.ok([{ bundle: createVersionedBundle('package-a'), status: 'new-version' }])
+        );
+        assert.strictEqual(tryBuildAndPublish.callCount, 0);
+        assert.strictEqual(buildAndPublish.callCount, 1);
+    });
 
-    const outcome = await packtory.resolveAndLinkAll(createConfigWithoutRegistry());
+    function subscribeToPackageFailed(
+        progressBroadcaster: PacktoryUnderTest['progressBroadcaster']
+    ): { packageName: string; stage: string; message: string }[] {
+        const received: { packageName: string; stage: string; message: string }[] = [];
+        progressBroadcaster.consumer.on('packageFailed', (payload) => {
+            received.push({ packageName: payload.packageName, stage: payload.stage, message: payload.message });
+        });
+        return received;
+    }
 
-    assert.strictEqual(outcome.getReport(), undefined);
-});
+    test('resolveAndLinkAll() emits packageFailed with stage "resolveAndLink" when the resolve step throws', async function () {
+        const resolveAndLink = fake(async () => {
+            throw new Error('resolve crashed');
+        });
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest({
+            resolveAndLink,
+            resolveStage: runPublishStageUntilFailure
+        });
+        const received = subscribeToPackageFailed(progressBroadcaster);
 
-test('buildAndPublishAll() with collectReport=true returns a non-undefined getReport', async () => {
-    const { packtory } = createPacktoryUnderTest();
+        await packtory.resolveAndLinkAll(createConfigWithoutRegistry());
 
-    const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+        assert.deepStrictEqual(received, [
+            { packageName: 'package-a', stage: 'resolveAndLink', message: 'resolve crashed' }
+        ]);
+    });
 
-    assert.notStrictEqual(outcome.getReport(), undefined);
-});
+    test('buildAndPublishAll() emits packageFailed with stage "publish" when the publish step throws', async function () {
+        const buildAndPublish = fake(async () => {
+            throw new Error('publish crashed');
+        });
+        const tryBuildAndPublish = fake(async () => {
+            throw new Error('publish crashed');
+        });
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest({
+            buildAndPublish,
+            tryBuildAndPublish,
+            publishStage: runPublishStageUntilFailure
+        });
+        const received = subscribeToPackageFailed(progressBroadcaster);
 
-test('buildAndPublishAll() without collectReport returns a getReport that yields undefined', async () => {
-    const { packtory } = createPacktoryUnderTest();
+        await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
 
-    const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
+        const publishFailures = received.filter((entry) => {
+            return entry.stage === 'publish';
+        });
+        assert.deepStrictEqual(publishFailures, [
+            { packageName: 'package-a', stage: 'publish', message: 'publish crashed' }
+        ]);
+    });
 
-    assert.strictEqual(outcome.getReport(), undefined);
+    test('resolveAndLinkAll() disposes the report aggregator after the call completes', async function () {
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest();
+
+        await packtory.resolveAndLinkAll(createConfigWithoutRegistry(), { collectReport: true });
+
+        assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
+    });
+
+    test('resolveAndLinkAll() disposes the report aggregator even when the call throws', async function () {
+        const resolveAndLink = fake(async () => {
+            throw new Error('boom');
+        });
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest({
+            resolveAndLink,
+            resolveStage: runPublishStageUntilFailure
+        });
+
+        await packtory.resolveAndLinkAll(createConfigWithoutRegistry(), { collectReport: true });
+
+        assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
+    });
+
+    test('buildAndPublishAll() disposes the report aggregator after the call completes', async function () {
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest();
+
+        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+
+        assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
+    });
+
+    test('buildAndPublishAll() disposes the report aggregator even when the call throws', async function () {
+        const buildAndPublish = fake(async () => {
+            throw new Error('boom');
+        });
+        const tryBuildAndPublish = fake(async () => {
+            throw new Error('boom');
+        });
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest({
+            buildAndPublish,
+            tryBuildAndPublish,
+            publishStage: runPublishStageUntilFailure
+        });
+
+        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+
+        assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
+    });
+
+    test('resolveAndLinkAll() with collectReport=true returns a non-undefined getReport', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const outcome = await packtory.resolveAndLinkAll(createConfigWithoutRegistry(), { collectReport: true });
+
+        assert.notStrictEqual(outcome.getReport(), undefined);
+    });
+
+    test('resolveAndLinkAll() without collectReport returns a getReport that yields undefined', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const outcome = await packtory.resolveAndLinkAll(createConfigWithoutRegistry());
+
+        assert.strictEqual(outcome.getReport(), undefined);
+    });
+
+    test('buildAndPublishAll() with collectReport=true returns a non-undefined getReport', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+
+        assert.notStrictEqual(outcome.getReport(), undefined);
+    });
+
+    test('buildAndPublishAll() without collectReport returns a getReport that yields undefined', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
+
+        assert.strictEqual(outcome.getReport(), undefined);
+    });
 });

--- a/source/packtory/publish-failure-mapping.test.ts
+++ b/source/packtory/publish-failure-mapping.test.ts
@@ -1,25 +1,27 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { mapResolveFailureToPublishFailure } from './publish-failure-mapping.ts';
 
-test('mapResolveFailureToPublishFailure passes config failures through unchanged', () => {
-    const failure = { type: 'config', issues: ['bad'] } as const;
-    assert.strictEqual(mapResolveFailureToPublishFailure(failure), failure);
-});
+suite('publish-failure-mapping', function () {
+    test('mapResolveFailureToPublishFailure passes config failures through unchanged', function () {
+        const failure = { type: 'config', issues: ['bad'] } as const;
+        assert.strictEqual(mapResolveFailureToPublishFailure(failure), failure);
+    });
 
-test('mapResolveFailureToPublishFailure passes check failures through unchanged', () => {
-    const failure = { type: 'checks', issues: ['rule'] } as const;
-    assert.strictEqual(mapResolveFailureToPublishFailure(failure), failure);
-});
+    test('mapResolveFailureToPublishFailure passes check failures through unchanged', function () {
+        const failure = { type: 'checks', issues: ['rule'] } as const;
+        assert.strictEqual(mapResolveFailureToPublishFailure(failure), failure);
+    });
 
-test('mapResolveFailureToPublishFailure converts a partial resolve failure into a publish-partial failure with empty succeeded', () => {
-    const failures = [{ message: 'boom' } as never];
-    const mapped = mapResolveFailureToPublishFailure({ type: 'partial', error: { succeeded: [], failures } });
+    test('mapResolveFailureToPublishFailure converts a partial resolve failure into a publish-partial failure with empty succeeded', function () {
+        const failures = [{ message: 'boom' } as never];
+        const mapped = mapResolveFailureToPublishFailure({ type: 'partial', error: { succeeded: [], failures } });
 
-    assert.strictEqual(mapped.type, 'partial');
-    if (mapped.type === 'partial') {
-        assert.deepStrictEqual(mapped.succeeded, []);
-        assert.strictEqual(mapped.failures, failures);
-    }
+        assert.strictEqual(mapped.type, 'partial');
+        if (mapped.type === 'partial') {
+            assert.deepStrictEqual(mapped.succeeded, []);
+            assert.strictEqual(mapped.failures, failures);
+        }
+    });
 });

--- a/source/packtory/report-attachment.test.ts
+++ b/source/packtory/report-attachment.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PacktoryConfig } from '../config/config.ts';
 import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
 import { createSpyingBroadcaster } from '../test-libraries/result-helpers.ts';
@@ -20,117 +20,119 @@ function createMinimalConfig(packageNames: readonly string[]): PacktoryConfig {
     } as unknown as PacktoryConfig;
 }
 
-test('maybeAttachAggregator() returns no-op getReport when collectReport is undefined', () => {
-    const broadcaster = createProgressBroadcaster();
+suite('report-attachment', function () {
+    test('maybeAttachAggregator() returns no-op getReport when collectReport is undefined', function () {
+        const broadcaster = createProgressBroadcaster();
 
-    const attachment = maybeAttachAggregator(broadcaster, undefined);
+        const attachment = maybeAttachAggregator(broadcaster, undefined);
 
-    assert.strictEqual(attachment.getReport(), undefined);
-});
-
-test('maybeAttachAggregator() returns no-op getReport when collectReport is false', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    const attachment = maybeAttachAggregator(broadcaster, false);
-
-    assert.strictEqual(attachment.getReport(), undefined);
-});
-
-test('maybeAttachAggregator() no-op dispose is callable without throwing when collectReport is false', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    const attachment = maybeAttachAggregator(broadcaster, false);
-
-    attachment.dispose();
-});
-
-test('maybeAttachAggregator() does not subscribe to broadcaster when collectReport is false', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    maybeAttachAggregator(broadcaster, false);
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), false);
-});
-
-test('maybeAttachAggregator() subscribes to broadcaster events when collectReport is true', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    maybeAttachAggregator(broadcaster, true);
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), true);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), true);
-});
-
-test('maybeAttachAggregator() getReport returns a materialized BuildReport when collectReport is true', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    const attachment = maybeAttachAggregator(broadcaster, true);
-    const report = attachment.getReport();
-
-    if (report === undefined) {
-        assert.fail('expected a BuildReport');
-    }
-    assert.strictEqual(report.schemaVersion, 1);
-    assert.deepStrictEqual(report.packages, {});
-    assert.deepStrictEqual(report.aggregate, { crossBundleLinks: [] });
-});
-
-test('maybeAttachAggregator() getReport reflects events emitted before build', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    const attachment = maybeAttachAggregator(broadcaster, true);
-    broadcaster.provider.emit('stageTimed', {
-        packageName: 'pkg-a',
-        stage: 'resolveAndLink',
-        durationMs: 12
+        assert.strictEqual(attachment.getReport(), undefined);
     });
 
-    const report = attachment.getReport();
-    if (report === undefined) {
-        assert.fail('expected a BuildReport');
-    }
-    assert.deepStrictEqual(report.packages['pkg-a']?.timings, { resolveAndLink: 12 });
-});
+    test('maybeAttachAggregator() returns no-op getReport when collectReport is false', function () {
+        const broadcaster = createProgressBroadcaster();
 
-test('maybeAttachAggregator() dispose unsubscribes the aggregator', () => {
-    const broadcaster = createProgressBroadcaster();
+        const attachment = maybeAttachAggregator(broadcaster, false);
 
-    const attachment = maybeAttachAggregator(broadcaster, true);
-    attachment.dispose();
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), false);
-});
-
-test('emitEffectiveConfigPerPackage() does not emit when no subscriber is registered', () => {
-    const wrapped = createSpyingBroadcaster();
-
-    emitEffectiveConfigPerPackage(wrapped, createMinimalConfig(['pkg-a', 'pkg-b']));
-
-    assert.strictEqual(wrapped.emitSpy.callCount, 0);
-});
-
-test('emitEffectiveConfigPerPackage() emits one effectiveConfigResolved per package when a subscriber is registered', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: string[] = [];
-    broadcaster.consumer.on('effectiveConfigResolved', (payload) => {
-        received.push(payload.packageName);
+        assert.strictEqual(attachment.getReport(), undefined);
     });
 
-    emitEffectiveConfigPerPackage(broadcaster, createMinimalConfig(['pkg-a', 'pkg-b']));
+    test('maybeAttachAggregator() no-op dispose is callable without throwing when collectReport is false', function () {
+        const broadcaster = createProgressBroadcaster();
 
-    assert.deepStrictEqual(received, ['pkg-a', 'pkg-b']);
-});
+        const attachment = maybeAttachAggregator(broadcaster, false);
 
-test('emitEffectiveConfigPerPackage() emits a redacted config with the package name', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { packageName: string; configName: string }[] = [];
-    broadcaster.consumer.on('effectiveConfigResolved', (payload) => {
-        received.push({ packageName: payload.packageName, configName: String(payload.config.name) });
+        attachment.dispose();
     });
 
-    emitEffectiveConfigPerPackage(broadcaster, createMinimalConfig(['only-pkg']));
+    test('maybeAttachAggregator() does not subscribe to broadcaster when collectReport is false', function () {
+        const broadcaster = createProgressBroadcaster();
 
-    assert.deepStrictEqual(received, [{ packageName: 'only-pkg', configName: 'only-pkg' }]);
+        maybeAttachAggregator(broadcaster, false);
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), false);
+    });
+
+    test('maybeAttachAggregator() subscribes to broadcaster events when collectReport is true', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        maybeAttachAggregator(broadcaster, true);
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), true);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), true);
+    });
+
+    test('maybeAttachAggregator() getReport returns a materialized BuildReport when collectReport is true', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        const attachment = maybeAttachAggregator(broadcaster, true);
+        const report = attachment.getReport();
+
+        if (report === undefined) {
+            assert.fail('expected a BuildReport');
+        }
+        assert.strictEqual(report.schemaVersion, 1);
+        assert.deepStrictEqual(report.packages, {});
+        assert.deepStrictEqual(report.aggregate, { crossBundleLinks: [] });
+    });
+
+    test('maybeAttachAggregator() getReport reflects events emitted before build', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        const attachment = maybeAttachAggregator(broadcaster, true);
+        broadcaster.provider.emit('stageTimed', {
+            packageName: 'pkg-a',
+            stage: 'resolveAndLink',
+            durationMs: 12
+        });
+
+        const report = attachment.getReport();
+        if (report === undefined) {
+            assert.fail('expected a BuildReport');
+        }
+        assert.deepStrictEqual(report.packages['pkg-a']?.timings, { resolveAndLink: 12 });
+    });
+
+    test('maybeAttachAggregator() dispose unsubscribes the aggregator', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        const attachment = maybeAttachAggregator(broadcaster, true);
+        attachment.dispose();
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), false);
+    });
+
+    test('emitEffectiveConfigPerPackage() does not emit when no subscriber is registered', function () {
+        const wrapped = createSpyingBroadcaster();
+
+        emitEffectiveConfigPerPackage(wrapped, createMinimalConfig(['pkg-a', 'pkg-b']));
+
+        assert.strictEqual(wrapped.emitSpy.callCount, 0);
+    });
+
+    test('emitEffectiveConfigPerPackage() emits one effectiveConfigResolved per package when a subscriber is registered', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: string[] = [];
+        broadcaster.consumer.on('effectiveConfigResolved', (payload) => {
+            received.push(payload.packageName);
+        });
+
+        emitEffectiveConfigPerPackage(broadcaster, createMinimalConfig(['pkg-a', 'pkg-b']));
+
+        assert.deepStrictEqual(received, ['pkg-a', 'pkg-b']);
+    });
+
+    test('emitEffectiveConfigPerPackage() emits a redacted config with the package name', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { packageName: string; configName: string }[] = [];
+        broadcaster.consumer.on('effectiveConfigResolved', (payload) => {
+            received.push({ packageName: payload.packageName, configName: String(payload.config.name) });
+        });
+
+        emitEffectiveConfigPerPackage(broadcaster, createMinimalConfig(['only-pkg']));
+
+        assert.deepStrictEqual(received, [{ packageName: 'only-pkg', configName: 'only-pkg' }]);
+    });
 });

--- a/source/packtory/resolved-package.test.ts
+++ b/source/packtory/resolved-package.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions, @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ConfigWithGraph } from '../config/validation.ts';
 import type { PacktoryConfigWithoutRegistry } from '../config/config.ts';
 import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
@@ -10,142 +10,144 @@ function validated(config: Partial<PacktoryConfigWithoutRegistry>): ConfigWithGr
     return { packtoryConfig: { packages: [], ...config } } as unknown as ConfigWithGraph<PacktoryConfigWithoutRegistry>;
 }
 
-test('createResolvedPackage assembles the three fields into a ResolvedPackage', () => {
-    const analyzedBundle = { name: 'pkg-a' } as never;
-    const resolveOptions = { name: 'pkg-a' } as never;
+suite('resolved-package', function () {
+    test('createResolvedPackage assembles the three fields into a ResolvedPackage', function () {
+        const analyzedBundle = { name: 'pkg-a' } as never;
+        const resolveOptions = { name: 'pkg-a' } as never;
 
-    assert.deepStrictEqual(createResolvedPackage('pkg-a', analyzedBundle, resolveOptions), {
-        name: 'pkg-a',
-        analyzedBundle,
-        resolveOptions
+        assert.deepStrictEqual(createResolvedPackage('pkg-a', analyzedBundle, resolveOptions), {
+            name: 'pkg-a',
+            analyzedBundle,
+            resolveOptions
+        });
     });
-});
 
-test('buildChecksResult returns an Ok holding the resolved packages when no checks are configured', () => {
-    const resolvedPackages: readonly ResolvedPackage[] = [];
+    test('buildChecksResult returns an Ok holding the resolved packages when no checks are configured', function () {
+        const resolvedPackages: readonly ResolvedPackage[] = [];
 
-    const result = buildChecksResult(validated({}), resolvedPackages);
+        const result = buildChecksResult(validated({}), resolvedPackages);
 
-    assert.strictEqual(result.isOk, true);
-    if (result.isOk) {
-        assert.strictEqual(result.value, resolvedPackages);
-    }
-});
+        assert.strictEqual(result.isOk, true);
+        if (result.isOk) {
+            assert.strictEqual(result.value, resolvedPackages);
+        }
+    });
 
-test('buildChecksResult returns a checks failure carrying every issue produced by a configured rule', () => {
-    const resolvedPackages = [
-        { name: 'pkg-a', analyzedBundle: checkBundle('pkg-a', ['shared.ts']), resolveOptions: {} as never },
-        { name: 'pkg-b', analyzedBundle: checkBundle('pkg-b', ['shared.ts']), resolveOptions: {} as never }
-    ];
+    test('buildChecksResult returns a checks failure carrying every issue produced by a configured rule', function () {
+        const resolvedPackages = [
+            { name: 'pkg-a', analyzedBundle: checkBundle('pkg-a', ['shared.ts']), resolveOptions: {} as never },
+            { name: 'pkg-b', analyzedBundle: checkBundle('pkg-b', ['shared.ts']), resolveOptions: {} as never }
+        ];
 
-    const result = buildChecksResult(
-        validated({
-            checks: { noDuplicatedFiles: { enabled: true } },
-            packages: [{ name: 'pkg-a', roots: {} } as never, { name: 'pkg-b', roots: {} } as never]
-        }),
-        resolvedPackages
-    );
+        const result = buildChecksResult(
+            validated({
+                checks: { noDuplicatedFiles: { enabled: true } },
+                packages: [{ name: 'pkg-a', roots: {} } as never, { name: 'pkg-b', roots: {} } as never]
+            }),
+            resolvedPackages
+        );
 
-    assert.strictEqual(result.isErr, true);
-    if (result.isErr) {
-        assert.deepStrictEqual(result.error, {
-            type: 'checks',
-            issues: ['File "shared.ts" is included in multiple packages: pkg-a, pkg-b']
-        });
-    }
-});
+        assert.strictEqual(result.isErr, true);
+        if (result.isErr) {
+            assert.deepStrictEqual(result.error, {
+                type: 'checks',
+                issues: ['File "shared.ts" is included in multiple packages: pkg-a, pkg-b']
+            });
+        }
+    });
 
-test('buildChecksResult threads per-package check settings to the runner so cross-package consent suppresses issues', () => {
-    const resolvedPackages = [
-        { name: 'pkg-a', analyzedBundle: checkBundle('pkg-a', ['shared.ts']), resolveOptions: {} as never },
-        { name: 'pkg-b', analyzedBundle: checkBundle('pkg-b', ['shared.ts']), resolveOptions: {} as never }
-    ];
-    const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
+    test('buildChecksResult threads per-package check settings to the runner so cross-package consent suppresses issues', function () {
+        const resolvedPackages = [
+            { name: 'pkg-a', analyzedBundle: checkBundle('pkg-a', ['shared.ts']), resolveOptions: {} as never },
+            { name: 'pkg-b', analyzedBundle: checkBundle('pkg-b', ['shared.ts']), resolveOptions: {} as never }
+        ];
+        const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
 
-    const result = buildChecksResult(
-        validated({
-            checks: { noDuplicatedFiles: { enabled: true } },
-            packages: [
-                { name: 'pkg-a', roots: {}, checks: consent } as never,
-                { name: 'pkg-b', roots: {}, checks: consent } as never
-            ]
-        }),
-        resolvedPackages
-    );
+        const result = buildChecksResult(
+            validated({
+                checks: { noDuplicatedFiles: { enabled: true } },
+                packages: [
+                    { name: 'pkg-a', roots: {}, checks: consent } as never,
+                    { name: 'pkg-b', roots: {}, checks: consent } as never
+                ]
+            }),
+            resolvedPackages
+        );
 
-    assert.strictEqual(result.isOk, true);
-});
+        assert.strictEqual(result.isOk, true);
+    });
 
-test('buildChecksResult falls back to commonPackageSettings.mainPackageJson when the package does not override it', () => {
-    const bundle = {
-        ...checkBundle('pkg-a', ['shared.ts']),
-        externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
-    };
+    test('buildChecksResult falls back to commonPackageSettings.mainPackageJson when the package does not override it', function () {
+        const bundle = {
+            ...checkBundle('pkg-a', ['shared.ts']),
+            externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
+        };
 
-    const result = buildChecksResult(
-        validated({
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module', dependencies: { 'runtime-dep': '1.0.0' } }
-            },
-            checks: { noDevDependencyImports: { enabled: true } },
-            packages: [{ name: 'pkg-a', roots: {} } as never]
-        }),
-        [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
-    );
-
-    assert.strictEqual(result.isOk, true);
-});
-
-test('buildChecksResult flags a dev-only import detected through the common mainPackageJson fallback', () => {
-    const bundle = {
-        ...checkBundle('pkg-a', ['shared.ts']),
-        externalDependencies: new Map([['dev-dep', { name: 'dev-dep', referencedFrom: ['/x'] }]])
-    };
-
-    const result = buildChecksResult(
-        validated({
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module', devDependencies: { 'dev-dep': '1.0.0' } }
-            },
-            checks: { noDevDependencyImports: { enabled: true } },
-            packages: [{ name: 'pkg-a', roots: {} } as never]
-        }),
-        [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
-    );
-
-    assert.strictEqual(result.isErr, true);
-    if (result.isErr) {
-        assert.deepStrictEqual(result.error, {
-            type: 'checks',
-            issues: [
-                'Package "pkg-a" imports "dev-dep" which is only declared in devDependencies of the main package.json'
-            ]
-        });
-    }
-});
-
-test('buildChecksResult prefers the package-level mainPackageJson over commonPackageSettings.mainPackageJson', () => {
-    const bundle = {
-        ...checkBundle('pkg-a', ['shared.ts']),
-        externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
-    };
-
-    const result = buildChecksResult(
-        validated({
-            commonPackageSettings: {
-                mainPackageJson: { type: 'module', devDependencies: { 'runtime-dep': '1.0.0' } }
-            },
-            checks: { noDevDependencyImports: { enabled: true } },
-            packages: [
-                {
-                    name: 'pkg-a',
-                    roots: {},
+        const result = buildChecksResult(
+            validated({
+                commonPackageSettings: {
                     mainPackageJson: { type: 'module', dependencies: { 'runtime-dep': '1.0.0' } }
-                } as never
-            ]
-        }),
-        [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
-    );
+                },
+                checks: { noDevDependencyImports: { enabled: true } },
+                packages: [{ name: 'pkg-a', roots: {} } as never]
+            }),
+            [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
+        );
 
-    assert.strictEqual(result.isOk, true);
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('buildChecksResult flags a dev-only import detected through the common mainPackageJson fallback', function () {
+        const bundle = {
+            ...checkBundle('pkg-a', ['shared.ts']),
+            externalDependencies: new Map([['dev-dep', { name: 'dev-dep', referencedFrom: ['/x'] }]])
+        };
+
+        const result = buildChecksResult(
+            validated({
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module', devDependencies: { 'dev-dep': '1.0.0' } }
+                },
+                checks: { noDevDependencyImports: { enabled: true } },
+                packages: [{ name: 'pkg-a', roots: {} } as never]
+            }),
+            [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
+        );
+
+        assert.strictEqual(result.isErr, true);
+        if (result.isErr) {
+            assert.deepStrictEqual(result.error, {
+                type: 'checks',
+                issues: [
+                    'Package "pkg-a" imports "dev-dep" which is only declared in devDependencies of the main package.json'
+                ]
+            });
+        }
+    });
+
+    test('buildChecksResult prefers the package-level mainPackageJson over commonPackageSettings.mainPackageJson', function () {
+        const bundle = {
+            ...checkBundle('pkg-a', ['shared.ts']),
+            externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
+        };
+
+        const result = buildChecksResult(
+            validated({
+                commonPackageSettings: {
+                    mainPackageJson: { type: 'module', devDependencies: { 'runtime-dep': '1.0.0' } }
+                },
+                checks: { noDevDependencyImports: { enabled: true } },
+                packages: [
+                    {
+                        name: 'pkg-a',
+                        roots: {},
+                        mainPackageJson: { type: 'module', dependencies: { 'runtime-dep': '1.0.0' } }
+                    } as never
+                ]
+            }),
+            [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
+        );
+
+        assert.strictEqual(result.isOk, true);
+    });
 });

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
 import { validateConfigWithoutRegistry, type ValidConfigWithoutRegistryResult } from '../config/validation.ts';
@@ -72,129 +72,131 @@ function createPackageExecutionSnapshots(config: ValidConfigWithoutRegistryResul
     return { snapshots, configs, createOptions, execute };
 }
 
-test('runForEachScheduledPackage() emits scheduled events per default and passes previous generation results into createOptions()', async () => {
-    const { scheduler, emit } = createTestScheduler();
-    const config = createValidatedConfig([
-        { name: 'dependency', roots: { main: { js: 'dependency.js' } } },
-        { name: 'package-a', roots: { main: { js: 'entry.js' } }, bundleDependencies: ['dependency'] }
-    ]);
-    const { snapshots, configs, createOptions, execute } = createPackageExecutionSnapshots(config);
+suite('scheduler', function () {
+    test('runForEachScheduledPackage() emits scheduled events per default and passes previous generation results into createOptions()', async function () {
+        const { scheduler, emit } = createTestScheduler();
+        const config = createValidatedConfig([
+            { name: 'dependency', roots: { main: { js: 'dependency.js' } } },
+            { name: 'package-a', roots: { main: { js: 'entry.js' } }, bundleDependencies: ['dependency'] }
+        ]);
+        const { snapshots, configs, createOptions, execute } = createPackageExecutionSnapshots(config);
 
-    const result = await scheduler.runForEachScheduledPackage({
-        config,
-        createOptions,
-        execute,
-        selectNext: (params: { result: string }) => {
-            return params.result;
-        }
+        const result = await scheduler.runForEachScheduledPackage({
+            config,
+            createOptions,
+            execute,
+            selectNext: (params: { result: string }) => {
+                return params.result;
+            }
+        });
+
+        assert.deepStrictEqual(result, Result.ok(['dependency-result', 'package-a-result']));
+        assert.deepStrictEqual(snapshots, [
+            { packageName: 'dependency', existing: [] },
+            { packageName: 'package-a', existing: ['dependency-result'] }
+        ]);
+        assert.deepStrictEqual(configs, [config, config]);
+        assert.deepStrictEqual(getEmitCallArguments(emit), [
+            ['scheduled', { packageName: 'dependency' }],
+            ['scheduled', { packageName: 'package-a' }]
+        ]);
     });
 
-    assert.deepStrictEqual(result, Result.ok(['dependency-result', 'package-a-result']));
-    assert.deepStrictEqual(snapshots, [
-        { packageName: 'dependency', existing: [] },
-        { packageName: 'package-a', existing: ['dependency-result'] }
-    ]);
-    assert.deepStrictEqual(configs, [config, config]);
-    assert.deepStrictEqual(getEmitCallArguments(emit), [
-        ['scheduled', { packageName: 'dependency' }],
-        ['scheduled', { packageName: 'package-a' }]
-    ]);
-});
+    test('runForEachScheduledPackage() can disable scheduled events and emits done events from createProgressEvent()', async function () {
+        const { scheduler, emit } = createTestScheduler();
 
-test('runForEachScheduledPackage() can disable scheduled events and emits done events from createProgressEvent()', async () => {
-    const { scheduler, emit } = createTestScheduler();
+        const result = await scheduler.runForEachScheduledPackage({
+            config: createValidatedConfig([{ name: 'package-a', roots: { main: { js: 'entry.js' } } }]),
+            createOptions: (context) => {
+                return context.packageName;
+            },
+            execute: async (packageName) => {
+                return { packageName };
+            },
+            selectNext: (params) => {
+                return params.result.packageName;
+            },
+            emitScheduledEvents: false,
+            createProgressEvent: (params) => {
+                return {
+                    version: '1.0.0',
+                    status: params.result.packageName === 'package-a' ? 'initial-version' : 'new-version'
+                };
+            }
+        });
 
-    const result = await scheduler.runForEachScheduledPackage({
-        config: createValidatedConfig([{ name: 'package-a', roots: { main: { js: 'entry.js' } } }]),
-        createOptions: (context) => {
-            return context.packageName;
-        },
-        execute: async (packageName) => {
-            return { packageName };
-        },
-        selectNext: (params) => {
-            return params.result.packageName;
-        },
-        emitScheduledEvents: false,
-        createProgressEvent: (params) => {
-            return {
-                version: '1.0.0',
-                status: params.result.packageName === 'package-a' ? 'initial-version' : 'new-version'
-            };
-        }
+        assert.deepStrictEqual(result, Result.ok([{ packageName: 'package-a' }]));
+        assert.deepStrictEqual(getEmitCallArguments(emit), [
+            ['done', { packageName: 'package-a', version: '1.0.0', status: 'initial-version' }]
+        ]);
     });
 
-    assert.deepStrictEqual(result, Result.ok([{ packageName: 'package-a' }]));
-    assert.deepStrictEqual(getEmitCallArguments(emit), [
-        ['done', { packageName: 'package-a', version: '1.0.0', status: 'initial-version' }]
-    ]);
-});
+    test('runForEachScheduledPackage() returns succeeded results from previous and current generations when a package fails', async function () {
+        const { scheduler, emit } = createTestScheduler();
+        const execute = fake(async (context: { packageName: string }) => {
+            if (context.packageName === 'package-b') {
+                throw new Error('package-b failed');
+            }
 
-test('runForEachScheduledPackage() returns succeeded results from previous and current generations when a package fails', async () => {
-    const { scheduler, emit } = createTestScheduler();
-    const execute = fake(async (context: { packageName: string }) => {
-        if (context.packageName === 'package-b') {
-            throw new Error('package-b failed');
-        }
+            return `${context.packageName}-result`;
+        });
 
-        return `${context.packageName}-result`;
+        const result = await scheduler.runForEachScheduledPackage({
+            config: createValidatedConfig([
+                { name: 'root', roots: { main: { js: 'root.js' } } },
+                { name: 'package-a', roots: { main: { js: 'package-a.js' } }, bundleDependencies: ['root'] },
+                { name: 'package-b', roots: { main: { js: 'package-b.js' } }, bundleDependencies: ['root'] }
+            ]),
+            createOptions: (context) => {
+                return { packageName: context.packageName };
+            },
+            execute,
+            selectNext: (params) => {
+                return params.result;
+            },
+            createProgressEvent: (params) => {
+                return {
+                    version: params.result,
+                    status: 'new-version'
+                };
+            }
+        });
+
+        const error = getErrResult(result, 'Expected result to be an error');
+        assert.deepStrictEqual(error.succeeded, ['root-result', 'package-a-result']);
+        assert.strictEqual(error.failures.length, 1);
+        assert.strictEqual(error.failures[0]?.message, 'package-b failed');
+        assert.deepStrictEqual(getEmitCallArguments(emit), [
+            ['scheduled', { packageName: 'root' }],
+            ['scheduled', { packageName: 'package-a' }],
+            ['scheduled', { packageName: 'package-b' }],
+            ['done', { packageName: 'root', version: 'root-result', status: 'new-version' }],
+            ['done', { packageName: 'package-a', version: 'package-a-result', status: 'new-version' }],
+            ['error', { packageName: 'package-b', error: new Error('package-b failed') }]
+        ]);
     });
 
-    const result = await scheduler.runForEachScheduledPackage({
-        config: createValidatedConfig([
-            { name: 'root', roots: { main: { js: 'root.js' } } },
-            { name: 'package-a', roots: { main: { js: 'package-a.js' } }, bundleDependencies: ['root'] },
-            { name: 'package-b', roots: { main: { js: 'package-b.js' } }, bundleDependencies: ['root'] }
-        ]),
-        createOptions: (context) => {
-            return { packageName: context.packageName };
-        },
-        execute,
-        selectNext: (params) => {
-            return params.result;
-        },
-        createProgressEvent: (params) => {
-            return {
-                version: params.result,
-                status: 'new-version'
-            };
-        }
+    test('runForEachScheduledPackage() converts non-Error throws into an unknown error event', async function () {
+        const { scheduler, emit } = createTestScheduler();
+
+        const result = await scheduler.runForEachScheduledPackage({
+            config: createValidatedConfig([{ name: 'package-a', roots: { main: { js: 'entry.js' } } }]),
+            createOptions: (context) => {
+                return context.packageName;
+            },
+            execute: async () => {
+                // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors, unicorn/no-useless-promise-resolve-reject -- we intentionally exercise non-Error rejection handling here
+                return Promise.reject('not-an-error');
+            },
+            selectNext: (params: { result: PackageNameResult }) => {
+                return params.result;
+            }
+        });
+
+        getErrResult(result, 'Expected result to be an error');
+        assert.deepStrictEqual(getEmitCallArguments(emit), [
+            ['scheduled', { packageName: 'package-a' }],
+            ['error', { packageName: 'package-a', error: new Error('Unknown error') }]
+        ]);
     });
-
-    const error = getErrResult(result, 'Expected result to be an error');
-    assert.deepStrictEqual(error.succeeded, ['root-result', 'package-a-result']);
-    assert.strictEqual(error.failures.length, 1);
-    assert.strictEqual(error.failures[0]?.message, 'package-b failed');
-    assert.deepStrictEqual(getEmitCallArguments(emit), [
-        ['scheduled', { packageName: 'root' }],
-        ['scheduled', { packageName: 'package-a' }],
-        ['scheduled', { packageName: 'package-b' }],
-        ['done', { packageName: 'root', version: 'root-result', status: 'new-version' }],
-        ['done', { packageName: 'package-a', version: 'package-a-result', status: 'new-version' }],
-        ['error', { packageName: 'package-b', error: new Error('package-b failed') }]
-    ]);
-});
-
-test('runForEachScheduledPackage() converts non-Error throws into an unknown error event', async () => {
-    const { scheduler, emit } = createTestScheduler();
-
-    const result = await scheduler.runForEachScheduledPackage({
-        config: createValidatedConfig([{ name: 'package-a', roots: { main: { js: 'entry.js' } } }]),
-        createOptions: (context) => {
-            return context.packageName;
-        },
-        execute: async () => {
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors, unicorn/no-useless-promise-resolve-reject -- we intentionally exercise non-Error rejection handling here
-            return Promise.reject('not-an-error');
-        },
-        selectNext: (params: { result: PackageNameResult }) => {
-            return params.result;
-        }
-    });
-
-    getErrResult(result, 'Expected result to be an error');
-    assert.deepStrictEqual(getEmitCallArguments(emit), [
-        ['scheduled', { packageName: 'package-a' }],
-        ['error', { packageName: 'package-a', error: new Error('Unknown error') }]
-    ]);
 });

--- a/source/packtory/stages/package-analysis-stage.test.ts
+++ b/source/packtory/stages/package-analysis-stage.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { DeadCodeEliminator } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { ValidConfigWithoutRegistryResult } from '../../config/validation.ts';
 import { analyzeResolvedPackages } from './package-analysis-stage.ts';
@@ -53,78 +53,80 @@ function captureTransformationsEnabled() {
     };
 }
 
-test('analyzeResolvedPackages returns an empty array when no linked packages are given', async () => {
-    const result = await analyzeResolvedPackages(
-        { deadCodeEliminator: stubEliminator(() => []) },
-        configWithPackages(),
-        []
-    );
+suite('package-analysis-stage', function () {
+    test('analyzeResolvedPackages returns an empty array when no linked packages are given', async function () {
+        const result = await analyzeResolvedPackages(
+            { deadCodeEliminator: stubEliminator(() => []) },
+            configWithPackages(),
+            []
+        );
 
-    assert.deepStrictEqual(result, []);
-});
-
-test('analyzeResolvedPackages passes each linked bundle into the dead-code eliminator', async () => {
-    const linkedPackage = linkedPackageNamed('pkg-a');
-    const analyzed = [{ name: 'pkg-a' } as never];
-    const eliminator = stubEliminator((inputs) => {
-        assert.strictEqual(inputs[0]?.bundle, linkedPackage.linkedBundle);
-        return analyzed;
+        assert.deepStrictEqual(result, []);
     });
 
-    const result = await analyzeResolvedPackages(
-        { deadCodeEliminator: eliminator },
-        configWithPackages({ name: 'pkg-a' }),
-        [linkedPackage]
-    );
+    test('analyzeResolvedPackages passes each linked bundle into the dead-code eliminator', async function () {
+        const linkedPackage = linkedPackageNamed('pkg-a');
+        const analyzed = [{ name: 'pkg-a' } as never];
+        const eliminator = stubEliminator((inputs) => {
+            assert.strictEqual(inputs[0]?.bundle, linkedPackage.linkedBundle);
+            return analyzed;
+        });
 
-    assert.strictEqual(result.length, 1);
-    assert.strictEqual(result[0]?.analyzedBundle, analyzed[0]);
-});
-
-test('analyzeResolvedPackages forwards the configured enabled flag through transformationsEnabled', async () => {
-    const { eliminator, getObserved } = captureTransformationsEnabled();
-
-    await analyzeResolvedPackages(
-        { deadCodeEliminator: eliminator },
-        configWithPackages({ name: 'pkg-a', enabled: false }),
-        [linkedPackageNamed('pkg-a')]
-    );
-
-    assert.strictEqual(getObserved(), false);
-});
-
-test('analyzeResolvedPackages defaults transformationsEnabled to true when no dead-code-elimination settings are configured', async () => {
-    const { eliminator, getObserved } = captureTransformationsEnabled();
-
-    await analyzeResolvedPackages({ deadCodeEliminator: eliminator }, configWithPackages({ name: 'pkg-a' }), [
-        linkedPackageNamed('pkg-a')
-    ]);
-
-    assert.strictEqual(getObserved(), true);
-});
-
-test('analyzeResolvedPackages throws when the dead-code eliminator returns fewer bundles than packages', async () => {
-    try {
-        await analyzeResolvedPackages(
-            { deadCodeEliminator: stubEliminator(() => []) },
-            configWithPackages({ name: 'pkg-missing' }),
-            [linkedPackageNamed('pkg-missing')]
+        const result = await analyzeResolvedPackages(
+            { deadCodeEliminator: eliminator },
+            configWithPackages({ name: 'pkg-a' }),
+            [linkedPackage]
         );
-        assert.fail('expected analyzeResolvedPackages to throw');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'Analyzed bundle missing for package "pkg-missing"');
-    }
-});
 
-test('analyzeResolvedPackages throws when the package has no dead-code-elimination entry in the resolution map', async () => {
-    try {
-        await analyzeResolvedPackages({ deadCodeEliminator: stubEliminator(() => []) }, configWithPackages(), [
-            linkedPackageNamed('pkg-unmapped')
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0]?.analyzedBundle, analyzed[0]);
+    });
+
+    test('analyzeResolvedPackages forwards the configured enabled flag through transformationsEnabled', async function () {
+        const { eliminator, getObserved } = captureTransformationsEnabled();
+
+        await analyzeResolvedPackages(
+            { deadCodeEliminator: eliminator },
+            configWithPackages({ name: 'pkg-a', enabled: false }),
+            [linkedPackageNamed('pkg-a')]
+        );
+
+        assert.strictEqual(getObserved(), false);
+    });
+
+    test('analyzeResolvedPackages defaults transformationsEnabled to true when no dead-code-elimination settings are configured', async function () {
+        const { eliminator, getObserved } = captureTransformationsEnabled();
+
+        await analyzeResolvedPackages({ deadCodeEliminator: eliminator }, configWithPackages({ name: 'pkg-a' }), [
+            linkedPackageNamed('pkg-a')
         ]);
-        assert.fail('expected analyzeResolvedPackages to throw');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'Missing dead-code elimination settings for package "pkg-unmapped"');
-    }
+
+        assert.strictEqual(getObserved(), true);
+    });
+
+    test('analyzeResolvedPackages throws when the dead-code eliminator returns fewer bundles than packages', async function () {
+        try {
+            await analyzeResolvedPackages(
+                { deadCodeEliminator: stubEliminator(() => []) },
+                configWithPackages({ name: 'pkg-missing' }),
+                [linkedPackageNamed('pkg-missing')]
+            );
+            assert.fail('expected analyzeResolvedPackages to throw');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'Analyzed bundle missing for package "pkg-missing"');
+        }
+    });
+
+    test('analyzeResolvedPackages throws when the package has no dead-code-elimination entry in the resolution map', async function () {
+        try {
+            await analyzeResolvedPackages({ deadCodeEliminator: stubEliminator(() => []) }, configWithPackages(), [
+                linkedPackageNamed('pkg-unmapped')
+            ]);
+            assert.fail('expected analyzeResolvedPackages to throw');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'Missing dead-code elimination settings for package "pkg-unmapped"');
+        }
+    });
 });

--- a/source/packtory/stages/package-resolution-stage.test.ts
+++ b/source/packtory/stages/package-resolution-stage.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import type { ProgressBroadcaster } from '../packtory-results.ts';
@@ -56,89 +56,91 @@ function configWithPackage(name: string) {
     };
 }
 
-test('resolvePackages returns Ok with the scheduler result when nothing is scheduled', async () => {
-    const result = await resolvePackages(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: emptyScheduler,
-            progressBroadcaster: stubProgressBroadcaster
-        },
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never
-    );
+suite('package-resolution-stage', function () {
+    test('resolvePackages returns Ok with the scheduler result when nothing is scheduled', async function () {
+        const result = await resolvePackages(
+            {
+                packageProcessor: stubPackageProcessor,
+                scheduler: emptyScheduler,
+                progressBroadcaster: stubProgressBroadcaster
+            },
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never
+        );
 
-    assert.strictEqual(result.isOk, true);
-});
-
-test('resolvePackages forwards scheduler failures unchanged to its caller', async () => {
-    const result = await resolvePackages(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] }),
-            progressBroadcaster: stubProgressBroadcaster
-        },
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never
-    );
-
-    assert.strictEqual(result.isErr, true);
-});
-
-test('resolvePackages emits inputsResolved with package name, roots, zero source files, and empty sibling versions when subscribed', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: {
-        readonly packageName: string;
-        readonly roots: Readonly<Record<string, string>>;
-        readonly sourceFileCount: number;
-        readonly siblingVersions: Readonly<Record<string, string>>;
-    }[] = [];
-    broadcaster.consumer.on('inputsResolved', (payload) => {
-        received.push({
-            packageName: payload.packageName,
-            roots: payload.roots,
-            sourceFileCount: payload.sourceFileCount,
-            siblingVersions: payload.siblingVersions
-        });
+        assert.strictEqual(result.isOk, true);
     });
 
-    await resolvePackages(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: iteratingScheduler(['pkg-a']),
-            progressBroadcaster: broadcaster as unknown as ProgressBroadcaster
-        },
-        configWithPackage('pkg-a') as never
-    );
-
-    assert.deepStrictEqual(received, [
-        { packageName: 'pkg-a', roots: { main: '/src/pkg-a/index.js' }, sourceFileCount: 0, siblingVersions: {} }
-    ]);
-});
-
-test('resolvePackages does NOT emit inputsResolved when no subscriber is registered', async () => {
-    const realBroadcaster = createProgressBroadcaster();
-    let emitCount = 0;
-    const trackingBroadcaster = {
-        consumer: realBroadcaster.consumer,
-        provider: {
-            emit: (eventName: string, payload: unknown) => {
-                if (eventName === 'inputsResolved') {
-                    emitCount += 1;
-                }
-                realBroadcaster.provider.emit(eventName as never, payload as never);
+    test('resolvePackages forwards scheduler failures unchanged to its caller', async function () {
+        const result = await resolvePackages(
+            {
+                packageProcessor: stubPackageProcessor,
+                scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] }),
+                progressBroadcaster: stubProgressBroadcaster
             },
-            hasSubscribers: (eventName: string) => {
-                return realBroadcaster.provider.hasSubscribers(eventName as never);
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never
+        );
+
+        assert.strictEqual(result.isErr, true);
+    });
+
+    test('resolvePackages emits inputsResolved with package name, roots, zero source files, and empty sibling versions when subscribed', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: {
+            readonly packageName: string;
+            readonly roots: Readonly<Record<string, string>>;
+            readonly sourceFileCount: number;
+            readonly siblingVersions: Readonly<Record<string, string>>;
+        }[] = [];
+        broadcaster.consumer.on('inputsResolved', (payload) => {
+            received.push({
+                packageName: payload.packageName,
+                roots: payload.roots,
+                sourceFileCount: payload.sourceFileCount,
+                siblingVersions: payload.siblingVersions
+            });
+        });
+
+        await resolvePackages(
+            {
+                packageProcessor: stubPackageProcessor,
+                scheduler: iteratingScheduler(['pkg-a']),
+                progressBroadcaster: broadcaster as unknown as ProgressBroadcaster
+            },
+            configWithPackage('pkg-a') as never
+        );
+
+        assert.deepStrictEqual(received, [
+            { packageName: 'pkg-a', roots: { main: '/src/pkg-a/index.js' }, sourceFileCount: 0, siblingVersions: {} }
+        ]);
+    });
+
+    test('resolvePackages does NOT emit inputsResolved when no subscriber is registered', async function () {
+        const realBroadcaster = createProgressBroadcaster();
+        let emitCount = 0;
+        const trackingBroadcaster = {
+            consumer: realBroadcaster.consumer,
+            provider: {
+                emit: (eventName: string, payload: unknown) => {
+                    if (eventName === 'inputsResolved') {
+                        emitCount += 1;
+                    }
+                    realBroadcaster.provider.emit(eventName as never, payload as never);
+                },
+                hasSubscribers: (eventName: string) => {
+                    return realBroadcaster.provider.hasSubscribers(eventName as never);
+                }
             }
-        }
-    };
+        };
 
-    await resolvePackages(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: iteratingScheduler(['pkg-a']),
-            progressBroadcaster: trackingBroadcaster as unknown as ProgressBroadcaster
-        },
-        configWithPackage('pkg-a') as never
-    );
+        await resolvePackages(
+            {
+                packageProcessor: stubPackageProcessor,
+                scheduler: iteratingScheduler(['pkg-a']),
+                progressBroadcaster: trackingBroadcaster as unknown as ProgressBroadcaster
+            },
+            configWithPackage('pkg-a') as never
+        );
 
-    assert.strictEqual(emitCount, 0);
+        assert.strictEqual(emitCount, 0);
+    });
 });

--- a/source/packtory/stages/publish-stage.test.ts
+++ b/source/packtory/stages/publish-stage.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
 import type { Scheduler as PackageScheduler } from '../scheduler.ts';
 import {
@@ -57,113 +57,118 @@ function iteratingScheduler(
     return value as unknown as PackageScheduler;
 }
 
-test('determineVersionAndPublishAll returns Ok([]) when no packages are scheduled', async () => {
-    const result = await determineVersionAndPublishAll(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: emptyScheduler,
-            progressBroadcaster: stubProgressBroadcaster
-        },
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-        [],
-        { dryRun: false }
-    );
-
-    assert.strictEqual(result.isOk, true);
-});
-
-test('determineVersionAndPublishAll forwards a scheduler failure unchanged', async () => {
-    const result = await determineVersionAndPublishAll(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] }),
-            progressBroadcaster: stubProgressBroadcaster
-        },
-        { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-        [],
-        { dryRun: false }
-    );
-
-    assert.strictEqual(result.isErr, true);
-});
-
-function publishableConfig(name: string) {
-    const packageEntry = {
-        name,
-        roots: { main: { js: 'index.js' } },
-        sourcesFolder: '/src',
-        mainPackageJson: { name, version: '1.0.0', type: 'module' },
-        publishSettings: { access: 'public' },
-        registrySettings: { registryUrl: 'https://example.com', token: 'x' }
-    };
-    return {
-        packageConfigs: { [name]: packageEntry },
-        packtoryConfig: { packages: [packageEntry] }
-    };
-}
-
-test('determineVersionAndPublishAll returns a partial failure when no analyzed bundle is found for a scheduled package', async () => {
-    const config = publishableConfig('pkg-orphan');
-
-    const result = await determineVersionAndPublishAll(
-        {
-            packageProcessor: stubPackageProcessor,
-            scheduler: iteratingScheduler(['pkg-orphan']),
-            progressBroadcaster: stubProgressBroadcaster
-        },
-        config as never,
-        [],
-        { dryRun: false }
-    );
-
-    if (!result.isErr) {
-        assert.fail('expected the result to be an error');
-    }
-    assert.strictEqual(result.error.failures.length, 1);
-    assert.match((result.error.failures[0] as Error).message, /Analyzed bundle for package "pkg-orphan" is missing/u);
-});
-
-test('determineVersionAndPublishAll exposes the published bundle via selectNext and the version+status via createProgressEvent', async () => {
-    const bundle = {
-        name: 'pkg-a',
-        version: '2.0.0',
-        packageJson: { name: 'pkg-a', version: '2.0.0' }
-    };
-    const buildResult = { bundle, status: 'new-version' as const };
-    const processor = {
-        ...stubPackageProcessor,
-        async buildAndPublish() {
-            return buildResult;
-        },
-        async tryBuildAndPublish() {
-            return buildResult;
-        }
-    } as never;
-    const capture = { events: [] as unknown[], selected: [] as unknown[] };
-    const config = publishableConfig('pkg-a');
-
-    await determineVersionAndPublishAll(
-        {
-            packageProcessor: processor,
-            scheduler: iteratingScheduler(['pkg-a'], capture),
-            progressBroadcaster: stubProgressBroadcaster
-        },
-        config as never,
-        [
+suite('publish-stage', function () {
+    test('determineVersionAndPublishAll returns Ok([]) when no packages are scheduled', async function () {
+        const result = await determineVersionAndPublishAll(
             {
-                name: 'pkg-a',
-                analyzedBundle: {
-                    name: 'pkg-a',
-                    contents: [],
-                    roots: {},
-                    surface: { mode: 'implicit', defaultModuleRoot: 'main' }
-                },
-                resolveOptions: {}
-            } as never
-        ],
-        { dryRun: false }
-    );
+                packageProcessor: stubPackageProcessor,
+                scheduler: emptyScheduler,
+                progressBroadcaster: stubProgressBroadcaster
+            },
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
+            [],
+            { dryRun: false }
+        );
 
-    assert.deepStrictEqual(capture.selected, [bundle]);
-    assert.deepStrictEqual(capture.events, [{ version: '2.0.0', status: 'new-version' }]);
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('determineVersionAndPublishAll forwards a scheduler failure unchanged', async function () {
+        const result = await determineVersionAndPublishAll(
+            {
+                packageProcessor: stubPackageProcessor,
+                scheduler: failingScheduler({ succeeded: [], failures: [new Error('boom')] }),
+                progressBroadcaster: stubProgressBroadcaster
+            },
+            { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
+            [],
+            { dryRun: false }
+        );
+
+        assert.strictEqual(result.isErr, true);
+    });
+
+    function publishableConfig(name: string) {
+        const packageEntry = {
+            name,
+            roots: { main: { js: 'index.js' } },
+            sourcesFolder: '/src',
+            mainPackageJson: { name, version: '1.0.0', type: 'module' },
+            publishSettings: { access: 'public' },
+            registrySettings: { registryUrl: 'https://example.com', token: 'x' }
+        };
+        return {
+            packageConfigs: { [name]: packageEntry },
+            packtoryConfig: { packages: [packageEntry] }
+        };
+    }
+
+    test('determineVersionAndPublishAll returns a partial failure when no analyzed bundle is found for a scheduled package', async function () {
+        const config = publishableConfig('pkg-orphan');
+
+        const result = await determineVersionAndPublishAll(
+            {
+                packageProcessor: stubPackageProcessor,
+                scheduler: iteratingScheduler(['pkg-orphan']),
+                progressBroadcaster: stubProgressBroadcaster
+            },
+            config as never,
+            [],
+            { dryRun: false }
+        );
+
+        if (!result.isErr) {
+            assert.fail('expected the result to be an error');
+        }
+        assert.strictEqual(result.error.failures.length, 1);
+        assert.match(
+            (result.error.failures[0] as Error).message,
+            /Analyzed bundle for package "pkg-orphan" is missing/u
+        );
+    });
+
+    test('determineVersionAndPublishAll exposes the published bundle via selectNext and the version+status via createProgressEvent', async function () {
+        const bundle = {
+            name: 'pkg-a',
+            version: '2.0.0',
+            packageJson: { name: 'pkg-a', version: '2.0.0' }
+        };
+        const buildResult = { bundle, status: 'new-version' as const };
+        const processor = {
+            ...stubPackageProcessor,
+            async buildAndPublish() {
+                return buildResult;
+            },
+            async tryBuildAndPublish() {
+                return buildResult;
+            }
+        } as never;
+        const capture = { events: [] as unknown[], selected: [] as unknown[] };
+        const config = publishableConfig('pkg-a');
+
+        await determineVersionAndPublishAll(
+            {
+                packageProcessor: processor,
+                scheduler: iteratingScheduler(['pkg-a'], capture),
+                progressBroadcaster: stubProgressBroadcaster
+            },
+            config as never,
+            [
+                {
+                    name: 'pkg-a',
+                    analyzedBundle: {
+                        name: 'pkg-a',
+                        contents: [],
+                        roots: {},
+                        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+                    },
+                    resolveOptions: {}
+                } as never
+            ],
+            { dryRun: false }
+        );
+
+        assert.deepStrictEqual(capture.selected, [bundle]);
+        assert.deepStrictEqual(capture.events, [{ version: '2.0.0', status: 'new-version' }]);
+    });
 });

--- a/source/progress/progress-broadcaster.test.ts
+++ b/source/progress/progress-broadcaster.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProgressBroadcaster } from './progress-broadcaster.ts';
 
 const eliminationCompletedPayload = {
@@ -13,89 +13,91 @@ const eliminationCompletedPayload = {
     ]
 } as const;
 
-test('emits events to registered listeners', () => {
-    const broadcaster = createProgressBroadcaster();
-    const receivedPayloads: unknown[] = [];
+suite('progress-broadcaster', function () {
+    test('emits events to registered listeners', function () {
+        const broadcaster = createProgressBroadcaster();
+        const receivedPayloads: unknown[] = [];
 
-    broadcaster.consumer.on('scheduled', (payload) => {
-        receivedPayloads.push(payload);
+        broadcaster.consumer.on('scheduled', (payload) => {
+            receivedPayloads.push(payload);
+        });
+
+        broadcaster.provider.emit('scheduled', { packageName: 'package-a' });
+
+        assert.deepStrictEqual(receivedPayloads, [{ packageName: 'package-a' }]);
     });
 
-    broadcaster.provider.emit('scheduled', { packageName: 'package-a' });
+    test('off() removes a registered listener', function () {
+        const broadcaster = createProgressBroadcaster();
+        const receivedPayloads: unknown[] = [];
+        const listener = (payload: { packageName: string }): void => {
+            receivedPayloads.push(payload);
+        };
 
-    assert.deepStrictEqual(receivedPayloads, [{ packageName: 'package-a' }]);
-});
+        broadcaster.consumer.on('scheduled', listener);
+        broadcaster.consumer.off('scheduled', listener);
+        broadcaster.provider.emit('scheduled', { packageName: 'package-a' });
 
-test('off() removes a registered listener', () => {
-    const broadcaster = createProgressBroadcaster();
-    const receivedPayloads: unknown[] = [];
-    const listener = (payload: { packageName: string }): void => {
-        receivedPayloads.push(payload);
+        assert.deepStrictEqual(receivedPayloads, []);
+    });
+
+    test('hasSubscribers() returns false when no listener is registered', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), false);
+    });
+
+    const noop = (): void => {
+        return undefined;
     };
 
-    broadcaster.consumer.on('scheduled', listener);
-    broadcaster.consumer.off('scheduled', listener);
-    broadcaster.provider.emit('scheduled', { packageName: 'package-a' });
+    test('hasSubscribers() returns true after a listener is registered', function () {
+        const broadcaster = createProgressBroadcaster();
 
-    assert.deepStrictEqual(receivedPayloads, []);
-});
+        broadcaster.consumer.on('eliminationCompleted', noop);
 
-test('hasSubscribers() returns false when no listener is registered', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), false);
-});
-
-const noop = (): void => {
-    return undefined;
-};
-
-test('hasSubscribers() returns true after a listener is registered', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    broadcaster.consumer.on('eliminationCompleted', noop);
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), true);
-});
-
-test('hasSubscribers() returns false after the last listener is removed', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    broadcaster.consumer.on('eliminationCompleted', noop);
-    broadcaster.consumer.off('eliminationCompleted', noop);
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), false);
-});
-
-test('hasSubscribers() is per-event-name', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    broadcaster.consumer.on('scanCompleted', noop);
-
-    assert.strictEqual(broadcaster.provider.hasSubscribers('scanCompleted'), true);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('linkingCompleted'), false);
-});
-
-test('decision events with no subscribers emit without error', () => {
-    const broadcaster = createProgressBroadcaster();
-
-    broadcaster.provider.emit('versionDetermined', {
-        packageName: 'package-a',
-        previousVersion: '1.0.0',
-        chosenVersion: '1.0.1',
-        trigger: 'auto-patch-bump'
-    });
-});
-
-test('round-trips an eliminationCompleted decision event', () => {
-    const broadcaster = createProgressBroadcaster();
-    const receivedPayloads: unknown[] = [];
-
-    broadcaster.consumer.on('eliminationCompleted', (payload) => {
-        receivedPayloads.push(payload);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), true);
     });
 
-    broadcaster.provider.emit('eliminationCompleted', eliminationCompletedPayload);
+    test('hasSubscribers() returns false after the last listener is removed', function () {
+        const broadcaster = createProgressBroadcaster();
 
-    assert.deepStrictEqual(receivedPayloads, [eliminationCompletedPayload]);
+        broadcaster.consumer.on('eliminationCompleted', noop);
+        broadcaster.consumer.off('eliminationCompleted', noop);
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), false);
+    });
+
+    test('hasSubscribers() is per-event-name', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        broadcaster.consumer.on('scanCompleted', noop);
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('scanCompleted'), true);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('linkingCompleted'), false);
+    });
+
+    test('decision events with no subscribers emit without error', function () {
+        const broadcaster = createProgressBroadcaster();
+
+        broadcaster.provider.emit('versionDetermined', {
+            packageName: 'package-a',
+            previousVersion: '1.0.0',
+            chosenVersion: '1.0.1',
+            trigger: 'auto-patch-bump'
+        });
+    });
+
+    test('round-trips an eliminationCompleted decision event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const receivedPayloads: unknown[] = [];
+
+        broadcaster.consumer.on('eliminationCompleted', (payload) => {
+            receivedPayloads.push(payload);
+        });
+
+        broadcaster.provider.emit('eliminationCompleted', eliminationCompletedPayload);
+
+        assert.deepStrictEqual(receivedPayloads, [eliminationCompletedPayload]);
+    });
 });

--- a/source/published-package/published-package.test.ts
+++ b/source/published-package/published-package.test.ts
@@ -1,33 +1,35 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { explicitBinTargetPaths } from './published-package.ts';
 
-test('explicitBinTargetPaths() returns an empty set when binField is undefined', () => {
-    const result = explicitBinTargetPaths({ binField: undefined });
-    assert.deepStrictEqual(result, new Set<string>());
-});
+suite('published-package', function () {
+    test('explicitBinTargetPaths() returns an empty set when binField is undefined', function () {
+        const result = explicitBinTargetPaths({ binField: undefined });
+        assert.deepStrictEqual(result, new Set<string>());
+    });
 
-test('explicitBinTargetPaths() returns a single-entry set for a string binField', () => {
-    const result = explicitBinTargetPaths({ binField: 'cli.js' });
-    assert.deepStrictEqual(result, new Set(['cli.js']));
-});
+    test('explicitBinTargetPaths() returns a single-entry set for a string binField', function () {
+        const result = explicitBinTargetPaths({ binField: 'cli.js' });
+        assert.deepStrictEqual(result, new Set(['cli.js']));
+    });
 
-test('explicitBinTargetPaths() strips a leading "./" from a string binField', () => {
-    const result = explicitBinTargetPaths({ binField: './cli.js' });
-    assert.deepStrictEqual(result, new Set(['cli.js']));
-});
+    test('explicitBinTargetPaths() strips a leading "./" from a string binField', function () {
+        const result = explicitBinTargetPaths({ binField: './cli.js' });
+        assert.deepStrictEqual(result, new Set(['cli.js']));
+    });
 
-test('explicitBinTargetPaths() collects target paths from a record binField', () => {
-    const result = explicitBinTargetPaths({ binField: { foo: 'foo.js', bar: './bar.js' } });
-    assert.deepStrictEqual(result, new Set(['foo.js', 'bar.js']));
-});
+    test('explicitBinTargetPaths() collects target paths from a record binField', function () {
+        const result = explicitBinTargetPaths({ binField: { foo: 'foo.js', bar: './bar.js' } });
+        assert.deepStrictEqual(result, new Set(['foo.js', 'bar.js']));
+    });
 
-test('explicitBinTargetPaths() ignores non-string entries in a record binField', () => {
-    const result = explicitBinTargetPaths({ binField: { foo: 'foo.js', bar: undefined } });
-    assert.deepStrictEqual(result, new Set(['foo.js']));
-});
+    test('explicitBinTargetPaths() ignores non-string entries in a record binField', function () {
+        const result = explicitBinTargetPaths({ binField: { foo: 'foo.js', bar: undefined } });
+        assert.deepStrictEqual(result, new Set(['foo.js']));
+    });
 
-test('explicitBinTargetPaths() leaves a target path without "./" untouched', () => {
-    const result = explicitBinTargetPaths({ binField: { foo: 'nested/foo.js' } });
-    assert.deepStrictEqual(result, new Set(['nested/foo.js']));
+    test('explicitBinTargetPaths() leaves a target path without "./" untouched', function () {
+        const result = explicitBinTargetPaths({ binField: { foo: 'nested/foo.js' } });
+        assert.deepStrictEqual(result, new Set(['nested/foo.js']));
+    });
 });

--- a/source/report/aggregator/artifact-entry-merger.test.ts
+++ b/source/report/aggregator/artifact-entry-merger.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ArtifactEntry } from '../../progress/progress-broadcaster.ts';
 import { mergeArtifactEntry } from './artifact-entry-merger.ts';
 
@@ -12,42 +12,44 @@ const baseEntry: ArtifactEntry = {
     badges: []
 };
 
-test('mergeArtifactEntry returns the entry unchanged when it has no sourcePath', () => {
-    const entry: ArtifactEntry = { ...baseEntry, sourcePath: undefined };
-    assert.strictEqual(mergeArtifactEntry(entry, new Set(['anything']), new Set(['anything'])), entry);
-});
+suite('artifact-entry-merger', function () {
+    test('mergeArtifactEntry returns the entry unchanged when it has no sourcePath', function () {
+        const entry: ArtifactEntry = { ...baseEntry, sourcePath: undefined };
+        assert.strictEqual(mergeArtifactEntry(entry, new Set(['anything']), new Set(['anything'])), entry);
+    });
 
-test('mergeArtifactEntry adds the import-path-rewrite badge and "changed" status for rewritten files', () => {
-    const merged = mergeArtifactEntry(baseEntry, new Set(['/workspace/src/index.js']), new Set());
+    test('mergeArtifactEntry adds the import-path-rewrite badge and "changed" status for rewritten files', function () {
+        const merged = mergeArtifactEntry(baseEntry, new Set(['/workspace/src/index.js']), new Set());
 
-    assert.strictEqual(merged.status, 'changed');
-    assert.deepStrictEqual(merged.badges, ['import-path-rewrite']);
-});
+        assert.strictEqual(merged.status, 'changed');
+        assert.deepStrictEqual(merged.badges, ['import-path-rewrite']);
+    });
 
-test('mergeArtifactEntry adds the dead-code-elimination badge and "changed" status for transformed files', () => {
-    const merged = mergeArtifactEntry(baseEntry, new Set(), new Set(['/workspace/src/index.js']));
+    test('mergeArtifactEntry adds the dead-code-elimination badge and "changed" status for transformed files', function () {
+        const merged = mergeArtifactEntry(baseEntry, new Set(), new Set(['/workspace/src/index.js']));
 
-    assert.strictEqual(merged.status, 'changed');
-    assert.deepStrictEqual(merged.badges, ['dead-code-elimination']);
-});
+        assert.strictEqual(merged.status, 'changed');
+        assert.deepStrictEqual(merged.badges, ['dead-code-elimination']);
+    });
 
-test('mergeArtifactEntry combines both badges when both rewrite and transform apply', () => {
-    const merged = mergeArtifactEntry(
-        baseEntry,
-        new Set(['/workspace/src/index.js']),
-        new Set(['/workspace/src/index.js'])
-    );
+    test('mergeArtifactEntry combines both badges when both rewrite and transform apply', function () {
+        const merged = mergeArtifactEntry(
+            baseEntry,
+            new Set(['/workspace/src/index.js']),
+            new Set(['/workspace/src/index.js'])
+        );
 
-    assert.strictEqual(merged.status, 'changed');
-    assert.deepStrictEqual(merged.badges.toSorted(), ['dead-code-elimination', 'import-path-rewrite']);
-});
+        assert.strictEqual(merged.status, 'changed');
+        assert.deepStrictEqual(merged.badges.toSorted(), ['dead-code-elimination', 'import-path-rewrite']);
+    });
 
-test('mergeArtifactEntry deduplicates badges that already appeared on the entry', () => {
-    const merged = mergeArtifactEntry(
-        { ...baseEntry, badges: ['import-path-rewrite'] },
-        new Set(['/workspace/src/index.js']),
-        new Set()
-    );
+    test('mergeArtifactEntry deduplicates badges that already appeared on the entry', function () {
+        const merged = mergeArtifactEntry(
+            { ...baseEntry, badges: ['import-path-rewrite'] },
+            new Set(['/workspace/src/index.js']),
+            new Set()
+        );
 
-    assert.deepStrictEqual(merged.badges, ['import-path-rewrite']);
+        assert.deepStrictEqual(merged.badges, ['import-path-rewrite']);
+    });
 });

--- a/source/report/aggregator/package-report-materialization.test.ts
+++ b/source/report/aggregator/package-report-materialization.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { MutablePackageReport } from './report-types.ts';
 import { toPackageReport } from './package-report-materialization.ts';
 
@@ -7,107 +7,111 @@ function mutable(overrides: Partial<MutablePackageReport> = {}): MutablePackageR
     return { decisions: {}, timings: {}, ...overrides };
 }
 
-test('toPackageReport returns only decisions and timings when no other sections are populated', () => {
-    assert.deepStrictEqual(toPackageReport(mutable()), { decisions: {}, timings: {} });
-});
-
-test('toPackageReport materializes inputs from roots and provides defaults for sibling versions and source count', () => {
-    const result = toPackageReport(mutable({ roots: { main: 'src/index.js' } }));
-
-    assert.deepStrictEqual(result.inputs, {
-        roots: { main: 'src/index.js' },
-        siblingVersions: {},
-        sourceFileCount: 0
+suite('package-report-materialization', function () {
+    test('toPackageReport returns only decisions and timings when no other sections are populated', function () {
+        assert.deepStrictEqual(toPackageReport(mutable()), { decisions: {}, timings: {} });
     });
-});
 
-test('toPackageReport includes effectiveConfig in inputs when it is provided', () => {
-    const result = toPackageReport(mutable({ roots: {}, effectiveConfig: { feature: 'on' } }));
+    test('toPackageReport materializes inputs from roots and provides defaults for sibling versions and source count', function () {
+        const result = toPackageReport(mutable({ roots: { main: 'src/index.js' } }));
 
-    assert.deepStrictEqual(result.inputs?.effectiveConfig, { feature: 'on' });
-});
+        assert.deepStrictEqual(result.inputs, {
+            roots: { main: 'src/index.js' },
+            siblingVersions: {},
+            sourceFileCount: 0
+        });
+    });
 
-test('toPackageReport omits inputs when neither roots nor effectiveConfig is provided', () => {
-    const result = toPackageReport(mutable({ timings: { build: 1 } }));
+    test('toPackageReport includes effectiveConfig in inputs when it is provided', function () {
+        const result = toPackageReport(mutable({ roots: {}, effectiveConfig: { feature: 'on' } }));
 
-    assert.strictEqual(Object.hasOwn(result, 'inputs'), false);
-});
+        assert.deepStrictEqual(result.inputs?.effectiveConfig, { feature: 'on' });
+    });
 
-test('toPackageReport omits outputs when no outputs entry exists on the mutable report', () => {
-    const result = toPackageReport(mutable());
+    test('toPackageReport omits inputs when neither roots nor effectiveConfig is provided', function () {
+        const result = toPackageReport(mutable({ timings: { build: 1 } }));
 
-    assert.strictEqual(Object.hasOwn(result, 'outputs'), false);
-});
+        assert.strictEqual(Object.hasOwn(result, 'inputs'), false);
+    });
 
-test('toPackageReport keeps non-rewritten, non-transformed tarball entries unchanged in outputs', () => {
-    const entry = {
-        path: 'a.js',
-        sizeBytes: 10,
-        kind: 'source' as const,
-        sourcePath: '/src/a.js',
-        status: 'generated' as const,
-        badges: [] as const
-    };
-    const result = toPackageReport(mutable({ outputs: { tarball: { entries: [entry], totalBytes: 10 } } }));
+    test('toPackageReport omits outputs when no outputs entry exists on the mutable report', function () {
+        const result = toPackageReport(mutable());
 
-    if (result.outputs === undefined) {
-        assert.fail('expected outputs to be present');
-    }
-    assert.strictEqual(result.outputs.tarball.totalBytes, 10);
-    const firstEntry = result.outputs.tarball.entries[0];
-    if (firstEntry === undefined) {
-        assert.fail('expected at least one tarball entry');
-    }
-    assert.strictEqual(firstEntry.status, 'generated');
-});
+        assert.strictEqual(Object.hasOwn(result, 'outputs'), false);
+    });
 
-test('toPackageReport surfaces eliminatedSourceFiles when present on the mutable report', () => {
-    const result = toPackageReport(
-        mutable({
-            eliminatedSourceFiles: [{ path: '/src/dead.js', sourceBytes: 5, reason: 'no-uses' }]
-        })
-    );
+    test('toPackageReport keeps non-rewritten, non-transformed tarball entries unchanged in outputs', function () {
+        const entry = {
+            path: 'a.js',
+            sizeBytes: 10,
+            kind: 'source' as const,
+            sourcePath: '/src/a.js',
+            status: 'generated' as const,
+            badges: [] as const
+        };
+        const result = toPackageReport(mutable({ outputs: { tarball: { entries: [entry], totalBytes: 10 } } }));
 
-    assert.deepStrictEqual(result.eliminatedSourceFiles, [{ path: '/src/dead.js', sourceBytes: 5, reason: 'no-uses' }]);
-});
+        if (result.outputs === undefined) {
+            assert.fail('expected outputs to be present');
+        }
+        assert.strictEqual(result.outputs.tarball.totalBytes, 10);
+        const firstEntry = result.outputs.tarball.entries[0];
+        if (firstEntry === undefined) {
+            assert.fail('expected at least one tarball entry');
+        }
+        assert.strictEqual(firstEntry.status, 'generated');
+    });
 
-test('toPackageReport surfaces failure when present on the mutable report', () => {
-    const result = toPackageReport(mutable({ failure: { stage: 'publish', message: 'boom' } }));
+    test('toPackageReport surfaces eliminatedSourceFiles when present on the mutable report', function () {
+        const result = toPackageReport(
+            mutable({
+                eliminatedSourceFiles: [{ path: '/src/dead.js', sourceBytes: 5, reason: 'no-uses' }]
+            })
+        );
 
-    assert.deepStrictEqual(result.failure, { stage: 'publish', message: 'boom' });
-});
+        assert.deepStrictEqual(result.eliminatedSourceFiles, [
+            { path: '/src/dead.js', sourceBytes: 5, reason: 'no-uses' }
+        ]);
+    });
 
-test('toPackageReport applies the import-path-rewrite badge to tarball entries whose source path appears in decisions.linker.rewrites', () => {
-    const entry = {
-        path: 'index.js',
-        sizeBytes: 10,
-        kind: 'source' as const,
-        sourcePath: '/src/index.js',
-        status: 'unchanged' as const,
-        badges: [] as const
-    };
-    const result = toPackageReport(
-        mutable({
-            outputs: { tarball: { entries: [entry], totalBytes: 10 } },
-            decisions: {
-                linker: {
-                    rewrites: [
-                        {
-                            file: '/src/index.js',
-                            fromSpecifier: './dep.js',
-                            toSpecifier: 'pkg-b',
-                            targetBundle: 'pkg-b'
-                        }
-                    ]
+    test('toPackageReport surfaces failure when present on the mutable report', function () {
+        const result = toPackageReport(mutable({ failure: { stage: 'publish', message: 'boom' } }));
+
+        assert.deepStrictEqual(result.failure, { stage: 'publish', message: 'boom' });
+    });
+
+    test('toPackageReport applies the import-path-rewrite badge to tarball entries whose source path appears in decisions.linker.rewrites', function () {
+        const entry = {
+            path: 'index.js',
+            sizeBytes: 10,
+            kind: 'source' as const,
+            sourcePath: '/src/index.js',
+            status: 'unchanged' as const,
+            badges: [] as const
+        };
+        const result = toPackageReport(
+            mutable({
+                outputs: { tarball: { entries: [entry], totalBytes: 10 } },
+                decisions: {
+                    linker: {
+                        rewrites: [
+                            {
+                                file: '/src/index.js',
+                                fromSpecifier: './dep.js',
+                                toSpecifier: 'pkg-b',
+                                targetBundle: 'pkg-b'
+                            }
+                        ]
+                    }
                 }
-            }
-        })
-    );
+            })
+        );
 
-    const firstEntry = result.outputs?.tarball.entries[0];
-    if (firstEntry === undefined) {
-        assert.fail('expected an output entry');
-    }
-    assert.ok(firstEntry.badges.includes('import-path-rewrite'));
-    assert.strictEqual(firstEntry.status, 'changed');
+        const firstEntry = result.outputs?.tarball.entries[0];
+        if (firstEntry === undefined) {
+            assert.fail('expected an output entry');
+        }
+        assert.ok(firstEntry.badges.includes('import-path-rewrite'));
+        assert.strictEqual(firstEntry.status, 'changed');
+    });
 });

--- a/source/report/aggregator/report-aggregator.test.ts
+++ b/source/report/aggregator/report-aggregator.test.ts
@@ -1,15 +1,62 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import { createReportAggregator } from './report-aggregator.ts';
 
-test('only transformed DCE files contribute changed status when outputs are materialized', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
+suite('report-aggregator', function () {
+    test('only transformed DCE files contribute changed status when outputs are materialized', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-    broadcaster.provider.emit('artifactsCollected', {
-        packageName: 'pkg-a',
-        entries: [
+        broadcaster.provider.emit('artifactsCollected', {
+            packageName: 'pkg-a',
+            entries: [
+                {
+                    path: 'package.json',
+                    sizeBytes: 2,
+                    kind: 'manifest',
+                    status: 'generated',
+                    badges: []
+                },
+                {
+                    path: 'index.js',
+                    sizeBytes: 20,
+                    kind: 'source',
+                    sourcePath: '/src/index.js',
+                    status: 'unchanged',
+                    badges: []
+                },
+                {
+                    path: 'kept.js',
+                    sizeBytes: 10,
+                    kind: 'source',
+                    sourcePath: '/src/kept.js',
+                    status: 'unchanged',
+                    badges: []
+                }
+            ]
+        });
+        broadcaster.provider.emit('eliminationCompleted', {
+            perBundle: [
+                {
+                    packageName: 'pkg-a',
+                    files: [
+                        {
+                            path: '/src/index.js',
+                            decision: 'transformed',
+                            reason: 'rewritten-after-analysis',
+                            sourceBytes: 30,
+                            outputBytes: 20
+                        },
+                        { path: '/src/kept.js', decision: 'kept', reason: 'reachable', sourceBytes: 10 }
+                    ],
+                    droppedSymbols: [],
+                    seeds: []
+                }
+            ]
+        });
+
+        assert.deepStrictEqual(aggregator.build().packages['pkg-a']?.outputs?.tarball.entries, [
             {
                 path: 'package.json',
                 sizeBytes: 2,
@@ -22,8 +69,8 @@ test('only transformed DCE files contribute changed status when outputs are mate
                 sizeBytes: 20,
                 kind: 'source',
                 sourcePath: '/src/index.js',
-                status: 'unchanged',
-                badges: []
+                status: 'changed',
+                badges: ['dead-code-elimination']
             },
             {
                 path: 'kept.js',
@@ -33,207 +80,162 @@ test('only transformed DCE files contribute changed status when outputs are mate
                 status: 'unchanged',
                 badges: []
             }
-        ]
-    });
-    broadcaster.provider.emit('eliminationCompleted', {
-        perBundle: [
-            {
-                packageName: 'pkg-a',
-                files: [
-                    {
-                        path: '/src/index.js',
-                        decision: 'transformed',
-                        reason: 'rewritten-after-analysis',
-                        sourceBytes: 30,
-                        outputBytes: 20
-                    },
-                    { path: '/src/kept.js', decision: 'kept', reason: 'reachable', sourceBytes: 10 }
-                ],
-                droppedSymbols: [],
-                seeds: []
-            }
-        ]
+        ]);
     });
 
-    assert.deepStrictEqual(aggregator.build().packages['pkg-a']?.outputs?.tarball.entries, [
-        {
-            path: 'package.json',
-            sizeBytes: 2,
-            kind: 'manifest',
-            status: 'generated',
-            badges: []
-        },
-        {
-            path: 'index.js',
-            sizeBytes: 20,
-            kind: 'source',
-            sourcePath: '/src/index.js',
-            status: 'changed',
-            badges: ['dead-code-elimination']
-        },
-        {
-            path: 'kept.js',
-            sizeBytes: 10,
-            kind: 'source',
-            sourcePath: '/src/kept.js',
-            status: 'unchanged',
-            badges: []
+    test('aggregator build() is memoised - second call returns the same object reference', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
+
+        broadcaster.provider.emit('inputsResolved', {
+            packageName: 'pkg-a',
+            roots: { main: 'x' },
+            sourceFileCount: 0,
+            siblingVersions: {}
+        });
+
+        const first = aggregator.build();
+        const second = aggregator.build();
+        assert.strictEqual(first, second);
+    });
+
+    test('unsubscribe() stops the aggregator from receiving further events', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
+
+        aggregator.unsubscribe();
+        broadcaster.provider.emit('versionDetermined', {
+            packageName: 'pkg-a',
+            previousVersion: undefined,
+            chosenVersion: '1.0.0',
+            trigger: 'initial'
+        });
+
+        assert.deepStrictEqual(aggregator.build().packages, {});
+    });
+
+    test('aggregator omits inputs / outputs / failure when no related event was received', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
+
+        broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'build', durationMs: 5 });
+
+        const pkg = aggregator.build().packages['pkg-a'];
+        if (pkg === undefined) {
+            assert.fail('expected pkg-a in report');
         }
-    ]);
-});
-
-test('aggregator build() is memoised - second call returns the same object reference', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-
-    broadcaster.provider.emit('inputsResolved', {
-        packageName: 'pkg-a',
-        roots: { main: 'x' },
-        sourceFileCount: 0,
-        siblingVersions: {}
+        assert.strictEqual('inputs' in pkg, false);
+        assert.strictEqual('outputs' in pkg, false);
+        assert.strictEqual('failure' in pkg, false);
     });
 
-    const first = aggregator.build();
-    const second = aggregator.build();
-    assert.strictEqual(first, second);
-});
+    test('build() reports schemaVersion 1 on an empty aggregator', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-test('unsubscribe() stops the aggregator from receiving further events', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-
-    aggregator.unsubscribe();
-    broadcaster.provider.emit('versionDetermined', {
-        packageName: 'pkg-a',
-        previousVersion: undefined,
-        chosenVersion: '1.0.0',
-        trigger: 'initial'
+        assert.strictEqual(aggregator.build().schemaVersion, 1);
     });
 
-    assert.deepStrictEqual(aggregator.build().packages, {});
-});
+    test('build() emits generatedAt as an ISO 8601 timestamp string', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-test('aggregator omits inputs / outputs / failure when no related event was received', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
+        const { generatedAt } = aggregator.build();
+        assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(generatedAt));
+    });
 
-    broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'build', durationMs: 5 });
+    test('build() reports an empty packages map when no events were observed', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-    const pkg = aggregator.build().packages['pkg-a'];
-    if (pkg === undefined) {
-        assert.fail('expected pkg-a in report');
+        assert.deepStrictEqual(aggregator.build().packages, {});
+    });
+
+    test('build() reports aggregate.crossBundleLinks as an empty array', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
+
+        broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'publish', durationMs: 1 });
+
+        assert.deepStrictEqual(aggregator.build().aggregate.crossBundleLinks, []);
+    });
+
+    function aggregatorWithEffectiveConfig(): ReturnType<typeof createReportAggregator> {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
+        const opaqueConfig: Readonly<Record<string, unknown>> = { name: 'pkg-a' };
+        broadcaster.provider.emit('effectiveConfigResolved', {
+            packageName: 'pkg-a',
+            config: opaqueConfig
+        });
+        return aggregator;
     }
-    assert.strictEqual('inputs' in pkg, false);
-    assert.strictEqual('outputs' in pkg, false);
-    assert.strictEqual('failure' in pkg, false);
-});
 
-test('build() reports schemaVersion 1 on an empty aggregator', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
+    test('buildInputs() backfills missing roots, siblingVersions, and sourceFileCount when only effectiveConfig is set', function () {
+        const aggregator = aggregatorWithEffectiveConfig();
 
-    assert.strictEqual(aggregator.build().schemaVersion, 1);
-});
-
-test('build() emits generatedAt as an ISO 8601 timestamp string', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-
-    const { generatedAt } = aggregator.build();
-    assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(generatedAt));
-});
-
-test('build() reports an empty packages map when no events were observed', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-
-    assert.deepStrictEqual(aggregator.build().packages, {});
-});
-
-test('build() reports aggregate.crossBundleLinks as an empty array', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-
-    broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'publish', durationMs: 1 });
-
-    assert.deepStrictEqual(aggregator.build().aggregate.crossBundleLinks, []);
-});
-
-function aggregatorWithEffectiveConfig(): ReturnType<typeof createReportAggregator> {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-    const opaqueConfig: Readonly<Record<string, unknown>> = { name: 'pkg-a' };
-    broadcaster.provider.emit('effectiveConfigResolved', {
-        packageName: 'pkg-a',
-        config: opaqueConfig
-    });
-    return aggregator;
-}
-
-test('buildInputs() backfills missing roots, siblingVersions, and sourceFileCount when only effectiveConfig is set', () => {
-    const aggregator = aggregatorWithEffectiveConfig();
-
-    assert.deepStrictEqual(aggregator.build().packages['pkg-a']?.inputs, {
-        roots: {},
-        siblingVersions: {},
-        sourceFileCount: 0,
-        effectiveConfig: { name: 'pkg-a' }
-    });
-});
-
-test('buildInputs() omits effectiveConfig when only inputsResolved fired', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
-
-    broadcaster.provider.emit('inputsResolved', {
-        packageName: 'pkg-a',
-        roots: { main: '/src/index.ts' },
-        sourceFileCount: 1,
-        siblingVersions: {}
+        assert.deepStrictEqual(aggregator.build().packages['pkg-a']?.inputs, {
+            roots: {},
+            siblingVersions: {},
+            sourceFileCount: 0,
+            effectiveConfig: { name: 'pkg-a' }
+        });
     });
 
-    const inputs = aggregator.build().packages['pkg-a']?.inputs;
-    if (inputs === undefined) {
-        assert.fail('expected inputs');
-    }
-    assert.strictEqual('effectiveConfig' in inputs, false);
-});
+    test('buildInputs() omits effectiveConfig when only inputsResolved fired', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-test('artifactsCollected reports totalBytes 0 for an empty entries list', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
+        broadcaster.provider.emit('inputsResolved', {
+            packageName: 'pkg-a',
+            roots: { main: '/src/index.ts' },
+            sourceFileCount: 1,
+            siblingVersions: {}
+        });
 
-    broadcaster.provider.emit('artifactsCollected', { packageName: 'pkg-a', entries: [] });
+        const inputs = aggregator.build().packages['pkg-a']?.inputs;
+        if (inputs === undefined) {
+            assert.fail('expected inputs');
+        }
+        assert.strictEqual('effectiveConfig' in inputs, false);
+    });
 
-    assert.strictEqual(aggregator.build().packages['pkg-a']?.outputs?.tarball.totalBytes, 0);
-});
+    test('artifactsCollected reports totalBytes 0 for an empty entries list', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-test('aggregator collects multiple packages independently', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
+        broadcaster.provider.emit('artifactsCollected', { packageName: 'pkg-a', entries: [] });
 
-    broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'publish', durationMs: 1 });
-    broadcaster.provider.emit('stageTimed', { packageName: 'pkg-b', stage: 'publish', durationMs: 2 });
+        assert.strictEqual(aggregator.build().packages['pkg-a']?.outputs?.tarball.totalBytes, 0);
+    });
 
-    const report = aggregator.build();
-    assert.deepStrictEqual(report.packages['pkg-a']?.timings, { publish: 1 });
-    assert.deepStrictEqual(report.packages['pkg-b']?.timings, { publish: 2 });
-});
+    test('aggregator collects multiple packages independently', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
 
-test('unsubscribe() removes every event subscription', () => {
-    const broadcaster = createProgressBroadcaster();
-    const aggregator = createReportAggregator(broadcaster.consumer);
+        broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'publish', durationMs: 1 });
+        broadcaster.provider.emit('stageTimed', { packageName: 'pkg-b', stage: 'publish', durationMs: 2 });
 
-    aggregator.unsubscribe();
+        const report = aggregator.build();
+        assert.deepStrictEqual(report.packages['pkg-a']?.timings, { publish: 1 });
+        assert.deepStrictEqual(report.packages['pkg-b']?.timings, { publish: 2 });
+    });
 
-    assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('effectiveConfigResolved'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('versionDetermined'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('packageJsonAssembled'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('scanCompleted'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('linkingCompleted'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('packageFailed'), false);
-    assert.strictEqual(broadcaster.provider.hasSubscribers('artifactsCollected'), false);
+    test('unsubscribe() removes every event subscription', function () {
+        const broadcaster = createProgressBroadcaster();
+        const aggregator = createReportAggregator(broadcaster.consumer);
+
+        aggregator.unsubscribe();
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('inputsResolved'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('effectiveConfigResolved'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('versionDetermined'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('packageJsonAssembled'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('scanCompleted'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('linkingCompleted'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('eliminationCompleted'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('stageTimed'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('packageFailed'), false);
+        assert.strictEqual(broadcaster.provider.hasSubscribers('artifactsCollected'), false);
+    });
 });

--- a/source/report/aggregator/report-event-handlers.test.ts
+++ b/source/report/aggregator/report-event-handlers.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import { registerSubscribers, type AggregatorState } from './report-event-handlers.ts';
 
@@ -26,192 +26,208 @@ function emitEliminationForPkgA(
     return state;
 }
 
-test('registerSubscribers records inputs when an inputsResolved event arrives', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
+suite('report-event-handlers', function () {
+    test('registerSubscribers records inputs when an inputsResolved event arrives', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
 
-    broadcaster.provider.emit('inputsResolved', {
-        packageName: 'pkg-a',
-        roots: { main: 'src/index.js' },
-        siblingVersions: { 'pkg-b': '1.0.0' },
-        sourceFileCount: 3
+        broadcaster.provider.emit('inputsResolved', {
+            packageName: 'pkg-a',
+            roots: { main: 'src/index.js' },
+            siblingVersions: { 'pkg-b': '1.0.0' },
+            sourceFileCount: 3
+        });
+
+        const entry = state.packages.get('pkg-a');
+        assert.notStrictEqual(entry, undefined);
+        assert.deepStrictEqual(entry!.roots, { main: 'src/index.js' });
+        assert.deepStrictEqual(entry!.siblingVersions, { 'pkg-b': '1.0.0' });
+        assert.strictEqual(entry!.sourceFileCount, 3);
     });
 
-    const entry = state.packages.get('pkg-a');
-    assert.notStrictEqual(entry, undefined);
-    assert.deepStrictEqual(entry!.roots, { main: 'src/index.js' });
-    assert.deepStrictEqual(entry!.siblingVersions, { 'pkg-b': '1.0.0' });
-    assert.strictEqual(entry!.sourceFileCount, 3);
-});
+    test('registerSubscribers records the assembled package.json fields on the package entry', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
 
-test('registerSubscribers records the assembled package.json fields on the package entry', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
+        broadcaster.provider.emit('packageJsonAssembled', {
+            packageName: 'pkg-a',
+            fields: { name: { source: 'mainPackageJson' }, version: { source: 'derived' } }
+        });
 
-    broadcaster.provider.emit('packageJsonAssembled', {
-        packageName: 'pkg-a',
-        fields: { name: { source: 'mainPackageJson' }, version: { source: 'derived' } }
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.packageJson, {
+            name: { source: 'mainPackageJson' },
+            version: { source: 'derived' }
+        });
     });
 
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.packageJson, {
-        name: { source: 'mainPackageJson' },
-        version: { source: 'derived' }
-    });
-});
+    test('registerSubscribers records the effective config on the package entry', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
 
-test('registerSubscribers records the effective config on the package entry', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
+        broadcaster.provider.emit('effectiveConfigResolved', { packageName: 'pkg-a', config: { feature: true } });
 
-    broadcaster.provider.emit('effectiveConfigResolved', { packageName: 'pkg-a', config: { feature: true } });
-
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.effectiveConfig, { feature: true });
-});
-
-test('registerSubscribers records the version decision on the package entry', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
-
-    broadcaster.provider.emit('versionDetermined', {
-        packageName: 'pkg-a',
-        previousVersion: '1.0.0',
-        chosenVersion: '1.0.1',
-        trigger: 'auto-patch-bump'
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.effectiveConfig, { feature: true });
     });
 
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.version, {
-        previousVersion: '1.0.0',
-        chosenVersion: '1.0.1',
-        trigger: 'auto-patch-bump'
-    });
-});
+    test('registerSubscribers records the version decision on the package entry', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
 
-test('registerSubscribers records linker rewrites on the package entry', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
+        broadcaster.provider.emit('versionDetermined', {
+            packageName: 'pkg-a',
+            previousVersion: '1.0.0',
+            chosenVersion: '1.0.1',
+            trigger: 'auto-patch-bump'
+        });
 
-    broadcaster.provider.emit('linkingCompleted', {
-        packageName: 'pkg-a',
-        rewrites: [{ file: 'a.js', fromSpecifier: 'old', toSpecifier: 'new', targetBundle: 'pkg-b' }]
-    });
-
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.linker, {
-        rewrites: [{ file: 'a.js', fromSpecifier: 'old', toSpecifier: 'new', targetBundle: 'pkg-b' }]
-    });
-});
-
-test('registerSubscribers stores stageTimed entries in the timings record', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
-
-    broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'build', durationMs: 42 });
-
-    assert.strictEqual(state.packages.get('pkg-a')?.timings.build, 42);
-});
-
-test('registerSubscribers records package failures', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
-
-    broadcaster.provider.emit('packageFailed', { packageName: 'pkg-a', stage: 'publish', message: 'boom' });
-
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.failure, { stage: 'publish', message: 'boom' });
-});
-
-test('registerSubscribers aggregates artifact size and entries on artifactsCollected', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
-
-    broadcaster.provider.emit('artifactsCollected', {
-        packageName: 'pkg-a',
-        entries: [
-            { path: 'a.js', sizeBytes: 10, kind: 'source', sourcePath: '/src/a.js', status: 'generated', badges: [] },
-            { path: 'b.js', sizeBytes: 20, kind: 'source', sourcePath: '/src/b.js', status: 'generated', badges: [] }
-        ]
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.version, {
+            previousVersion: '1.0.0',
+            chosenVersion: '1.0.1',
+            trigger: 'auto-patch-bump'
+        });
     });
 
-    assert.strictEqual(state.packages.get('pkg-a')?.outputs?.tarball.totalBytes, 30);
-    assert.strictEqual(state.packages.get('pkg-a')?.outputs?.tarball.entries.length, 2);
-});
+    test('registerSubscribers records linker rewrites on the package entry', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
 
-test('registerSubscribers records scanCompleted entries under decisions.dependencyScan', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
+        broadcaster.provider.emit('linkingCompleted', {
+            packageName: 'pkg-a',
+            rewrites: [{ file: 'a.js', fromSpecifier: 'old', toSpecifier: 'new', targetBundle: 'pkg-b' }]
+        });
 
-    broadcaster.provider.emit('scanCompleted', {
-        packageName: 'pkg-a',
-        included: [{ path: '/src/a.ts', reason: 'reachable-from-entry' }],
-        excluded: [{ specifier: 'lodash', reason: 'external-module' }]
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.linker, {
+            rewrites: [{ file: 'a.js', fromSpecifier: 'old', toSpecifier: 'new', targetBundle: 'pkg-b' }]
+        });
     });
 
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.dependencyScan, {
-        included: [{ path: '/src/a.ts', reason: 'reachable-from-entry' }],
-        excluded: [{ specifier: 'lodash', reason: 'external-module' }]
+    test('registerSubscribers stores stageTimed entries in the timings record', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
+
+        broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'build', durationMs: 42 });
+
+        assert.strictEqual(state.packages.get('pkg-a')?.timings.build, 42);
     });
-});
 
-test('registerSubscribers omits eliminatedSourceFiles when no files were eliminated', () => {
-    const state = emitEliminationForPkgA([
-        { path: '/src/a.js', decision: 'kept', reason: 'reachable', sourceBytes: 1 }
-    ]);
+    test('registerSubscribers records package failures', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
 
-    const entry = state.packages.get('pkg-a');
-    assert.notStrictEqual(entry, undefined);
-    assert.strictEqual('eliminatedSourceFiles' in entry!, false);
-});
+        broadcaster.provider.emit('packageFailed', { packageName: 'pkg-a', stage: 'publish', message: 'boom' });
 
-test('registerSubscribers preserves outputBytes on eliminated files when it is provided', () => {
-    const state = emitEliminationForPkgA([
-        {
-            path: '/src/a.js',
-            decision: 'eliminated',
-            reason: 'not-emitted-after-analysis',
-            sourceBytes: 5,
-            outputBytes: 1
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.failure, { stage: 'publish', message: 'boom' });
+    });
+
+    test('registerSubscribers aggregates artifact size and entries on artifactsCollected', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
+
+        broadcaster.provider.emit('artifactsCollected', {
+            packageName: 'pkg-a',
+            entries: [
+                {
+                    path: 'a.js',
+                    sizeBytes: 10,
+                    kind: 'source',
+                    sourcePath: '/src/a.js',
+                    status: 'generated',
+                    badges: []
+                },
+                {
+                    path: 'b.js',
+                    sizeBytes: 20,
+                    kind: 'source',
+                    sourcePath: '/src/b.js',
+                    status: 'generated',
+                    badges: []
+                }
+            ]
+        });
+
+        assert.strictEqual(state.packages.get('pkg-a')?.outputs?.tarball.totalBytes, 30);
+        assert.strictEqual(state.packages.get('pkg-a')?.outputs?.tarball.entries.length, 2);
+    });
+
+    test('registerSubscribers records scanCompleted entries under decisions.dependencyScan', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
+
+        broadcaster.provider.emit('scanCompleted', {
+            packageName: 'pkg-a',
+            included: [{ path: '/src/a.ts', reason: 'reachable-from-entry' }],
+            excluded: [{ specifier: 'lodash', reason: 'external-module' }]
+        });
+
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.decisions.dependencyScan, {
+            included: [{ path: '/src/a.ts', reason: 'reachable-from-entry' }],
+            excluded: [{ specifier: 'lodash', reason: 'external-module' }]
+        });
+    });
+
+    test('registerSubscribers omits eliminatedSourceFiles when no files were eliminated', function () {
+        const state = emitEliminationForPkgA([
+            { path: '/src/a.js', decision: 'kept', reason: 'reachable', sourceBytes: 1 }
+        ]);
+
+        const entry = state.packages.get('pkg-a');
+        assert.notStrictEqual(entry, undefined);
+        assert.strictEqual('eliminatedSourceFiles' in entry!, false);
+    });
+
+    test('registerSubscribers preserves outputBytes on eliminated files when it is provided', function () {
+        const state = emitEliminationForPkgA([
+            {
+                path: '/src/a.js',
+                decision: 'eliminated',
+                reason: 'not-emitted-after-analysis',
+                sourceBytes: 5,
+                outputBytes: 1
+            }
+        ]);
+
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.eliminatedSourceFiles, [
+            { path: '/src/a.js', reason: 'not-emitted-after-analysis', sourceBytes: 5, outputBytes: 1 }
+        ]);
+    });
+
+    test('registerSubscribers separates eliminated source files from kept files when elimination completes', function () {
+        const state = emitEliminationForPkgA([
+            { path: 'a.js', decision: 'kept', reason: 'kept', sourceBytes: 10 },
+            { path: 'b.js', decision: 'eliminated', reason: 'no-uses', sourceBytes: 5 }
+        ]);
+
+        const entry = state.packages.get('pkg-a');
+        assert.notStrictEqual(entry, undefined);
+        assert.strictEqual(entry!.decisions.deadCodeElimination?.files.length, 1);
+        assert.deepStrictEqual(entry!.eliminatedSourceFiles, [{ path: 'b.js', sourceBytes: 5, reason: 'no-uses' }]);
+    });
+
+    test('registerSubscribers exposes disposers that unsubscribe registered handlers', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
+
+        for (const dispose of state.disposers) {
+            dispose();
         }
-    ]);
 
-    assert.deepStrictEqual(state.packages.get('pkg-a')?.eliminatedSourceFiles, [
-        { path: '/src/a.js', reason: 'not-emitted-after-analysis', sourceBytes: 5, outputBytes: 1 }
-    ]);
-});
+        broadcaster.provider.emit('inputsResolved', {
+            packageName: 'pkg-a',
+            roots: { main: 'src/index.js' },
+            siblingVersions: {},
+            sourceFileCount: 0
+        });
 
-test('registerSubscribers separates eliminated source files from kept files when elimination completes', () => {
-    const state = emitEliminationForPkgA([
-        { path: 'a.js', decision: 'kept', reason: 'kept', sourceBytes: 10 },
-        { path: 'b.js', decision: 'eliminated', reason: 'no-uses', sourceBytes: 5 }
-    ]);
-
-    const entry = state.packages.get('pkg-a');
-    assert.notStrictEqual(entry, undefined);
-    assert.strictEqual(entry!.decisions.deadCodeElimination?.files.length, 1);
-    assert.deepStrictEqual(entry!.eliminatedSourceFiles, [{ path: 'b.js', sourceBytes: 5, reason: 'no-uses' }]);
-});
-
-test('registerSubscribers exposes disposers that unsubscribe registered handlers', () => {
-    const state = freshState();
-    const broadcaster = createProgressBroadcaster();
-    registerSubscribers(state, broadcaster.consumer);
-
-    for (const dispose of state.disposers) {
-        dispose();
-    }
-
-    broadcaster.provider.emit('inputsResolved', {
-        packageName: 'pkg-a',
-        roots: { main: 'src/index.js' },
-        siblingVersions: {},
-        sourceFileCount: 0
+        assert.strictEqual(state.packages.has('pkg-a'), false);
     });
-
-    assert.strictEqual(state.packages.has('pkg-a'), false);
 });

--- a/source/report/aggregator/report-types.test.ts
+++ b/source/report/aggregator/report-types.test.ts
@@ -1,18 +1,20 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createEmptyMutablePackageReport } from './report-types.ts';
 
-test('createEmptyMutablePackageReport returns an empty decisions object', () => {
-    assert.deepStrictEqual(createEmptyMutablePackageReport().decisions, {});
-});
+suite('report-types', function () {
+    test('createEmptyMutablePackageReport returns an empty decisions object', function () {
+        assert.deepStrictEqual(createEmptyMutablePackageReport().decisions, {});
+    });
 
-test('createEmptyMutablePackageReport returns an empty timings record', () => {
-    assert.deepStrictEqual(createEmptyMutablePackageReport().timings, {});
-});
+    test('createEmptyMutablePackageReport returns an empty timings record', function () {
+        assert.deepStrictEqual(createEmptyMutablePackageReport().timings, {});
+    });
 
-test('createEmptyMutablePackageReport returns a fresh object on every call', () => {
-    const first = createEmptyMutablePackageReport();
-    const second = createEmptyMutablePackageReport();
+    test('createEmptyMutablePackageReport returns a fresh object on every call', function () {
+        const first = createEmptyMutablePackageReport();
+        const second = createEmptyMutablePackageReport();
 
-    assert.notStrictEqual(first, second);
+        assert.notStrictEqual(first, second);
+    });
 });

--- a/source/report/config-redactor.test.ts
+++ b/source/report/config-redactor.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PacktoryConfig } from '../config/config.ts';
 import { redactConfigForPackage } from './config-redactor.ts';
 
@@ -14,151 +14,153 @@ function baseConfig(overrides: Partial<PacktoryConfig> = {}): PacktoryConfig {
     } as unknown as PacktoryConfig;
 }
 
-test('redactConfigForPackage() returns the package name', () => {
-    const redacted = redactConfigForPackage(baseConfig(), 'pkg-a');
+suite('config-redactor', function () {
+    test('redactConfigForPackage() returns the package name', function () {
+        const redacted = redactConfigForPackage(baseConfig(), 'pkg-a');
 
-    assert.strictEqual(redacted.name, 'pkg-a');
-});
-
-test('redactConfigForPackage() always redacts the registry settings', () => {
-    const redacted = redactConfigForPackage(baseConfig(), 'pkg-a');
-
-    assert.deepStrictEqual(redacted.registrySettings, {
-        registryUrl: 'https://registry.example.com',
-        auth: { type: 'bearer-token', token: '[redacted]' }
+        assert.strictEqual(redacted.name, 'pkg-a');
     });
-});
 
-test('redactConfigForPackage() omits publishSettings when neither package nor common defines it', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            packages: [
-                {
-                    name: 'pkg-a',
-                    roots: { main: { js: 'pkg-a/index.js' } }
-                }
-            ]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() always redacts the registry settings', function () {
+        const redacted = redactConfigForPackage(baseConfig(), 'pkg-a');
 
-    assert.strictEqual('publishSettings' in redacted, false);
-});
+        assert.deepStrictEqual(redacted.registrySettings, {
+            registryUrl: 'https://registry.example.com',
+            auth: { type: 'bearer-token', token: '[redacted]' }
+        });
+    });
 
-test('redactConfigForPackage() uses package publishSettings when present', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            packages: [
-                {
-                    name: 'pkg-a',
-                    roots: { main: { js: 'pkg-a/index.js' } },
-                    publishSettings: { access: 'restricted', allowScripts: true }
-                }
-            ]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() omits publishSettings when neither package nor common defines it', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                packages: [
+                    {
+                        name: 'pkg-a',
+                        roots: { main: { js: 'pkg-a/index.js' } }
+                    }
+                ]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.deepStrictEqual(redacted.publishSettings, { access: 'restricted', allowScripts: true });
-});
+        assert.strictEqual('publishSettings' in redacted, false);
+    });
 
-test('redactConfigForPackage() falls back to commonPackageSettings.publishSettings when the package omits it', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            commonPackageSettings: { publishSettings: { access: 'public' } },
-            packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() uses package publishSettings when present', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                packages: [
+                    {
+                        name: 'pkg-a',
+                        roots: { main: { js: 'pkg-a/index.js' } },
+                        publishSettings: { access: 'restricted', allowScripts: true }
+                    }
+                ]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.deepStrictEqual(redacted.publishSettings, { access: 'public' });
-});
+        assert.deepStrictEqual(redacted.publishSettings, { access: 'restricted', allowScripts: true });
+    });
 
-test('redactConfigForPackage() prefers package publishSettings over commonPackageSettings', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            commonPackageSettings: { publishSettings: { access: 'public' } },
-            packages: [
-                {
-                    name: 'pkg-a',
-                    roots: { main: { js: 'pkg-a/index.js' } },
-                    publishSettings: { access: 'restricted' }
-                }
-            ]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() falls back to commonPackageSettings.publishSettings when the package omits it', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                commonPackageSettings: { publishSettings: { access: 'public' } },
+                packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.deepStrictEqual(redacted.publishSettings, { access: 'restricted' });
-});
+        assert.deepStrictEqual(redacted.publishSettings, { access: 'public' });
+    });
 
-test('redactConfigForPackage() omits sourcesFolder when neither package nor common defines it', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() prefers package publishSettings over commonPackageSettings', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                commonPackageSettings: { publishSettings: { access: 'public' } },
+                packages: [
+                    {
+                        name: 'pkg-a',
+                        roots: { main: { js: 'pkg-a/index.js' } },
+                        publishSettings: { access: 'restricted' }
+                    }
+                ]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.strictEqual('sourcesFolder' in redacted, false);
-});
+        assert.deepStrictEqual(redacted.publishSettings, { access: 'restricted' });
+    });
 
-test('redactConfigForPackage() prefers package sourcesFolder over commonPackageSettings', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            commonPackageSettings: { sourcesFolder: '/common/src' },
-            packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } }, sourcesFolder: '/pkg-a/src' }]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() omits sourcesFolder when neither package nor common defines it', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.strictEqual(redacted.sourcesFolder, '/pkg-a/src');
-});
+        assert.strictEqual('sourcesFolder' in redacted, false);
+    });
 
-test('redactConfigForPackage() falls back to commonPackageSettings.sourcesFolder when the package omits it', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            commonPackageSettings: { sourcesFolder: '/common/src' },
-            packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-a'
-    );
+    test('redactConfigForPackage() prefers package sourcesFolder over commonPackageSettings', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                commonPackageSettings: { sourcesFolder: '/common/src' },
+                packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } }, sourcesFolder: '/pkg-a/src' }]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.strictEqual(redacted.sourcesFolder, '/common/src');
-});
+        assert.strictEqual(redacted.sourcesFolder, '/pkg-a/src');
+    });
 
-test('redactConfigForPackage() returns undefined publishSettings and sourcesFolder when the package name does not match', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            packages: [
-                {
-                    name: 'pkg-a',
-                    roots: { main: { js: 'pkg-a/index.js' } },
-                    publishSettings: { access: 'restricted' },
-                    sourcesFolder: '/pkg-a/src'
-                }
-            ]
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-missing'
-    );
+    test('redactConfigForPackage() falls back to commonPackageSettings.sourcesFolder when the package omits it', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                commonPackageSettings: { sourcesFolder: '/common/src' },
+                packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-a'
+        );
 
-    assert.strictEqual('publishSettings' in redacted, false);
-    assert.strictEqual('sourcesFolder' in redacted, false);
-    assert.strictEqual(redacted.name, 'pkg-missing');
-});
+        assert.strictEqual(redacted.sourcesFolder, '/common/src');
+    });
 
-test('redactConfigForPackage() falls back to common settings when the package name does not match but common settings exist', () => {
-    const redacted = redactConfigForPackage(
-        baseConfig({
-            commonPackageSettings: {
-                publishSettings: { access: 'public' },
-                sourcesFolder: '/common/src'
-            },
-            packages: []
-        } as unknown as Partial<PacktoryConfig>),
-        'pkg-missing'
-    );
+    test('redactConfigForPackage() returns undefined publishSettings and sourcesFolder when the package name does not match', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                packages: [
+                    {
+                        name: 'pkg-a',
+                        roots: { main: { js: 'pkg-a/index.js' } },
+                        publishSettings: { access: 'restricted' },
+                        sourcesFolder: '/pkg-a/src'
+                    }
+                ]
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-missing'
+        );
 
-    assert.deepStrictEqual(redacted.publishSettings, { access: 'public' });
-    assert.strictEqual(redacted.sourcesFolder, '/common/src');
+        assert.strictEqual('publishSettings' in redacted, false);
+        assert.strictEqual('sourcesFolder' in redacted, false);
+        assert.strictEqual(redacted.name, 'pkg-missing');
+    });
+
+    test('redactConfigForPackage() falls back to common settings when the package name does not match but common settings exist', function () {
+        const redacted = redactConfigForPackage(
+            baseConfig({
+                commonPackageSettings: {
+                    publishSettings: { access: 'public' },
+                    sourcesFolder: '/common/src'
+                },
+                packages: []
+            } as unknown as Partial<PacktoryConfig>),
+            'pkg-missing'
+        );
+
+        assert.deepStrictEqual(redacted.publishSettings, { access: 'public' });
+        assert.strictEqual(redacted.sourcesFolder, '/common/src');
+    });
 });

--- a/source/report/decorators.test.ts
+++ b/source/report/decorators.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import type { PackageProcessor } from '../packtory/package-processor.ts';
 import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
@@ -39,253 +39,257 @@ function createStagePayloadCollector(): {
     return { broadcaster, received };
 }
 
-test('withStageTimings emits a stageTimed event on resolveAndLink', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: unknown[] = [];
-    broadcaster.consumer.on('stageTimed', (payload) => {
-        received.push(payload);
+suite('decorators', function () {
+    test('withStageTimings emits a stageTimed event on resolveAndLink', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: unknown[] = [];
+        broadcaster.consumer.on('stageTimed', (payload) => {
+            received.push(payload);
+        });
+
+        const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
+        await wrapped.resolveAndLink({ name: 'pkg-a' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
+
+        assert.strictEqual(received.length, 1);
+        const [payload] = received as readonly { packageName: string; stage: string; durationMs: number }[];
+        if (payload === undefined) {
+            assert.fail('expected one payload');
+        }
+        assert.strictEqual(payload.packageName, 'pkg-a');
+        assert.strictEqual(payload.stage, 'resolveAndLink');
+        assert.ok(typeof payload.durationMs === 'number' && payload.durationMs >= 0);
     });
 
-    const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
-    await wrapped.resolveAndLink({ name: 'pkg-a' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
+    test('withStageTimings emits stage "publish" for buildAndPublish using buildOptions.name', async function () {
+        const { broadcaster, received } = createStagePayloadCollector();
 
-    assert.strictEqual(received.length, 1);
-    const [payload] = received as readonly { packageName: string; stage: string; durationMs: number }[];
-    if (payload === undefined) {
-        assert.fail('expected one payload');
-    }
-    assert.strictEqual(payload.packageName, 'pkg-a');
-    assert.strictEqual(payload.stage, 'resolveAndLink');
-    assert.ok(typeof payload.durationMs === 'number' && payload.durationMs >= 0);
-});
+        const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
+        await wrapped.buildAndPublish({ buildOptions: { name: 'pkg-b' } } as unknown as Parameters<
+            PackageProcessor['buildAndPublish']
+        >[0]);
 
-test('withStageTimings emits stage "publish" for buildAndPublish using buildOptions.name', async () => {
-    const { broadcaster, received } = createStagePayloadCollector();
-
-    const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
-    await wrapped.buildAndPublish({ buildOptions: { name: 'pkg-b' } } as unknown as Parameters<
-        PackageProcessor['buildAndPublish']
-    >[0]);
-
-    assert.deepStrictEqual(received, [{ stage: 'publish', packageName: 'pkg-b' }]);
-});
-
-test('withStageTimings.buildAndPublish forwards the wrapped method result', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const sentinel = { sentinel: 'build-and-publish' };
-    const wrapped = withStageTimings(
-        createPlainProcessor({
-            buildAndPublish: fake.resolves(sentinel) as unknown as PackageProcessor['buildAndPublish']
-        }),
-        broadcaster.provider
-    );
-
-    const result = await wrapped.buildAndPublish({ buildOptions: { name: 'pkg-b' } } as unknown as Parameters<
-        PackageProcessor['buildAndPublish']
-    >[0]);
-
-    assert.strictEqual(result, sentinel);
-});
-
-test('withStageTimings.tryBuildAndPublish forwards the wrapped method result', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const sentinel = { sentinel: 'try-build-and-publish' };
-    const wrapped = withStageTimings(
-        createPlainProcessor({
-            tryBuildAndPublish: fake.resolves(sentinel) as unknown as PackageProcessor['tryBuildAndPublish']
-        }),
-        broadcaster.provider
-    );
-
-    const result = await wrapped.tryBuildAndPublish({ buildOptions: { name: 'pkg-c' } } as unknown as Parameters<
-        PackageProcessor['tryBuildAndPublish']
-    >[0]);
-
-    assert.strictEqual(result, sentinel);
-});
-
-test('withStageTimings emits stage "tryPublish" for tryBuildAndPublish', async () => {
-    const { broadcaster, stages } = createStageCollector();
-
-    const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
-    await wrapped.tryBuildAndPublish({ buildOptions: { name: 'pkg-c' } } as unknown as Parameters<
-        PackageProcessor['tryBuildAndPublish']
-    >[0]);
-
-    assert.deepStrictEqual(stages, ['tryPublish']);
-});
-
-test('withStageTimings still emits when the wrapped method rejects', async () => {
-    const { broadcaster, stages } = createStageCollector();
-
-    const wrapped = withStageTimings(
-        createPlainProcessor({
-            resolveAndLink: fake.rejects(new Error('boom')) as unknown as PackageProcessor['resolveAndLink']
-        }),
-        broadcaster.provider
-    );
-
-    try {
-        await wrapped.resolveAndLink({ name: 'pkg-d' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
-        assert.fail('expected resolveAndLink to throw');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'boom');
-    }
-    assert.deepStrictEqual(stages, ['resolveAndLink']);
-});
-
-test('withStageTimings skips emit when no subscriber is registered', async () => {
-    const wrappedBroadcaster = createSpyingBroadcaster();
-
-    const wrapped = withStageTimings(createPlainProcessor(), wrappedBroadcaster.provider);
-    await wrapped.resolveAndLink({ name: 'pkg-e' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
-
-    assert.strictEqual(wrappedBroadcaster.emitSpy.callCount, 0);
-});
-
-test('withStageTimings forwards the wrapped method return value', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const sentinel = { sentinel: true };
-    const wrapped = withStageTimings(
-        createPlainProcessor({
-            build: fake.resolves(sentinel) as unknown as PackageProcessor['build']
-        }),
-        broadcaster.provider
-    );
-
-    const result = await wrapped.build({ name: 'pkg-f' } as unknown as Parameters<PackageProcessor['build']>[0]);
-    assert.strictEqual(result, sentinel);
-});
-
-test('withStageTimings emits stage "build" for build using options.name', async () => {
-    const { broadcaster, received } = createStagePayloadCollector();
-
-    const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
-    await wrapped.build({ name: 'pkg-build' } as unknown as Parameters<PackageProcessor['build']>[0]);
-
-    assert.deepStrictEqual(received, [{ stage: 'build', packageName: 'pkg-build' }]);
-});
-
-test('withStageTimings emits a non-negative durationMs that reflects elapsed time, not wall-clock', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: number[] = [];
-    broadcaster.consumer.on('stageTimed', (payload) => {
-        received.push(payload.durationMs);
+        assert.deepStrictEqual(received, [{ stage: 'publish', packageName: 'pkg-b' }]);
     });
 
-    const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
-    await wrapped.resolveAndLink({ name: 'pkg-a' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
+    test('withStageTimings.buildAndPublish forwards the wrapped method result', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const sentinel = { sentinel: 'build-and-publish' };
+        const wrapped = withStageTimings(
+            createPlainProcessor({
+                buildAndPublish: fake.resolves(sentinel) as unknown as PackageProcessor['buildAndPublish']
+            }),
+            broadcaster.provider
+        );
 
-    const [durationMs] = received;
-    if (durationMs === undefined) {
-        assert.fail('expected durationMs');
-    }
-    assert.ok(durationMs >= 0, 'durationMs must be non-negative');
-    assert.ok(durationMs < 10_000, 'durationMs must reflect elapsed time, not wall clock or a sum');
-});
+        const result = await wrapped.buildAndPublish({ buildOptions: { name: 'pkg-b' } } as unknown as Parameters<
+            PackageProcessor['buildAndPublish']
+        >[0]);
 
-test('withFailureCapture forwards the wrapped success value when execute resolves', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const sentinel = { ok: true };
-
-    const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
-        return sentinel;
+        assert.strictEqual(result, sentinel);
     });
 
-    const result = await wrapped({ name: 'pkg-a' });
+    test('withStageTimings.tryBuildAndPublish forwards the wrapped method result', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const sentinel = { sentinel: 'try-build-and-publish' };
+        const wrapped = withStageTimings(
+            createPlainProcessor({
+                tryBuildAndPublish: fake.resolves(sentinel) as unknown as PackageProcessor['tryBuildAndPublish']
+            }),
+            broadcaster.provider
+        );
 
-    assert.strictEqual(result, sentinel);
-});
+        const result = await wrapped.tryBuildAndPublish({ buildOptions: { name: 'pkg-c' } } as unknown as Parameters<
+            PackageProcessor['tryBuildAndPublish']
+        >[0]);
 
-test('withFailureCapture emits packageFailed with the error message when execute throws an Error', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { packageName: string; stage: string; message: string }[] = [];
-    broadcaster.consumer.on('packageFailed', (payload) => {
-        received.push({ packageName: payload.packageName, stage: payload.stage, message: payload.message });
+        assert.strictEqual(result, sentinel);
     });
 
-    const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
-        throw new Error('kaboom');
+    test('withStageTimings emits stage "tryPublish" for tryBuildAndPublish', async function () {
+        const { broadcaster, stages } = createStageCollector();
+
+        const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
+        await wrapped.tryBuildAndPublish({ buildOptions: { name: 'pkg-c' } } as unknown as Parameters<
+            PackageProcessor['tryBuildAndPublish']
+        >[0]);
+
+        assert.deepStrictEqual(stages, ['tryPublish']);
     });
 
-    try {
+    test('withStageTimings still emits when the wrapped method rejects', async function () {
+        const { broadcaster, stages } = createStageCollector();
+
+        const wrapped = withStageTimings(
+            createPlainProcessor({
+                resolveAndLink: fake.rejects(new Error('boom')) as unknown as PackageProcessor['resolveAndLink']
+            }),
+            broadcaster.provider
+        );
+
+        try {
+            await wrapped.resolveAndLink({ name: 'pkg-d' } as unknown as Parameters<
+                PackageProcessor['resolveAndLink']
+            >[0]);
+            assert.fail('expected resolveAndLink to throw');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'boom');
+        }
+        assert.deepStrictEqual(stages, ['resolveAndLink']);
+    });
+
+    test('withStageTimings skips emit when no subscriber is registered', async function () {
+        const wrappedBroadcaster = createSpyingBroadcaster();
+
+        const wrapped = withStageTimings(createPlainProcessor(), wrappedBroadcaster.provider);
+        await wrapped.resolveAndLink({ name: 'pkg-e' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
+
+        assert.strictEqual(wrappedBroadcaster.emitSpy.callCount, 0);
+    });
+
+    test('withStageTimings forwards the wrapped method return value', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const sentinel = { sentinel: true };
+        const wrapped = withStageTimings(
+            createPlainProcessor({
+                build: fake.resolves(sentinel) as unknown as PackageProcessor['build']
+            }),
+            broadcaster.provider
+        );
+
+        const result = await wrapped.build({ name: 'pkg-f' } as unknown as Parameters<PackageProcessor['build']>[0]);
+        assert.strictEqual(result, sentinel);
+    });
+
+    test('withStageTimings emits stage "build" for build using options.name', async function () {
+        const { broadcaster, received } = createStagePayloadCollector();
+
+        const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
+        await wrapped.build({ name: 'pkg-build' } as unknown as Parameters<PackageProcessor['build']>[0]);
+
+        assert.deepStrictEqual(received, [{ stage: 'build', packageName: 'pkg-build' }]);
+    });
+
+    test('withStageTimings emits a non-negative durationMs that reflects elapsed time, not wall-clock', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: number[] = [];
+        broadcaster.consumer.on('stageTimed', (payload) => {
+            received.push(payload.durationMs);
+        });
+
+        const wrapped = withStageTimings(createPlainProcessor(), broadcaster.provider);
+        await wrapped.resolveAndLink({ name: 'pkg-a' } as unknown as Parameters<PackageProcessor['resolveAndLink']>[0]);
+
+        const [durationMs] = received;
+        if (durationMs === undefined) {
+            assert.fail('expected durationMs');
+        }
+        assert.ok(durationMs >= 0, 'durationMs must be non-negative');
+        assert.ok(durationMs < 10_000, 'durationMs must reflect elapsed time, not wall clock or a sum');
+    });
+
+    test('withFailureCapture forwards the wrapped success value when execute resolves', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const sentinel = { ok: true };
+
+        const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
+            return sentinel;
+        });
+
+        const result = await wrapped({ name: 'pkg-a' });
+
+        assert.strictEqual(result, sentinel);
+    });
+
+    test('withFailureCapture emits packageFailed with the error message when execute throws an Error', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { packageName: string; stage: string; message: string }[] = [];
+        broadcaster.consumer.on('packageFailed', (payload) => {
+            received.push({ packageName: payload.packageName, stage: payload.stage, message: payload.message });
+        });
+
+        const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
+            throw new Error('kaboom');
+        });
+
+        try {
+            await wrapped({ name: 'pkg-a' });
+            assert.fail('expected wrapped() to throw');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'kaboom');
+        }
+        assert.deepStrictEqual(received, [{ packageName: 'pkg-a', stage: 'publish', message: 'kaboom' }]);
+    });
+
+    test('withFailureCapture coerces a non-Error throwable into a string message', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: string[] = [];
+        broadcaster.consumer.on('packageFailed', (payload) => {
+            received.push(payload.message);
+        });
+
+        const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
+            const stringThrowable: unknown = 'plain string';
+
+            throw stringThrowable;
+        });
+
+        try {
+            await wrapped({ name: 'pkg-a' });
+            assert.fail('expected wrapped() to throw');
+        } catch (error: unknown) {
+            assert.strictEqual(error, 'plain string');
+        }
+        assert.deepStrictEqual(received, ['plain string']);
+    });
+
+    test('withFailureCapture re-throws the original error', async function () {
+        const broadcaster = createProgressBroadcaster();
+        broadcaster.consumer.on('packageFailed', () => {
+            return undefined;
+        });
+        const original = new Error('orig');
+
+        const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
+            throw original;
+        });
+
+        try {
+            await wrapped({ name: 'pkg-a' });
+            assert.fail('expected wrapped() to throw');
+        } catch (error: unknown) {
+            assert.strictEqual(error, original);
+        }
+    });
+
+    test('withFailureCapture skips the emit when no subscriber is registered for packageFailed', async function () {
+        const wrappedBroadcaster = createSpyingBroadcaster();
+
+        const wrapped = withFailureCapture(wrappedBroadcaster.provider, 'publish', async (_: { name: string }) => {
+            throw new Error('boom');
+        });
+
+        try {
+            await wrapped({ name: 'pkg-a' });
+            assert.fail('expected wrapped() to throw');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'boom');
+        }
+        assert.strictEqual(wrappedBroadcaster.emitSpy.callCount, 0);
+    });
+
+    test('withFailureCapture does NOT emit when execute resolves successfully', async function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: unknown[] = [];
+        broadcaster.consumer.on('packageFailed', (payload) => {
+            received.push(payload);
+        });
+
+        const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
+            return undefined;
+        });
+
         await wrapped({ name: 'pkg-a' });
-        assert.fail('expected wrapped() to throw');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'kaboom');
-    }
-    assert.deepStrictEqual(received, [{ packageName: 'pkg-a', stage: 'publish', message: 'kaboom' }]);
-});
 
-test('withFailureCapture coerces a non-Error throwable into a string message', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: string[] = [];
-    broadcaster.consumer.on('packageFailed', (payload) => {
-        received.push(payload.message);
+        assert.deepStrictEqual(received, []);
     });
-
-    const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
-        const stringThrowable: unknown = 'plain string';
-
-        throw stringThrowable;
-    });
-
-    try {
-        await wrapped({ name: 'pkg-a' });
-        assert.fail('expected wrapped() to throw');
-    } catch (error: unknown) {
-        assert.strictEqual(error, 'plain string');
-    }
-    assert.deepStrictEqual(received, ['plain string']);
-});
-
-test('withFailureCapture re-throws the original error', async () => {
-    const broadcaster = createProgressBroadcaster();
-    broadcaster.consumer.on('packageFailed', () => {
-        return undefined;
-    });
-    const original = new Error('orig');
-
-    const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
-        throw original;
-    });
-
-    try {
-        await wrapped({ name: 'pkg-a' });
-        assert.fail('expected wrapped() to throw');
-    } catch (error: unknown) {
-        assert.strictEqual(error, original);
-    }
-});
-
-test('withFailureCapture skips the emit when no subscriber is registered for packageFailed', async () => {
-    const wrappedBroadcaster = createSpyingBroadcaster();
-
-    const wrapped = withFailureCapture(wrappedBroadcaster.provider, 'publish', async (_: { name: string }) => {
-        throw new Error('boom');
-    });
-
-    try {
-        await wrapped({ name: 'pkg-a' });
-        assert.fail('expected wrapped() to throw');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'boom');
-    }
-    assert.strictEqual(wrappedBroadcaster.emitSpy.callCount, 0);
-});
-
-test('withFailureCapture does NOT emit when execute resolves successfully', async () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: unknown[] = [];
-    broadcaster.consumer.on('packageFailed', (payload) => {
-        received.push(payload);
-    });
-
-    const wrapped = withFailureCapture(broadcaster.provider, 'publish', async (_: { name: string }) => {
-        return undefined;
-    });
-
-    await wrapped({ name: 'pkg-a' });
-
-    assert.deepStrictEqual(received, []);
 });

--- a/source/report/html-renderer/artifact-tree-renderer.test.ts
+++ b/source/report/html-renderer/artifact-tree-renderer.test.ts
@@ -1,82 +1,84 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewArtifactNode } from '../preview/artifact-tree-builder.ts';
 import { renderArtifactNode } from './artifact-tree-renderer.ts';
 
-test('renderArtifactNode renders a directory entry with the depth-driven indentation', () => {
-    const directory: PreviewArtifactNode = {
-        type: 'directory',
-        name: 'src',
-        path: 'src',
-        depth: 1
-    };
+suite('artifact-tree-renderer', function () {
+    test('renderArtifactNode renders a directory entry with the depth-driven indentation', function () {
+        const directory: PreviewArtifactNode = {
+            type: 'directory',
+            name: 'src',
+            path: 'src',
+            depth: 1
+        };
 
-    assert.strictEqual(
-        renderArtifactNode(directory),
-        '<li class="tree-row directory" style="--depth:1"><span class="tree-name">src/</span></li>'
-    );
-});
+        assert.strictEqual(
+            renderArtifactNode(directory),
+            '<li class="tree-row directory" style="--depth:1"><span class="tree-name">src/</span></li>'
+        );
+    });
 
-test('renderArtifactNode renders a file entry with the kind, byte size, and a status badge', () => {
-    const file: PreviewArtifactNode = {
-        type: 'file',
-        name: 'index.js',
-        path: 'src/index.js',
-        depth: 1,
-        artifact: {
+    test('renderArtifactNode renders a file entry with the kind, byte size, and a status badge', function () {
+        const file: PreviewArtifactNode = {
+            type: 'file',
+            name: 'index.js',
             path: 'src/index.js',
-            sizeBytes: 20,
-            kind: 'source',
-            sourcePath: '/src/index.js',
-            status: 'changed',
-            badges: []
-        }
-    };
-    const html = renderArtifactNode(file);
+            depth: 1,
+            artifact: {
+                path: 'src/index.js',
+                sizeBytes: 20,
+                kind: 'source',
+                sourcePath: '/src/index.js',
+                status: 'changed',
+                badges: []
+            }
+        };
+        const html = renderArtifactNode(file);
 
-    assert.ok(html.includes('class="tree-row file"'));
-    assert.ok(html.includes('<span class="tree-name">index.js</span>'));
-    assert.ok(html.includes('source · 20 B'));
-    assert.ok(html.includes('<span class="badge status-changed">changed</span>'));
-});
+        assert.ok(html.includes('class="tree-row file"'));
+        assert.ok(html.includes('<span class="tree-name">index.js</span>'));
+        assert.ok(html.includes('source · 20 B'));
+        assert.ok(html.includes('<span class="badge status-changed">changed</span>'));
+    });
 
-test('renderArtifactNode renders additional artifact badges as secondary badges', () => {
-    const file: PreviewArtifactNode = {
-        type: 'file',
-        name: 'index.js',
-        path: 'src/index.js',
-        depth: 0,
-        artifact: {
+    test('renderArtifactNode renders additional artifact badges as secondary badges', function () {
+        const file: PreviewArtifactNode = {
+            type: 'file',
+            name: 'index.js',
             path: 'src/index.js',
-            sizeBytes: 0,
-            kind: 'source',
-            sourcePath: '/src/index.js',
-            status: 'generated',
-            badges: ['import-path-rewrite']
-        }
-    };
-    const html = renderArtifactNode(file);
+            depth: 0,
+            artifact: {
+                path: 'src/index.js',
+                sizeBytes: 0,
+                kind: 'source',
+                sourcePath: '/src/index.js',
+                status: 'generated',
+                badges: ['import-path-rewrite']
+            }
+        };
+        const html = renderArtifactNode(file);
 
-    assert.ok(html.includes('<span class="badge status-generated">generated</span>'));
-    assert.ok(html.includes('<span class="badge secondary">'));
-});
+        assert.ok(html.includes('<span class="badge status-generated">generated</span>'));
+        assert.ok(html.includes('<span class="badge secondary">'));
+    });
 
-test('renderArtifactNode escapes HTML special characters in file names', () => {
-    const file: PreviewArtifactNode = {
-        type: 'file',
-        name: 'a<b>.js',
-        path: 'a<b>.js',
-        depth: 0,
-        artifact: {
+    test('renderArtifactNode escapes HTML special characters in file names', function () {
+        const file: PreviewArtifactNode = {
+            type: 'file',
+            name: 'a<b>.js',
             path: 'a<b>.js',
-            sizeBytes: 0,
-            kind: 'source',
-            sourcePath: '/src/a.js',
-            status: 'unchanged',
-            badges: []
-        }
-    };
-    const html = renderArtifactNode(file);
+            depth: 0,
+            artifact: {
+                path: 'a<b>.js',
+                sizeBytes: 0,
+                kind: 'source',
+                sourcePath: '/src/a.js',
+                status: 'unchanged',
+                badges: []
+            }
+        };
+        const html = renderArtifactNode(file);
 
-    assert.ok(html.includes('a&lt;b&gt;.js'));
+        assert.ok(html.includes('a&lt;b&gt;.js'));
+    });
 });

--- a/source/report/html-renderer/diagnostics-renderer.test.ts
+++ b/source/report/html-renderer/diagnostics-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { renderDiagnostics, renderFailureBanner } from './diagnostics-renderer.ts';
 
@@ -12,74 +12,76 @@ function packageWithDiagnostics(diagnostics: PreviewPackage['diagnostics']): Pic
     return { diagnostics };
 }
 
-test('renderDiagnostics returns an empty string when all diagnostic sections are empty', () => {
-    assert.strictEqual(renderDiagnostics(packageWithDiagnostics(emptyDiagnostics) as PreviewPackage), '');
-});
+suite('diagnostics-renderer', function () {
+    test('renderDiagnostics returns an empty string when all diagnostic sections are empty', function () {
+        assert.strictEqual(renderDiagnostics(packageWithDiagnostics(emptyDiagnostics) as PreviewPackage), '');
+    });
 
-test('renderDiagnostics renders the Inputs section when inputs are present', () => {
-    const html = renderDiagnostics(
-        packageWithDiagnostics({
-            ...emptyDiagnostics,
-            inputs: { roots: { main: 'src/index.js' }, siblingVersions: {}, sourceFileCount: 1 }
-        }) as PreviewPackage
-    );
+    test('renderDiagnostics renders the Inputs section when inputs are present', function () {
+        const html = renderDiagnostics(
+            packageWithDiagnostics({
+                ...emptyDiagnostics,
+                inputs: { roots: { main: 'src/index.js' }, siblingVersions: {}, sourceFileCount: 1 }
+            }) as PreviewPackage
+        );
 
-    assert.ok(html.includes('<summary>Inputs</summary>'));
-    assert.ok(html.includes('&quot;sourceFileCount&quot;: 1'));
-});
+        assert.ok(html.includes('<summary>Inputs</summary>'));
+        assert.ok(html.includes('&quot;sourceFileCount&quot;: 1'));
+    });
 
-test('renderDiagnostics renders the Decisions section when decisions are populated', () => {
-    const html = renderDiagnostics(
-        packageWithDiagnostics({
-            ...emptyDiagnostics,
-            decisions: { linker: { rewrites: [] } }
-        }) as PreviewPackage
-    );
+    test('renderDiagnostics renders the Decisions section when decisions are populated', function () {
+        const html = renderDiagnostics(
+            packageWithDiagnostics({
+                ...emptyDiagnostics,
+                decisions: { linker: { rewrites: [] } }
+            }) as PreviewPackage
+        );
 
-    assert.ok(html.includes('<summary>Decisions</summary>'));
-});
+        assert.ok(html.includes('<summary>Decisions</summary>'));
+    });
 
-test('renderDiagnostics renders the Outputs section when outputs are present', () => {
-    const html = renderDiagnostics(
-        packageWithDiagnostics({
-            ...emptyDiagnostics,
-            outputs: { tarball: { entries: [], totalBytes: 0 } }
-        }) as PreviewPackage
-    );
+    test('renderDiagnostics renders the Outputs section when outputs are present', function () {
+        const html = renderDiagnostics(
+            packageWithDiagnostics({
+                ...emptyDiagnostics,
+                outputs: { tarball: { entries: [], totalBytes: 0 } }
+            }) as PreviewPackage
+        );
 
-    assert.ok(html.includes('<summary>Outputs</summary>'));
-});
+        assert.ok(html.includes('<summary>Outputs</summary>'));
+    });
 
-test('renderDiagnostics renders the Timings section when timings are populated', () => {
-    const html = renderDiagnostics(
-        packageWithDiagnostics({ ...emptyDiagnostics, timings: { publish: 5 } }) as PreviewPackage
-    );
+    test('renderDiagnostics renders the Timings section when timings are populated', function () {
+        const html = renderDiagnostics(
+            packageWithDiagnostics({ ...emptyDiagnostics, timings: { publish: 5 } }) as PreviewPackage
+        );
 
-    assert.ok(html.includes('<summary>Timings (ms)</summary>'));
-});
+        assert.ok(html.includes('<summary>Timings (ms)</summary>'));
+    });
 
-test('renderDiagnostics renders the Failure section when a failure is recorded', () => {
-    const html = renderDiagnostics(
-        packageWithDiagnostics({
-            ...emptyDiagnostics,
-            failure: { stage: 'publish', message: 'boom' }
-        }) as PreviewPackage
-    );
+    test('renderDiagnostics renders the Failure section when a failure is recorded', function () {
+        const html = renderDiagnostics(
+            packageWithDiagnostics({
+                ...emptyDiagnostics,
+                failure: { stage: 'publish', message: 'boom' }
+            }) as PreviewPackage
+        );
 
-    assert.ok(html.includes('<summary>Failure</summary>'));
-});
+        assert.ok(html.includes('<summary>Failure</summary>'));
+    });
 
-test('renderFailureBanner returns an empty string when the package has no failure', () => {
-    const html = renderFailureBanner({ failure: undefined } as PreviewPackage);
+    test('renderFailureBanner returns an empty string when the package has no failure', function () {
+        const html = renderFailureBanner({ failure: undefined } as PreviewPackage);
 
-    assert.strictEqual(html, '');
-});
+        assert.strictEqual(html, '');
+    });
 
-test('renderFailureBanner renders the failure stage and message with HTML escaping', () => {
-    const html = renderFailureBanner({
-        failure: { stage: 'publish', message: 'boom <oops>' }
-    } as PreviewPackage);
+    test('renderFailureBanner renders the failure stage and message with HTML escaping', function () {
+        const html = renderFailureBanner({
+            failure: { stage: 'publish', message: 'boom <oops>' }
+        } as PreviewPackage);
 
-    assert.ok(html.includes('Failed in stage <strong>publish</strong>'));
-    assert.ok(html.includes('boom &lt;oops&gt;'));
+        assert.ok(html.includes('Failed in stage <strong>publish</strong>'));
+        assert.ok(html.includes('boom &lt;oops&gt;'));
+    });
 });

--- a/source/report/html-renderer/diff-renderer.test.ts
+++ b/source/report/html-renderer/diff-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewArtifactNode } from '../preview/artifact-tree-builder.ts';
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { renderPackageDiffs } from './diff-renderer.ts';
@@ -29,44 +29,46 @@ function packageWithTree(tree: readonly PreviewArtifactNode[]): Pick<PreviewPack
     return { tree };
 }
 
-test('renderPackageDiffs returns an empty string when no file in the tree has a diff', () => {
-    assert.strictEqual(renderPackageDiffs(packageWithTree([fileNode('a.js')]) as PreviewPackage), '');
-});
+suite('diff-renderer', function () {
+    test('renderPackageDiffs returns an empty string when no file in the tree has a diff', function () {
+        assert.strictEqual(renderPackageDiffs(packageWithTree([fileNode('a.js')]) as PreviewPackage), '');
+    });
 
-test('renderPackageDiffs renders a Changed files section when at least one file has a diff', () => {
-    const file: PreviewArtifactNode = {
-        type: 'file',
-        name: 'a.js',
-        path: 'src/a.js',
-        depth: 0,
-        artifact: {
+    test('renderPackageDiffs renders a Changed files section when at least one file has a diff', function () {
+        const file: PreviewArtifactNode = {
+            type: 'file',
+            name: 'a.js',
             path: 'src/a.js',
-            sizeBytes: 0,
-            kind: 'source',
-            sourcePath: '/src/a.js',
-            status: 'changed',
-            badges: [],
-            diff: [
-                {
-                    header: '@@ -1,1 +1,1 @@',
-                    lines: [
-                        { type: 'remove', text: '-old' },
-                        { type: 'add', text: '+new' }
-                    ]
-                }
-            ]
-        }
-    };
-    const html = renderPackageDiffs(packageWithTree([file]) as PreviewPackage);
+            depth: 0,
+            artifact: {
+                path: 'src/a.js',
+                sizeBytes: 0,
+                kind: 'source',
+                sourcePath: '/src/a.js',
+                status: 'changed',
+                badges: [],
+                diff: [
+                    {
+                        header: '@@ -1,1 +1,1 @@',
+                        lines: [
+                            { type: 'remove', text: '-old' },
+                            { type: 'add', text: '+new' }
+                        ]
+                    }
+                ]
+            }
+        };
+        const html = renderPackageDiffs(packageWithTree([file]) as PreviewPackage);
 
-    assert.ok(html.includes('<h3>Changed files</h3>'));
-    assert.ok(html.includes('<summary>src/a.js</summary>'));
-    assert.ok(html.includes('@@ -1,1 +1,1 @@'));
-    assert.ok(html.includes('<div class="diff-line remove">-old</div>'));
-    assert.ok(html.includes('<div class="diff-line add">+new</div>'));
-});
+        assert.ok(html.includes('<h3>Changed files</h3>'));
+        assert.ok(html.includes('<summary>src/a.js</summary>'));
+        assert.ok(html.includes('@@ -1,1 +1,1 @@'));
+        assert.ok(html.includes('<div class="diff-line remove">-old</div>'));
+        assert.ok(html.includes('<div class="diff-line add">+new</div>'));
+    });
 
-test('renderPackageDiffs ignores directory nodes when collecting diffs', () => {
-    const dirNode: PreviewArtifactNode = { type: 'directory', name: 'src', path: 'src', depth: 0 };
-    assert.strictEqual(renderPackageDiffs(packageWithTree([dirNode]) as PreviewPackage), '');
+    test('renderPackageDiffs ignores directory nodes when collecting diffs', function () {
+        const dirNode: PreviewArtifactNode = { type: 'directory', name: 'src', path: 'src', depth: 0 };
+        assert.strictEqual(renderPackageDiffs(packageWithTree([dirNode]) as PreviewPackage), '');
+    });
 });

--- a/source/report/html-renderer/eliminated-files-renderer.test.ts
+++ b/source/report/html-renderer/eliminated-files-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { renderEliminatedFiles } from './eliminated-files-renderer.ts';
 
@@ -9,29 +9,31 @@ function previewPackage(
     return { eliminatedSourceFiles };
 }
 
-test('renderEliminatedFiles returns an empty string when the package has no eliminated files', () => {
-    assert.strictEqual(renderEliminatedFiles(previewPackage([]) as PreviewPackage), '');
-});
+suite('eliminated-files-renderer', function () {
+    test('renderEliminatedFiles returns an empty string when the package has no eliminated files', function () {
+        assert.strictEqual(renderEliminatedFiles(previewPackage([]) as PreviewPackage), '');
+    });
 
-test('renderEliminatedFiles renders a single eliminated source file with formatted bytes', () => {
-    const html = renderEliminatedFiles(
-        previewPackage([{ path: '/src/dead.js', sourceBytes: 42, reason: 'no-uses' }]) as PreviewPackage
-    );
+    test('renderEliminatedFiles renders a single eliminated source file with formatted bytes', function () {
+        const html = renderEliminatedFiles(
+            previewPackage([{ path: '/src/dead.js', sourceBytes: 42, reason: 'no-uses' }]) as PreviewPackage
+        );
 
-    assert.ok(html.includes('<h3>Eliminated source files</h3>'));
-    assert.ok(html.includes('<code>/src/dead.js</code>'));
-    assert.ok(html.includes('42 B'));
-});
+        assert.ok(html.includes('<h3>Eliminated source files</h3>'));
+        assert.ok(html.includes('<code>/src/dead.js</code>'));
+        assert.ok(html.includes('42 B'));
+    });
 
-test('renderEliminatedFiles renders multiple eliminated source files in order', () => {
-    const html = renderEliminatedFiles(
-        previewPackage([
-            { path: '/src/a.js', sourceBytes: 10, reason: 'no-uses' },
-            { path: '/src/b.js', sourceBytes: 20, reason: 'no-uses' }
-        ]) as PreviewPackage
-    );
+    test('renderEliminatedFiles renders multiple eliminated source files in order', function () {
+        const html = renderEliminatedFiles(
+            previewPackage([
+                { path: '/src/a.js', sourceBytes: 10, reason: 'no-uses' },
+                { path: '/src/b.js', sourceBytes: 20, reason: 'no-uses' }
+            ]) as PreviewPackage
+        );
 
-    const positionOfA = html.indexOf('/src/a.js');
-    const positionOfB = html.indexOf('/src/b.js');
-    assert.ok(positionOfA !== -1 && positionOfB > positionOfA);
+        const positionOfA = html.indexOf('/src/a.js');
+        const positionOfB = html.indexOf('/src/b.js');
+        assert.ok(positionOfA !== -1 && positionOfB > positionOfA);
+    });
 });

--- a/source/report/html-renderer/html-escaping.test.ts
+++ b/source/report/html-renderer/html-escaping.test.ts
@@ -1,27 +1,29 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { escapeHtml } from './html-escaping.ts';
 
-test('escapeHtml returns plain text unchanged when no special characters are present', () => {
-    assert.strictEqual(escapeHtml('hello world'), 'hello world');
-});
+suite('html-escaping', function () {
+    test('escapeHtml returns plain text unchanged when no special characters are present', function () {
+        assert.strictEqual(escapeHtml('hello world'), 'hello world');
+    });
 
-test('escapeHtml escapes ampersand before any other character', () => {
-    assert.strictEqual(escapeHtml('A & B'), 'A &amp; B');
-});
+    test('escapeHtml escapes ampersand before any other character', function () {
+        assert.strictEqual(escapeHtml('A & B'), 'A &amp; B');
+    });
 
-test('escapeHtml escapes less-than and greater-than characters', () => {
-    assert.strictEqual(escapeHtml('<tag>'), '&lt;tag&gt;');
-});
+    test('escapeHtml escapes less-than and greater-than characters', function () {
+        assert.strictEqual(escapeHtml('<tag>'), '&lt;tag&gt;');
+    });
 
-test('escapeHtml escapes double quotes and single quotes', () => {
-    assert.strictEqual(escapeHtml('"hello" \'world\''), '&quot;hello&quot; &#39;world&#39;');
-});
+    test('escapeHtml escapes double quotes and single quotes', function () {
+        assert.strictEqual(escapeHtml('"hello" \'world\''), '&quot;hello&quot; &#39;world&#39;');
+    });
 
-test('escapeHtml escapes every occurrence of a special character', () => {
-    assert.strictEqual(escapeHtml('<<>>'), '&lt;&lt;&gt;&gt;');
-});
+    test('escapeHtml escapes every occurrence of a special character', function () {
+        assert.strictEqual(escapeHtml('<<>>'), '&lt;&lt;&gt;&gt;');
+    });
 
-test('escapeHtml does not double-escape an existing entity-like substring', () => {
-    assert.strictEqual(escapeHtml('&amp;'), '&amp;amp;');
+    test('escapeHtml does not double-escape an existing entity-like substring', function () {
+        assert.strictEqual(escapeHtml('&amp;'), '&amp;amp;');
+    });
 });

--- a/source/report/html-renderer/html-primitives.test.ts
+++ b/source/report/html-renderer/html-primitives.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     formatBytes,
     renderBadge,
@@ -9,43 +9,48 @@ import {
     serializeJsonBlock
 } from './html-primitives.ts';
 
-test('formatBytes appends the unit suffix to the byte count', () => {
-    assert.strictEqual(formatBytes(0), '0 B');
-});
+suite('html-primitives', function () {
+    test('formatBytes appends the unit suffix to the byte count', function () {
+        assert.strictEqual(formatBytes(0), '0 B');
+    });
 
-test('formatBytes preserves the numeric value verbatim', () => {
-    assert.strictEqual(formatBytes(1024), '1024 B');
-});
+    test('formatBytes preserves the numeric value verbatim', function () {
+        assert.strictEqual(formatBytes(1024), '1024 B');
+    });
 
-test('renderBadge wraps the label in a span with the merged class name', () => {
-    assert.strictEqual(renderBadge('changed', 'status-changed'), '<span class="badge status-changed">changed</span>');
-});
+    test('renderBadge wraps the label in a span with the merged class name', function () {
+        assert.strictEqual(
+            renderBadge('changed', 'status-changed'),
+            '<span class="badge status-changed">changed</span>'
+        );
+    });
 
-test('renderBadge escapes HTML in the label', () => {
-    assert.strictEqual(renderBadge('<bad>', 'secondary'), '<span class="badge secondary">&lt;bad&gt;</span>');
-});
+    test('renderBadge escapes HTML in the label', function () {
+        assert.strictEqual(renderBadge('<bad>', 'secondary'), '<span class="badge secondary">&lt;bad&gt;</span>');
+    });
 
-test('renderSummaryCard renders a card with the label and value', () => {
-    assert.strictEqual(
-        renderSummaryCard('Packages', 3),
-        '<div class="summary-card"><span class="summary-label">Packages</span><strong>3</strong></div>'
-    );
-});
+    test('renderSummaryCard renders a card with the label and value', function () {
+        assert.strictEqual(
+            renderSummaryCard('Packages', 3),
+            '<div class="summary-card"><span class="summary-label">Packages</span><strong>3</strong></div>'
+        );
+    });
 
-test('renderIssuesSection wraps the supplied list items in an Issues section', () => {
-    assert.strictEqual(
-        renderIssuesSection('<li>boom</li>'),
-        '<section class="issues"><h2>Issues</h2><ul><li>boom</li></ul></section>'
-    );
-});
+    test('renderIssuesSection wraps the supplied list items in an Issues section', function () {
+        assert.strictEqual(
+            renderIssuesSection('<li>boom</li>'),
+            '<section class="issues"><h2>Issues</h2><ul><li>boom</li></ul></section>'
+        );
+    });
 
-test('serializeJsonBlock returns a stable two-space indented JSON string', () => {
-    assert.strictEqual(serializeJsonBlock({ a: 1, b: [2, 3] }), '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}');
-});
+    test('serializeJsonBlock returns a stable two-space indented JSON string', function () {
+        assert.strictEqual(serializeJsonBlock({ a: 1, b: [2, 3] }), '{\n  "a": 1,\n  "b": [\n    2,\n    3\n  ]\n}');
+    });
 
-test('renderCollapsibleSection wraps the JSON-encoded value in an escaped <pre> inside <details>', () => {
-    assert.strictEqual(
-        renderCollapsibleSection('Inputs', { foo: 'bar' }),
-        '<details class="diagnostic secondary"><summary>Inputs</summary><pre>{\n  &quot;foo&quot;: &quot;bar&quot;\n}</pre></details>'
-    );
+    test('renderCollapsibleSection wraps the JSON-encoded value in an escaped <pre> inside <details>', function () {
+        assert.strictEqual(
+            renderCollapsibleSection('Inputs', { foo: 'bar' }),
+            '<details class="diagnostic secondary"><summary>Inputs</summary><pre>{\n  &quot;foo&quot;: &quot;bar&quot;\n}</pre></details>'
+        );
+    });
 });

--- a/source/report/html-renderer/html-renderer.test.ts
+++ b/source/report/html-renderer/html-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     createBuildReportFixture,
     createDirectoryDiffPreviewPackageFixture,
@@ -19,162 +19,164 @@ function decodeHtmlEntities(value: string): string {
         .replaceAll('&amp;', '&');
 }
 
-test('renders a doctype and html skeleton', () => {
-    const html = renderHtmlReport(createPreviewDocumentFixture());
+suite('html-renderer', function () {
+    test('renders a doctype and html skeleton', function () {
+        const html = renderHtmlReport(createPreviewDocumentFixture());
 
-    assert.match(html, /^<!doctype html>/);
-    assert.ok(html.includes('<title>Packtory build report</title>'));
-    assert.match(html, /<style>[\s\S]*color-scheme: light;[\s\S]*\.summary-card[\s\S]*<\/style>/u);
-});
+        assert.match(html, /^<!doctype html>/);
+        assert.ok(html.includes('<title>Packtory build report</title>'));
+        assert.match(html, /<style>[\s\S]*color-scheme: light;[\s\S]*\.summary-card[\s\S]*<\/style>/u);
+    });
 
-test('renders summary cards, package sections, tree metadata, and diff hunks', () => {
-    const html = renderHtmlReport(createPreviewDocumentFixture());
+    test('renders summary cards, package sections, tree metadata, and diff hunks', function () {
+        const html = renderHtmlReport(createPreviewDocumentFixture());
 
-    assert.match(
-        html,
-        /<section class="summary">[\s\S]*<span class="summary-label">Packages<\/span><strong>1<\/strong>[\s\S]*<span class="summary-label">Changed<\/span><strong>1<\/strong>[\s\S]*<span class="summary-label">Unchanged<\/span><strong>0<\/strong>[\s\S]*<span class="summary-label">Failed<\/span><strong>0<\/strong>[\s\S]*<span class="summary-label">Artifacts<\/span><strong>2<\/strong>[\s\S]*<span class="summary-label">Changed files<\/span><strong>1<\/strong>[\s\S]*<span class="summary-label">Eliminated<\/span><strong>1<\/strong>[\s\S]*<\/section>/u
-    );
-    assert.match(
-        html,
-        /<details class="package" open>[\s\S]*<span class="package-title">pkg-a<\/span>[\s\S]*<span class="badge status-changed">changed<\/span>[\s\S]*<span class="badge secondary">1\.0\.0 -&gt; 1\.0\.1<\/span>[\s\S]*<\/details>/u
-    );
-    assert.ok(
-        [
-            '<ul class="tree"><li class="tree-row file" style="--depth:0">',
-            '<span class="tree-name">package.json</span>',
-            '<span class="tree-meta">manifest · 2 B</span>',
-            '<span class="badge status-generated">generated</span>',
-            '<li class="tree-row directory" style="--depth:0"><span class="tree-name">src/</span></li>',
-            '<span class="tree-name">index.js</span>',
-            '<span class="tree-meta">source · 20 B</span>',
-            '<span class="badge status-changed">changed</span>',
-            '<span class="badge secondary">DCE</span>'
-        ].every((fragment) => html.includes(fragment))
-    );
-    assert.match(
-        html,
-        /<section class="package-block"><h3>Changed files<\/h3>[\s\S]*<summary>src\/index\.js<\/summary>[\s\S]*@@ -1,1 \+1,1 @@[\s\S]*-export const removed = 1;[\s\S]*\+export const kept = 1;[\s\S]*<\/section>/u
-    );
-    assert.match(
-        html,
-        /<section class="package-block">[\s\S]*<h3>Eliminated source files<\/h3>[\s\S]*\/workspace\/src\/unused\.js[\s\S]*14 B[\s\S]*<\/section>/u
-    );
-    assert.ok(!html.includes('Stryker was here'));
-});
+        assert.match(
+            html,
+            /<section class="summary">[\s\S]*<span class="summary-label">Packages<\/span><strong>1<\/strong>[\s\S]*<span class="summary-label">Changed<\/span><strong>1<\/strong>[\s\S]*<span class="summary-label">Unchanged<\/span><strong>0<\/strong>[\s\S]*<span class="summary-label">Failed<\/span><strong>0<\/strong>[\s\S]*<span class="summary-label">Artifacts<\/span><strong>2<\/strong>[\s\S]*<span class="summary-label">Changed files<\/span><strong>1<\/strong>[\s\S]*<span class="summary-label">Eliminated<\/span><strong>1<\/strong>[\s\S]*<\/section>/u
+        );
+        assert.match(
+            html,
+            /<details class="package" open>[\s\S]*<span class="package-title">pkg-a<\/span>[\s\S]*<span class="badge status-changed">changed<\/span>[\s\S]*<span class="badge secondary">1\.0\.0 -&gt; 1\.0\.1<\/span>[\s\S]*<\/details>/u
+        );
+        assert.ok(
+            [
+                '<ul class="tree"><li class="tree-row file" style="--depth:0">',
+                '<span class="tree-name">package.json</span>',
+                '<span class="tree-meta">manifest · 2 B</span>',
+                '<span class="badge status-generated">generated</span>',
+                '<li class="tree-row directory" style="--depth:0"><span class="tree-name">src/</span></li>',
+                '<span class="tree-name">index.js</span>',
+                '<span class="tree-meta">source · 20 B</span>',
+                '<span class="badge status-changed">changed</span>',
+                '<span class="badge secondary">DCE</span>'
+            ].every((fragment) => html.includes(fragment))
+        );
+        assert.match(
+            html,
+            /<section class="package-block"><h3>Changed files<\/h3>[\s\S]*<summary>src\/index\.js<\/summary>[\s\S]*@@ -1,1 \+1,1 @@[\s\S]*-export const removed = 1;[\s\S]*\+export const kept = 1;[\s\S]*<\/section>/u
+        );
+        assert.match(
+            html,
+            /<section class="package-block">[\s\S]*<h3>Eliminated source files<\/h3>[\s\S]*\/workspace\/src\/unused\.js[\s\S]*14 B[\s\S]*<\/section>/u
+        );
+        assert.ok(!html.includes('Stryker was here'));
+    });
 
-test('opens changed packages by default and collapses unchanged ones', () => {
-    const changedHtml = renderHtmlReport(createPreviewDocumentFixture());
-    const unchangedHtml = renderHtmlReport(
-        createPreviewDocumentFixture({
-            packages: [createPreviewPackageFixture({ hasChanges: false, openByDefault: false })]
-        })
-    );
+    test('opens changed packages by default and collapses unchanged ones', function () {
+        const changedHtml = renderHtmlReport(createPreviewDocumentFixture());
+        const unchangedHtml = renderHtmlReport(
+            createPreviewDocumentFixture({
+                packages: [createPreviewPackageFixture({ hasChanges: false, openByDefault: false })]
+            })
+        );
 
-    assert.ok(changedHtml.includes('<details class="package" open>'));
-    assert.ok(unchangedHtml.includes('<details class="package">'));
-});
+        assert.ok(changedHtml.includes('<details class="package" open>'));
+        assert.ok(unchangedHtml.includes('<details class="package">'));
+    });
 
-test('renders issues and diagnostics sections', () => {
-    const html = renderHtmlReport(
-        createPreviewDocumentFixture({
-            issues: ['<bad>'],
-            packages: [
-                createPreviewPackageFixture({
-                    diagnostics: {
-                        inputs: { roots: { main: 'src/index.js' }, siblingVersions: {}, sourceFileCount: 1 },
-                        decisions: { linker: { rewrites: [] } },
-                        outputs: { tarball: { entries: [], totalBytes: 0 } },
-                        timings: { publish: 5 },
-                        failure: { stage: 'publish', message: 'secondary' }
+    test('renders issues and diagnostics sections', function () {
+        const html = renderHtmlReport(
+            createPreviewDocumentFixture({
+                issues: ['<bad>'],
+                packages: [
+                    createPreviewPackageFixture({
+                        diagnostics: {
+                            inputs: { roots: { main: 'src/index.js' }, siblingVersions: {}, sourceFileCount: 1 },
+                            decisions: { linker: { rewrites: [] } },
+                            outputs: { tarball: { entries: [], totalBytes: 0 } },
+                            timings: { publish: 5 },
+                            failure: { stage: 'publish', message: 'secondary' }
+                        }
+                    })
+                ]
+            })
+        );
+
+        assert.ok(html.includes('<h2>Issues</h2>'));
+        assert.ok(html.includes('<summary>Inputs</summary>'));
+        assert.ok(html.includes('<summary>Decisions</summary>'));
+        assert.ok(html.includes('<summary>Outputs</summary>'));
+        assert.ok(html.includes('<summary>Timings (ms)</summary>'));
+        assert.ok(html.includes('<summary>Failure</summary>'));
+        assert.ok(html.includes('&lt;bad&gt;'));
+        assert.match(html, /<pre>\{\n {2}&quot;roots&quot;:/u);
+        assert.ok(!html.includes('Stryker was here'));
+    });
+
+    test('renders a failure paragraph when the package failed', function () {
+        const html = renderHtmlReport(
+            createPreviewDocumentFixture({
+                packages: [createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } })]
+            })
+        );
+
+        assert.ok(html.includes('Failed in stage <strong>publish</strong>: boom'));
+    });
+
+    test('omits eliminated, diff, and diagnostics blocks when the package has none', function () {
+        const html = renderHtmlReport(
+            createPreviewDocumentFixture({
+                packages: [createManifestOnlyPreviewPackageFixture()]
+            })
+        );
+
+        assert.ok(!html.includes('Eliminated source files'));
+        assert.ok(!html.includes('<h3>Changed files</h3>'));
+        assert.ok(!html.includes('Diagnostics'));
+        assert.ok(!html.includes('<h2>Issues</h2>'));
+        assert.ok(!html.includes('Stryker was here'));
+    });
+
+    test('embeds the entire BuildReport as escaped JSON in the data script tag', function () {
+        const document = createPreviewDocumentFixture();
+        const html = renderHtmlReport(document);
+
+        const scriptMatch =
+            /<script type="application\/json" id="packtory-report-data">(?<encoded>[\s\S]*?)<\/script>/u.exec(html);
+        const encoded = scriptMatch?.groups?.encoded;
+        if (encoded === undefined) {
+            assert.fail('expected packtory-report-data script tag');
+        }
+        assert.deepStrictEqual(JSON.parse(decodeHtmlEntities(encoded)), document.report);
+    });
+
+    test('renders package names from the provided report', function () {
+        const html = renderHtmlReport(
+            createPreviewDocumentFixture({
+                report: createBuildReportFixture({
+                    packages: {
+                        'pkg-a': { decisions: {}, timings: {} }
                     }
                 })
-            ]
-        })
-    );
-
-    assert.ok(html.includes('<h2>Issues</h2>'));
-    assert.ok(html.includes('<summary>Inputs</summary>'));
-    assert.ok(html.includes('<summary>Decisions</summary>'));
-    assert.ok(html.includes('<summary>Outputs</summary>'));
-    assert.ok(html.includes('<summary>Timings (ms)</summary>'));
-    assert.ok(html.includes('<summary>Failure</summary>'));
-    assert.ok(html.includes('&lt;bad&gt;'));
-    assert.match(html, /<pre>\{\n {2}&quot;roots&quot;:/u);
-    assert.ok(!html.includes('Stryker was here'));
-});
-
-test('renders a failure paragraph when the package failed', () => {
-    const html = renderHtmlReport(
-        createPreviewDocumentFixture({
-            packages: [createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } })]
-        })
-    );
-
-    assert.ok(html.includes('Failed in stage <strong>publish</strong>: boom'));
-});
-
-test('omits eliminated, diff, and diagnostics blocks when the package has none', () => {
-    const html = renderHtmlReport(
-        createPreviewDocumentFixture({
-            packages: [createManifestOnlyPreviewPackageFixture()]
-        })
-    );
-
-    assert.ok(!html.includes('Eliminated source files'));
-    assert.ok(!html.includes('<h3>Changed files</h3>'));
-    assert.ok(!html.includes('Diagnostics'));
-    assert.ok(!html.includes('<h2>Issues</h2>'));
-    assert.ok(!html.includes('Stryker was here'));
-});
-
-test('embeds the entire BuildReport as escaped JSON in the data script tag', () => {
-    const document = createPreviewDocumentFixture();
-    const html = renderHtmlReport(document);
-
-    const scriptMatch =
-        /<script type="application\/json" id="packtory-report-data">(?<encoded>[\s\S]*?)<\/script>/u.exec(html);
-    const encoded = scriptMatch?.groups?.encoded;
-    if (encoded === undefined) {
-        assert.fail('expected packtory-report-data script tag');
-    }
-    assert.deepStrictEqual(JSON.parse(decodeHtmlEntities(encoded)), document.report);
-});
-
-test('renders package names from the provided report', () => {
-    const html = renderHtmlReport(
-        createPreviewDocumentFixture({
-            report: createBuildReportFixture({
-                packages: {
-                    'pkg-a': { decisions: {}, timings: {} }
-                }
             })
-        })
-    );
+        );
 
-    assert.ok(html.includes('pkg-a'));
-});
+        assert.ok(html.includes('pkg-a'));
+    });
 
-test('escapeHtml escapes ampersands and apostrophes', () => {
-    assert.strictEqual(escapeHtml("Tom & 'Jerry' <tag>"), 'Tom &amp; &#39;Jerry&#39; &lt;tag&gt;');
-});
+    test('escapeHtml escapes ampersands and apostrophes', function () {
+        assert.strictEqual(escapeHtml("Tom & 'Jerry' <tag>"), 'Tom &amp; &#39;Jerry&#39; &lt;tag&gt;');
+    });
 
-test('renderHtmlReport only renders diff sections for file nodes and omits empty package joins', () => {
-    const html = renderHtmlReport(
-        createPreviewDocumentFixture({
-            packages: [
-                createDirectoryDiffPreviewPackageFixture({
-                    hasChanges: false
-                }),
-                createManifestOnlyPreviewPackageFixture({
-                    name: 'pkg-b',
-                    hasChanges: false
-                })
-            ]
-        })
-    );
+    test('renderHtmlReport only renders diff sections for file nodes and omits empty package joins', function () {
+        const html = renderHtmlReport(
+            createPreviewDocumentFixture({
+                packages: [
+                    createDirectoryDiffPreviewPackageFixture({
+                        hasChanges: false
+                    }),
+                    createManifestOnlyPreviewPackageFixture({
+                        name: 'pkg-b',
+                        hasChanges: false
+                    })
+                ]
+            })
+        );
 
-    assert.ok(!html.includes('<summary>src/index.js</summary>'));
-    assert.ok(html.includes('<span class="badge status-unchanged">unchanged</span>'));
-    assert.ok(html.includes('pkg-b'));
-    assert.ok(!html.includes('Stryker was here'));
+        assert.ok(!html.includes('<summary>src/index.js</summary>'));
+        assert.ok(html.includes('<span class="badge status-unchanged">unchanged</span>'));
+        assert.ok(html.includes('pkg-b'));
+        assert.ok(!html.includes('Stryker was here'));
+    });
 });

--- a/source/report/html-renderer/html-styles.test.ts
+++ b/source/report/html-renderer/html-styles.test.ts
@@ -1,15 +1,17 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { htmlReportStyles } from './html-styles.ts';
 
-test('htmlReportStyles declares the light color scheme', () => {
-    assert.match(htmlReportStyles, /color-scheme: light;/u);
-});
+suite('html-styles', function () {
+    test('htmlReportStyles declares the light color scheme', function () {
+        assert.match(htmlReportStyles, /color-scheme: light;/u);
+    });
 
-test('htmlReportStyles defines the summary-card style block', () => {
-    assert.match(htmlReportStyles, /\.summary-card\s*\{/u);
-});
+    test('htmlReportStyles defines the summary-card style block', function () {
+        assert.match(htmlReportStyles, /\.summary-card\s*\{/u);
+    });
 
-test('htmlReportStyles defines the changed-status badge color', () => {
-    assert.match(htmlReportStyles, /\.badge\.status-changed/u);
+    test('htmlReportStyles defines the changed-status badge color', function () {
+        assert.match(htmlReportStyles, /\.badge\.status-changed/u);
+    });
 });

--- a/source/report/html-renderer/package-renderer.test.ts
+++ b/source/report/html-renderer/package-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { renderPackage } from './package-renderer.ts';
 
@@ -20,51 +20,53 @@ function minimalPackage(overrides: Partial<PreviewPackage> = {}): PreviewPackage
     };
 }
 
-test('renderPackage marks the changed badge when the package has changes', () => {
-    const html = renderPackage(minimalPackage({ hasChanges: true, openByDefault: true }));
+suite('package-renderer', function () {
+    test('renderPackage marks the changed badge when the package has changes', function () {
+        const html = renderPackage(minimalPackage({ hasChanges: true, openByDefault: true }));
 
-    assert.ok(html.includes('<details class="package" open>'));
-    assert.ok(html.includes('<span class="badge status-changed">changed</span>'));
-});
+        assert.ok(html.includes('<details class="package" open>'));
+        assert.ok(html.includes('<span class="badge status-changed">changed</span>'));
+    });
 
-test('renderPackage marks the unchanged badge when the package has no changes', () => {
-    const html = renderPackage(minimalPackage({ hasChanges: false }));
+    test('renderPackage marks the unchanged badge when the package has no changes', function () {
+        const html = renderPackage(minimalPackage({ hasChanges: false }));
 
-    assert.ok(html.includes('<span class="badge status-unchanged">unchanged</span>'));
-});
+        assert.ok(html.includes('<span class="badge status-unchanged">unchanged</span>'));
+    });
 
-test('renderPackage renders the version transition badge when supplied', () => {
-    const html = renderPackage(minimalPackage({ versionTransition: '1.0.0 -> 1.0.1' }));
+    test('renderPackage renders the version transition badge when supplied', function () {
+        const html = renderPackage(minimalPackage({ versionTransition: '1.0.0 -> 1.0.1' }));
 
-    assert.ok(html.includes('<span class="badge secondary">1.0.0 -&gt; 1.0.1</span>'));
-});
+        assert.ok(html.includes('<span class="badge secondary">1.0.0 -&gt; 1.0.1</span>'));
+    });
 
-test('renderPackage renders the failure banner when the package has a failure', () => {
-    const html = renderPackage(minimalPackage({ failure: { stage: 'publish', message: 'boom' } }));
+    test('renderPackage renders the failure banner when the package has a failure', function () {
+        const html = renderPackage(minimalPackage({ failure: { stage: 'publish', message: 'boom' } }));
 
-    assert.ok(html.includes('Failed in stage <strong>publish</strong>: boom'));
-});
+        assert.ok(html.includes('Failed in stage <strong>publish</strong>: boom'));
+    });
 
-test('renderPackage omits the Changed files section when the tree contains no diffs', () => {
-    const html = renderPackage(minimalPackage());
+    test('renderPackage omits the Changed files section when the tree contains no diffs', function () {
+        const html = renderPackage(minimalPackage());
 
-    assert.ok(!html.includes('<h3>Changed files</h3>'));
-});
+        assert.ok(!html.includes('<h3>Changed files</h3>'));
+    });
 
-test('renderPackage omits the Eliminated source files section when none are present', () => {
-    const html = renderPackage(minimalPackage());
+    test('renderPackage omits the Eliminated source files section when none are present', function () {
+        const html = renderPackage(minimalPackage());
 
-    assert.ok(!html.includes('Eliminated source files'));
-});
+        assert.ok(!html.includes('Eliminated source files'));
+    });
 
-test('renderPackage omits the Diagnostics section when every diagnostic group is empty', () => {
-    const html = renderPackage(minimalPackage());
+    test('renderPackage omits the Diagnostics section when every diagnostic group is empty', function () {
+        const html = renderPackage(minimalPackage());
 
-    assert.ok(!html.includes('Diagnostics'));
-});
+        assert.ok(!html.includes('Diagnostics'));
+    });
 
-test('renderPackage escapes special characters in the package name', () => {
-    const html = renderPackage(minimalPackage({ name: '<scary>' }));
+    test('renderPackage escapes special characters in the package name', function () {
+        const html = renderPackage(minimalPackage({ name: '<scary>' }));
 
-    assert.ok(html.includes('<span class="package-title">&lt;scary&gt;</span>'));
+        assert.ok(html.includes('<span class="package-title">&lt;scary&gt;</span>'));
+    });
 });

--- a/source/report/inspectors/inspect-artifact-sizes.test.ts
+++ b/source/report/inspectors/inspect-artifact-sizes.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { FileDescription } from '../../file-manager/file-description.ts';
 import { inspectArtifactSizes } from './inspect-artifact-sizes.ts';
 
@@ -7,157 +7,159 @@ function description(filePath: string, content = ''): FileDescription {
     return { filePath, content, isExecutable: false };
 }
 
-test('inspectArtifactSizes maps file paths and content lengths', () => {
-    const entries = inspectArtifactSizes([
-        { filePath: 'package.json', content: '{"name":"a"}', isExecutable: false },
-        {
-            filePath: 'src/index.js',
-            content: 'export const a = 1;',
-            isExecutable: false,
-            sourceFilePath: '/workspace/src/index.js'
-        }
-    ]);
+suite('inspect-artifact-sizes', function () {
+    test('inspectArtifactSizes maps file paths and content lengths', function () {
+        const entries = inspectArtifactSizes([
+            { filePath: 'package.json', content: '{"name":"a"}', isExecutable: false },
+            {
+                filePath: 'src/index.js',
+                content: 'export const a = 1;',
+                isExecutable: false,
+                sourceFilePath: '/workspace/src/index.js'
+            }
+        ]);
 
-    assert.deepStrictEqual(entries, [
-        { path: 'package.json', sizeBytes: 12, kind: 'manifest', status: 'generated', badges: [] },
-        {
-            path: 'src/index.js',
-            sizeBytes: 19,
-            kind: 'source',
-            sourcePath: '/workspace/src/index.js',
-            status: 'unchanged',
-            badges: []
-        }
-    ]);
-});
-
-test('inspectArtifactSizes classifies a nested package.json as manifest', () => {
-    const [entry] = inspectArtifactSizes([description('nested/dir/package.json')]);
-    assert.strictEqual(entry?.kind, 'manifest');
-});
-
-test('inspectArtifactSizes does NOT classify a sibling-suffixed package.json as manifest', () => {
-    const [entry] = inspectArtifactSizes([description('inner-package.json')]);
-    assert.notStrictEqual(entry?.kind, 'manifest');
-});
-
-test('inspectArtifactSizes recognizes sbom files', () => {
-    const entries = inspectArtifactSizes([
-        { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false },
-        { filePath: 'project.sbom.json', content: '{}', isExecutable: false }
-    ]);
-
-    assert.deepStrictEqual(
-        entries.map((entry) => {
-            return entry.kind;
-        }),
-        ['sbom', 'sbom']
-    );
-});
-
-test('inspectArtifactSizes treats unknown files as additional', () => {
-    const entries = inspectArtifactSizes([{ filePath: 'README.md', content: '# hi', isExecutable: false }]);
-
-    assert.strictEqual(entries[0]?.kind, 'additional');
-});
-
-test('inspectArtifactSizes does not classify a generic .json as source', () => {
-    const [entry] = inspectArtifactSizes([description('data.json')]);
-    assert.strictEqual(entry?.kind, 'additional');
-});
-
-test('inspectArtifactSizes classifies .js as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.js')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .cjs as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.cjs')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .mjs as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.mjs')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .ts as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.ts')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .tsx as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.tsx')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .jsx as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.jsx')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .d.ts as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.d.ts')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .d.cts as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.d.cts')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .d.mts as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.d.mts')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes classifies .map as source', () => {
-    const [entry] = inspectArtifactSizes([description('a.js.map')]);
-    assert.strictEqual(entry?.kind, 'source');
-});
-
-test('inspectArtifactSizes returns utf-8 byte length for multi-byte content', () => {
-    const entries = inspectArtifactSizes([{ filePath: 'note.txt', content: '✓', isExecutable: false }]);
-
-    assert.strictEqual(entries[0]?.sizeBytes, 3);
-});
-
-test('inspectArtifactSizes reports zero bytes for empty content', () => {
-    const [entry] = inspectArtifactSizes([description('file.txt', '')]);
-    assert.strictEqual(entry?.sizeBytes, 0);
-});
-
-test('inspectArtifactSizes preserves the original file path on each entry', () => {
-    const [entry] = inspectArtifactSizes([description('deep/nested/file.js')]);
-    assert.strictEqual(entry?.path, 'deep/nested/file.js');
-});
-
-test('inspectArtifactSizes marks a substituted source file as changed with an import rewrite badge', () => {
-    const [entry] = inspectArtifactSizes([
-        {
-            filePath: 'deep/nested/file.js',
-            content: 'export {};',
-            isExecutable: false,
-            sourceFilePath: '/workspace/src/file.js',
-            isSubstituted: true
-        }
-    ]);
-
-    assert.deepStrictEqual(entry, {
-        path: 'deep/nested/file.js',
-        sizeBytes: 10,
-        kind: 'source',
-        sourcePath: '/workspace/src/file.js',
-        status: 'changed',
-        badges: ['import-path-rewrite']
+        assert.deepStrictEqual(entries, [
+            { path: 'package.json', sizeBytes: 12, kind: 'manifest', status: 'generated', badges: [] },
+            {
+                path: 'src/index.js',
+                sizeBytes: 19,
+                kind: 'source',
+                sourcePath: '/workspace/src/index.js',
+                status: 'unchanged',
+                badges: []
+            }
+        ]);
     });
-});
 
-test('inspectArtifactSizes returns one entry per input descriptor', () => {
-    const entries = inspectArtifactSizes([
-        description('a.js', 'a'),
-        description('b.ts', 'bb'),
-        description('c.txt', 'ccc')
-    ]);
-    assert.strictEqual(entries.length, 3);
+    test('inspectArtifactSizes classifies a nested package.json as manifest', function () {
+        const [entry] = inspectArtifactSizes([description('nested/dir/package.json')]);
+        assert.strictEqual(entry?.kind, 'manifest');
+    });
+
+    test('inspectArtifactSizes does NOT classify a sibling-suffixed package.json as manifest', function () {
+        const [entry] = inspectArtifactSizes([description('inner-package.json')]);
+        assert.notStrictEqual(entry?.kind, 'manifest');
+    });
+
+    test('inspectArtifactSizes recognizes sbom files', function () {
+        const entries = inspectArtifactSizes([
+            { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false },
+            { filePath: 'project.sbom.json', content: '{}', isExecutable: false }
+        ]);
+
+        assert.deepStrictEqual(
+            entries.map((entry) => {
+                return entry.kind;
+            }),
+            ['sbom', 'sbom']
+        );
+    });
+
+    test('inspectArtifactSizes treats unknown files as additional', function () {
+        const entries = inspectArtifactSizes([{ filePath: 'README.md', content: '# hi', isExecutable: false }]);
+
+        assert.strictEqual(entries[0]?.kind, 'additional');
+    });
+
+    test('inspectArtifactSizes does not classify a generic .json as source', function () {
+        const [entry] = inspectArtifactSizes([description('data.json')]);
+        assert.strictEqual(entry?.kind, 'additional');
+    });
+
+    test('inspectArtifactSizes classifies .js as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.js')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .cjs as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.cjs')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .mjs as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.mjs')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .ts as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.ts')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .tsx as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.tsx')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .jsx as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.jsx')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .d.ts as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.d.ts')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .d.cts as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.d.cts')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .d.mts as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.d.mts')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes classifies .map as source', function () {
+        const [entry] = inspectArtifactSizes([description('a.js.map')]);
+        assert.strictEqual(entry?.kind, 'source');
+    });
+
+    test('inspectArtifactSizes returns utf-8 byte length for multi-byte content', function () {
+        const entries = inspectArtifactSizes([{ filePath: 'note.txt', content: '✓', isExecutable: false }]);
+
+        assert.strictEqual(entries[0]?.sizeBytes, 3);
+    });
+
+    test('inspectArtifactSizes reports zero bytes for empty content', function () {
+        const [entry] = inspectArtifactSizes([description('file.txt', '')]);
+        assert.strictEqual(entry?.sizeBytes, 0);
+    });
+
+    test('inspectArtifactSizes preserves the original file path on each entry', function () {
+        const [entry] = inspectArtifactSizes([description('deep/nested/file.js')]);
+        assert.strictEqual(entry?.path, 'deep/nested/file.js');
+    });
+
+    test('inspectArtifactSizes marks a substituted source file as changed with an import rewrite badge', function () {
+        const [entry] = inspectArtifactSizes([
+            {
+                filePath: 'deep/nested/file.js',
+                content: 'export {};',
+                isExecutable: false,
+                sourceFilePath: '/workspace/src/file.js',
+                isSubstituted: true
+            }
+        ]);
+
+        assert.deepStrictEqual(entry, {
+            path: 'deep/nested/file.js',
+            sizeBytes: 10,
+            kind: 'source',
+            sourcePath: '/workspace/src/file.js',
+            status: 'changed',
+            badges: ['import-path-rewrite']
+        });
+    });
+
+    test('inspectArtifactSizes returns one entry per input descriptor', function () {
+        const entries = inspectArtifactSizes([
+            description('a.js', 'a'),
+            description('b.ts', 'bb'),
+            description('c.txt', 'ccc')
+        ]);
+        assert.strictEqual(entries.length, 3);
+    });
 });

--- a/source/report/inspectors/inspect-linker-rewrites.test.ts
+++ b/source/report/inspectors/inspect-linker-rewrites.test.ts
@@ -1,64 +1,66 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { inspectLinkerRewrites } from './inspect-linker-rewrites.ts';
 
-test('inspectLinkerRewrites returns no rewrites when no resource is substituted', () => {
-    const rewrites = inspectLinkerRewrites({
-        contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: false }],
-        linkedBundleDependencies: new Map<string, unknown>([['pkg-b', {}]])
+suite('inspect-linker-rewrites', function () {
+    test('inspectLinkerRewrites returns no rewrites when no resource is substituted', function () {
+        const rewrites = inspectLinkerRewrites({
+            contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: false }],
+            linkedBundleDependencies: new Map<string, unknown>([['pkg-b', {}]])
+        });
+
+        assert.deepStrictEqual(rewrites, []);
     });
 
-    assert.deepStrictEqual(rewrites, []);
-});
+    test('inspectLinkerRewrites emits one rewrite per substituted resource per linked bundle', function () {
+        const rewrites = inspectLinkerRewrites({
+            contents: [
+                { fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true },
+                { fileDescription: { sourceFilePath: '/src/b.ts' }, isSubstituted: true }
+            ],
+            linkedBundleDependencies: new Map<string, unknown>([
+                ['pkg-b', {}],
+                ['pkg-c', {}]
+            ])
+        });
 
-test('inspectLinkerRewrites emits one rewrite per substituted resource per linked bundle', () => {
-    const rewrites = inspectLinkerRewrites({
-        contents: [
-            { fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true },
-            { fileDescription: { sourceFilePath: '/src/b.ts' }, isSubstituted: true }
-        ],
-        linkedBundleDependencies: new Map<string, unknown>([
-            ['pkg-b', {}],
-            ['pkg-c', {}]
-        ])
+        assert.deepStrictEqual(rewrites, [
+            { file: '/src/a.ts', fromSpecifier: '/src/a.ts', toSpecifier: 'pkg-b', targetBundle: 'pkg-b' },
+            { file: '/src/a.ts', fromSpecifier: '/src/a.ts', toSpecifier: 'pkg-c', targetBundle: 'pkg-c' },
+            { file: '/src/b.ts', fromSpecifier: '/src/b.ts', toSpecifier: 'pkg-b', targetBundle: 'pkg-b' },
+            { file: '/src/b.ts', fromSpecifier: '/src/b.ts', toSpecifier: 'pkg-c', targetBundle: 'pkg-c' }
+        ]);
     });
 
-    assert.deepStrictEqual(rewrites, [
-        { file: '/src/a.ts', fromSpecifier: '/src/a.ts', toSpecifier: 'pkg-b', targetBundle: 'pkg-b' },
-        { file: '/src/a.ts', fromSpecifier: '/src/a.ts', toSpecifier: 'pkg-c', targetBundle: 'pkg-c' },
-        { file: '/src/b.ts', fromSpecifier: '/src/b.ts', toSpecifier: 'pkg-b', targetBundle: 'pkg-b' },
-        { file: '/src/b.ts', fromSpecifier: '/src/b.ts', toSpecifier: 'pkg-c', targetBundle: 'pkg-c' }
-    ]);
-});
+    test('inspectLinkerRewrites returns an empty array when given no resources', function () {
+        const rewrites = inspectLinkerRewrites({
+            contents: [],
+            linkedBundleDependencies: new Map<string, unknown>([['pkg-b', {}]])
+        });
 
-test('inspectLinkerRewrites returns an empty array when given no resources', () => {
-    const rewrites = inspectLinkerRewrites({
-        contents: [],
-        linkedBundleDependencies: new Map<string, unknown>([['pkg-b', {}]])
+        assert.deepStrictEqual(rewrites, []);
     });
 
-    assert.deepStrictEqual(rewrites, []);
-});
+    test('inspectLinkerRewrites returns an empty array when there are no linked bundle dependencies', function () {
+        const rewrites = inspectLinkerRewrites({
+            contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true }],
+            linkedBundleDependencies: new Map<string, unknown>()
+        });
 
-test('inspectLinkerRewrites returns an empty array when there are no linked bundle dependencies', () => {
-    const rewrites = inspectLinkerRewrites({
-        contents: [{ fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true }],
-        linkedBundleDependencies: new Map<string, unknown>()
+        assert.deepStrictEqual(rewrites, []);
     });
 
-    assert.deepStrictEqual(rewrites, []);
-});
+    test('inspectLinkerRewrites emits rewrites only for the substituted resources when the bundle mixes substituted and unmodified files', function () {
+        const rewrites = inspectLinkerRewrites({
+            contents: [
+                { fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true },
+                { fileDescription: { sourceFilePath: '/src/b.ts' }, isSubstituted: false }
+            ],
+            linkedBundleDependencies: new Map<string, unknown>([['pkg-b', {}]])
+        });
 
-test('inspectLinkerRewrites emits rewrites only for the substituted resources when the bundle mixes substituted and unmodified files', () => {
-    const rewrites = inspectLinkerRewrites({
-        contents: [
-            { fileDescription: { sourceFilePath: '/src/a.ts' }, isSubstituted: true },
-            { fileDescription: { sourceFilePath: '/src/b.ts' }, isSubstituted: false }
-        ],
-        linkedBundleDependencies: new Map<string, unknown>([['pkg-b', {}]])
+        assert.deepStrictEqual(rewrites, [
+            { file: '/src/a.ts', fromSpecifier: '/src/a.ts', toSpecifier: 'pkg-b', targetBundle: 'pkg-b' }
+        ]);
     });
-
-    assert.deepStrictEqual(rewrites, [
-        { file: '/src/a.ts', fromSpecifier: '/src/a.ts', toSpecifier: 'pkg-b', targetBundle: 'pkg-b' }
-    ]);
 });

--- a/source/report/inspectors/inspect-package-json-provenance.test.ts
+++ b/source/report/inspectors/inspect-package-json-provenance.test.ts
@@ -1,50 +1,52 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { inspectPackageJsonProvenance } from './inspect-package-json-provenance.ts';
 
-test('inspectPackageJsonProvenance marks fields present in mainPackageJson', () => {
-    const provenance = inspectPackageJsonProvenance(
-        { name: 'pkg', version: '1.0.0', type: 'module' },
-        { type: 'module' },
-        undefined
-    );
+suite('inspect-package-json-provenance', function () {
+    test('inspectPackageJsonProvenance marks fields present in mainPackageJson', function () {
+        const provenance = inspectPackageJsonProvenance(
+            { name: 'pkg', version: '1.0.0', type: 'module' },
+            { type: 'module' },
+            undefined
+        );
 
-    assert.deepStrictEqual(provenance.type, { source: 'mainPackageJson' });
-});
+        assert.deepStrictEqual(provenance.type, { source: 'mainPackageJson' });
+    });
 
-test('inspectPackageJsonProvenance marks fields present in additionalAttributes', () => {
-    const provenance = inspectPackageJsonProvenance(
-        { name: 'pkg', version: '1.0.0', publishConfig: { access: 'public' } },
-        {},
-        { publishConfig: { access: 'public' } }
-    );
+    test('inspectPackageJsonProvenance marks fields present in additionalAttributes', function () {
+        const provenance = inspectPackageJsonProvenance(
+            { name: 'pkg', version: '1.0.0', publishConfig: { access: 'public' } },
+            {},
+            { publishConfig: { access: 'public' } }
+        );
 
-    assert.deepStrictEqual(provenance.publishConfig, { source: 'additionalAttributes' });
-});
+        assert.deepStrictEqual(provenance.publishConfig, { source: 'additionalAttributes' });
+    });
 
-test('inspectPackageJsonProvenance marks fields not in any source as derived', () => {
-    const provenance = inspectPackageJsonProvenance({ name: 'pkg', version: '1.0.0' }, {}, undefined);
+    test('inspectPackageJsonProvenance marks fields not in any source as derived', function () {
+        const provenance = inspectPackageJsonProvenance({ name: 'pkg', version: '1.0.0' }, {}, undefined);
 
-    assert.deepStrictEqual(provenance.name, { source: 'derived' });
-    assert.deepStrictEqual(provenance.version, { source: 'derived' });
-});
+        assert.deepStrictEqual(provenance.name, { source: 'derived' });
+        assert.deepStrictEqual(provenance.version, { source: 'derived' });
+    });
 
-test('inspectPackageJsonProvenance prefers additionalAttributes over mainPackageJson when both contain the field', () => {
-    const provenance = inspectPackageJsonProvenance(
-        { keywords: ['a', 'b'] },
-        { keywords: ['x'] },
-        { keywords: ['a', 'b'] }
-    );
+    test('inspectPackageJsonProvenance prefers additionalAttributes over mainPackageJson when both contain the field', function () {
+        const provenance = inspectPackageJsonProvenance(
+            { keywords: ['a', 'b'] },
+            { keywords: ['x'] },
+            { keywords: ['a', 'b'] }
+        );
 
-    assert.deepStrictEqual(provenance.keywords, { source: 'additionalAttributes' });
-});
+        assert.deepStrictEqual(provenance.keywords, { source: 'additionalAttributes' });
+    });
 
-test('inspectPackageJsonProvenance treats undefined additionalAttributes as absent', () => {
-    const provenance = inspectPackageJsonProvenance({ name: 'pkg' }, { name: 'pkg' }, undefined);
-    assert.deepStrictEqual(provenance, { name: { source: 'mainPackageJson' } });
-});
+    test('inspectPackageJsonProvenance treats undefined additionalAttributes as absent', function () {
+        const provenance = inspectPackageJsonProvenance({ name: 'pkg' }, { name: 'pkg' }, undefined);
+        assert.deepStrictEqual(provenance, { name: { source: 'mainPackageJson' } });
+    });
 
-test('inspectPackageJsonProvenance returns an empty object for an empty assembled manifest', () => {
-    const provenance = inspectPackageJsonProvenance({}, { name: 'pkg' }, { scripts: {} });
-    assert.deepStrictEqual(provenance, {});
+    test('inspectPackageJsonProvenance returns an empty object for an empty assembled manifest', function () {
+        const provenance = inspectPackageJsonProvenance({}, { name: 'pkg' }, { scripts: {} });
+        assert.deepStrictEqual(provenance, {});
+    });
 });

--- a/source/report/inspectors/inspect-scan-results.test.ts
+++ b/source/report/inspectors/inspect-scan-results.test.ts
@@ -1,47 +1,49 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { inspectScanResults } from './inspect-scan-results.ts';
 
-test('inspectScanResults returns included files with reason "reachable-from-entry"', () => {
-    const bundle = {
-        contents: [
-            { fileDescription: { sourceFilePath: '/src/a.ts' } },
-            { fileDescription: { sourceFilePath: '/src/b.ts' } }
-        ],
-        externalDependencies: new Map<string, unknown>()
-    };
+suite('inspect-scan-results', function () {
+    test('inspectScanResults returns included files with reason "reachable-from-entry"', function () {
+        const bundle = {
+            contents: [
+                { fileDescription: { sourceFilePath: '/src/a.ts' } },
+                { fileDescription: { sourceFilePath: '/src/b.ts' } }
+            ],
+            externalDependencies: new Map<string, unknown>()
+        };
 
-    const { included } = inspectScanResults(bundle);
+        const { included } = inspectScanResults(bundle);
 
-    assert.deepStrictEqual(included, [
-        { path: '/src/a.ts', reason: 'reachable-from-entry' },
-        { path: '/src/b.ts', reason: 'reachable-from-entry' }
-    ]);
-});
-
-test('inspectScanResults returns excluded specifiers with reason "external-module"', () => {
-    const bundle = {
-        contents: [],
-        externalDependencies: new Map<string, unknown>([
-            ['lodash', { version: '^4' }],
-            ['react', { version: '^18' }]
-        ])
-    };
-
-    const { excluded } = inspectScanResults(bundle);
-
-    assert.deepStrictEqual(excluded, [
-        { specifier: 'lodash', reason: 'external-module' },
-        { specifier: 'react', reason: 'external-module' }
-    ]);
-});
-
-test('inspectScanResults returns empty arrays when the bundle has no contents and no externals', () => {
-    const { included, excluded } = inspectScanResults({
-        contents: [],
-        externalDependencies: new Map<string, unknown>()
+        assert.deepStrictEqual(included, [
+            { path: '/src/a.ts', reason: 'reachable-from-entry' },
+            { path: '/src/b.ts', reason: 'reachable-from-entry' }
+        ]);
     });
 
-    assert.deepStrictEqual(included, []);
-    assert.deepStrictEqual(excluded, []);
+    test('inspectScanResults returns excluded specifiers with reason "external-module"', function () {
+        const bundle = {
+            contents: [],
+            externalDependencies: new Map<string, unknown>([
+                ['lodash', { version: '^4' }],
+                ['react', { version: '^18' }]
+            ])
+        };
+
+        const { excluded } = inspectScanResults(bundle);
+
+        assert.deepStrictEqual(excluded, [
+            { specifier: 'lodash', reason: 'external-module' },
+            { specifier: 'react', reason: 'external-module' }
+        ]);
+    });
+
+    test('inspectScanResults returns empty arrays when the bundle has no contents and no externals', function () {
+        const { included, excluded } = inspectScanResults({
+            contents: [],
+            externalDependencies: new Map<string, unknown>()
+        });
+
+        assert.deepStrictEqual(included, []);
+        assert.deepStrictEqual(excluded, []);
+    });
 });

--- a/source/report/preview/artifact-diff-builder.test.ts
+++ b/source/report/preview/artifact-diff-builder.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ArtifactEntry } from '../../progress/progress-broadcaster.ts';
 import { buildDiffForArtifact } from './artifact-diff-builder.ts';
 import type { BundleArtifactIndex } from './bundle-artifact-index.ts';
@@ -27,40 +27,42 @@ async function alwaysRead(originalContent: string): Promise<(filePath: string) =
     return async () => originalContent;
 }
 
-test('buildDiffForArtifact returns undefined when the artifact is not diffable', async () => {
-    const nonDiffable = diffableArtifact({ status: 'unchanged', badges: [] });
-    const result = await buildDiffForArtifact('pkg-a', nonDiffable, new Map(), async () => '');
+suite('artifact-diff-builder', function () {
+    test('buildDiffForArtifact returns undefined when the artifact is not diffable', async function () {
+        const nonDiffable = diffableArtifact({ status: 'unchanged', badges: [] });
+        const result = await buildDiffForArtifact('pkg-a', nonDiffable, new Map(), async () => '');
 
-    assert.strictEqual(result, undefined);
-});
+        assert.strictEqual(result, undefined);
+    });
 
-test('buildDiffForArtifact returns undefined when the source path no longer matches the indexed artifact', async () => {
-    const index = bundleIndex('pkg-a', new Map([['a.js', { content: 'final', sourcePath: '/src/other.js' }]]));
-    const result = await buildDiffForArtifact('pkg-a', diffableArtifact(), index, async () => 'final');
+    test('buildDiffForArtifact returns undefined when the source path no longer matches the indexed artifact', async function () {
+        const index = bundleIndex('pkg-a', new Map([['a.js', { content: 'final', sourcePath: '/src/other.js' }]]));
+        const result = await buildDiffForArtifact('pkg-a', diffableArtifact(), index, async () => 'final');
 
-    assert.strictEqual(result, undefined);
-});
+        assert.strictEqual(result, undefined);
+    });
 
-test('buildDiffForArtifact returns undefined when the original and final content match exactly', async () => {
-    const index = bundleIndex('pkg-a', new Map([['a.js', { content: 'same-bytes', sourcePath: '/src/a.js' }]]));
-    const result = await buildDiffForArtifact('pkg-a', diffableArtifact(), index, await alwaysRead('same-bytes'));
+    test('buildDiffForArtifact returns undefined when the original and final content match exactly', async function () {
+        const index = bundleIndex('pkg-a', new Map([['a.js', { content: 'same-bytes', sourcePath: '/src/a.js' }]]));
+        const result = await buildDiffForArtifact('pkg-a', diffableArtifact(), index, await alwaysRead('same-bytes'));
 
-    assert.strictEqual(result, undefined);
-});
+        assert.strictEqual(result, undefined);
+    });
 
-test('buildDiffForArtifact returns hunks when the original and final content differ', async () => {
-    const index = bundleIndex(
-        'pkg-a',
-        new Map([['a.js', { content: 'export const kept = 1;', sourcePath: '/src/a.js' }]])
-    );
-    const result = await buildDiffForArtifact(
-        'pkg-a',
-        diffableArtifact(),
-        index,
-        await alwaysRead('export const removed = 1;')
-    );
+    test('buildDiffForArtifact returns hunks when the original and final content differ', async function () {
+        const index = bundleIndex(
+            'pkg-a',
+            new Map([['a.js', { content: 'export const kept = 1;', sourcePath: '/src/a.js' }]])
+        );
+        const result = await buildDiffForArtifact(
+            'pkg-a',
+            diffableArtifact(),
+            index,
+            await alwaysRead('export const removed = 1;')
+        );
 
-    assert.notStrictEqual(result, undefined);
-    assert.ok((result ?? []).length > 0);
-    assert.match((result ?? [])[0]?.header ?? '', /^@@ -\d+,\d+ \+\d+,\d+ @@$/u);
+        assert.notStrictEqual(result, undefined);
+        assert.ok((result ?? []).length > 0);
+        assert.match((result ?? [])[0]?.header ?? '', /^@@ -\d+,\d+ \+\d+,\d+ @@$/u);
+    });
 });

--- a/source/report/preview/artifact-tree-builder.test.ts
+++ b/source/report/preview/artifact-tree-builder.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ArtifactEntry } from '../../progress/progress-broadcaster.ts';
 import { buildArtifactTree, type PreviewArtifact } from './artifact-tree-builder.ts';
 
@@ -8,29 +8,31 @@ function artifact(path: string, overrides: Partial<ArtifactEntry> = {}): Preview
     return { path, sizeBytes: 0, kind: 'additional', status: 'unchanged', badges: [], ...overrides };
 }
 
-test('buildArtifactTree returns an empty array when no artifacts are given', () => {
-    assert.deepStrictEqual(buildArtifactTree([]), []);
-});
+suite('artifact-tree-builder', function () {
+    test('buildArtifactTree returns an empty array when no artifacts are given', function () {
+        assert.deepStrictEqual(buildArtifactTree([]), []);
+    });
 
-test('buildArtifactTree returns a single file node for an artifact at the root', () => {
-    const [node, ...rest] = buildArtifactTree([artifact('package.json', { kind: 'manifest' })]);
-    assert.strictEqual(node?.type, 'file');
-    assert.strictEqual(node?.path, 'package.json');
-    assert.deepStrictEqual(rest, []);
-});
+    test('buildArtifactTree returns a single file node for an artifact at the root', function () {
+        const [node, ...rest] = buildArtifactTree([artifact('package.json', { kind: 'manifest' })]);
+        assert.strictEqual(node?.type, 'file');
+        assert.strictEqual(node?.path, 'package.json');
+        assert.deepStrictEqual(rest, []);
+    });
 
-test('buildArtifactTree orders the root package.json before directories and nested files', () => {
-    const nodes = buildArtifactTree([artifact('src/index.js'), artifact('package.json', { kind: 'manifest' })]);
+    test('buildArtifactTree orders the root package.json before directories and nested files', function () {
+        const nodes = buildArtifactTree([artifact('src/index.js'), artifact('package.json', { kind: 'manifest' })]);
 
-    const types = nodes.map((node) => node.type);
-    assert.deepStrictEqual(types, ['file', 'directory', 'file']);
-    assert.strictEqual(nodes[0]?.name, 'package.json');
-    assert.strictEqual(nodes[1]?.name, 'src');
-    assert.strictEqual(nodes[2]?.path, 'src/index.js');
-});
+        const types = nodes.map((node) => node.type);
+        assert.deepStrictEqual(types, ['file', 'directory', 'file']);
+        assert.strictEqual(nodes[0]?.name, 'package.json');
+        assert.strictEqual(nodes[1]?.name, 'src');
+        assert.strictEqual(nodes[2]?.path, 'src/index.js');
+    });
 
-test('buildArtifactTree assigns increasing depth to nested directories and the leaf file', () => {
-    const nodes = buildArtifactTree([artifact('src/lib/util.js')]);
-    const depths = nodes.map((node) => node.depth);
-    assert.deepStrictEqual(depths, [1, 2, 2]);
+    test('buildArtifactTree assigns increasing depth to nested directories and the leaf file', function () {
+        const nodes = buildArtifactTree([artifact('src/lib/util.js')]);
+        const depths = nodes.map((node) => node.depth);
+        assert.deepStrictEqual(depths, [1, 2, 2]);
+    });
 });

--- a/source/report/preview/bundle-artifact-index.test.ts
+++ b/source/report/preview/bundle-artifact-index.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { BuildAndPublishResult } from '../../packtory/package-processor.ts';
 import { buildBundleArtifactIndex } from './bundle-artifact-index.ts';
 
@@ -30,28 +30,30 @@ function buildResult(
     } as unknown as BuildAndPublishResult;
 }
 
-test('buildBundleArtifactIndex returns an empty map when given no results', () => {
-    assert.strictEqual(buildBundleArtifactIndex([]).size, 0);
-});
+suite('bundle-artifact-index', function () {
+    test('buildBundleArtifactIndex returns an empty map when given no results', function () {
+        assert.strictEqual(buildBundleArtifactIndex([]).size, 0);
+    });
 
-test('buildBundleArtifactIndex always seeds an entry for package.json from the manifest content', () => {
-    const index = buildBundleArtifactIndex([buildResult('pkg-a', '{"name":"pkg-a"}')]);
+    test('buildBundleArtifactIndex always seeds an entry for package.json from the manifest content', function () {
+        const index = buildBundleArtifactIndex([buildResult('pkg-a', '{"name":"pkg-a"}')]);
 
-    assert.deepStrictEqual(index.get('pkg-a')?.get('package.json'), { content: '{"name":"pkg-a"}' });
-});
+        assert.deepStrictEqual(index.get('pkg-a')?.get('package.json'), { content: '{"name":"pkg-a"}' });
+    });
 
-test('buildBundleArtifactIndex includes each bundle content entry keyed by target file path', () => {
-    const index = buildBundleArtifactIndex([
-        buildResult('pkg-a', '{}', [{ sourceFilePath: '/src/a.ts', targetFilePath: 'a.js', content: 'content-a' }])
-    ]);
+    test('buildBundleArtifactIndex includes each bundle content entry keyed by target file path', function () {
+        const index = buildBundleArtifactIndex([
+            buildResult('pkg-a', '{}', [{ sourceFilePath: '/src/a.ts', targetFilePath: 'a.js', content: 'content-a' }])
+        ]);
 
-    assert.deepStrictEqual(index.get('pkg-a')?.get('a.js'), { content: 'content-a', sourcePath: '/src/a.ts' });
-});
+        assert.deepStrictEqual(index.get('pkg-a')?.get('a.js'), { content: 'content-a', sourcePath: '/src/a.ts' });
+    });
 
-test('buildBundleArtifactIndex maps each bundle to its own inner index by package name', () => {
-    const index = buildBundleArtifactIndex([buildResult('pkg-a', '{}'), buildResult('pkg-b', '{}')]);
+    test('buildBundleArtifactIndex maps each bundle to its own inner index by package name', function () {
+        const index = buildBundleArtifactIndex([buildResult('pkg-a', '{}'), buildResult('pkg-b', '{}')]);
 
-    assert.strictEqual(index.get('pkg-a') === index.get('pkg-b'), false);
-    assert.strictEqual(index.has('pkg-a'), true);
-    assert.strictEqual(index.has('pkg-b'), true);
+        assert.strictEqual(index.get('pkg-a') === index.get('pkg-b'), false);
+        assert.strictEqual(index.has('pkg-a'), true);
+        assert.strictEqual(index.has('pkg-b'), true);
+    });
 });

--- a/source/report/preview/changed-artifacts.test.ts
+++ b/source/report/preview/changed-artifacts.test.ts
@@ -1,44 +1,46 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createPreviewPackageFixture } from '../../test-libraries/preview-fixtures.ts';
 import { collectChangedArtifacts } from './changed-artifacts.ts';
 
-test('collectChangedArtifacts ignores non-file nodes and unchanged files', () => {
-    assert.deepStrictEqual(
-        collectChangedArtifacts(
-            createPreviewPackageFixture({
-                tree: [
-                    { path: 'src', name: 'src', depth: 0, type: 'directory' },
-                    {
-                        path: 'ok.js',
-                        name: 'ok.js',
-                        depth: 0,
-                        type: 'file',
-                        artifact: {
+suite('changed-artifacts', function () {
+    test('collectChangedArtifacts ignores non-file nodes and unchanged files', function () {
+        assert.deepStrictEqual(
+            collectChangedArtifacts(
+                createPreviewPackageFixture({
+                    tree: [
+                        { path: 'src', name: 'src', depth: 0, type: 'directory' },
+                        {
                             path: 'ok.js',
-                            sizeBytes: 1,
-                            kind: 'source',
-                            status: 'changed',
-                            badges: [],
-                            diff: [{ header: '@@ -1,1 +1,1 @@', lines: [] }]
-                        }
-                    },
-                    {
-                        path: 'same.js',
-                        name: 'same.js',
-                        depth: 0,
-                        type: 'file',
-                        artifact: {
+                            name: 'ok.js',
+                            depth: 0,
+                            type: 'file',
+                            artifact: {
+                                path: 'ok.js',
+                                sizeBytes: 1,
+                                kind: 'source',
+                                status: 'changed',
+                                badges: [],
+                                diff: [{ header: '@@ -1,1 +1,1 @@', lines: [] }]
+                            }
+                        },
+                        {
                             path: 'same.js',
-                            sizeBytes: 1,
-                            kind: 'source',
-                            status: 'unchanged',
-                            badges: []
+                            name: 'same.js',
+                            depth: 0,
+                            type: 'file',
+                            artifact: {
+                                path: 'same.js',
+                                sizeBytes: 1,
+                                kind: 'source',
+                                status: 'unchanged',
+                                badges: []
+                            }
                         }
-                    }
-                ]
-            }).tree
-        ).map((artifact) => artifact.path),
-        ['ok.js']
-    );
+                    ]
+                }).tree
+            ).map((artifact) => artifact.path),
+            ['ok.js']
+        );
+    });
 });

--- a/source/report/preview/preview-document-diff.test.ts
+++ b/source/report/preview/preview-document-diff.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ArtifactEntry } from '../../progress/progress-broadcaster.ts';
 import { isDiffableArtifact, toDiffLineType } from './preview-document-diff.ts';
 
@@ -12,35 +12,37 @@ const diffable: ArtifactEntry = {
     badges: []
 };
 
-test('isDiffableArtifact returns true for a changed source file with a source path and a code extension', () => {
-    assert.strictEqual(isDiffableArtifact(diffable), true);
-});
+suite('preview-document-diff', function () {
+    test('isDiffableArtifact returns true for a changed source file with a source path and a code extension', function () {
+        assert.strictEqual(isDiffableArtifact(diffable), true);
+    });
 
-test('isDiffableArtifact returns false when the entry has no sourcePath', () => {
-    assert.strictEqual(isDiffableArtifact({ ...diffable, sourcePath: undefined }), false);
-});
+    test('isDiffableArtifact returns false when the entry has no sourcePath', function () {
+        assert.strictEqual(isDiffableArtifact({ ...diffable, sourcePath: undefined }), false);
+    });
 
-test('isDiffableArtifact returns false when the entry status is not "changed"', () => {
-    assert.strictEqual(isDiffableArtifact({ ...diffable, status: 'unchanged' }), false);
-});
+    test('isDiffableArtifact returns false when the entry status is not "changed"', function () {
+        assert.strictEqual(isDiffableArtifact({ ...diffable, status: 'unchanged' }), false);
+    });
 
-test('isDiffableArtifact returns false when the entry kind is not "source"', () => {
-    assert.strictEqual(isDiffableArtifact({ ...diffable, kind: 'manifest' }), false);
-});
+    test('isDiffableArtifact returns false when the entry kind is not "source"', function () {
+        assert.strictEqual(isDiffableArtifact({ ...diffable, kind: 'manifest' }), false);
+    });
 
-test('isDiffableArtifact returns false for a non-code file extension', () => {
-    assert.strictEqual(isDiffableArtifact({ ...diffable, path: 'README.md' }), false);
-});
+    test('isDiffableArtifact returns false for a non-code file extension', function () {
+        assert.strictEqual(isDiffableArtifact({ ...diffable, path: 'README.md' }), false);
+    });
 
-test('toDiffLineType returns "add" for lines starting with +', () => {
-    assert.strictEqual(toDiffLineType('+new'), 'add');
-});
+    test('toDiffLineType returns "add" for lines starting with +', function () {
+        assert.strictEqual(toDiffLineType('+new'), 'add');
+    });
 
-test('toDiffLineType returns "remove" for lines starting with -', () => {
-    assert.strictEqual(toDiffLineType('-gone'), 'remove');
-});
+    test('toDiffLineType returns "remove" for lines starting with -', function () {
+        assert.strictEqual(toDiffLineType('-gone'), 'remove');
+    });
 
-test('toDiffLineType returns "context" for lines starting with anything else', () => {
-    assert.strictEqual(toDiffLineType(' same'), 'context');
-    assert.strictEqual(toDiffLineType('@@ hunk'), 'context');
+    test('toDiffLineType returns "context" for lines starting with anything else', function () {
+        assert.strictEqual(toDiffLineType(' same'), 'context');
+        assert.strictEqual(toDiffLineType('@@ hunk'), 'context');
+    });
 });

--- a/source/report/preview/preview-document-helpers.test.ts
+++ b/source/report/preview/preview-document-helpers.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageReport } from '../aggregator/report-types.ts';
 import type { PreviewArtifact } from './artifact-tree-builder.ts';
 import { buildVersionTransition, hasMeaningfulChanges } from './preview-document-helpers.ts';
@@ -20,36 +20,41 @@ function artifact(overrides: Partial<PreviewArtifact> = {}): PreviewArtifact {
     };
 }
 
-test('buildVersionTransition returns undefined when the report has no version decision', () => {
-    assert.strictEqual(buildVersionTransition({ decisions: {}, timings: {} }), undefined);
-});
+suite('preview-document-helpers', function () {
+    test('buildVersionTransition returns undefined when the report has no version decision', function () {
+        assert.strictEqual(buildVersionTransition({ decisions: {}, timings: {} }), undefined);
+    });
 
-test('buildVersionTransition returns the chosen version when no previous version exists', () => {
-    assert.strictEqual(
-        buildVersionTransition(
-            reportWithVersion({ chosenVersion: '1.0.0', previousVersion: undefined, trigger: 'initial' })
-        ),
-        '1.0.0'
-    );
-});
+    test('buildVersionTransition returns the chosen version when no previous version exists', function () {
+        assert.strictEqual(
+            buildVersionTransition(
+                reportWithVersion({ chosenVersion: '1.0.0', previousVersion: undefined, trigger: 'initial' })
+            ),
+            '1.0.0'
+        );
+    });
 
-test('buildVersionTransition returns "previous -> chosen" when both versions exist', () => {
-    assert.strictEqual(
-        buildVersionTransition(
-            reportWithVersion({ chosenVersion: '1.0.1', previousVersion: '1.0.0', trigger: 'auto-patch-bump' })
-        ),
-        '1.0.0 -> 1.0.1'
-    );
-});
+    test('buildVersionTransition returns "previous -> chosen" when both versions exist', function () {
+        assert.strictEqual(
+            buildVersionTransition(
+                reportWithVersion({ chosenVersion: '1.0.1', previousVersion: '1.0.0', trigger: 'auto-patch-bump' })
+            ),
+            '1.0.0 -> 1.0.1'
+        );
+    });
 
-test('hasMeaningfulChanges returns true when any eliminated source files are present', () => {
-    assert.strictEqual(hasMeaningfulChanges([], [{ path: '/src/dead.js', sourceBytes: 1, reason: 'no-uses' }]), true);
-});
+    test('hasMeaningfulChanges returns true when any eliminated source files are present', function () {
+        assert.strictEqual(
+            hasMeaningfulChanges([], [{ path: '/src/dead.js', sourceBytes: 1, reason: 'no-uses' }]),
+            true
+        );
+    });
 
-test('hasMeaningfulChanges returns true when any artifact has the changed status', () => {
-    assert.strictEqual(hasMeaningfulChanges([artifact({ status: 'changed' })], []), true);
-});
+    test('hasMeaningfulChanges returns true when any artifact has the changed status', function () {
+        assert.strictEqual(hasMeaningfulChanges([artifact({ status: 'changed' })], []), true);
+    });
 
-test('hasMeaningfulChanges returns false when no artifact is changed and no source file was eliminated', () => {
-    assert.strictEqual(hasMeaningfulChanges([artifact({ status: 'unchanged' })], []), false);
+    test('hasMeaningfulChanges returns false when no artifact is changed and no source file was eliminated', function () {
+        assert.strictEqual(hasMeaningfulChanges([artifact({ status: 'unchanged' })], []), false);
+    });
 });

--- a/source/report/preview/preview-document-tree.test.ts
+++ b/source/report/preview/preview-document-tree.test.ts
@@ -1,28 +1,30 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { compareTreeNodes, treeNodeSortKey } from './preview-document-tree.ts';
 
-test('treeNodeSortKey gives the root package.json file the highest precedence', () => {
-    assert.strictEqual(treeNodeSortKey({ name: 'package.json', type: 'file' }), '0:package.json');
-});
+suite('preview-document-tree', function () {
+    test('treeNodeSortKey gives the root package.json file the highest precedence', function () {
+        assert.strictEqual(treeNodeSortKey({ name: 'package.json', type: 'file' }), '0:package.json');
+    });
 
-test('treeNodeSortKey gives a directory a higher precedence than a regular file', () => {
-    assert.strictEqual(treeNodeSortKey({ name: 'src', type: 'directory' }), '1:src');
-    assert.strictEqual(treeNodeSortKey({ name: 'README.md', type: 'file' }), '2:README.md');
-});
+    test('treeNodeSortKey gives a directory a higher precedence than a regular file', function () {
+        assert.strictEqual(treeNodeSortKey({ name: 'src', type: 'directory' }), '1:src');
+        assert.strictEqual(treeNodeSortKey({ name: 'README.md', type: 'file' }), '2:README.md');
+    });
 
-test('compareTreeNodes orders the root package.json before directories', () => {
-    assert.ok(compareTreeNodes({ name: 'package.json', type: 'file' }, { name: 'src', type: 'directory' }) < 0);
-});
+    test('compareTreeNodes orders the root package.json before directories', function () {
+        assert.ok(compareTreeNodes({ name: 'package.json', type: 'file' }, { name: 'src', type: 'directory' }) < 0);
+    });
 
-test('compareTreeNodes orders directories before non-manifest files', () => {
-    assert.ok(compareTreeNodes({ name: 'src', type: 'directory' }, { name: 'a.txt', type: 'file' }) < 0);
-});
+    test('compareTreeNodes orders directories before non-manifest files', function () {
+        assert.ok(compareTreeNodes({ name: 'src', type: 'directory' }, { name: 'a.txt', type: 'file' }) < 0);
+    });
 
-test('compareTreeNodes returns zero for two nodes with the same sort key', () => {
-    assert.strictEqual(compareTreeNodes({ name: 'a', type: 'file' }, { name: 'a', type: 'file' }), 0);
-});
+    test('compareTreeNodes returns zero for two nodes with the same sort key', function () {
+        assert.strictEqual(compareTreeNodes({ name: 'a', type: 'file' }, { name: 'a', type: 'file' }), 0);
+    });
 
-test('treeNodeSortKey treats a directory literally named "package.json" as a directory, not the root manifest', () => {
-    assert.strictEqual(treeNodeSortKey({ name: 'package.json', type: 'directory' }), '1:package.json');
+    test('treeNodeSortKey treats a directory literally named "package.json" as a directory, not the root manifest', function () {
+        assert.strictEqual(treeNodeSortKey({ name: 'package.json', type: 'directory' }), '1:package.json');
+    });
 });

--- a/source/report/preview/preview-document.test.ts
+++ b/source/report/preview/preview-document.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { mkdtemp, writeFile } from 'node:fs/promises';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
 import { createFileManager, type FileManager } from '../../file-manager/file-manager.ts';
 import type { BuildAndPublishResult } from '../../packtory/package-processor.ts';
@@ -300,438 +300,442 @@ function assertFirstFileHasNoDiff(document: PreviewDocument): void {
     assert.strictEqual(requireFileNodeAt(document, 0, 0).artifact.diff, undefined);
 }
 
-test('buildPreviewDocument orders packages by report order and formats version transitions', async () => {
-    const document = await buildPreviewDocument({
-        report: baseReport(),
-        result: Result.ok([
-            buildResult(),
+suite('preview-document', function () {
+    test('buildPreviewDocument orders packages by report order and formats version transitions', async function () {
+        const document = await buildPreviewDocument({
+            report: baseReport(),
+            result: Result.ok([
+                buildResult(),
+                createBuildResultFixture({
+                    packageName: 'pkg-b',
+                    version: '0.0.1',
+                    status: 'initial-version',
+                    contents: [
+                        createAnalyzedResource({
+                            sourceFilePath: '/workspace/pkg-b/index.js',
+                            targetFilePath: 'index.js',
+                            content: 'export {};\n'
+                        })
+                    ]
+                })
+            ]),
+            dryRun: true,
+            fileManager: workspaceFileManager(
+                workspaceReader({ '/workspace/src/index.js': 'export const removed = 1;\n' })
+            )
+        });
+
+        assert.deepStrictEqual(
+            document.packages.map((pkg) => [pkg.name, pkg.versionTransition]),
+            [
+                ['pkg-a', '1.0.0 -> 1.0.1'],
+                ['pkg-b', '0.0.1']
+            ]
+        );
+    });
+
+    test('buildPreviewDocument sorts package.json first and creates diffs only for changed source files', async function () {
+        const document = await buildPreviewDocument({
+            report: baseReport(),
+            result: Result.ok([buildResult()]),
+            dryRun: true,
+            fileManager: workspaceFileManager(
+                workspaceReader({
+                    '/workspace/src/index.js': 'export const removed = 1;\n',
+                    '/workspace/src/index.js.map': '{"version":2}',
+                    '/workspace/types/index.d.ts': 'export declare const kept: number;\n'
+                })
+            )
+        });
+
+        const pkg = requireSinglePackage(document);
+        assert.strictEqual(requireTreeNodeAt(document, 0, 0).path, 'package.json');
+        assert.deepStrictEqual(
+            pkg.tree
+                .filter((entry) => entry.type === 'file' && entry.artifact.diff !== undefined)
+                .map((entry) => entry.path),
+            ['src/index.js']
+        );
+    });
+
+    test('buildPreviewDocument builds exact tree ordering, depths, and summary counts', async function () {
+        const report = createBuildReportFixture({
+            packages: {
+                'pkg-a': createPackageReport(
+                    [
+                        createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
+                        createArtifactEntryFixture({
+                            path: 'dist/index.js',
+                            sizeBytes: 10,
+                            sourcePath: '/workspace/src/index.js',
+                            status: 'changed',
+                            badges: []
+                        }),
+                        createArtifactEntryFixture({
+                            path: 'types/internal/index.d.ts',
+                            sizeBytes: 5,
+                            sourcePath: '/workspace/types/internal/index.d.ts',
+                            status: 'unchanged',
+                            badges: []
+                        })
+                    ],
+                    {
+                        eliminatedSourceFiles: [
+                            { path: '/workspace/src/unused.js', reason: 'not-emitted-after-analysis', sourceBytes: 14 }
+                        ]
+                    }
+                ),
+                'pkg-b': createPackageReport([
+                    createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
+                    createArtifactEntryFixture({
+                        path: 'index.js',
+                        sizeBytes: 3,
+                        sourcePath: '/workspace/pkg-b/index.js',
+                        status: 'unchanged',
+                        badges: []
+                    })
+                ])
+            }
+        });
+        const result = Result.ok([
+            createBuildResultFixture({
+                contents: [
+                    createAnalyzedResource({
+                        sourceFilePath: '/workspace/src/index.js',
+                        targetFilePath: 'dist/index.js',
+                        content: 'export const changed = 1;\n'
+                    }),
+                    createAnalyzedResource({
+                        sourceFilePath: '/workspace/types/internal/index.d.ts',
+                        targetFilePath: 'types/internal/index.d.ts',
+                        content: 'export declare const kept: number;\n'
+                    })
+                ]
+            }),
             createBuildResultFixture({
                 packageName: 'pkg-b',
-                version: '0.0.1',
-                status: 'initial-version',
                 contents: [
                     createAnalyzedResource({
                         sourceFilePath: '/workspace/pkg-b/index.js',
                         targetFilePath: 'index.js',
-                        content: 'export {};\n'
+                        content: 'ok\n'
                     })
                 ]
             })
-        ]),
-        dryRun: true,
-        fileManager: workspaceFileManager(workspaceReader({ '/workspace/src/index.js': 'export const removed = 1;\n' }))
+        ]);
+        const document = await buildPreviewDocument({
+            report,
+            result,
+            dryRun: true,
+            fileManager: workspaceFileManager(
+                workspaceReader({
+                    '/workspace/src/index.js': 'export const original = 1;\n',
+                    '/workspace/types/internal/index.d.ts': 'export declare const kept: number;\n',
+                    '/workspace/pkg-b/index.js': 'ok\n'
+                })
+            )
+        });
+
+        assert.deepStrictEqual(document.summary, {
+            totalPackages: 2,
+            changedPackages: 1,
+            unchangedPackages: 1,
+            failedPackages: 0,
+            emittedArtifacts: 5,
+            changedArtifacts: 1,
+            eliminatedSourceFiles: 1
+        });
+        assert.deepStrictEqual(
+            requirePackageAt(document, 0).tree.map((entry) => [entry.path, entry.depth, entry.type]),
+            [
+                ['package.json', 0, 'file'],
+                ['dist', 1, 'directory'],
+                ['dist/index.js', 1, 'file'],
+                ['types', 1, 'directory'],
+                ['types/internal', 2, 'directory'],
+                ['types/internal/index.d.ts', 2, 'file']
+            ]
+        );
+        assert.deepStrictEqual(
+            requirePackageAt(document, 1).tree.map((entry) => [entry.path, entry.depth, entry.type]),
+            [
+                ['package.json', 0, 'file'],
+                ['index.js', 0, 'file']
+            ]
+        );
     });
 
-    assert.deepStrictEqual(
-        document.packages.map((pkg) => [pkg.name, pkg.versionTransition]),
-        [
-            ['pkg-a', '1.0.0 -> 1.0.1'],
-            ['pkg-b', '0.0.1']
-        ]
-    );
-});
+    test('buildPreviewDocument keeps eliminated files separate from the emitted tree', async function () {
+        const document = await buildPreviewDocument({
+            report: baseReport(),
+            result: Result.ok([buildResult()]),
+            dryRun: true,
+            fileManager: workspaceFileManager(async () => 'export {};\n')
+        });
 
-test('buildPreviewDocument sorts package.json first and creates diffs only for changed source files', async () => {
-    const document = await buildPreviewDocument({
-        report: baseReport(),
-        result: Result.ok([buildResult()]),
-        dryRun: true,
-        fileManager: workspaceFileManager(
-            workspaceReader({
-                '/workspace/src/index.js': 'export const removed = 1;\n',
-                '/workspace/src/index.js.map': '{"version":2}',
-                '/workspace/types/index.d.ts': 'export declare const kept: number;\n'
-            })
-        )
+        const pkg = requireSinglePackage(document);
+        assert.deepStrictEqual(pkg.eliminatedSourceFiles, [eliminatedUnusedFile]);
+        assert.strictEqual(
+            pkg.tree.some((entry) => entry.path === eliminatedUnusedFile.path),
+            false
+        );
     });
 
-    const pkg = requireSinglePackage(document);
-    assert.strictEqual(requireTreeNodeAt(document, 0, 0).path, 'package.json');
-    assert.deepStrictEqual(
-        pkg.tree
-            .filter((entry) => entry.type === 'file' && entry.artifact.diff !== undefined)
-            .map((entry) => entry.path),
-        ['src/index.js']
-    );
-});
+    test('buildPreviewDocument treats eliminated-only packages as changed and opens them by default', async function () {
+        const document = await buildUnchangedPackageDocument({ eliminatedSourceFiles: [eliminatedUnusedFile] });
 
-test('buildPreviewDocument builds exact tree ordering, depths, and summary counts', async () => {
-    const report = createBuildReportFixture({
-        packages: {
-            'pkg-a': createPackageReport(
-                [
-                    createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
-                    createArtifactEntryFixture({
-                        path: 'dist/index.js',
-                        sizeBytes: 10,
-                        sourcePath: '/workspace/src/index.js',
-                        status: 'changed',
-                        badges: []
-                    }),
-                    createArtifactEntryFixture({
-                        path: 'types/internal/index.d.ts',
-                        sizeBytes: 5,
-                        sourcePath: '/workspace/types/internal/index.d.ts',
-                        status: 'unchanged',
-                        badges: []
-                    })
-                ],
-                {
-                    eliminatedSourceFiles: [
-                        { path: '/workspace/src/unused.js', reason: 'not-emitted-after-analysis', sourceBytes: 14 }
-                    ]
+        assert.strictEqual(requirePackageAt(document, 0).hasChanges, true);
+        assert.strictEqual(requirePackageAt(document, 0).openByDefault, true);
+    });
+
+    test('buildPreviewDocument reports failure-only runs with direct issues', async function () {
+        const document = await buildPreviewDocument({
+            report: { ...baseReport(), packages: {} },
+            result: Result.err({ type: 'checks', issues: ['bundle is too large'] }),
+            dryRun: true,
+            fileManager: workspaceFileManager(async () => 'export {};\n')
+        });
+
+        assert.strictEqual(document.previewable, false);
+        assert.strictEqual(document.resultType, 'checks');
+        assert.deepStrictEqual(document.issues, ['bundle is too large']);
+    });
+
+    test('buildPreviewDocument marks a partial run with succeeded packages as previewable', async function () {
+        const document = await buildPreviewDocument({
+            report: baseReport(),
+            result: Result.err({ type: 'partial', succeeded: [buildResult()], failures: [new Error('boom')] }),
+            dryRun: true,
+            fileManager: workspaceFileManager(async () => 'export {};\n')
+        });
+
+        assert.strictEqual(document.previewable, true);
+        assert.strictEqual(document.resultType, 'partial');
+        assert.deepStrictEqual(document.issues, ['boom']);
+    });
+
+    test('buildPreviewDocument keeps unchanged packages closed unless they failed', async function () {
+        const unchangedDocument = await buildUnchangedPackageDocument({ eliminatedSourceFiles: [] });
+        const failedDocument = await buildUnchangedPackageDocument({
+            eliminatedSourceFiles: [],
+            failure: { stage: 'publish', message: 'boom' }
+        });
+
+        assert.strictEqual(requirePackageAt(unchangedDocument, 0).hasChanges, false);
+        assert.strictEqual(requirePackageAt(unchangedDocument, 0).openByDefault, false);
+        assert.strictEqual(requirePackageAt(failedDocument, 0).openByDefault, true);
+        assert.strictEqual(failedDocument.summary.failedPackages, 1);
+    });
+
+    test('buildPreviewDocument leaves versionTransition undefined when no version decision exists', async function () {
+        const document = await buildPreviewDocument({
+            report: createBuildReportFixture({
+                packages: {
+                    'pkg-a': createPackageReport([
+                        createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] })
+                    ])
                 }
-            ),
-            'pkg-b': createPackageReport([
-                createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
+            }),
+            result: Result.ok([buildResult()]),
+            dryRun: true,
+            fileManager: workspaceFileManager(async () => 'export {};\n')
+        });
+
+        assert.strictEqual(requirePackageAt(document, 0).versionTransition, undefined);
+    });
+
+    test('buildPreviewDocument uses publish mode when dryRun is false', async function () {
+        const document = await buildSingleArtifactDocument({ dryRun: false });
+
+        assert.strictEqual(document.modeLabel, 'Publish');
+    });
+
+    test('buildPreviewDocument omits diffs when the artifact source path does not match the emitted content source', async function () {
+        const document = await buildSingleArtifactDocument({
+            artifactSourcePath: '/workspace/actual.js',
+            reportSourcePath: '/workspace/other.js',
+            emittedContent: 'export const changed = 1;\n',
+            workspaceContent: 'export const original = 1;\n'
+        });
+
+        assertFirstFileHasNoDiff(document);
+    });
+
+    test('buildPreviewDocument reads workspace files through the injected file manager', async function () {
+        const tempDir = await mkdtemp(path.join(os.tmpdir(), 'packtory-preview-test-'));
+        const sourceFilePath = path.join(tempDir, 'index.js');
+        await writeFile(sourceFilePath, 'export const original = 1;\n');
+        const fileManager = createFileManager({ hostFileSystem: fs.promises });
+
+        const document = await buildPreviewDocument({
+            report: reportForPkgA([
                 createArtifactEntryFixture({
                     path: 'index.js',
-                    sizeBytes: 3,
-                    sourcePath: '/workspace/pkg-b/index.js',
-                    status: 'unchanged',
+                    sizeBytes: 10,
+                    sourcePath: sourceFilePath,
                     badges: []
                 })
-            ])
+            ]),
+            result: Result.ok([
+                createBuildResultFixture({
+                    contents: [
+                        createAnalyzedResource({
+                            sourceFilePath,
+                            targetFilePath: 'index.js',
+                            content: 'export const changed = 1;\n'
+                        })
+                    ]
+                })
+            ]),
+            dryRun: true,
+            fileManager
+        });
+
+        const fileNode = requirePackageAt(document, 0).tree.find(
+            (entry) => entry.type === 'file' && entry.path === 'index.js'
+        );
+        if (fileNode?.type !== 'file') {
+            assert.fail('expected index.js file node');
         }
+        assert.ok(fileNode.artifact.diff !== undefined);
     });
-    const result = Result.ok([
-        createBuildResultFixture({
-            contents: [
-                createAnalyzedResource({
-                    sourceFilePath: '/workspace/src/index.js',
-                    targetFilePath: 'dist/index.js',
-                    content: 'export const changed = 1;\n'
-                }),
-                createAnalyzedResource({
-                    sourceFilePath: '/workspace/types/internal/index.d.ts',
-                    targetFilePath: 'types/internal/index.d.ts',
-                    content: 'export declare const kept: number;\n'
-                })
+
+    test('buildPreviewDocument orders directories before files and sorts alphabetically after package.json', async function () {
+        await expectTreePaths(
+            [
+                tinyUnchangedSource('z-last.js'),
+                createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
+                tinyUnchangedSource('a/inside.js')
+            ],
+            ['package.json', 'a', 'a/inside.js', 'z-last.js']
+        );
+    });
+
+    test('buildPreviewDocument limits diffs to two hunks and drops patch metadata lines', async function () {
+        const document = await buildChangedSourceDiffDocument(
+            'a();\nkeep1();\nkeep2();\nkeep3();\nkeep4();\nkeep5();\nkeep6();\nkeep7();\nkeep8();\nb();\nkeep9();\nkeep10();\nkeep11();\nkeep12();\nkeep13();\nkeep14();\nkeep15();\nkeep16();\nc();\n',
+            'oldA();\nkeep1();\nkeep2();\nkeep3();\nkeep4();\nkeep5();\nkeep6();\nkeep7();\nkeep8();\noldB();\nkeep9();\nkeep10();\nkeep11();\nkeep12();\nkeep13();\nkeep14();\nkeep15();\nkeep16();\noldC();\n'
+        );
+
+        const { diff } = requireFileNodeByPath(document, 0, 'src/index.js').artifact;
+        if (diff === undefined) {
+            assert.fail('expected diff');
+        }
+        assert.deepStrictEqual(
+            diff.map((hunk) => [hunk.header, hunk.lines.some((line) => line.text.startsWith('\\'))]),
+            [
+                ['@@ -1,4 +1,4 @@', false],
+                ['@@ -7,7 +7,7 @@', false]
             ]
-        }),
-        createBuildResultFixture({
-            packageName: 'pkg-b',
-            contents: [
-                createAnalyzedResource({
-                    sourceFilePath: '/workspace/pkg-b/index.js',
-                    targetFilePath: 'index.js',
-                    content: 'ok\n'
-                })
-            ]
-        })
-    ]);
-    const document = await buildPreviewDocument({
-        report,
-        result,
-        dryRun: true,
-        fileManager: workspaceFileManager(
-            workspaceReader({
-                '/workspace/src/index.js': 'export const original = 1;\n',
-                '/workspace/types/internal/index.d.ts': 'export declare const kept: number;\n',
-                '/workspace/pkg-b/index.js': 'ok\n'
+        );
+    });
+
+    test('buildPreviewDocument drops no-newline markers from diff lines', async function () {
+        const document = await buildChangedSourceDiffDocument('changed', 'original');
+
+        const { diff } = requireFileNodeByPath(document, 0, 'src/index.js').artifact;
+        if (diff === undefined) {
+            assert.fail('expected diff');
+        }
+        assert.ok(
+            diff.every((hunk) => {
+                return hunk.lines.every((line) => {
+                    return !line.text.startsWith('\\');
+                });
             })
-        )
+        );
     });
 
-    assert.deepStrictEqual(document.summary, {
-        totalPackages: 2,
-        changedPackages: 1,
-        unchangedPackages: 1,
-        failedPackages: 0,
-        emittedArtifacts: 5,
-        changedArtifacts: 1,
-        eliminatedSourceFiles: 1
-    });
-    assert.deepStrictEqual(
-        requirePackageAt(document, 0).tree.map((entry) => [entry.path, entry.depth, entry.type]),
-        [
-            ['package.json', 0, 'file'],
-            ['dist', 1, 'directory'],
-            ['dist/index.js', 1, 'file'],
-            ['types', 1, 'directory'],
-            ['types/internal', 2, 'directory'],
-            ['types/internal/index.d.ts', 2, 'file']
-        ]
-    );
-    assert.deepStrictEqual(
-        requirePackageAt(document, 1).tree.map((entry) => [entry.path, entry.depth, entry.type]),
-        [
-            ['package.json', 0, 'file'],
-            ['index.js', 0, 'file']
-        ]
-    );
-});
+    test('buildPreviewDocument does not attach a diff property when no diff exists', async function () {
+        const document = await buildSingleArtifactDocument();
+        const fileNode = requireFileNodeAt(document, 0, 0);
 
-test('buildPreviewDocument keeps eliminated files separate from the emitted tree', async () => {
-    const document = await buildPreviewDocument({
-        report: baseReport(),
-        result: Result.ok([buildResult()]),
-        dryRun: true,
-        fileManager: workspaceFileManager(async () => 'export {};\n')
+        assert.strictEqual('diff' in fileNode.artifact, false);
     });
 
-    const pkg = requireSinglePackage(document);
-    assert.deepStrictEqual(pkg.eliminatedSourceFiles, [eliminatedUnusedFile]);
-    assert.strictEqual(
-        pkg.tree.some((entry) => entry.path === eliminatedUnusedFile.path),
-        false
-    );
-});
-
-test('buildPreviewDocument treats eliminated-only packages as changed and opens them by default', async () => {
-    const document = await buildUnchangedPackageDocument({ eliminatedSourceFiles: [eliminatedUnusedFile] });
-
-    assert.strictEqual(requirePackageAt(document, 0).hasChanges, true);
-    assert.strictEqual(requirePackageAt(document, 0).openByDefault, true);
-});
-
-test('buildPreviewDocument reports failure-only runs with direct issues', async () => {
-    const document = await buildPreviewDocument({
-        report: { ...baseReport(), packages: {} },
-        result: Result.err({ type: 'checks', issues: ['bundle is too large'] }),
-        dryRun: true,
-        fileManager: workspaceFileManager(async () => 'export {};\n')
+    test('buildPreviewDocument skips diffs when the emitted artifact content matches the workspace file', async function () {
+        assertFirstFileHasNoDiff(await buildSingleArtifactDocument());
     });
 
-    assert.strictEqual(document.previewable, false);
-    assert.strictEqual(document.resultType, 'checks');
-    assert.deepStrictEqual(document.issues, ['bundle is too large']);
-});
-
-test('buildPreviewDocument marks a partial run with succeeded packages as previewable', async () => {
-    const document = await buildPreviewDocument({
-        report: baseReport(),
-        result: Result.err({ type: 'partial', succeeded: [buildResult()], failures: [new Error('boom')] }),
-        dryRun: true,
-        fileManager: workspaceFileManager(async () => 'export {};\n')
-    });
-
-    assert.strictEqual(document.previewable, true);
-    assert.strictEqual(document.resultType, 'partial');
-    assert.deepStrictEqual(document.issues, ['boom']);
-});
-
-test('buildPreviewDocument keeps unchanged packages closed unless they failed', async () => {
-    const unchangedDocument = await buildUnchangedPackageDocument({ eliminatedSourceFiles: [] });
-    const failedDocument = await buildUnchangedPackageDocument({
-        eliminatedSourceFiles: [],
-        failure: { stage: 'publish', message: 'boom' }
-    });
-
-    assert.strictEqual(requirePackageAt(unchangedDocument, 0).hasChanges, false);
-    assert.strictEqual(requirePackageAt(unchangedDocument, 0).openByDefault, false);
-    assert.strictEqual(requirePackageAt(failedDocument, 0).openByDefault, true);
-    assert.strictEqual(failedDocument.summary.failedPackages, 1);
-});
-
-test('buildPreviewDocument leaves versionTransition undefined when no version decision exists', async () => {
-    const document = await buildPreviewDocument({
-        report: createBuildReportFixture({
-            packages: {
-                'pkg-a': createPackageReport([
-                    createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] })
-                ])
-            }
-        }),
-        result: Result.ok([buildResult()]),
-        dryRun: true,
-        fileManager: workspaceFileManager(async () => 'export {};\n')
-    });
-
-    assert.strictEqual(requirePackageAt(document, 0).versionTransition, undefined);
-});
-
-test('buildPreviewDocument uses publish mode when dryRun is false', async () => {
-    const document = await buildSingleArtifactDocument({ dryRun: false });
-
-    assert.strictEqual(document.modeLabel, 'Publish');
-});
-
-test('buildPreviewDocument omits diffs when the artifact source path does not match the emitted content source', async () => {
-    const document = await buildSingleArtifactDocument({
-        artifactSourcePath: '/workspace/actual.js',
-        reportSourcePath: '/workspace/other.js',
-        emittedContent: 'export const changed = 1;\n',
-        workspaceContent: 'export const original = 1;\n'
-    });
-
-    assertFirstFileHasNoDiff(document);
-});
-
-test('buildPreviewDocument reads workspace files through the injected file manager', async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'packtory-preview-test-'));
-    const sourceFilePath = path.join(tempDir, 'index.js');
-    await writeFile(sourceFilePath, 'export const original = 1;\n');
-    const fileManager = createFileManager({ hostFileSystem: fs.promises });
-
-    const document = await buildPreviewDocument({
-        report: reportForPkgA([
-            createArtifactEntryFixture({
-                path: 'index.js',
-                sizeBytes: 10,
-                sourcePath: sourceFilePath,
-                badges: []
+    test('buildPreviewDocument skips diffs when the report source path does not match the emitted artifact source path', async function () {
+        assertFirstFileHasNoDiff(
+            await buildSingleArtifactDocument({
+                reportSourcePath: '/workspace/report-index.js',
+                workspaceContent: 'export const same = 1;\n'
             })
-        ]),
-        result: Result.ok([
-            createBuildResultFixture({
-                contents: [
-                    createAnalyzedResource({
-                        sourceFilePath,
-                        targetFilePath: 'index.js',
-                        content: 'export const changed = 1;\n'
-                    })
-                ]
-            })
-        ]),
-        dryRun: true,
-        fileManager
+        );
     });
 
-    const fileNode = requirePackageAt(document, 0).tree.find(
-        (entry) => entry.type === 'file' && entry.path === 'index.js'
-    );
-    if (fileNode?.type !== 'file') {
-        assert.fail('expected index.js file node');
-    }
-    assert.ok(fileNode.artifact.diff !== undefined);
-});
-
-test('buildPreviewDocument orders directories before files and sorts alphabetically after package.json', async () => {
-    await expectTreePaths(
-        [
-            tinyUnchangedSource('z-last.js'),
-            createArtifactEntryFixture({ kind: 'manifest', path: 'package.json', badges: [] }),
-            tinyUnchangedSource('a/inside.js')
-        ],
-        ['package.json', 'a', 'a/inside.js', 'z-last.js']
-    );
-});
-
-test('buildPreviewDocument limits diffs to two hunks and drops patch metadata lines', async () => {
-    const document = await buildChangedSourceDiffDocument(
-        'a();\nkeep1();\nkeep2();\nkeep3();\nkeep4();\nkeep5();\nkeep6();\nkeep7();\nkeep8();\nb();\nkeep9();\nkeep10();\nkeep11();\nkeep12();\nkeep13();\nkeep14();\nkeep15();\nkeep16();\nc();\n',
-        'oldA();\nkeep1();\nkeep2();\nkeep3();\nkeep4();\nkeep5();\nkeep6();\nkeep7();\nkeep8();\noldB();\nkeep9();\nkeep10();\nkeep11();\nkeep12();\nkeep13();\nkeep14();\nkeep15();\nkeep16();\noldC();\n'
-    );
-
-    const { diff } = requireFileNodeByPath(document, 0, 'src/index.js').artifact;
-    if (diff === undefined) {
-        assert.fail('expected diff');
-    }
-    assert.deepStrictEqual(
-        diff.map((hunk) => [hunk.header, hunk.lines.some((line) => line.text.startsWith('\\'))]),
-        [
-            ['@@ -1,4 +1,4 @@', false],
-            ['@@ -7,7 +7,7 @@', false]
-        ]
-    );
-});
-
-test('buildPreviewDocument drops no-newline markers from diff lines', async () => {
-    const document = await buildChangedSourceDiffDocument('changed', 'original');
-
-    const { diff } = requireFileNodeByPath(document, 0, 'src/index.js').artifact;
-    if (diff === undefined) {
-        assert.fail('expected diff');
-    }
-    assert.ok(
-        diff.every((hunk) => {
-            return hunk.lines.every((line) => {
-                return !line.text.startsWith('\\');
-            });
-        })
-    );
-});
-
-test('buildPreviewDocument does not attach a diff property when no diff exists', async () => {
-    const document = await buildSingleArtifactDocument();
-    const fileNode = requireFileNodeAt(document, 0, 0);
-
-    assert.strictEqual('diff' in fileNode.artifact, false);
-});
-
-test('buildPreviewDocument skips diffs when the emitted artifact content matches the workspace file', async () => {
-    assertFirstFileHasNoDiff(await buildSingleArtifactDocument());
-});
-
-test('buildPreviewDocument skips diffs when the report source path does not match the emitted artifact source path', async () => {
-    assertFirstFileHasNoDiff(
-        await buildSingleArtifactDocument({
-            reportSourcePath: '/workspace/report-index.js',
-            workspaceContent: 'export const same = 1;\n'
-        })
-    );
-});
-
-test('buildPreviewDocument labels unchanged context lines in generated diffs', async () => {
-    const document = await buildSingleArtifactDocument({
-        emittedContent: 'keep();\nnewLine();\n',
-        workspaceContent: 'keep();\noldLine();\n'
+    test('buildPreviewDocument labels unchanged context lines in generated diffs', async function () {
+        const document = await buildSingleArtifactDocument({
+            emittedContent: 'keep();\nnewLine();\n',
+            workspaceContent: 'keep();\noldLine();\n'
+        });
+        const { artifact } = requireFileNodeAt(document, 0, 0);
+        const { diff } = artifact;
+        if (diff === undefined) {
+            assert.fail('expected diff');
+        }
+        assert.strictEqual(
+            diff.some((hunk) => hunk.lines.some((line) => line.type === 'context')),
+            true
+        );
     });
-    const { artifact } = requireFileNodeAt(document, 0, 0);
-    const { diff } = artifact;
-    if (diff === undefined) {
-        assert.fail('expected diff');
-    }
-    assert.strictEqual(
-        diff.some((hunk) => hunk.lines.some((line) => line.type === 'context')),
-        true
-    );
-});
 
-test('buildPreviewDocument handles failed packages without outputs and publish-mode labels', async () => {
-    const document = await buildPreviewDocument({
-        report: createBuildReportFixture({
-            packages: {
-                'pkg-a': {
-                    decisions: {},
-                    failure: { stage: 'publish', message: 'boom' },
-                    timings: {}
+    test('buildPreviewDocument handles failed packages without outputs and publish-mode labels', async function () {
+        const document = await buildPreviewDocument({
+            report: createBuildReportFixture({
+                packages: {
+                    'pkg-a': {
+                        decisions: {},
+                        failure: { stage: 'publish', message: 'boom' },
+                        timings: {}
+                    }
                 }
-            }
-        }),
-        result: Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }),
-        dryRun: false,
-        fileManager: workspaceFileManager(async () => 'export {};\n')
+            }),
+            result: Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }),
+            dryRun: false,
+            fileManager: workspaceFileManager(async () => 'export {};\n')
+        });
+
+        assert.strictEqual(document.modeLabel, 'Publish');
+        const pkg = requireSinglePackage(document);
+        if (pkg.failure === undefined) {
+            assert.fail('expected package failure');
+        }
+        assert.strictEqual(pkg.failure.message, 'boom');
+        assert.strictEqual(pkg.openByDefault, true);
+        assert.deepStrictEqual(pkg.tree, []);
+        assert.deepStrictEqual(document.summary, {
+            totalPackages: 1,
+            changedPackages: 0,
+            unchangedPackages: 0,
+            failedPackages: 1,
+            emittedArtifacts: 0,
+            changedArtifacts: 0,
+            eliminatedSourceFiles: 0
+        });
     });
 
-    assert.strictEqual(document.modeLabel, 'Publish');
-    const pkg = requireSinglePackage(document);
-    if (pkg.failure === undefined) {
-        assert.fail('expected package failure');
-    }
-    assert.strictEqual(pkg.failure.message, 'boom');
-    assert.strictEqual(pkg.openByDefault, true);
-    assert.deepStrictEqual(pkg.tree, []);
-    assert.deepStrictEqual(document.summary, {
-        totalPackages: 1,
-        changedPackages: 0,
-        unchangedPackages: 0,
-        failedPackages: 1,
-        emittedArtifacts: 0,
-        changedArtifacts: 0,
-        eliminatedSourceFiles: 0
+    test('buildPreviewDocument reuses existing directories and supports nested directory sorting', async function () {
+        await expectTreePaths(
+            [
+                tinyUnchangedSource('top.js'),
+                tinyUnchangedSource('nested/deeper/a.js'),
+                tinyUnchangedSource('nested/deeper/b.js')
+            ],
+            ['nested', 'nested/deeper', 'nested/deeper/a.js', 'nested/deeper/b.js', 'top.js']
+        );
     });
-});
 
-test('buildPreviewDocument reuses existing directories and supports nested directory sorting', async () => {
-    await expectTreePaths(
-        [
-            tinyUnchangedSource('top.js'),
-            tinyUnchangedSource('nested/deeper/a.js'),
-            tinyUnchangedSource('nested/deeper/b.js')
-        ],
-        ['nested', 'nested/deeper', 'nested/deeper/a.js', 'nested/deeper/b.js', 'top.js']
-    );
-});
+    test('artifactStatusLabel returns the canonical "generated", "changed", or "unchanged" string for each artifact status', function () {
+        assert.strictEqual(artifactStatusLabel('generated'), 'generated');
+        assert.strictEqual(artifactStatusLabel('changed'), 'changed');
+        assert.strictEqual(artifactStatusLabel('unchanged'), 'unchanged');
+    });
 
-test('artifactStatusLabel returns the canonical "generated", "changed", or "unchanged" string for each artifact status', () => {
-    assert.strictEqual(artifactStatusLabel('generated'), 'generated');
-    assert.strictEqual(artifactStatusLabel('changed'), 'changed');
-    assert.strictEqual(artifactStatusLabel('unchanged'), 'unchanged');
-});
-
-test('artifactBadgeLabel returns "DCE" for dead-code-elimination and "rewrite" for import-path-rewrite', () => {
-    assert.strictEqual(artifactBadgeLabel('dead-code-elimination'), 'DCE');
-    assert.strictEqual(artifactBadgeLabel('import-path-rewrite'), 'rewrite');
+    test('artifactBadgeLabel returns "DCE" for dead-code-elimination and "rewrite" for import-path-rewrite', function () {
+        assert.strictEqual(artifactBadgeLabel('dead-code-elimination'), 'DCE');
+        assert.strictEqual(artifactBadgeLabel('import-path-rewrite'), 'rewrite');
+    });
 });

--- a/source/report/preview/preview-result-inspectors.test.ts
+++ b/source/report/preview/preview-result-inspectors.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PublishAllResult } from '../../packtory/packtory.ts';
 import { getIssues, getResultType, getSucceededResults, isPreviewableResult } from './preview-result-inspectors.ts';
 
@@ -11,86 +11,91 @@ function errResult(error: PublishAllResult extends { error: infer T } ? T : neve
     return { isOk: false, isErr: true, error } as unknown as PublishAllResult;
 }
 
-test('isPreviewableResult returns true for an ok result', () => {
-    assert.strictEqual(isPreviewableResult(okResult()), true);
-});
+suite('preview-result-inspectors', function () {
+    test('isPreviewableResult returns true for an ok result', function () {
+        assert.strictEqual(isPreviewableResult(okResult()), true);
+    });
 
-test('isPreviewableResult returns true for a partial error with at least one succeeded entry', () => {
-    assert.strictEqual(
-        isPreviewableResult(
-            errResult({
-                type: 'partial',
-                succeeded: [{ name: 'pkg-a' }],
-                failures: []
-            } as never)
-        ),
-        true
-    );
-});
+    test('isPreviewableResult returns true for a partial error with at least one succeeded entry', function () {
+        assert.strictEqual(
+            isPreviewableResult(
+                errResult({
+                    type: 'partial',
+                    succeeded: [{ name: 'pkg-a' }],
+                    failures: []
+                } as never)
+            ),
+            true
+        );
+    });
 
-test('isPreviewableResult returns false for a non-partial error', () => {
-    assert.strictEqual(isPreviewableResult(errResult({ type: 'config', issues: [] } as never)), false);
-});
+    test('isPreviewableResult returns false for a non-partial error', function () {
+        assert.strictEqual(isPreviewableResult(errResult({ type: 'config', issues: [] } as never)), false);
+    });
 
-test('isPreviewableResult returns false for a partial error with no succeeded entries', () => {
-    assert.strictEqual(
-        isPreviewableResult(
-            errResult({
-                type: 'partial',
-                succeeded: [],
-                failures: [{ message: 'boom' }]
-            } as never)
-        ),
-        false
-    );
-});
+    test('isPreviewableResult returns false for a partial error with no succeeded entries', function () {
+        assert.strictEqual(
+            isPreviewableResult(
+                errResult({
+                    type: 'partial',
+                    succeeded: [],
+                    failures: [{ message: 'boom' }]
+                } as never)
+            ),
+            false
+        );
+    });
 
-test('getSucceededResults returns the value when the result is ok', () => {
-    assert.deepStrictEqual(getSucceededResults(okResult([{ name: 'pkg-a' }] as never)), [{ name: 'pkg-a' }]);
-});
+    test('getSucceededResults returns the value when the result is ok', function () {
+        assert.deepStrictEqual(getSucceededResults(okResult([{ name: 'pkg-a' }] as never)), [{ name: 'pkg-a' }]);
+    });
 
-test('getSucceededResults returns the succeeded list when the error is partial', () => {
-    assert.deepStrictEqual(
-        getSucceededResults(
-            errResult({
-                type: 'partial',
-                succeeded: [{ name: 'pkg-a' }],
-                failures: []
-            } as never)
-        ),
-        [{ name: 'pkg-a' }]
-    );
-});
+    test('getSucceededResults returns the succeeded list when the error is partial', function () {
+        assert.deepStrictEqual(
+            getSucceededResults(
+                errResult({
+                    type: 'partial',
+                    succeeded: [{ name: 'pkg-a' }],
+                    failures: []
+                } as never)
+            ),
+            [{ name: 'pkg-a' }]
+        );
+    });
 
-test('getSucceededResults returns an empty array for non-partial errors', () => {
-    assert.deepStrictEqual(getSucceededResults(errResult({ type: 'config', issues: [] } as never)), []);
-});
+    test('getSucceededResults returns an empty array for non-partial errors', function () {
+        assert.deepStrictEqual(getSucceededResults(errResult({ type: 'config', issues: [] } as never)), []);
+    });
 
-test('getIssues returns an empty array for an ok result', () => {
-    assert.deepStrictEqual(getIssues(okResult()), []);
-});
+    test('getIssues returns an empty array for an ok result', function () {
+        assert.deepStrictEqual(getIssues(okResult()), []);
+    });
 
-test('getIssues maps partial failure messages onto the issues list', () => {
-    assert.deepStrictEqual(
-        getIssues(
-            errResult({
-                type: 'partial',
-                succeeded: [],
-                failures: [{ message: 'boom' }, { message: 'bang' }]
-            } as never)
-        ),
-        ['boom', 'bang']
-    );
-});
+    test('getIssues maps partial failure messages onto the issues list', function () {
+        assert.deepStrictEqual(
+            getIssues(
+                errResult({
+                    type: 'partial',
+                    succeeded: [],
+                    failures: [{ message: 'boom' }, { message: 'bang' }]
+                } as never)
+            ),
+            ['boom', 'bang']
+        );
+    });
 
-test('getIssues returns the config issues for a config error', () => {
-    assert.deepStrictEqual(getIssues(errResult({ type: 'config', issues: ['missing'] } as never)), ['missing']);
-});
+    test('getIssues returns the config issues for a config error', function () {
+        assert.deepStrictEqual(getIssues(errResult({ type: 'config', issues: ['missing'] } as never)), ['missing']);
+    });
 
-test('getResultType returns "success" for an ok result', () => {
-    assert.strictEqual(getResultType(okResult()), 'success');
-});
+    test('getResultType returns "success" for an ok result', function () {
+        assert.strictEqual(getResultType(okResult()), 'success');
+    });
 
-test('getResultType returns the underlying error type for an err result', () => {
-    assert.strictEqual(getResultType(errResult({ type: 'partial', succeeded: [], failures: [] } as never)), 'partial');
+    test('getResultType returns the underlying error type for an err result', function () {
+        assert.strictEqual(
+            getResultType(errResult({ type: 'partial', succeeded: [], failures: [] } as never)),
+            'partial'
+        );
+    });
 });

--- a/source/report/preview/preview-summary.test.ts
+++ b/source/report/preview/preview-summary.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewArtifactNode } from './artifact-tree-builder.ts';
 import { summarizePackages } from './preview-summary.ts';
 
@@ -16,51 +16,55 @@ function fileNode(status: 'changed' | 'generated' | 'unchanged'): PreviewArtifac
 
 const directoryNode: PreviewArtifactNode = { type: 'directory', name: 'src', path: 'src', depth: 0 };
 
-test('summarizePackages returns zero counts for an empty package list', () => {
-    assert.deepStrictEqual(summarizePackages([]), {
-        totalPackages: 0,
-        changedPackages: 0,
-        unchangedPackages: 0,
-        failedPackages: 0,
-        emittedArtifacts: 0,
-        changedArtifacts: 0,
-        eliminatedSourceFiles: 0
+suite('preview-summary', function () {
+    test('summarizePackages returns zero counts for an empty package list', function () {
+        assert.deepStrictEqual(summarizePackages([]), {
+            totalPackages: 0,
+            changedPackages: 0,
+            unchangedPackages: 0,
+            failedPackages: 0,
+            emittedArtifacts: 0,
+            changedArtifacts: 0,
+            eliminatedSourceFiles: 0
+        });
     });
-});
 
-test('summarizePackages counts a package as changed when it has changes', () => {
-    const summary = summarizePackages([{ hasChanges: true, eliminatedSourceFiles: [], tree: [fileNode('changed')] }]);
-    assert.strictEqual(summary.changedPackages, 1);
-    assert.strictEqual(summary.unchangedPackages, 0);
-});
+    test('summarizePackages counts a package as changed when it has changes', function () {
+        const summary = summarizePackages([
+            { hasChanges: true, eliminatedSourceFiles: [], tree: [fileNode('changed')] }
+        ]);
+        assert.strictEqual(summary.changedPackages, 1);
+        assert.strictEqual(summary.unchangedPackages, 0);
+    });
 
-test('summarizePackages counts an unchanged success as an unchanged package', () => {
-    const summary = summarizePackages([{ hasChanges: false, eliminatedSourceFiles: [], tree: [] }]);
-    assert.strictEqual(summary.unchangedPackages, 1);
-    assert.strictEqual(summary.changedPackages, 0);
-});
+    test('summarizePackages counts an unchanged success as an unchanged package', function () {
+        const summary = summarizePackages([{ hasChanges: false, eliminatedSourceFiles: [], tree: [] }]);
+        assert.strictEqual(summary.unchangedPackages, 1);
+        assert.strictEqual(summary.changedPackages, 0);
+    });
 
-test('summarizePackages counts a package as failed when it has a failure entry', () => {
-    const summary = summarizePackages([
-        {
-            hasChanges: false,
-            failure: { stage: 'publish', message: 'boom' } as never,
-            eliminatedSourceFiles: [],
-            tree: []
-        }
-    ]);
-    assert.strictEqual(summary.failedPackages, 1);
-});
+    test('summarizePackages counts a package as failed when it has a failure entry', function () {
+        const summary = summarizePackages([
+            {
+                hasChanges: false,
+                failure: { stage: 'publish', message: 'boom' } as never,
+                eliminatedSourceFiles: [],
+                tree: []
+            }
+        ]);
+        assert.strictEqual(summary.failedPackages, 1);
+    });
 
-test('summarizePackages sums emitted and changed artifacts across packages and ignores directories', () => {
-    const summary = summarizePackages([
-        {
-            hasChanges: true,
-            eliminatedSourceFiles: [{ path: '/a.js' }],
-            tree: [directoryNode, fileNode('changed'), fileNode('unchanged')]
-        }
-    ]);
-    assert.strictEqual(summary.emittedArtifacts, 2);
-    assert.strictEqual(summary.changedArtifacts, 1);
-    assert.strictEqual(summary.eliminatedSourceFiles, 1);
+    test('summarizePackages sums emitted and changed artifacts across packages and ignores directories', function () {
+        const summary = summarizePackages([
+            {
+                hasChanges: true,
+                eliminatedSourceFiles: [{ path: '/a.js' }],
+                tree: [directoryNode, fileNode('changed'), fileNode('unchanged')]
+            }
+        ]);
+        assert.strictEqual(summary.emittedArtifacts, 2);
+        assert.strictEqual(summary.changedArtifacts, 1);
+        assert.strictEqual(summary.eliminatedSourceFiles, 1);
+    });
 });

--- a/source/report/terminal-renderer/terminal-artifact-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-artifact-renderer.test.ts
@@ -1,43 +1,45 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PreviewArtifactNode } from '../preview/artifact-tree-builder.ts';
 import { renderArtifactNode } from './terminal-artifact-renderer.ts';
 import { createColors } from './terminal-preview-renderer-shared.ts';
 
 const colors = createColors(false);
 
-test('renderArtifactNode renders a directory with a triangle marker indented by depth', () => {
-    const node: PreviewArtifactNode = { type: 'directory', name: 'src', path: 'src/', depth: 1 };
+suite('terminal-artifact-renderer', function () {
+    test('renderArtifactNode renders a directory with a triangle marker indented by depth', function () {
+        const node: PreviewArtifactNode = { type: 'directory', name: 'src', path: 'src/', depth: 1 };
 
-    assert.strictEqual(renderArtifactNode(node, colors), '    ▸ src/');
-});
+        assert.strictEqual(renderArtifactNode(node, colors), '    ▸ src/');
+    });
 
-test('renderArtifactNode renders a file node with kind, byte size, status and badge labels', () => {
-    const node: PreviewArtifactNode = {
-        type: 'file',
-        name: 'index.js',
-        path: 'src/index.js',
-        depth: 0,
-        artifact: {
+    test('renderArtifactNode renders a file node with kind, byte size, status and badge labels', function () {
+        const node: PreviewArtifactNode = {
+            type: 'file',
+            name: 'index.js',
             path: 'src/index.js',
-            sizeBytes: 42,
-            kind: 'source',
-            status: 'changed',
-            badges: ['import-path-rewrite']
-        }
-    };
+            depth: 0,
+            artifact: {
+                path: 'src/index.js',
+                sizeBytes: 42,
+                kind: 'source',
+                status: 'changed',
+                badges: ['import-path-rewrite']
+            }
+        };
 
-    assert.strictEqual(renderArtifactNode(node, colors), '  • src/index.js (source, 42 B) [changed, rewrite]');
-});
+        assert.strictEqual(renderArtifactNode(node, colors), '  • src/index.js (source, 42 B) [changed, rewrite]');
+    });
 
-test('renderArtifactNode omits trailing whitespace when there are no badges and the status label is empty', () => {
-    const node: PreviewArtifactNode = {
-        type: 'file',
-        name: 'file.txt',
-        path: 'file.txt',
-        depth: 0,
-        artifact: { path: 'file.txt', sizeBytes: 0, kind: 'additional', status: 'unchanged', badges: [] }
-    };
+    test('renderArtifactNode omits trailing whitespace when there are no badges and the status label is empty', function () {
+        const node: PreviewArtifactNode = {
+            type: 'file',
+            name: 'file.txt',
+            path: 'file.txt',
+            depth: 0,
+            artifact: { path: 'file.txt', sizeBytes: 0, kind: 'additional', status: 'unchanged', badges: [] }
+        };
 
-    assert.strictEqual(renderArtifactNode(node, colors).endsWith(' '), false);
+        assert.strictEqual(renderArtifactNode(node, colors).endsWith(' '), false);
+    });
 });

--- a/source/report/terminal-renderer/terminal-package-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-package-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     createManifestOnlyPreviewPackageFixture,
     createPreviewPackageFixture
@@ -9,46 +9,48 @@ import { createColors } from './terminal-preview-renderer-shared.ts';
 
 const colors = createColors(false);
 
-test('renderPackage renders the name, version transition, tree, eliminated files, and diffs', () => {
-    const output = renderPackage(createPreviewPackageFixture(), colors);
+suite('terminal-package-renderer', function () {
+    test('renderPackage renders the name, version transition, tree, eliminated files, and diffs', function () {
+        const output = renderPackage(createPreviewPackageFixture(), colors);
 
-    assert.strictEqual(
-        output,
-        [
-            'pkg-a 1.0.0 -> 1.0.1',
-            '  • package.json (manifest, 2 B) [generated]',
-            '  ▸ src/',
-            '    • src/index.js (source, 20 B) [changed, DCE]',
-            '  Eliminated source files',
-            '    - /workspace/src/unused.js (14 B)',
-            '  Diffs',
-            '    src/index.js',
-            '      @@ -1,1 +1,1 @@',
-            '      -export const removed = 1;',
-            '      +export const kept = 1;'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            output,
+            [
+                'pkg-a 1.0.0 -> 1.0.1',
+                '  • package.json (manifest, 2 B) [generated]',
+                '  ▸ src/',
+                '    • src/index.js (source, 20 B) [changed, DCE]',
+                '  Eliminated source files',
+                '    - /workspace/src/unused.js (14 B)',
+                '  Diffs',
+                '    src/index.js',
+                '      @@ -1,1 +1,1 @@',
+                '      -export const removed = 1;',
+                '      +export const kept = 1;'
+            ].join('\n')
+        );
+    });
 
-test('renderPackage omits the version transition when it is undefined', () => {
-    const output = renderPackage(createPreviewPackageFixture({ versionTransition: undefined }), colors);
+    test('renderPackage omits the version transition when it is undefined', function () {
+        const output = renderPackage(createPreviewPackageFixture({ versionTransition: undefined }), colors);
 
-    assert.ok(output.startsWith('pkg-a\n'));
-    assert.ok(!output.includes('undefined'));
-});
+        assert.ok(output.startsWith('pkg-a\n'));
+        assert.ok(!output.includes('undefined'));
+    });
 
-test('renderPackage prepends a failure line when the package has a failure', () => {
-    const output = renderPackage(
-        createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } }),
-        colors
-    );
+    test('renderPackage prepends a failure line when the package has a failure', function () {
+        const output = renderPackage(
+            createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } }),
+            colors
+        );
 
-    assert.ok(output.includes('failure publish: boom'));
-});
+        assert.ok(output.includes('failure publish: boom'));
+    });
 
-test('renderPackage omits the diffs and eliminated-files sections when both are absent', () => {
-    const output = renderPackage(createManifestOnlyPreviewPackageFixture(), colors);
+    test('renderPackage omits the diffs and eliminated-files sections when both are absent', function () {
+        const output = renderPackage(createManifestOnlyPreviewPackageFixture(), colors);
 
-    assert.ok(!output.includes('Diffs'));
-    assert.ok(!output.includes('Eliminated source files'));
+        assert.ok(!output.includes('Diffs'));
+        assert.ok(!output.includes('Eliminated source files'));
+    });
 });

--- a/source/report/terminal-renderer/terminal-preview-renderer-shared.test.ts
+++ b/source/report/terminal-renderer/terminal-preview-renderer-shared.test.ts
@@ -1,37 +1,41 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { bold as defaultBoldFormatter } from 'yoctocolors';
 import { createColors, renderDiffLine } from './terminal-preview-renderer-shared.ts';
 
 const escapeSequenceStart = String.fromCodePoint(27);
 
-test('renderDiffLine colors add and remove lines and leaves context lines unchanged', () => {
-    const colors = createColors(true);
+suite('terminal-preview-renderer-shared', function () {
+    test('renderDiffLine colors add and remove lines and leaves context lines unchanged', function () {
+        const colors = createColors(true);
 
-    assert.ok(renderDiffLine({ type: 'add', text: '+ok' }, colors).startsWith(`${escapeSequenceStart}[32m+ok`));
-    assert.ok(renderDiffLine({ type: 'remove', text: '-nope' }, colors).startsWith(`${escapeSequenceStart}[31m-nope`));
-    assert.strictEqual(renderDiffLine({ type: 'context', text: ' same' }, colors), ' same');
-});
+        assert.ok(renderDiffLine({ type: 'add', text: '+ok' }, colors).startsWith(`${escapeSequenceStart}[32m+ok`));
+        assert.ok(
+            renderDiffLine({ type: 'remove', text: '-nope' }, colors).startsWith(`${escapeSequenceStart}[31m-nope`)
+        );
+        assert.strictEqual(renderDiffLine({ type: 'context', text: ' same' }, colors), ' same');
+    });
 
-test('createColors returns forced ANSI formatters when enabled', () => {
-    const colors = createColors(true);
+    test('createColors returns forced ANSI formatters when enabled', function () {
+        const colors = createColors(true);
 
-    assert.strictEqual(colors.bold('x'), `${escapeSequenceStart}[1mx${escapeSequenceStart}[22m`);
-    assert.strictEqual(colors.yellow('y'), `${escapeSequenceStart}[33my${escapeSequenceStart}[39m`);
-    assert.notStrictEqual(colors.bold, defaultBoldFormatter);
-});
+        assert.strictEqual(colors.bold('x'), `${escapeSequenceStart}[1mx${escapeSequenceStart}[22m`);
+        assert.strictEqual(colors.yellow('y'), `${escapeSequenceStart}[33my${escapeSequenceStart}[39m`);
+        assert.notStrictEqual(colors.bold, defaultBoldFormatter);
+    });
 
-test('createColors returns identity formatters when disabled', () => {
-    const colors = createColors(false);
+    test('createColors returns identity formatters when disabled', function () {
+        const colors = createColors(false);
 
-    assert.strictEqual(colors.bold('x'), 'x');
-    assert.strictEqual(colors.yellow('y'), 'y');
-    assert.strictEqual(colors.bold, colors.dim);
-});
+        assert.strictEqual(colors.bold('x'), 'x');
+        assert.strictEqual(colors.yellow('y'), 'y');
+        assert.strictEqual(colors.bold, colors.dim);
+    });
 
-test('createColors defaults to non-forced output when color is undefined in this environment', () => {
-    const colors = createColors(undefined);
+    test('createColors defaults to non-forced output when color is undefined in this environment', function () {
+        const colors = createColors(undefined);
 
-    assert.strictEqual(colors.bold('x'), defaultBoldFormatter('x'));
-    assert.strictEqual(colors.bold, defaultBoldFormatter);
+        assert.strictEqual(colors.bold('x'), defaultBoldFormatter('x'));
+        assert.strictEqual(colors.bold, defaultBoldFormatter);
+    });
 });

--- a/source/report/terminal-renderer/terminal-preview-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-preview-renderer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     createDirectoryDiffPreviewPackageFixture,
     createManifestOnlyPreviewPackageFixture,
@@ -10,179 +10,181 @@ import { renderFailureOnlyTerminalPreview, renderTerminalPreview } from './termi
 
 const escapeSequenceStart = String.fromCodePoint(27);
 
-test('renderTerminalPreview renders the full tree with metadata, badges, and diffs', () => {
-    const output = renderTerminalPreview(createPreviewDocumentFixture(), { color: false });
+suite('terminal-preview-renderer', function () {
+    test('renderTerminalPreview renders the full tree with metadata, badges, and diffs', function () {
+        const output = renderTerminalPreview(createPreviewDocumentFixture(), { color: false });
 
-    assert.strictEqual(
-        output,
-        [
-            'Packtory preview [Dry run]',
-            '',
-            '1 package(s) · 1 changed · 0 failed',
-            '',
-            'pkg-a 1.0.0 -> 1.0.1',
-            '  • package.json (manifest, 2 B) [generated]',
-            '  ▸ src/',
-            '    • src/index.js (source, 20 B) [changed, DCE]',
-            '  Eliminated source files',
-            '    - /workspace/src/unused.js (14 B)',
-            '  Diffs',
-            '    src/index.js',
-            '      @@ -1,1 +1,1 @@',
-            '      -export const removed = 1;',
-            '      +export const kept = 1;',
-            ''
-        ].join('\n')
-    );
-    assert.ok(!output.includes('Stryker was here'));
-});
+        assert.strictEqual(
+            output,
+            [
+                'Packtory preview [Dry run]',
+                '',
+                '1 package(s) · 1 changed · 0 failed',
+                '',
+                'pkg-a 1.0.0 -> 1.0.1',
+                '  • package.json (manifest, 2 B) [generated]',
+                '  ▸ src/',
+                '    • src/index.js (source, 20 B) [changed, DCE]',
+                '  Eliminated source files',
+                '    - /workspace/src/unused.js (14 B)',
+                '  Diffs',
+                '    src/index.js',
+                '      @@ -1,1 +1,1 @@',
+                '      -export const removed = 1;',
+                '      +export const kept = 1;',
+                ''
+            ].join('\n')
+        );
+        assert.ok(!output.includes('Stryker was here'));
+    });
 
-test('renderFailureOnlyTerminalPreview renders issues and package failures for failure-only runs', () => {
-    const output = renderFailureOnlyTerminalPreview(
-        createPreviewDocumentFixture({
-            previewable: false,
-            resultType: 'checks',
-            issues: ['bundle is too large'],
-            packages: [createPreviewPackageFixture({ failure: { stage: 'resolveAndLink', message: 'boom' } })]
-        }),
-        { color: false }
-    );
+    test('renderFailureOnlyTerminalPreview renders issues and package failures for failure-only runs', function () {
+        const output = renderFailureOnlyTerminalPreview(
+            createPreviewDocumentFixture({
+                previewable: false,
+                resultType: 'checks',
+                issues: ['bundle is too large'],
+                packages: [createPreviewPackageFixture({ failure: { stage: 'resolveAndLink', message: 'boom' } })]
+            }),
+            { color: false }
+        );
 
-    assert.strictEqual(
-        output,
-        [
-            'Packtory preview [Dry run]',
-            'Check failures',
-            '- bundle is too large',
-            'pkg-a resolveAndLink: boom',
-            ''
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            output,
+            [
+                'Packtory preview [Dry run]',
+                'Check failures',
+                '- bundle is too large',
+                'pkg-a resolveAndLink: boom',
+                ''
+            ].join('\n')
+        );
+    });
 
-test('renderTerminalPreview renders issues and package failures in the normal preview view', () => {
-    const output = renderTerminalPreview(
-        createPreviewDocumentFixture({
-            issues: ['warning'],
-            packages: [createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } })]
-        }),
-        { color: false }
-    );
+    test('renderTerminalPreview renders issues and package failures in the normal preview view', function () {
+        const output = renderTerminalPreview(
+            createPreviewDocumentFixture({
+                issues: ['warning'],
+                packages: [createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } })]
+            }),
+            { color: false }
+        );
 
-    assert.ok(output.includes('Issues'));
-    assert.ok(output.includes('- warning'));
-    assert.ok(output.includes('failure publish: boom'));
-});
+        assert.ok(output.includes('Issues'));
+        assert.ok(output.includes('- warning'));
+        assert.ok(output.includes('failure publish: boom'));
+    });
 
-test('renderTerminalPreview joins multiple issues with newlines and skips directory diff payloads', () => {
-    const output = renderTerminalPreview(
-        createPreviewDocumentFixture({
-            issues: ['first', 'second'],
-            packages: [createDirectoryDiffPreviewPackageFixture()]
-        }),
-        { color: false }
-    );
+    test('renderTerminalPreview joins multiple issues with newlines and skips directory diff payloads', function () {
+        const output = renderTerminalPreview(
+            createPreviewDocumentFixture({
+                issues: ['first', 'second'],
+                packages: [createDirectoryDiffPreviewPackageFixture()]
+            }),
+            { color: false }
+        );
 
-    assert.ok(output.includes('Issues\n- first\n- second'));
-    assert.ok(!output.includes('src/index.js'));
-});
+        assert.ok(output.includes('Issues\n- first\n- second'));
+        assert.ok(!output.includes('src/index.js'));
+    });
 
-test('renderFailureOnlyTerminalPreview renders config and partial headings', () => {
-    const configOutput = renderFailureOnlyTerminalPreview(
-        createPreviewDocumentFixture({ previewable: false, resultType: 'config', packages: [] }),
-        { color: false }
-    );
-    const partialOutput = renderFailureOnlyTerminalPreview(
-        createPreviewDocumentFixture({ previewable: false, resultType: 'partial', packages: [] }),
-        { color: false }
-    );
+    test('renderFailureOnlyTerminalPreview renders config and partial headings', function () {
+        const configOutput = renderFailureOnlyTerminalPreview(
+            createPreviewDocumentFixture({ previewable: false, resultType: 'config', packages: [] }),
+            { color: false }
+        );
+        const partialOutput = renderFailureOnlyTerminalPreview(
+            createPreviewDocumentFixture({ previewable: false, resultType: 'partial', packages: [] }),
+            { color: false }
+        );
 
-    assert.ok(configOutput.includes('Configuration issues'));
-    assert.ok(partialOutput.includes('Package failures'));
-});
+        assert.ok(configOutput.includes('Configuration issues'));
+        assert.ok(partialOutput.includes('Package failures'));
+    });
 
-test('renderFailureOnlyTerminalPreview omits failure headings for success results', () => {
-    const output = renderFailureOnlyTerminalPreview(
-        createPreviewDocumentFixture({ previewable: false, resultType: 'success', issues: [] }),
-        { color: false }
-    );
+    test('renderFailureOnlyTerminalPreview omits failure headings for success results', function () {
+        const output = renderFailureOnlyTerminalPreview(
+            createPreviewDocumentFixture({ previewable: false, resultType: 'success', issues: [] }),
+            { color: false }
+        );
 
-    assert.strictEqual(output, 'Packtory preview [Dry run]\n');
-});
+        assert.strictEqual(output, 'Packtory preview [Dry run]\n');
+    });
 
-test('renderTerminalPreview supports color-enabled rendering', () => {
-    const output = renderTerminalPreview(createPreviewDocumentFixture(), { color: true });
+    test('renderTerminalPreview supports color-enabled rendering', function () {
+        const output = renderTerminalPreview(createPreviewDocumentFixture(), { color: true });
 
-    assert.ok(output.includes(`${escapeSequenceStart}[`));
-    assert.ok(output.includes('Packtory preview'));
-});
+        assert.ok(output.includes(`${escapeSequenceStart}[`));
+        assert.ok(output.includes('Packtory preview'));
+    });
 
-test('renderTerminalPreview renders context diff lines unchanged', () => {
-    const output = renderTerminalPreview(
-        createPreviewDocumentFixture({
-            packages: [
-                createPreviewPackageFixture({
-                    tree: [
-                        {
-                            path: 'src/index.js',
-                            name: 'index.js',
-                            depth: 0,
-                            type: 'file',
-                            artifact: {
+    test('renderTerminalPreview renders context diff lines unchanged', function () {
+        const output = renderTerminalPreview(
+            createPreviewDocumentFixture({
+                packages: [
+                    createPreviewPackageFixture({
+                        tree: [
+                            {
                                 path: 'src/index.js',
-                                sizeBytes: 20,
-                                kind: 'source',
-                                status: 'changed',
-                                badges: [],
-                                diff: [
-                                    {
-                                        header: '@@ -1,2 +1,2 @@',
-                                        lines: [{ type: 'context', text: ' unchanged();' }]
-                                    }
-                                ]
+                                name: 'index.js',
+                                depth: 0,
+                                type: 'file',
+                                artifact: {
+                                    path: 'src/index.js',
+                                    sizeBytes: 20,
+                                    kind: 'source',
+                                    status: 'changed',
+                                    badges: [],
+                                    diff: [
+                                        {
+                                            header: '@@ -1,2 +1,2 @@',
+                                            lines: [{ type: 'context', text: ' unchanged();' }]
+                                        }
+                                    ]
+                                }
                             }
-                        }
-                    ]
-                })
-            ]
-        }),
-        { color: false }
-    );
+                        ]
+                    })
+                ]
+            }),
+            { color: false }
+        );
 
-    assert.ok(output.includes('unchanged();'));
-});
+        assert.ok(output.includes('unchanged();'));
+    });
 
-test('renderTerminalPreview omits the version suffix when no version transition is present', () => {
-    const output = renderTerminalPreview(
-        createPreviewDocumentFixture({
-            packages: [createPreviewPackageFixture({ versionTransition: undefined })]
-        }),
-        { color: false }
-    );
+    test('renderTerminalPreview omits the version suffix when no version transition is present', function () {
+        const output = renderTerminalPreview(
+            createPreviewDocumentFixture({
+                packages: [createPreviewPackageFixture({ versionTransition: undefined })]
+            }),
+            { color: false }
+        );
 
-    assert.ok(output.includes('pkg-a'));
-    assert.ok(!output.includes('undefined'));
-});
+        assert.ok(output.includes('pkg-a'));
+        assert.ok(!output.includes('undefined'));
+    });
 
-test('renderTerminalPreview omits issues, eliminated files, and diffs when they are absent', () => {
-    const output = renderTerminalPreview(
-        createPreviewDocumentFixture({
-            issues: [],
-            packages: [createManifestOnlyPreviewPackageFixture()]
-        }),
-        { color: false }
-    );
+    test('renderTerminalPreview omits issues, eliminated files, and diffs when they are absent', function () {
+        const output = renderTerminalPreview(
+            createPreviewDocumentFixture({
+                issues: [],
+                packages: [createManifestOnlyPreviewPackageFixture()]
+            }),
+            { color: false }
+        );
 
-    assert.strictEqual(
-        output,
-        [
-            'Packtory preview [Dry run]',
-            '',
-            '1 package(s) · 1 changed · 0 failed',
-            '',
-            'pkg-a',
-            '  • package.json (manifest, 2 B) [generated]',
-            ''
-        ].join('\n')
-    );
+        assert.strictEqual(
+            output,
+            [
+                'Packtory preview [Dry run]',
+                '',
+                '1 package(s) · 1 changed · 0 failed',
+                '',
+                'pkg-a',
+                '  • package.json (manifest, 2 B) [generated]',
+                ''
+            ].join('\n')
+        );
+    });
 });

--- a/source/resource-resolver/bundle-resource-lookup.test.ts
+++ b/source/resource-resolver/bundle-resource-lookup.test.ts
@@ -1,63 +1,65 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { bundleResource } from '../test-libraries/bundle-fixtures.ts';
 import { buildResolvedRoots } from './bundle-resource-lookup.ts';
 
 const jsResource = bundleResource('/src/index.ts', { targetFilePath: 'index.js' });
 const dtsResource = bundleResource('/src/index.d.ts', { targetFilePath: 'index.d.ts' });
 
-test('buildResolvedRoots returns one entry per declared root', () => {
-    const normalized = {
-        roots: {
-            main: { js: '/src/index.ts' }
-        },
-        surface: undefined as never
-    };
+suite('bundle-resource-lookup', function () {
+    test('buildResolvedRoots returns one entry per declared root', function () {
+        const normalized = {
+            roots: {
+                main: { js: '/src/index.ts' }
+            },
+            surface: undefined as never
+        };
 
-    const result = buildResolvedRoots(normalized, [jsResource]);
+        const result = buildResolvedRoots(normalized, [jsResource]);
 
-    assert.deepStrictEqual(Object.keys(result), ['main']);
-});
+        assert.deepStrictEqual(Object.keys(result), ['main']);
+    });
 
-test('buildResolvedRoots attaches the matching declaration file when one is declared', () => {
-    const normalized = {
-        roots: {
-            main: { js: '/src/index.ts', declarationFile: '/src/index.d.ts' }
-        },
-        surface: undefined as never
-    };
+    test('buildResolvedRoots attaches the matching declaration file when one is declared', function () {
+        const normalized = {
+            roots: {
+                main: { js: '/src/index.ts', declarationFile: '/src/index.d.ts' }
+            },
+            surface: undefined as never
+        };
 
-    const result = buildResolvedRoots(normalized, [jsResource, dtsResource]);
+        const result = buildResolvedRoots(normalized, [jsResource, dtsResource]);
 
-    assert.strictEqual(result.main?.declarationFile?.sourceFilePath, '/src/index.d.ts');
-});
+        assert.strictEqual(result.main?.declarationFile?.sourceFilePath, '/src/index.d.ts');
+    });
 
-test('buildResolvedRoots leaves declarationFile undefined when none is declared', () => {
-    const normalized = {
-        roots: {
-            main: { js: '/src/index.ts' }
-        },
-        surface: undefined as never
-    };
+    test('buildResolvedRoots leaves declarationFile undefined when none is declared', function () {
+        const normalized = {
+            roots: {
+                main: { js: '/src/index.ts' }
+            },
+            surface: undefined as never
+        };
 
-    const result = buildResolvedRoots(normalized, [jsResource]);
+        const result = buildResolvedRoots(normalized, [jsResource]);
 
-    assert.strictEqual(result.main?.declarationFile, undefined);
-});
+        assert.strictEqual(result.main?.declarationFile, undefined);
+    });
 
-test('buildResolvedRoots throws when no resource exposes the declared js path', () => {
-    const normalized = {
-        roots: {
-            main: { js: '/src/missing.ts' }
-        },
-        surface: undefined as never
-    };
+    test('buildResolvedRoots throws when no resource exposes the declared js path', function () {
+        const normalized = {
+            roots: {
+                main: { js: '/src/missing.ts' }
+            },
+            surface: undefined as never
+        };
 
-    try {
-        buildResolvedRoots(normalized, [jsResource]);
-        assert.fail('expected buildResolvedRoots to throw');
-    } catch (error) {
-        assert.ok(error instanceof Error);
-        assert.strictEqual(error.message, 'Failed to resolve resource for root /src/missing.ts');
-    }
+        try {
+            buildResolvedRoots(normalized, [jsResource]);
+            assert.fail('expected buildResolvedRoots to throw');
+        } catch (error) {
+            assert.ok(error instanceof Error);
+            assert.strictEqual(error.message, 'Failed to resolve resource for root /src/missing.ts');
+        }
+    });
 });

--- a/source/resource-resolver/content.test.ts
+++ b/source/resource-resolver/content.test.ts
@@ -1,126 +1,128 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { combineAllBundleFiles } from './content.ts';
 
-test('combines all bundle files correctly', () => {
-    const result = combineAllBundleFiles('/foo', [], []);
-    assert.deepStrictEqual(result, []);
-});
+suite('content', function () {
+    test('combines all bundle files correctly', function () {
+        const result = combineAllBundleFiles('/foo', [], []);
+        assert.deepStrictEqual(result, []);
+    });
 
-test('keeps absolute local dependency paths and derives relative target paths from sourcesFolder', () => {
-    const result = combineAllBundleFiles(
-        '/src',
-        [
+    test('keeps absolute local dependency paths and derives relative target paths from sourcesFolder', function () {
+        const result = combineAllBundleFiles(
+            '/src',
+            [
+                {
+                    filePath: '/src/nested/index.js',
+                    directDependencies: new Set(['/src/nested/internal.js']),
+                    project: 'project' as never
+                }
+            ],
+            []
+        );
+
+        assert.deepStrictEqual(result, [
             {
-                filePath: '/src/nested/index.js',
+                sourceFilePath: '/src/nested/index.js',
+                targetFilePath: 'nested/index.js',
                 directDependencies: new Set(['/src/nested/internal.js']),
-                project: 'project' as never
+                project: 'project',
+                isExplicitlyIncluded: false
             }
-        ],
-        []
-    );
+        ]);
+    });
 
-    assert.deepStrictEqual(result, [
-        {
-            sourceFilePath: '/src/nested/index.js',
-            targetFilePath: 'nested/index.js',
-            directDependencies: new Set(['/src/nested/internal.js']),
-            project: 'project',
-            isExplicitlyIncluded: false
-        }
-    ]);
-});
-
-test('normalizes object-form additional files and marks them as explicitly included', () => {
-    const result = combineAllBundleFiles(
-        '/src',
-        [],
-        [
-            { sourceFilePath: 'assets/readme.md', targetFilePath: 'readme.md' },
-            { sourceFilePath: '/absolute/license.txt', targetFilePath: 'license.txt' }
-        ]
-    );
-
-    assert.deepStrictEqual(result, [
-        {
-            sourceFilePath: '/src/assets/readme.md',
-            targetFilePath: 'readme.md',
-            directDependencies: new Set(),
-            isExplicitlyIncluded: true
-        },
-        {
-            sourceFilePath: '/absolute/license.txt',
-            targetFilePath: 'license.txt',
-            directDependencies: new Set(),
-            isExplicitlyIncluded: true
-        }
-    ]);
-});
-
-test('marks string-form additional files as explicitly included', () => {
-    const result = combineAllBundleFiles('/src', [], ['readme.md']);
-
-    assert.deepStrictEqual(result, [
-        {
-            sourceFilePath: '/src/readme.md',
-            targetFilePath: 'readme.md',
-            directDependencies: new Set(),
-            isExplicitlyIncluded: true
-        }
-    ]);
-});
-
-test('throws when an object-form additional file uses an absolute target path', () => {
-    try {
-        combineAllBundleFiles('/src', [], [{ sourceFilePath: 'file.txt', targetFilePath: '/absolute/file.txt' }]);
-        assert.fail('Expected combineAllBundleFiles() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'The targetFilePath must be relative');
-    }
-});
-
-const additionalCodeFileErrorMessage = [
-    'additionalFiles must not include code files; received "lib/template.ts".',
-    'Code that should ship in the bundle must be reachable from a root so',
-    'dependency, side-effect and dead-code analyses can run on it.',
-    'If you intend to ship code as a static asset (e.g. a template),',
-    'use a non-code extension like .txt.'
-].join(' ');
-
-test('throws when a string-form additional file points at a code file', () => {
-    try {
-        combineAllBundleFiles('/src', [], ['lib/template.ts']);
-        assert.fail('Expected combineAllBundleFiles() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, additionalCodeFileErrorMessage);
-    }
-});
-
-test('throws when an object-form additional file targets a code file', () => {
-    try {
-        combineAllBundleFiles(
+    test('normalizes object-form additional files and marks them as explicitly included', function () {
+        const result = combineAllBundleFiles(
             '/src',
             [],
-            [{ sourceFilePath: 'assets/template.txt', targetFilePath: 'lib/template.ts' }]
+            [
+                { sourceFilePath: 'assets/readme.md', targetFilePath: 'readme.md' },
+                { sourceFilePath: '/absolute/license.txt', targetFilePath: 'license.txt' }
+            ]
         );
-        assert.fail('Expected combineAllBundleFiles() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, additionalCodeFileErrorMessage);
-    }
-});
 
-test('accepts an additional file whose target path retains a code-shaped source via a non-code extension', () => {
-    const result = combineAllBundleFiles(
-        '/src',
-        [],
-        [{ sourceFilePath: 'fixtures/template.ts', targetFilePath: 'fixtures/template.ts.txt' }]
-    );
-    assert.deepStrictEqual(result, [
-        {
-            sourceFilePath: '/src/fixtures/template.ts',
-            targetFilePath: 'fixtures/template.ts.txt',
-            directDependencies: new Set(),
-            isExplicitlyIncluded: true
+        assert.deepStrictEqual(result, [
+            {
+                sourceFilePath: '/src/assets/readme.md',
+                targetFilePath: 'readme.md',
+                directDependencies: new Set(),
+                isExplicitlyIncluded: true
+            },
+            {
+                sourceFilePath: '/absolute/license.txt',
+                targetFilePath: 'license.txt',
+                directDependencies: new Set(),
+                isExplicitlyIncluded: true
+            }
+        ]);
+    });
+
+    test('marks string-form additional files as explicitly included', function () {
+        const result = combineAllBundleFiles('/src', [], ['readme.md']);
+
+        assert.deepStrictEqual(result, [
+            {
+                sourceFilePath: '/src/readme.md',
+                targetFilePath: 'readme.md',
+                directDependencies: new Set(),
+                isExplicitlyIncluded: true
+            }
+        ]);
+    });
+
+    test('throws when an object-form additional file uses an absolute target path', function () {
+        try {
+            combineAllBundleFiles('/src', [], [{ sourceFilePath: 'file.txt', targetFilePath: '/absolute/file.txt' }]);
+            assert.fail('Expected combineAllBundleFiles() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'The targetFilePath must be relative');
         }
-    ]);
+    });
+
+    const additionalCodeFileErrorMessage = [
+        'additionalFiles must not include code files; received "lib/template.ts".',
+        'Code that should ship in the bundle must be reachable from a root so',
+        'dependency, side-effect and dead-code analyses can run on it.',
+        'If you intend to ship code as a static asset (e.g. a template),',
+        'use a non-code extension like .txt.'
+    ].join(' ');
+
+    test('throws when a string-form additional file points at a code file', function () {
+        try {
+            combineAllBundleFiles('/src', [], ['lib/template.ts']);
+            assert.fail('Expected combineAllBundleFiles() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, additionalCodeFileErrorMessage);
+        }
+    });
+
+    test('throws when an object-form additional file targets a code file', function () {
+        try {
+            combineAllBundleFiles(
+                '/src',
+                [],
+                [{ sourceFilePath: 'assets/template.txt', targetFilePath: 'lib/template.ts' }]
+            );
+            assert.fail('Expected combineAllBundleFiles() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, additionalCodeFileErrorMessage);
+        }
+    });
+
+    test('accepts an additional file whose target path retains a code-shaped source via a non-code extension', function () {
+        const result = combineAllBundleFiles(
+            '/src',
+            [],
+            [{ sourceFilePath: 'fixtures/template.ts', targetFilePath: 'fixtures/template.ts.txt' }]
+        );
+        assert.deepStrictEqual(result, [
+            {
+                sourceFilePath: '/src/fixtures/template.ts',
+                targetFilePath: 'fixtures/template.ts.txt',
+                directDependencies: new Set(),
+                isExplicitlyIncluded: true
+            }
+        ]);
+    });
 });

--- a/source/resource-resolver/dependency-resolution-walker.test.ts
+++ b/source/resource-resolver/dependency-resolution-walker.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { DependencyScanner } from '../dependency-scanner/scanner.ts';
 import type { ResourceResolveOptions } from './resource-resolve-options.ts';
 import { resolveDependenciesForAllRoots } from './dependency-resolution-walker.ts';
@@ -40,28 +40,30 @@ function optionsForRoots(roots: ResourceResolveOptions['roots']): ResourceResolv
     };
 }
 
-test('resolveDependenciesForAllRoots scans every root js entry once', async () => {
-    const { scanner, calls } = trackingScanner();
-    await resolveDependenciesForAllRoots(
-        scanner,
-        optionsForRoots({
-            main: { js: '/src/index.js' },
-            other: { js: '/src/other.js' }
-        })
-    );
+suite('dependency-resolution-walker', function () {
+    test('resolveDependenciesForAllRoots scans every root js entry once', async function () {
+        const { scanner, calls } = trackingScanner();
+        await resolveDependenciesForAllRoots(
+            scanner,
+            optionsForRoots({
+                main: { js: '/src/index.js' },
+                other: { js: '/src/other.js' }
+            })
+        );
 
-    assert.deepStrictEqual(calls.map((call) => call.entry).toSorted(), ['/src/index.js', '/src/other.js']);
-});
+        assert.deepStrictEqual(calls.map((call) => call.entry).toSorted(), ['/src/index.js', '/src/other.js']);
+    });
 
-test('resolveDependenciesForAllRoots also scans the declaration entry with resolveDeclarationFiles=true when present', async () => {
-    const { scanner, calls } = trackingScanner();
-    await resolveDependenciesForAllRoots(
-        scanner,
-        optionsForRoots({ main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' } })
-    );
+    test('resolveDependenciesForAllRoots also scans the declaration entry with resolveDeclarationFiles=true when present', async function () {
+        const { scanner, calls } = trackingScanner();
+        await resolveDependenciesForAllRoots(
+            scanner,
+            optionsForRoots({ main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' } })
+        );
 
-    assert.deepStrictEqual(calls, [
-        { entry: '/src/index.js', resolveDeclarationFiles: false },
-        { entry: '/src/index.d.ts', resolveDeclarationFiles: true }
-    ]);
+        assert.deepStrictEqual(calls, [
+            { entry: '/src/index.js', resolveDeclarationFiles: false },
+            { entry: '/src/index.d.ts', resolveDeclarationFiles: true }
+        ]);
+    });
 });

--- a/source/resource-resolver/resolved-bundle.test.ts
+++ b/source/resource-resolver/resolved-bundle.test.ts
@@ -1,25 +1,27 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { rootHasDeclarationFile, type RootFileDescription } from './resolved-bundle.ts';
 
 const jsOnly: RootFileDescription = {
     js: { sourceFilePath: '/a/index.ts', targetFilePath: 'index.js', content: '', isExecutable: false }
 };
 
-test('rootHasDeclarationFile returns false when only the js entry is present', () => {
-    assert.strictEqual(rootHasDeclarationFile(jsOnly), false);
-});
+suite('resolved-bundle', function () {
+    test('rootHasDeclarationFile returns false when only the js entry is present', function () {
+        assert.strictEqual(rootHasDeclarationFile(jsOnly), false);
+    });
 
-test('rootHasDeclarationFile returns true when a declarationFile entry is attached', () => {
-    const withDts: RootFileDescription = {
-        ...jsOnly,
-        declarationFile: {
-            sourceFilePath: '/a/index.d.ts',
-            targetFilePath: 'index.d.ts',
-            content: '',
-            isExecutable: false
-        }
-    };
+    test('rootHasDeclarationFile returns true when a declarationFile entry is attached', function () {
+        const withDts: RootFileDescription = {
+            ...jsOnly,
+            declarationFile: {
+                sourceFilePath: '/a/index.d.ts',
+                targetFilePath: 'index.d.ts',
+                content: '',
+                isExecutable: false
+            }
+        };
 
-    assert.strictEqual(rootHasDeclarationFile(withDts), true);
+        assert.strictEqual(rootHasDeclarationFile(withDts), true);
+    });
 });

--- a/source/resource-resolver/resource-resolve-options.test.ts
+++ b/source/resource-resolver/resource-resolve-options.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { resolveRootsAndSurface, type ResourceResolveOptions } from './resource-resolve-options.ts';
 
 const mainRoot = { js: '/src/index.js', declarationFile: '/src/index.d.ts' } as const;
@@ -23,46 +23,48 @@ function baseOptions(): BaseOptions {
     };
 }
 
-test('resolveRootsAndSurface() derives an implicit surface defaulting to the first root', () => {
-    const result = resolveRootsAndSurface({
-        ...baseOptions(),
-        roots: { feature: helperRoot, main: mainRoot }
-    });
-
-    assert.deepStrictEqual(result, {
-        roots: { feature: helperRoot, main: mainRoot },
-        surface: { mode: 'implicit', defaultModuleRoot: 'feature' }
-    });
-});
-
-test('resolveRootsAndSurface() preserves an explicit surface override', () => {
-    const result = resolveRootsAndSurface({
-        ...baseOptions(),
-        roots: { main: mainRoot, helper: helperRoot },
-        surface: {
-            mode: 'explicit',
-            packageInterface: {
-                modules: [{ root: 'main', export: '.' }]
-            }
-        }
-    });
-
-    assert.deepStrictEqual(result, {
-        roots: { main: mainRoot, helper: helperRoot },
-        surface: {
-            mode: 'explicit',
-            packageInterface: {
-                modules: [{ root: 'main', export: '.' }]
-            }
-        }
-    });
-});
-
-test('resolveRootsAndSurface() throws when roots are empty', () => {
-    assert.throws(() => {
-        resolveRootsAndSurface({
+suite('resource-resolve-options', function () {
+    test('resolveRootsAndSurface() derives an implicit surface defaulting to the first root', function () {
+        const result = resolveRootsAndSurface({
             ...baseOptions(),
-            roots: {}
-        } as ResourceResolveOptions);
-    }, /^Error: Package "package-a" must define at least one root$/u);
+            roots: { feature: helperRoot, main: mainRoot }
+        });
+
+        assert.deepStrictEqual(result, {
+            roots: { feature: helperRoot, main: mainRoot },
+            surface: { mode: 'implicit', defaultModuleRoot: 'feature' }
+        });
+    });
+
+    test('resolveRootsAndSurface() preserves an explicit surface override', function () {
+        const result = resolveRootsAndSurface({
+            ...baseOptions(),
+            roots: { main: mainRoot, helper: helperRoot },
+            surface: {
+                mode: 'explicit',
+                packageInterface: {
+                    modules: [{ root: 'main', export: '.' }]
+                }
+            }
+        });
+
+        assert.deepStrictEqual(result, {
+            roots: { main: mainRoot, helper: helperRoot },
+            surface: {
+                mode: 'explicit',
+                packageInterface: {
+                    modules: [{ root: 'main', export: '.' }]
+                }
+            }
+        });
+    });
+
+    test('resolveRootsAndSurface() throws when roots are empty', function () {
+        assert.throws(() => {
+            resolveRootsAndSurface({
+                ...baseOptions(),
+                roots: {}
+            } as ResourceResolveOptions);
+        }, /^Error: Package "package-a" must define at least one root$/u);
+    });
 });

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, stub, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
 import { createDependencyGraph } from '../dependency-scanner/dependency-graph.ts';
@@ -107,154 +107,156 @@ function configureScanForJsAndDeclarationGraphs(
     return scan;
 }
 
-test('resolve() scans js roots and additional files and returns their file descriptions', async () => {
-    const jsGraph = createGraph({ rootFile: '/src/index.js', additionalLocalFiles: ['/src/internal.js'] });
-    const scan = fake.resolves(jsGraph);
-    const { resolver } = createResolver({ scan });
+suite('resource-resolver', function () {
+    test('resolve() scans js roots and additional files and returns their file descriptions', async function () {
+        const jsGraph = createGraph({ rootFile: '/src/index.js', additionalLocalFiles: ['/src/internal.js'] });
+        const scan = fake.resolves(jsGraph);
+        const { resolver } = createResolver({ scan });
 
-    const result = await resolver.resolve({
-        ...baseResolveOptions,
-        includeSourceMapFiles: true,
-        additionalFiles: ['readme.md']
-    });
-
-    assert.deepStrictEqual(scan.firstCall.args, [
-        '/src/index.js',
-        '/src',
-        {
+        const result = await resolver.resolve({
+            ...baseResolveOptions,
             includeSourceMapFiles: true,
-            resolveDeclarationFiles: false,
-            mainPackageJson: { type: 'module' }
-        }
-    ]);
-    assert.strictEqual(result.name, 'package-a');
-    assert.strictEqual(result.contents.length, 3);
-    assert.deepStrictEqual(result.roots, {
-        main: { js: createTransferableFile('/src/index.js', 'index.js'), declarationFile: undefined }
-    });
-});
+            additionalFiles: ['readme.md']
+        });
 
-test('resolve() keeps declarationFile undefined when a root does not define one', async () => {
-    const jsGraph = createGraph({ rootFile: '/src/index.js' });
-    const scan = fake.resolves(jsGraph);
-    const { resolver } = createResolver({ scan });
-
-    const result = await resolver.resolve(baseResolveOptions);
-
-    assert.strictEqual(result.roots.main?.declarationFile, undefined);
-});
-
-test('resolve() scans declaration roots separately and merges local and external dependencies', async () => {
-    const jsGraph = createGraph({
-        rootFile: '/src/index.js',
-        additionalLocalFiles: ['/src/shared.js'],
-        externalDependencyName: 'left-pad'
-    });
-    const declarationGraph = createGraph({
-        rootFile: '/src/index.d.ts',
-        additionalLocalFiles: ['/src/shared.js'],
-        externalDependencyName: 'typescript'
-    });
-    const scan = configureScanForJsAndDeclarationGraphs(jsGraph, declarationGraph);
-    const { resolver } = createResolver({ scan });
-
-    const result = await resolver.resolve({
-        name: 'package-a',
-        sourcesFolder: '/src',
-        roots: { main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' } },
-        includeSourceMapFiles: false,
-        additionalFiles: [],
-        mainPackageJson: { type: 'module' }
+        assert.deepStrictEqual(scan.firstCall.args, [
+            '/src/index.js',
+            '/src',
+            {
+                includeSourceMapFiles: true,
+                resolveDeclarationFiles: false,
+                mainPackageJson: { type: 'module' }
+            }
+        ]);
+        assert.strictEqual(result.name, 'package-a');
+        assert.strictEqual(result.contents.length, 3);
+        assert.deepStrictEqual(result.roots, {
+            main: { js: createTransferableFile('/src/index.js', 'index.js'), declarationFile: undefined }
+        });
     });
 
-    assert.strictEqual(scan.callCount, 2);
-    assert.deepStrictEqual(scan.secondCall.args, [
-        '/src/index.d.ts',
-        '/src',
-        {
-            includeSourceMapFiles: false,
-            resolveDeclarationFiles: true,
-            mainPackageJson: { type: 'module' }
-        }
-    ]);
-    assert.deepStrictEqual(
-        Array.from(result.externalDependencies.keys()).toSorted((left, right) => {
-            return left.localeCompare(right);
-        }),
-        ['left-pad', 'typescript']
-    );
-    assert.deepStrictEqual(result.roots, {
-        main: {
-            js: createTransferableFile('/src/index.js', 'index.js'),
-            declarationFile: createTransferableFile('/src/index.d.ts', 'index.d.ts')
-        }
-    });
-});
+    test('resolve() keeps declarationFile undefined when a root does not define one', async function () {
+        const jsGraph = createGraph({ rootFile: '/src/index.js' });
+        const scan = fake.resolves(jsGraph);
+        const { resolver } = createResolver({ scan });
 
-test('resolve() preserves additional modern roots', async () => {
-    const firstGraph = createGraph({ rootFile: '/src/index.js' });
-    const secondGraph = createGraph({ rootFile: '/src/feature.js' });
-    const scan = stub();
-    scan.onFirstCall().resolves(firstGraph);
-    scan.onSecondCall().resolves(secondGraph);
-    const { resolver } = createResolver({ scan });
+        const result = await resolver.resolve(baseResolveOptions);
 
-    const result = await resolver.resolve({
-        ...baseResolveOptions,
-        roots: {
-            main: { js: '/src/index.js' },
-            feature: { js: '/src/feature.js' }
-        }
+        assert.strictEqual(result.roots.main?.declarationFile, undefined);
     });
 
-    assert.deepStrictEqual(result.roots, {
-        main: { js: createTransferableFile('/src/index.js', 'index.js'), declarationFile: undefined },
-        feature: { js: createTransferableFile('/src/feature.js', 'feature.js'), declarationFile: undefined }
-    });
-});
+    test('resolve() scans declaration roots separately and merges local and external dependencies', async function () {
+        const jsGraph = createGraph({
+            rootFile: '/src/index.js',
+            additionalLocalFiles: ['/src/shared.js'],
+            externalDependencyName: 'left-pad'
+        });
+        const declarationGraph = createGraph({
+            rootFile: '/src/index.d.ts',
+            additionalLocalFiles: ['/src/shared.js'],
+            externalDependencyName: 'typescript'
+        });
+        const scan = configureScanForJsAndDeclarationGraphs(jsGraph, declarationGraph);
+        const { resolver } = createResolver({ scan });
 
-test('resolve() throws when a root resource cannot be resolved from the scanned contents', async () => {
-    const graph = createGraph({ rootFile: '/src/index.js' });
-    const scan = fake.resolves(graph);
-    const { resolver } = createResolver({
-        scan,
-        transferableFileDescriptionResponder: () => {
-            return createTransferableFile('/src/not-the-entry.js');
-        }
-    });
-
-    try {
-        await resolver.resolve({
+        const result = await resolver.resolve({
             name: 'package-a',
             sourcesFolder: '/src',
-            roots: { main: { js: '/src/index.js' } },
+            roots: { main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' } },
             includeSourceMapFiles: false,
             additionalFiles: [],
             mainPackageJson: { type: 'module' }
         });
-        assert.fail('Expected resolve() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Failed to resolve resource for root /src/index.js');
-    }
-});
 
-test('resolve() throws when a declared root resource cannot be resolved from the scanned contents', async () => {
-    const graph = createGraph({ rootFile: '/src/missing.js' });
-    const scan = fake.resolves(graph);
-    const { resolver } = createResolver({
-        scan,
-        transferableFileDescriptionResponder: () => {
-            return createTransferableFile('/src/index.js');
+        assert.strictEqual(scan.callCount, 2);
+        assert.deepStrictEqual(scan.secondCall.args, [
+            '/src/index.d.ts',
+            '/src',
+            {
+                includeSourceMapFiles: false,
+                resolveDeclarationFiles: true,
+                mainPackageJson: { type: 'module' }
+            }
+        ]);
+        assert.deepStrictEqual(
+            Array.from(result.externalDependencies.keys()).toSorted((left, right) => {
+                return left.localeCompare(right);
+            }),
+            ['left-pad', 'typescript']
+        );
+        assert.deepStrictEqual(result.roots, {
+            main: {
+                js: createTransferableFile('/src/index.js', 'index.js'),
+                declarationFile: createTransferableFile('/src/index.d.ts', 'index.d.ts')
+            }
+        });
+    });
+
+    test('resolve() preserves additional modern roots', async function () {
+        const firstGraph = createGraph({ rootFile: '/src/index.js' });
+        const secondGraph = createGraph({ rootFile: '/src/feature.js' });
+        const scan = stub();
+        scan.onFirstCall().resolves(firstGraph);
+        scan.onSecondCall().resolves(secondGraph);
+        const { resolver } = createResolver({ scan });
+
+        const result = await resolver.resolve({
+            ...baseResolveOptions,
+            roots: {
+                main: { js: '/src/index.js' },
+                feature: { js: '/src/feature.js' }
+            }
+        });
+
+        assert.deepStrictEqual(result.roots, {
+            main: { js: createTransferableFile('/src/index.js', 'index.js'), declarationFile: undefined },
+            feature: { js: createTransferableFile('/src/feature.js', 'feature.js'), declarationFile: undefined }
+        });
+    });
+
+    test('resolve() throws when a root resource cannot be resolved from the scanned contents', async function () {
+        const graph = createGraph({ rootFile: '/src/index.js' });
+        const scan = fake.resolves(graph);
+        const { resolver } = createResolver({
+            scan,
+            transferableFileDescriptionResponder: () => {
+                return createTransferableFile('/src/not-the-entry.js');
+            }
+        });
+
+        try {
+            await resolver.resolve({
+                name: 'package-a',
+                sourcesFolder: '/src',
+                roots: { main: { js: '/src/index.js' } },
+                includeSourceMapFiles: false,
+                additionalFiles: [],
+                mainPackageJson: { type: 'module' }
+            });
+            assert.fail('Expected resolve() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Failed to resolve resource for root /src/index.js');
         }
     });
 
-    try {
-        await resolver.resolve({
-            ...baseResolveOptions,
-            roots: { main: { js: '/src/missing.js' } }
+    test('resolve() throws when a declared root resource cannot be resolved from the scanned contents', async function () {
+        const graph = createGraph({ rootFile: '/src/missing.js' });
+        const scan = fake.resolves(graph);
+        const { resolver } = createResolver({
+            scan,
+            transferableFileDescriptionResponder: () => {
+                return createTransferableFile('/src/index.js');
+            }
         });
-        assert.fail('Expected resolve() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Failed to resolve resource for root /src/missing.js');
-    }
+
+        try {
+            await resolver.resolve({
+                ...baseResolveOptions,
+                roots: { main: { js: '/src/missing.js' } }
+            });
+            assert.fail('Expected resolve() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Failed to resolve resource for root /src/missing.js');
+        }
+    });
 });

--- a/source/runtime-imports.test.ts
+++ b/source/runtime-imports.test.ts
@@ -1,14 +1,16 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 
-test('loads runtime modules that currently only export type shapes', async () => {
-    await Promise.all([
-        import('./checks/rule.ts'),
-        import('./file-manager/file-description.ts'),
-        import('./linker/linked-bundle.ts'),
-        import('./resource-resolver/resolved-bundle.ts'),
-        import('./resource-resolver/resource-resolve-options.ts')
-    ]);
+suite('runtime-imports', function () {
+    test('loads runtime modules that currently only export type shapes', async function () {
+        await Promise.all([
+            import('./checks/rule.ts'),
+            import('./file-manager/file-description.ts'),
+            import('./linker/linked-bundle.ts'),
+            import('./resource-resolver/resolved-bundle.ts'),
+            import('./resource-resolver/resource-resolve-options.ts')
+        ]);
 
-    assert.ok(true);
+        assert.ok(true);
+    });
 });

--- a/source/sbom/extract-license.test.ts
+++ b/source/sbom/extract-license.test.ts
@@ -1,30 +1,32 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { extractLicenseFromManifest } from './extract-license.ts';
 
-test('returns the license string when the manifest declares a non-empty string license', () => {
-    assert.strictEqual(extractLicenseFromManifest({ license: 'MIT' }), 'MIT');
-});
+suite('extract-license', function () {
+    test('returns the license string when the manifest declares a non-empty string license', function () {
+        assert.strictEqual(extractLicenseFromManifest({ license: 'MIT' }), 'MIT');
+    });
 
-test('returns undefined when the manifest declares an empty license string', () => {
-    assert.strictEqual(extractLicenseFromManifest({ license: '' }), undefined);
-});
+    test('returns undefined when the manifest declares an empty license string', function () {
+        assert.strictEqual(extractLicenseFromManifest({ license: '' }), undefined);
+    });
 
-test('returns undefined when the manifest declares a non-string license', () => {
-    assert.strictEqual(extractLicenseFromManifest({ license: { type: 'MIT' } }), undefined);
-});
+    test('returns undefined when the manifest declares a non-string license', function () {
+        assert.strictEqual(extractLicenseFromManifest({ license: { type: 'MIT' } }), undefined);
+    });
 
-test('returns undefined when the manifest has no license field', () => {
-    assert.strictEqual(extractLicenseFromManifest({ name: 'pkg' }), undefined);
-});
+    test('returns undefined when the manifest has no license field', function () {
+        assert.strictEqual(extractLicenseFromManifest({ name: 'pkg' }), undefined);
+    });
 
-test('returns undefined when the input is not an object', () => {
-    assert.strictEqual(extractLicenseFromManifest(null), undefined);
-    assert.strictEqual(extractLicenseFromManifest('not an object'), undefined);
-    assert.strictEqual(extractLicenseFromManifest(42), undefined);
-    assert.strictEqual(extractLicenseFromManifest(undefined), undefined);
-});
+    test('returns undefined when the input is not an object', function () {
+        assert.strictEqual(extractLicenseFromManifest(null), undefined);
+        assert.strictEqual(extractLicenseFromManifest('not an object'), undefined);
+        assert.strictEqual(extractLicenseFromManifest(42), undefined);
+        assert.strictEqual(extractLicenseFromManifest(undefined), undefined);
+    });
 
-test('returns undefined when the input is an array', () => {
-    assert.strictEqual(extractLicenseFromManifest(['MIT']), undefined);
+    test('returns undefined when the input is an array', function () {
+        assert.strictEqual(extractLicenseFromManifest(['MIT']), undefined);
+    });
 });

--- a/source/sbom/license-resolver.test.ts
+++ b/source/sbom/license-resolver.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import { createLicenseResolver } from './license-resolver.ts';
 
@@ -12,63 +12,67 @@ async function expectResolvedLicense(packageJsonContent: string): Promise<string
     return resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
 }
 
-test('resolveLicense() returns the SPDX expression when the dependency’s package.json has a string license', async () => {
-    const result = await expectResolvedLicense(JSON.stringify({ license: 'MIT' }));
+suite('license-resolver', function () {
+    test('resolveLicense() returns the SPDX expression when the dependency’s package.json has a string license', async function () {
+        const result = await expectResolvedLicense(JSON.stringify({ license: 'MIT' }));
 
-    assert.strictEqual(result, 'MIT');
-});
-
-test('resolveLicense() reads from the dependency’s package.json under node_modules', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedReadFileResponses: [{ value: JSON.stringify({ license: 'MIT' }) }]
+        assert.strictEqual(result, 'MIT');
     });
-    const resolver = createLicenseResolver({ fileManager });
 
-    await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+    test('resolveLicense() reads from the dependency’s package.json under node_modules', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: JSON.stringify({ license: 'MIT' }) }]
+        });
+        const resolver = createLicenseResolver({ fileManager });
 
-    assert.strictEqual(fileManager.getReadFileCallCount(), 1);
-    assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/project/node_modules/lodash/package.json' });
-});
-
-test('resolveLicense() returns undefined when the dependency’s package.json does not declare a license', async () => {
-    const result = await expectResolvedLicense(JSON.stringify({}));
-
-    assert.strictEqual(result, undefined);
-});
-
-test('resolveLicense() returns undefined when the license field is not a non-empty string', async () => {
-    const result = await expectResolvedLicense(JSON.stringify({ license: '' }));
-
-    assert.strictEqual(result, undefined);
-});
-
-test('resolveLicense() returns undefined when the license field is an object', async () => {
-    const result = await expectResolvedLicense(
-        JSON.stringify({ license: { type: 'MIT', url: 'https://example.test' } })
-    );
-
-    assert.strictEqual(result, undefined);
-});
-
-test('resolveLicense() preserves a free-text license string verbatim', async () => {
-    const result = await expectResolvedLicense(JSON.stringify({ license: 'See LICENSE.txt for details' }));
-
-    assert.strictEqual(result, 'See LICENSE.txt for details');
-});
-
-test('resolveLicense() throws a descriptive error when the dependency is not installed', async () => {
-    const fileManager = createFakeFileManager({
-        simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
-    });
-    const resolver = createLicenseResolver({ fileManager });
-
-    try {
         await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
-        assert.fail('Expected resolveLicense() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Dependency "lodash" is declared in the published manifest but is not installed in node_modules'
+
+        assert.strictEqual(fileManager.getReadFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), {
+            filePath: '/project/node_modules/lodash/package.json'
+        });
+    });
+
+    test('resolveLicense() returns undefined when the dependency’s package.json does not declare a license', async function () {
+        const result = await expectResolvedLicense(JSON.stringify({}));
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test('resolveLicense() returns undefined when the license field is not a non-empty string', async function () {
+        const result = await expectResolvedLicense(JSON.stringify({ license: '' }));
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test('resolveLicense() returns undefined when the license field is an object', async function () {
+        const result = await expectResolvedLicense(
+            JSON.stringify({ license: { type: 'MIT', url: 'https://example.test' } })
         );
-    }
+
+        assert.strictEqual(result, undefined);
+    });
+
+    test('resolveLicense() preserves a free-text license string verbatim', async function () {
+        const result = await expectResolvedLicense(JSON.stringify({ license: 'See LICENSE.txt for details' }));
+
+        assert.strictEqual(result, 'See LICENSE.txt for details');
+    });
+
+    test('resolveLicense() throws a descriptive error when the dependency is not installed', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+        });
+        const resolver = createLicenseResolver({ fileManager });
+
+        try {
+            await resolver.resolveLicense({ projectFolder: '/project', dependencyName: 'lodash' });
+            assert.fail('Expected resolveLicense() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Dependency "lodash" is declared in the published manifest but is not installed in node_modules'
+            );
+        }
+    });
 });

--- a/source/sbom/sbom-builder.test.ts
+++ b/source/sbom/sbom-builder.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { buildSbom } from './sbom-builder.ts';
 import { createSbomSerializer } from './sbom-serializer.ts';
 
@@ -22,99 +22,103 @@ function buildAndSerialize(options: Partial<SbomBuilderOptions>): Record<string,
     );
 }
 
-test('builds an SBOM with root component metadata and no dependencies when there are none', () => {
-    const serialized = buildAndSerialize({});
+suite('sbom-builder', function () {
+    test('builds an SBOM with root component metadata and no dependencies when there are none', function () {
+        const serialized = buildAndSerialize({});
 
-    assert.strictEqual(serialized.bomFormat, 'CycloneDX');
-    assert.strictEqual(serialized.specVersion, '1.6');
-    assert.deepStrictEqual(serialized.components, []);
-    assert.deepStrictEqual(serialized.metadata, {
-        tools: {
-            components: [{ type: 'application', name: 'packtory', version: '1.2.3' }]
-        },
-        component: {
-            type: 'library',
-            name: 'my-pkg',
-            version: '1.0.0',
-            'bom-ref': 'pkg:npm/my-pkg@1.0.0',
-            purl: 'pkg:npm/my-pkg@1.0.0'
-        }
-    });
-});
-
-test('does not emit metadata.timestamp or serialNumber to keep the SBOM reproducible', () => {
-    const serialized = buildAndSerialize({});
-    const metadata = serialized.metadata as Record<string, unknown>;
-
-    assert.strictEqual('timestamp' in metadata, false);
-    assert.strictEqual('serialNumber' in serialized, false);
-});
-
-test('adds a runtime dependency with required scope and SPDX expression license', () => {
-    const serialized = buildAndSerialize({
-        dependencies: [{ name: 'lodash', specifier: '^4.17.0', kind: 'runtime', license: 'MIT' }]
+        assert.strictEqual(serialized.bomFormat, 'CycloneDX');
+        assert.strictEqual(serialized.specVersion, '1.6');
+        assert.deepStrictEqual(serialized.components, []);
+        assert.deepStrictEqual(serialized.metadata, {
+            tools: {
+                components: [{ type: 'application', name: 'packtory', version: '1.2.3' }]
+            },
+            component: {
+                type: 'library',
+                name: 'my-pkg',
+                version: '1.0.0',
+                'bom-ref': 'pkg:npm/my-pkg@1.0.0',
+                purl: 'pkg:npm/my-pkg@1.0.0'
+            }
+        });
     });
 
-    assert.deepStrictEqual(serialized.components, [
-        {
-            type: 'library',
-            name: 'lodash',
-            version: '^4.17.0',
-            'bom-ref': 'pkg:npm/lodash@%5E4.17.0',
-            scope: 'required',
-            licenses: [{ expression: 'MIT' }],
-            purl: 'pkg:npm/lodash@%5E4.17.0'
-        }
-    ]);
-});
+    test('does not emit metadata.timestamp or serialNumber to keep the SBOM reproducible', function () {
+        const serialized = buildAndSerialize({});
+        const metadata = serialized.metadata as Record<string, unknown>;
 
-test('adds a peer dependency with optional scope', () => {
-    const serialized = buildAndSerialize({
-        dependencies: [{ name: 'react', specifier: '>=18', kind: 'peer', license: 'MIT' }]
-    });
-    const components = serialized.components as readonly Record<string, unknown>[];
-
-    assert.strictEqual(components[0]?.scope, 'optional');
-});
-
-test('falls back to a named license when the license string is not a valid SPDX expression', () => {
-    const serialized = buildAndSerialize({
-        dependencies: [{ name: 'weird', specifier: '1.0.0', kind: 'runtime', license: 'See LICENSE.txt for details' }]
-    });
-    const components = serialized.components as readonly Record<string, unknown>[];
-
-    assert.deepStrictEqual(components[0]?.licenses, [{ license: { name: 'See LICENSE.txt for details' } }]);
-});
-
-test('omits the licenses field entirely when no license is known for a dependency', () => {
-    const serialized = buildAndSerialize({
-        dependencies: [{ name: 'no-license', specifier: '1.0.0', kind: 'runtime', license: undefined }]
-    });
-    const components = serialized.components as readonly Record<string, unknown>[];
-
-    assert.strictEqual('licenses' in (components[0] ?? {}), false);
-});
-
-test('encodes the version specifier inside the purl using URL-encoding', () => {
-    const serialized = buildAndSerialize({
-        dependencies: [{ name: 'lodash', specifier: '^4.17.0', kind: 'runtime', license: 'MIT' }]
-    });
-    const components = serialized.components as readonly Record<string, unknown>[];
-
-    assert.strictEqual(components[0]?.purl, 'pkg:npm/lodash@%5E4.17.0');
-});
-
-test('records every direct dependency under the root component dependency graph', () => {
-    const serialized = buildAndSerialize({
-        dependencies: [
-            { name: 'lodash', specifier: '^4.17.0', kind: 'runtime', license: 'MIT' },
-            { name: 'react', specifier: '>=18', kind: 'peer', license: 'MIT' }
-        ]
-    });
-    const dependencies = serialized.dependencies as readonly Record<string, unknown>[];
-    const root = dependencies.find((entry) => {
-        return entry.ref === 'pkg:npm/my-pkg@1.0.0';
+        assert.strictEqual('timestamp' in metadata, false);
+        assert.strictEqual('serialNumber' in serialized, false);
     });
 
-    assert.deepStrictEqual(root?.dependsOn, ['pkg:npm/lodash@%5E4.17.0', 'pkg:npm/react@%3E%3D18']);
+    test('adds a runtime dependency with required scope and SPDX expression license', function () {
+        const serialized = buildAndSerialize({
+            dependencies: [{ name: 'lodash', specifier: '^4.17.0', kind: 'runtime', license: 'MIT' }]
+        });
+
+        assert.deepStrictEqual(serialized.components, [
+            {
+                type: 'library',
+                name: 'lodash',
+                version: '^4.17.0',
+                'bom-ref': 'pkg:npm/lodash@%5E4.17.0',
+                scope: 'required',
+                licenses: [{ expression: 'MIT' }],
+                purl: 'pkg:npm/lodash@%5E4.17.0'
+            }
+        ]);
+    });
+
+    test('adds a peer dependency with optional scope', function () {
+        const serialized = buildAndSerialize({
+            dependencies: [{ name: 'react', specifier: '>=18', kind: 'peer', license: 'MIT' }]
+        });
+        const components = serialized.components as readonly Record<string, unknown>[];
+
+        assert.strictEqual(components[0]?.scope, 'optional');
+    });
+
+    test('falls back to a named license when the license string is not a valid SPDX expression', function () {
+        const serialized = buildAndSerialize({
+            dependencies: [
+                { name: 'weird', specifier: '1.0.0', kind: 'runtime', license: 'See LICENSE.txt for details' }
+            ]
+        });
+        const components = serialized.components as readonly Record<string, unknown>[];
+
+        assert.deepStrictEqual(components[0]?.licenses, [{ license: { name: 'See LICENSE.txt for details' } }]);
+    });
+
+    test('omits the licenses field entirely when no license is known for a dependency', function () {
+        const serialized = buildAndSerialize({
+            dependencies: [{ name: 'no-license', specifier: '1.0.0', kind: 'runtime', license: undefined }]
+        });
+        const components = serialized.components as readonly Record<string, unknown>[];
+
+        assert.strictEqual('licenses' in (components[0] ?? {}), false);
+    });
+
+    test('encodes the version specifier inside the purl using URL-encoding', function () {
+        const serialized = buildAndSerialize({
+            dependencies: [{ name: 'lodash', specifier: '^4.17.0', kind: 'runtime', license: 'MIT' }]
+        });
+        const components = serialized.components as readonly Record<string, unknown>[];
+
+        assert.strictEqual(components[0]?.purl, 'pkg:npm/lodash@%5E4.17.0');
+    });
+
+    test('records every direct dependency under the root component dependency graph', function () {
+        const serialized = buildAndSerialize({
+            dependencies: [
+                { name: 'lodash', specifier: '^4.17.0', kind: 'runtime', license: 'MIT' },
+                { name: 'react', specifier: '>=18', kind: 'peer', license: 'MIT' }
+            ]
+        });
+        const dependencies = serialized.dependencies as readonly Record<string, unknown>[];
+        const root = dependencies.find((entry) => {
+            return entry.ref === 'pkg:npm/my-pkg@1.0.0';
+        });
+
+        assert.deepStrictEqual(root?.dependsOn, ['pkg:npm/lodash@%5E4.17.0', 'pkg:npm/react@%3E%3D18']);
+    });
 });

--- a/source/sbom/sbom-file.test.ts
+++ b/source/sbom/sbom-file.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { PublishSettings } from '../config/publish-settings.ts';
 import type { SbomPackage } from '../published-package/published-package.ts';
@@ -60,136 +60,151 @@ function createBundle(overrides: BundleOverrides): SbomPackage {
     };
 }
 
-test('generate() returns a single sbom.cdx.json FileDescription when SBOM is enabled', async () => {
-    const { builder } = createBuilder();
-    const result = await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], enabledSbom);
+suite('sbom-file', function () {
+    test('generate() returns a single sbom.cdx.json FileDescription when SBOM is enabled', async function () {
+        const { builder } = createBuilder();
+        const result = await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], enabledSbom);
 
-    assert.deepStrictEqual(result, [{ filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false }]);
-});
+        assert.deepStrictEqual(result, [
+            { filePath: 'sbom.cdx.json', content: '{"sbom":"stub"}', isExecutable: false }
+        ]);
+    });
 
-test('generate() defaults to enabled when publish settings do not specify sbom', async () => {
-    const { builder } = createBuilder();
-    const result = await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], defaultPublishSettings);
+    test('generate() defaults to enabled when publish settings do not specify sbom', async function () {
+        const { builder } = createBuilder();
+        const result = await builder.generate(
+            createBundle({ name: 'pkg', version: '1.0.0' }),
+            [],
+            defaultPublishSettings
+        );
 
-    assert.notStrictEqual(result, undefined);
-});
+        assert.notStrictEqual(result, undefined);
+    });
 
-test('generate() does not invoke the toolVersion provider when SBOM is disabled', async () => {
-    const toolVersionProvider = fake.resolves('tool-version');
-    const { builder } = createBuilder({ toolVersionProvider });
-    const result = await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], disabledSbom);
+    test('generate() does not invoke the toolVersion provider when SBOM is disabled', async function () {
+        const toolVersionProvider = fake.resolves('tool-version');
+        const { builder } = createBuilder({ toolVersionProvider });
+        const result = await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], disabledSbom);
 
-    assert.strictEqual(result, undefined);
-    assert.strictEqual(toolVersionProvider.callCount, 0);
-});
+        assert.strictEqual(result, undefined);
+        assert.strictEqual(toolVersionProvider.callCount, 0);
+    });
 
-test('generate() invokes the toolVersion provider when SBOM is enabled', async () => {
-    const toolVersionProvider = fake.resolves('tool-version');
-    const { builder } = createBuilder({ toolVersionProvider });
-    await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], enabledSbom);
+    test('generate() invokes the toolVersion provider when SBOM is enabled', async function () {
+        const toolVersionProvider = fake.resolves('tool-version');
+        const { builder } = createBuilder({ toolVersionProvider });
+        await builder.generate(createBundle({ name: 'pkg', version: '1.0.0' }), [], enabledSbom);
 
-    assert.strictEqual(toolVersionProvider.callCount, 1);
-});
+        assert.strictEqual(toolVersionProvider.callCount, 1);
+    });
 
-test('generate() looks up licenses for external dependencies via the license resolver', async () => {
-    const resolveLicense = fake.resolves('MIT');
-    const { builder } = createBuilder({ resolveLicense });
-    await builder.generate(
-        createBundle({ name: 'pkg', version: '1.0.0', dependencies: { 'left-pad': '^1.0.0' } }),
-        [],
-        enabledSbom
-    );
+    test('generate() looks up licenses for external dependencies via the license resolver', async function () {
+        const resolveLicense = fake.resolves('MIT');
+        const { builder } = createBuilder({ resolveLicense });
+        await builder.generate(
+            createBundle({ name: 'pkg', version: '1.0.0', dependencies: { 'left-pad': '^1.0.0' } }),
+            [],
+            enabledSbom
+        );
 
-    assert.deepStrictEqual(resolveLicense.firstCall.args, [
-        { projectFolder: '/the-project', dependencyName: 'left-pad' }
-    ]);
-});
+        assert.deepStrictEqual(resolveLicense.firstCall.args, [
+            { projectFolder: '/the-project', dependencyName: 'left-pad' }
+        ]);
+    });
 
-test('generate() reuses the sibling bundle’s license instead of calling the resolver for bundle dependencies', async () => {
-    const resolveLicense = fake.resolves('MIT');
-    const { builder } = createBuilder({ resolveLicense });
-    await builder.generate(
-        createBundle({ name: 'pkg', version: '1.0.0', dependencies: { 'bundle-sibling': '0.0.1' } }),
-        [createSibling('bundle-sibling', 'BSD-3-Clause')],
-        enabledSbom
-    );
+    test('generate() reuses the sibling bundle’s license instead of calling the resolver for bundle dependencies', async function () {
+        const resolveLicense = fake.resolves('MIT');
+        const { builder } = createBuilder({ resolveLicense });
+        await builder.generate(
+            createBundle({ name: 'pkg', version: '1.0.0', dependencies: { 'bundle-sibling': '0.0.1' } }),
+            [createSibling('bundle-sibling', 'BSD-3-Clause')],
+            enabledSbom
+        );
 
-    assert.strictEqual(resolveLicense.callCount, 0);
-});
+        assert.strictEqual(resolveLicense.callCount, 0);
+    });
 
-async function captureSiblingLicenseCount(siblingLicense: string | undefined): Promise<number> {
-    const serialize = fake.returns('{"sbom":"stub"}');
-    const { builder } = createBuilder({ serialize });
-    await builder.generate(
-        createBundle({ name: 'pkg', version: '1.0.0', dependencies: { 'bundle-sibling': '0.0.1' } }),
-        [createSibling('bundle-sibling', siblingLicense)],
-        enabledSbom
-    );
-    const bom = serialize.firstCall.args[0] as { components: Iterable<{ name: string; licenses: Iterable<unknown> }> };
-    for (const component of bom.components) {
-        if (component.name === 'bundle-sibling') {
-            return Array.from(component.licenses).length;
+    async function captureSiblingLicenseCount(siblingLicense: string | undefined): Promise<number> {
+        const serialize = fake.returns('{"sbom":"stub"}');
+        const { builder } = createBuilder({ serialize });
+        await builder.generate(
+            createBundle({ name: 'pkg', version: '1.0.0', dependencies: { 'bundle-sibling': '0.0.1' } }),
+            [createSibling('bundle-sibling', siblingLicense)],
+            enabledSbom
+        );
+        const bom = serialize.firstCall.args[0] as {
+            components: Iterable<{ name: string; licenses: Iterable<unknown> }>;
+        };
+        for (const component of bom.components) {
+            if (component.name === 'bundle-sibling') {
+                return Array.from(component.licenses).length;
+            }
         }
+        return -1;
     }
-    return -1;
-}
 
-test('generate() emits the sibling’s license as the bundle dependency component license', async () => {
-    assert.strictEqual(await captureSiblingLicenseCount('BSD-3-Clause'), 1);
-});
+    test('generate() emits the sibling’s license as the bundle dependency component license', async function () {
+        assert.strictEqual(await captureSiblingLicenseCount('BSD-3-Clause'), 1);
+    });
 
-test('generate() leaves the sibling component without a license when the sibling has no license field', async () => {
-    assert.strictEqual(await captureSiblingLicenseCount(undefined), 0);
-});
+    test('generate() leaves the sibling component without a license when the sibling has no license field', async function () {
+        assert.strictEqual(await captureSiblingLicenseCount(undefined), 0);
+    });
 
-test('generate() looks up licenses for peer dependencies as well', async () => {
-    const resolveLicense = fake.resolves('Apache-2.0');
-    const { builder } = createBuilder({ resolveLicense });
-    await builder.generate(
-        createBundle({ name: 'pkg', version: '1.0.0', peerDependencies: { react: '>=18' } }),
-        [],
-        enabledSbom
-    );
+    test('generate() looks up licenses for peer dependencies as well', async function () {
+        const resolveLicense = fake.resolves('Apache-2.0');
+        const { builder } = createBuilder({ resolveLicense });
+        await builder.generate(
+            createBundle({ name: 'pkg', version: '1.0.0', peerDependencies: { react: '>=18' } }),
+            [],
+            enabledSbom
+        );
 
-    assert.deepStrictEqual(resolveLicense.firstCall.args, [{ projectFolder: '/the-project', dependencyName: 'react' }]);
-});
+        assert.deepStrictEqual(resolveLicense.firstCall.args, [
+            { projectFolder: '/the-project', dependencyName: 'react' }
+        ]);
+    });
 
-async function captureScopeFor(
-    name: string,
-    dependenciesShape: Pick<SbomPackage, 'dependencies' | 'peerDependencies'>
-): Promise<string | undefined> {
-    const serialize = fake.returns('{"sbom":"stub"}');
-    const { builder } = createBuilder({ serialize });
-    await builder.generate(
-        { ...createBundle({ name: 'pkg', version: '1.0.0' }), ...dependenciesShape },
-        [],
-        enabledSbom
-    );
-    const bom = serialize.firstCall.args[0] as { components: Iterable<{ name: string; scope?: string }> };
-    for (const component of bom.components) {
-        if (component.name === name) {
-            return component.scope;
+    async function captureScopeFor(
+        name: string,
+        dependenciesShape: Pick<SbomPackage, 'dependencies' | 'peerDependencies'>
+    ): Promise<string | undefined> {
+        const serialize = fake.returns('{"sbom":"stub"}');
+        const { builder } = createBuilder({ serialize });
+        await builder.generate(
+            { ...createBundle({ name: 'pkg', version: '1.0.0' }), ...dependenciesShape },
+            [],
+            enabledSbom
+        );
+        const bom = serialize.firstCall.args[0] as { components: Iterable<{ name: string; scope?: string }> };
+        for (const component of bom.components) {
+            if (component.name === name) {
+                return component.scope;
+            }
         }
+        return undefined;
     }
-    return undefined;
-}
 
-test('generate() emits required scope for runtime dependencies', async () => {
-    const scope = await captureScopeFor('left-pad', { dependencies: { 'left-pad': '^1.0.0' }, peerDependencies: {} });
-    assert.strictEqual(scope, 'required');
-});
+    test('generate() emits required scope for runtime dependencies', async function () {
+        const scope = await captureScopeFor('left-pad', {
+            dependencies: { 'left-pad': '^1.0.0' },
+            peerDependencies: {}
+        });
+        assert.strictEqual(scope, 'required');
+    });
 
-test('generate() emits optional scope for peer dependencies', async () => {
-    const scope = await captureScopeFor('react', { dependencies: {}, peerDependencies: { react: '>=18' } });
-    assert.strictEqual(scope, 'optional');
-});
+    test('generate() emits optional scope for peer dependencies', async function () {
+        const scope = await captureScopeFor('react', { dependencies: {}, peerDependencies: { react: '>=18' } });
+        assert.strictEqual(scope, 'optional');
+    });
 
-test('generate() places the published bundle name and version on the SBOM root component', async () => {
-    const serialize = fake.returns('{"sbom":"stub"}');
-    const { builder } = createBuilder({ serialize });
-    await builder.generate(createBundle({ name: 'my-pkg', version: '4.5.6' }), [], enabledSbom);
+    test('generate() places the published bundle name and version on the SBOM root component', async function () {
+        const serialize = fake.returns('{"sbom":"stub"}');
+        const { builder } = createBuilder({ serialize });
+        await builder.generate(createBundle({ name: 'my-pkg', version: '4.5.6' }), [], enabledSbom);
 
-    const bom = serialize.firstCall.args[0] as { metadata: { component: { name: string; version: string } } };
-    assert.strictEqual(bom.metadata.component.name, 'my-pkg');
-    assert.strictEqual(bom.metadata.component.version, '4.5.6');
+        const bom = serialize.firstCall.args[0] as { metadata: { component: { name: string; version: string } } };
+        assert.strictEqual(bom.metadata.component.name, 'my-pkg');
+        assert.strictEqual(bom.metadata.component.version, '4.5.6');
+    });
 });

--- a/source/sbom/sbom-serializer.test.ts
+++ b/source/sbom/sbom-serializer.test.ts
@@ -1,59 +1,61 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { buildSbom } from './sbom-builder.ts';
 import { createSbomSerializer } from './sbom-serializer.ts';
 
-test('serialize() produces JSON conforming to the CycloneDX 1.6 schema reference', () => {
-    const serializer = createSbomSerializer();
-    const bom = buildSbom({
-        toolVersion: '1.2.3',
-        rootComponent: { name: 'my-pkg', version: '1.0.0' },
-        dependencies: []
+suite('sbom-serializer', function () {
+    test('serialize() produces JSON conforming to the CycloneDX 1.6 schema reference', function () {
+        const serializer = createSbomSerializer();
+        const bom = buildSbom({
+            toolVersion: '1.2.3',
+            rootComponent: { name: 'my-pkg', version: '1.0.0' },
+            dependencies: []
+        });
+
+        const result = JSON.parse(serializer.serialize(bom)) as Record<string, unknown>;
+
+        assert.strictEqual(result.specVersion, '1.6');
+        assert.strictEqual(result.bomFormat, 'CycloneDX');
     });
 
-    const result = JSON.parse(serializer.serialize(bom)) as Record<string, unknown>;
-
-    assert.strictEqual(result.specVersion, '1.6');
-    assert.strictEqual(result.bomFormat, 'CycloneDX');
-});
-
-test('serialize() yields byte-identical output for the same inputs', () => {
-    const serializer = createSbomSerializer();
-    const buildOptions = {
-        toolVersion: '1.2.3',
-        rootComponent: { name: 'my-pkg', version: '1.0.0' },
-        dependencies: [{ name: 'lodash', specifier: '^4.17.0', kind: 'runtime' as const, license: 'MIT' }]
-    };
-
-    const first = serializer.serialize(buildSbom(buildOptions));
-    const second = serializer.serialize(buildSbom(buildOptions));
-
-    assert.strictEqual(first, second);
-});
-
-test('serialize() produces dependencies independently of the input order when sortLists is enabled', () => {
-    const serializer = createSbomSerializer();
-
-    const sortedAscending = serializer.serialize(
-        buildSbom({
+    test('serialize() yields byte-identical output for the same inputs', function () {
+        const serializer = createSbomSerializer();
+        const buildOptions = {
             toolVersion: '1.2.3',
             rootComponent: { name: 'my-pkg', version: '1.0.0' },
-            dependencies: [
-                { name: 'a-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' },
-                { name: 'z-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' }
-            ]
-        })
-    );
-    const sortedDescending = serializer.serialize(
-        buildSbom({
-            toolVersion: '1.2.3',
-            rootComponent: { name: 'my-pkg', version: '1.0.0' },
-            dependencies: [
-                { name: 'z-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' },
-                { name: 'a-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' }
-            ]
-        })
-    );
+            dependencies: [{ name: 'lodash', specifier: '^4.17.0', kind: 'runtime' as const, license: 'MIT' }]
+        };
 
-    assert.strictEqual(sortedAscending, sortedDescending);
+        const first = serializer.serialize(buildSbom(buildOptions));
+        const second = serializer.serialize(buildSbom(buildOptions));
+
+        assert.strictEqual(first, second);
+    });
+
+    test('serialize() produces dependencies independently of the input order when sortLists is enabled', function () {
+        const serializer = createSbomSerializer();
+
+        const sortedAscending = serializer.serialize(
+            buildSbom({
+                toolVersion: '1.2.3',
+                rootComponent: { name: 'my-pkg', version: '1.0.0' },
+                dependencies: [
+                    { name: 'a-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' },
+                    { name: 'z-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' }
+                ]
+            })
+        );
+        const sortedDescending = serializer.serialize(
+            buildSbom({
+                toolVersion: '1.2.3',
+                rootComponent: { name: 'my-pkg', version: '1.0.0' },
+                dependencies: [
+                    { name: 'z-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' },
+                    { name: 'a-dep', specifier: '1.0.0', kind: 'runtime', license: 'MIT' }
+                ]
+            })
+        );
+
+        assert.strictEqual(sortedAscending, sortedDescending);
+    });
 });

--- a/source/sbom/tool-version.test.ts
+++ b/source/sbom/tool-version.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { createPacktoryToolVersionResolver } from './tool-version.ts';
 
@@ -72,139 +72,144 @@ async function expectResolutionError(expectedResolutionError: ExpectedResolution
     }
 }
 
-test('returns the version from @packtory/cli when its package.json resolves inside node_modules', async () => {
-    await expectResolvedVersion({
-        importPackageJson: createJsonImporter('@packtory/cli/package.json', {
-            default: { name: '@packtory/cli', version: '1.2.3' }
-        }),
-        expectedVersion: '1.2.3'
+suite('tool-version', function () {
+    test('returns the version from @packtory/cli when its package.json resolves inside node_modules', async function () {
+        await expectResolvedVersion({
+            importPackageJson: createJsonImporter('@packtory/cli/package.json', {
+                default: { name: '@packtory/cli', version: '1.2.3' }
+            }),
+            expectedVersion: '1.2.3'
+        });
     });
-});
 
-test('falls back to packtory when @packtory/cli is not resolvable', async () => {
-    await expectResolvedVersion({
-        importPackageJson: createJsonImporter('packtory/package.json', {
-            default: { name: 'packtory', version: '4.5.6' }
-        }),
-        expectedVersion: '4.5.6'
+    test('falls back to packtory when @packtory/cli is not resolvable', async function () {
+        await expectResolvedVersion({
+            importPackageJson: createJsonImporter('packtory/package.json', {
+                default: { name: 'packtory', version: '4.5.6' }
+            }),
+            expectedVersion: '4.5.6'
+        });
     });
-});
 
-test('falls back to packtory when @packtory/cli is missing from node_modules entirely', async () => {
-    await expectResolvedVersion({
-        importPackageJson: fake(async (specifier: string) => {
-            if (specifier === '@packtory/cli/package.json') {
+    test('falls back to packtory when @packtory/cli is missing from node_modules entirely', async function () {
+        await expectResolvedVersion({
+            importPackageJson: fake(async (specifier: string) => {
+                if (specifier === '@packtory/cli/package.json') {
+                    throw Object.assign(new Error(`Cannot resolve ${specifier}`), {
+                        code: 'ERR_MODULE_NOT_FOUND'
+                    });
+                }
+                if (specifier === 'packtory/package.json') {
+                    return { default: { name: 'packtory', version: '4.5.6' } };
+                }
+                throw new Error(`Unexpected specifier: ${specifier}`);
+            }),
+            expectedVersion: '4.5.6'
+        });
+    });
+
+    test('accepts package.json imports that resolve directly without a default wrapper', async function () {
+        await expectResolvedVersion({
+            importPackageJson: createJsonImporter('@packtory/cli/package.json', {
+                name: '@packtory/cli',
+                version: '7.8.9'
+            }),
+            expectedVersion: '7.8.9'
+        });
+    });
+
+    test('throws when neither @packtory/cli nor packtory can be resolved', async function () {
+        await expectResolutionError({
+            importPackageJson: fake.rejects(
+                Object.assign(new Error('missing'), { code: 'ERR_PACKAGE_PATH_NOT_EXPORTED' })
+            ),
+            expectedMessage: unresolvableExpectedMessage
+        });
+    });
+
+    test('rethrows errors that are not import-resolution errors', async function () {
+        const expectedError = Object.assign(new Error('boom'), { code: 'SOMETHING_ELSE' });
+        const importPackageJson = fake.rejects(expectedError);
+        const { resolve } = createResolver({ importPackageJson });
+
+        try {
+            await resolve();
+            assert.fail('Expected resolve() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(error, expectedError);
+        }
+
+        assert.strictEqual(importPackageJson.callCount, 1);
+        assert.deepStrictEqual(importPackageJson.firstCall.args, ['@packtory/cli/package.json']);
+    });
+
+    test('rethrows non-object import failures instead of treating them as resolution errors', async function () {
+        const rejectPromise = Reflect.get(Promise, 'reject').bind(Promise) as (reason: unknown) => Promise<never>;
+        const importPackageJson = fake(async () => await rejectPromise('boom'));
+        const { resolve } = createResolver({ importPackageJson });
+
+        try {
+            await resolve();
+            assert.fail('Expected resolve() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(error, 'boom');
+        }
+
+        assert.strictEqual(importPackageJson.callCount, 1);
+        assert.deepStrictEqual(importPackageJson.firstCall.args, ['@packtory/cli/package.json']);
+    });
+
+    test('rethrows null import failures instead of treating them as resolution errors', async function () {
+        const rejectPromise = Reflect.get(Promise, 'reject').bind(Promise) as (reason: unknown) => Promise<never>;
+        const importPackageJson = fake(async () => await rejectPromise(null));
+        const { resolve } = createResolver({ importPackageJson });
+
+        try {
+            await resolve();
+            assert.fail('Expected resolve() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(error, null);
+        }
+
+        assert.strictEqual(importPackageJson.callCount, 1);
+        assert.deepStrictEqual(importPackageJson.firstCall.args, ['@packtory/cli/package.json']);
+    });
+
+    test('throws when the imported package.json has an unexpected package name', async function () {
+        await expectResolutionError({
+            importPackageJson: createJsonImporter('packtory/package.json', {
+                default: { name: 'not-packtory', version: '1.2.3' }
+            }),
+            expectedMessage: 'Imported packtory package.json from "packtory/package.json" has unexpected package name'
+        });
+    });
+
+    test('throws when the imported package.json has no version field', async function () {
+        await expectResolutionError({
+            importPackageJson: fake(async (specifier: string) => {
+                if (specifier === 'packtory/package.json') {
+                    return { default: { name: 'packtory' } };
+                }
                 throw Object.assign(new Error(`Cannot resolve ${specifier}`), {
-                    code: 'ERR_MODULE_NOT_FOUND'
+                    code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
                 });
-            }
-            if (specifier === 'packtory/package.json') {
-                return { default: { name: 'packtory', version: '4.5.6' } };
-            }
-            throw new Error(`Unexpected specifier: ${specifier}`);
-        }),
-        expectedVersion: '4.5.6'
+            }),
+            expectedMessage: 'Imported packtory package.json from "packtory/package.json" is missing a version field'
+        });
     });
-});
 
-test('accepts package.json imports that resolve directly without a default wrapper', async () => {
-    await expectResolvedVersion({
-        importPackageJson: createJsonImporter('@packtory/cli/package.json', {
-            name: '@packtory/cli',
-            version: '7.8.9'
-        }),
-        expectedVersion: '7.8.9'
-    });
-});
-
-test('throws when neither @packtory/cli nor packtory can be resolved', async () => {
-    await expectResolutionError({
-        importPackageJson: fake.rejects(Object.assign(new Error('missing'), { code: 'ERR_PACKAGE_PATH_NOT_EXPORTED' })),
-        expectedMessage: unresolvableExpectedMessage
-    });
-});
-
-test('rethrows errors that are not import-resolution errors', async () => {
-    const expectedError = Object.assign(new Error('boom'), { code: 'SOMETHING_ELSE' });
-    const importPackageJson = fake.rejects(expectedError);
-    const { resolve } = createResolver({ importPackageJson });
-
-    try {
-        await resolve();
-        assert.fail('Expected resolve() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(error, expectedError);
-    }
-
-    assert.strictEqual(importPackageJson.callCount, 1);
-    assert.deepStrictEqual(importPackageJson.firstCall.args, ['@packtory/cli/package.json']);
-});
-
-test('rethrows non-object import failures instead of treating them as resolution errors', async () => {
-    const rejectPromise = Reflect.get(Promise, 'reject').bind(Promise) as (reason: unknown) => Promise<never>;
-    const importPackageJson = fake(async () => await rejectPromise('boom'));
-    const { resolve } = createResolver({ importPackageJson });
-
-    try {
-        await resolve();
-        assert.fail('Expected resolve() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(error, 'boom');
-    }
-
-    assert.strictEqual(importPackageJson.callCount, 1);
-    assert.deepStrictEqual(importPackageJson.firstCall.args, ['@packtory/cli/package.json']);
-});
-
-test('rethrows null import failures instead of treating them as resolution errors', async () => {
-    const rejectPromise = Reflect.get(Promise, 'reject').bind(Promise) as (reason: unknown) => Promise<never>;
-    const importPackageJson = fake(async () => await rejectPromise(null));
-    const { resolve } = createResolver({ importPackageJson });
-
-    try {
-        await resolve();
-        assert.fail('Expected resolve() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(error, null);
-    }
-
-    assert.strictEqual(importPackageJson.callCount, 1);
-    assert.deepStrictEqual(importPackageJson.firstCall.args, ['@packtory/cli/package.json']);
-});
-
-test('throws when the imported package.json has an unexpected package name', async () => {
-    await expectResolutionError({
-        importPackageJson: createJsonImporter('packtory/package.json', {
-            default: { name: 'not-packtory', version: '1.2.3' }
-        }),
-        expectedMessage: 'Imported packtory package.json from "packtory/package.json" has unexpected package name'
-    });
-});
-
-test('throws when the imported package.json has no version field', async () => {
-    await expectResolutionError({
-        importPackageJson: fake(async (specifier: string) => {
-            if (specifier === 'packtory/package.json') {
-                return { default: { name: 'packtory' } };
-            }
-            throw Object.assign(new Error(`Cannot resolve ${specifier}`), {
-                code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
-            });
-        }),
-        expectedMessage: 'Imported packtory package.json from "packtory/package.json" is missing a version field'
-    });
-});
-
-test('throws when the imported package.json module shape is malformed', async () => {
-    await expectResolutionError({
-        importPackageJson: fake(async (specifier: string) => {
-            if (specifier === '@packtory/cli/package.json') {
-                return null;
-            }
-            throw Object.assign(new Error(`Cannot resolve ${specifier}`), {
-                code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
-            });
-        }),
-        expectedMessage: 'Imported packtory package.json from "@packtory/cli/package.json" is missing a version field'
+    test('throws when the imported package.json module shape is malformed', async function () {
+        await expectResolutionError({
+            importPackageJson: fake(async (specifier: string) => {
+                if (specifier === '@packtory/cli/package.json') {
+                    return null;
+                }
+                throw Object.assign(new Error(`Cannot resolve ${specifier}`), {
+                    code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+                });
+            }),
+            expectedMessage:
+                'Imported packtory package.json from "@packtory/cli/package.json" is missing a version field'
+        });
     });
 });

--- a/source/tar/extract-tar.property.ts
+++ b/source/tar/extract-tar.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { extractTarEntries } from './extract-tar.ts';
 
 const nonGzipBufferArbitrary = fc.uint8Array({ maxLength: 256 }).filter((data) => {
@@ -16,27 +16,29 @@ async function expectFailure(action: () => Promise<unknown>): Promise<void> {
     }
 }
 
-test('extractTarEntries() rejects malformed non-gzip buffers explicitly', async () => {
-    await fc.assert(
-        fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
-            await expectFailure(async () => {
-                await extractTarEntries(Buffer.from(data));
-            });
-        }),
-        { numRuns: 50 }
-    );
-});
+suite('extract-tar', function () {
+    test('extractTarEntries() rejects malformed non-gzip buffers explicitly', async function () {
+        await fc.assert(
+            fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
+                await expectFailure(async () => {
+                    await extractTarEntries(Buffer.from(data));
+                });
+            }),
+            { numRuns: 50 }
+        );
+    });
 
-test('extractTarEntries() rejects malformed non-gzip buffers without needing exact error text', async () => {
-    await fc.assert(
-        fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
-            try {
-                const result = await extractTarEntries(Buffer.from(data));
-                assert.fail(`Expected extractTarEntries() to reject, but it returned ${result.length} entries`);
-            } catch (error: unknown) {
-                assert.ok(error instanceof Error);
-            }
-        }),
-        { numRuns: 50 }
-    );
+    test('extractTarEntries() rejects malformed non-gzip buffers without needing exact error text', async function () {
+        await fc.assert(
+            fc.asyncProperty(nonGzipBufferArbitrary, async (data) => {
+                try {
+                    const result = await extractTarEntries(Buffer.from(data));
+                    assert.fail(`Expected extractTarEntries() to reject, but it returned ${result.length} entries`);
+                } catch (error: unknown) {
+                    assert.ok(error instanceof Error);
+                }
+            }),
+            { numRuns: 50 }
+        );
+    });
 });

--- a/source/tar/extract-tar.test.ts
+++ b/source/tar/extract-tar.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import type { Readable } from 'node:stream';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import sinon from 'sinon';
 import { withPromiseDeadline } from '../test-libraries/promise-with-deadline.ts';
 import { extractTarEntries } from './extract-tar.ts';
@@ -20,206 +20,208 @@ async function expectFailure(action: () => Promise<unknown>, expectedError: RegE
     }
 }
 
-test('returns an empty array when the given tar buffer has no files', async () => {
-    const builder = createTarballBuilder();
-    const tar = await builder.build([]);
-    const entries = await withPromiseDeadline(extractTarEntries(tar), 'empty tar extraction');
+suite('extract-tar', function () {
+    test('returns an empty array when the given tar buffer has no files', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([]);
+        const entries = await withPromiseDeadline(extractTarEntries(tar), 'empty tar extraction');
 
-    assert.deepStrictEqual(entries, []);
-});
+        assert.deepStrictEqual(entries, []);
+    });
 
-function expectedSingleFileEntry(mode: number): unknown[] {
-    return [
-        {
-            content: 'bar',
-            header: {
-                devmajor: 0,
-                devminor: 0,
-                gid: 0,
-                gname: '',
-                linkname: null,
-                mode,
-                mtime: new Date(0),
-                name: 'foo',
-                pax: null,
-                size: 3,
-                type: 'file',
-                uid: 0,
-                uname: ''
+    function expectedSingleFileEntry(mode: number): unknown[] {
+        return [
+            {
+                content: 'bar',
+                header: {
+                    devmajor: 0,
+                    devminor: 0,
+                    gid: 0,
+                    gname: '',
+                    linkname: null,
+                    mode,
+                    mtime: new Date(0),
+                    name: 'foo',
+                    pax: null,
+                    size: 3,
+                    type: 'file',
+                    uid: 0,
+                    uname: ''
+                }
             }
-        }
-    ];
-}
+        ];
+    }
 
-test('returns the extracted entries when the given tar buffer has files', async () => {
-    const builder = createTarballBuilder();
-    const tar = await builder.build([{ filePath: 'foo', content: 'bar', isExecutable: false }]);
-    const entries = await withPromiseDeadline(extractTarEntries(tar), 'single-file tar extraction');
+    test('returns the extracted entries when the given tar buffer has files', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([{ filePath: 'foo', content: 'bar', isExecutable: false }]);
+        const entries = await withPromiseDeadline(extractTarEntries(tar), 'single-file tar extraction');
 
-    assert.deepStrictEqual(entries, expectedSingleFileEntry(420));
-});
+        assert.deepStrictEqual(entries, expectedSingleFileEntry(420));
+    });
 
-test('returns the extracted entries when the given tar buffer has files which are executable', async () => {
-    const builder = createTarballBuilder();
-    const tar = await builder.build([{ filePath: 'foo', content: 'bar', isExecutable: true }]);
-    const entries = await withPromiseDeadline(extractTarEntries(tar), 'executable tar extraction');
+    test('returns the extracted entries when the given tar buffer has files which are executable', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([{ filePath: 'foo', content: 'bar', isExecutable: true }]);
+        const entries = await withPromiseDeadline(extractTarEntries(tar), 'executable tar extraction');
 
-    assert.deepStrictEqual(entries, expectedSingleFileEntry(493));
-});
+        assert.deepStrictEqual(entries, expectedSingleFileEntry(493));
+    });
 
-test('returns every extracted entry in tar order when the tarball contains multiple files', async () => {
-    const builder = createTarballBuilder();
-    const tar = await builder.build([
-        { filePath: 'first.txt', content: 'first', isExecutable: false },
-        { filePath: 'second.txt', content: 'second', isExecutable: false }
-    ]);
+    test('returns every extracted entry in tar order when the tarball contains multiple files', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([
+            { filePath: 'first.txt', content: 'first', isExecutable: false },
+            { filePath: 'second.txt', content: 'second', isExecutable: false }
+        ]);
 
-    const entries = await withPromiseDeadline(extractTarEntries(tar), 'multi-file tar extraction');
+        const entries = await withPromiseDeadline(extractTarEntries(tar), 'multi-file tar extraction');
 
-    assert.deepStrictEqual(
-        entries.map((entry) => {
-            return [entry.header.name, entry.content];
-        }),
-        [
-            ['first.txt', 'first'],
-            ['second.txt', 'second']
-        ]
-    );
-});
+        assert.deepStrictEqual(
+            entries.map((entry) => {
+                return [entry.header.name, entry.content];
+            }),
+            [
+                ['first.txt', 'first'],
+                ['second.txt', 'second']
+            ]
+        );
+    });
 
-test('rejects when the given buffer is not a valid gzip tarball', async () => {
-    await expectFailure(async () => {
-        await withPromiseDeadline(extractTarEntries(Buffer.from('not-a-tarball')), 'invalid tar extraction');
-    }, 'error');
-});
+    test('rejects when the given buffer is not a valid gzip tarball', async function () {
+        await expectFailure(async () => {
+            await withPromiseDeadline(extractTarEntries(Buffer.from('not-a-tarball')), 'invalid tar extraction');
+        }, 'error');
+    });
 
-async function runWithThrowingStream(thrown: () => never, expectedError: RegExp): Promise<void> {
-    const throwingStream = {
-        [Symbol.asyncIterator](): AsyncIterator<unknown> {
-            return {
-                async next(): Promise<IteratorResult<unknown>> {
-                    thrown();
-                }
-            };
-        }
-    };
-    const intermediateStream = { pipe: () => throwingStream };
-    const source = {
-        once() {
-            return source;
-        },
-        pipe: () => intermediateStream
-    };
-    await expectFailure(async () => {
-        await withPromiseDeadline(
+    async function runWithThrowingStream(thrown: () => never, expectedError: RegExp): Promise<void> {
+        const throwingStream = {
+            [Symbol.asyncIterator](): AsyncIterator<unknown> {
+                return {
+                    async next(): Promise<IteratorResult<unknown>> {
+                        thrown();
+                    }
+                };
+            }
+        };
+        const intermediateStream = { pipe: () => throwingStream };
+        const source = {
+            once() {
+                return source;
+            },
+            pipe: () => intermediateStream
+        };
+        await expectFailure(async () => {
+            await withPromiseDeadline(
+                extractTarEntries(Buffer.from('unused'), {
+                    createSource: () => source as unknown as Readable
+                }),
+                'throwing tar extraction'
+            );
+        }, expectedError);
+    }
+
+    test('rejects with an Error when iteration throws a non-Error value', async function () {
+        await runWithThrowingStream(() => {
+            // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- This test exercises non-Error rejection normalization.
+            throw 'boom';
+        }, /^Error: boom$/u);
+    });
+
+    test('preserves Error instances when iteration rejects with an Error', async function () {
+        await runWithThrowingStream(() => {
+            throw new Error('boom');
+        }, /^Error: boom$/u);
+    });
+
+    test('registers the shared error event handler on the source stream', async function () {
+        const sourceOnce = sinon.spy();
+        const extractStream = {
+            once() {
+                return extractStream;
+            },
+            pipe() {
+                return extractStream;
+            },
+            [Symbol.asyncIterator](): AsyncIterator<unknown> {
+                return {
+                    next: async (): Promise<IteratorResult<unknown>> => {
+                        return { done: true, value: undefined };
+                    }
+                };
+            }
+        };
+        const gunzip = {
+            once() {
+                return gunzip;
+            },
+            pipe() {
+                return extractStream;
+            }
+        };
+        const source = {
+            once: sourceOnce,
+            pipe() {
+                return gunzip;
+            }
+        };
+        const entries = await withPromiseDeadline(
             extractTarEntries(Buffer.from('unused'), {
                 createSource: () => source as unknown as Readable
             }),
-            'throwing tar extraction'
+            'source stream error registration'
         );
-    }, expectedError);
-}
 
-test('rejects with an Error when iteration throws a non-Error value', async () => {
-    await runWithThrowingStream(() => {
-        // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- This test exercises non-Error rejection normalization.
-        throw 'boom';
-    }, /^Error: boom$/u);
-});
+        assert.deepStrictEqual(entries, []);
+        assert.strictEqual(sourceOnce.firstCall.firstArg, 'error');
+    });
 
-test('preserves Error instances when iteration rejects with an Error', async () => {
-    await runWithThrowingStream(() => {
-        throw new Error('boom');
-    }, /^Error: boom$/u);
-});
+    test('rejects when the injected source stream emits an error event', async function () {
+        let sourceErrorListener = (error: unknown): void => {
+            throw new Error(`expected the source error listener to be registered before piping: ${String(error)}`);
+        };
+        const extractStream = {
+            once() {
+                return extractStream;
+            },
+            [Symbol.asyncIterator](): AsyncIterator<unknown> {
+                return {
+                    next: async (): Promise<IteratorResult<unknown>> => {
+                        return await new Promise<IteratorResult<unknown>>(() => {
+                            // keep pending so the error race decides the outcome
+                        });
+                    }
+                };
+            }
+        };
+        const gunzip = {
+            once() {
+                return gunzip;
+            },
+            pipe() {
+                return extractStream;
+            }
+        };
+        const source = {
+            once(_eventName: 'error', listener: (error: unknown) => void) {
+                sourceErrorListener = listener;
+                return source;
+            },
+            pipe() {
+                queueMicrotask(() => {
+                    sourceErrorListener(new Error('source boom'));
+                });
+                return gunzip;
+            }
+        };
 
-test('registers the shared error event handler on the source stream', async () => {
-    const sourceOnce = sinon.spy();
-    const extractStream = {
-        once() {
-            return extractStream;
-        },
-        pipe() {
-            return extractStream;
-        },
-        [Symbol.asyncIterator](): AsyncIterator<unknown> {
-            return {
-                next: async (): Promise<IteratorResult<unknown>> => {
-                    return { done: true, value: undefined };
-                }
-            };
-        }
-    };
-    const gunzip = {
-        once() {
-            return gunzip;
-        },
-        pipe() {
-            return extractStream;
-        }
-    };
-    const source = {
-        once: sourceOnce,
-        pipe() {
-            return gunzip;
-        }
-    };
-    const entries = await withPromiseDeadline(
-        extractTarEntries(Buffer.from('unused'), {
-            createSource: () => source as unknown as Readable
-        }),
-        'source stream error registration'
-    );
-
-    assert.deepStrictEqual(entries, []);
-    assert.strictEqual(sourceOnce.firstCall.firstArg, 'error');
-});
-
-test('rejects when the injected source stream emits an error event', async () => {
-    let sourceErrorListener = (error: unknown): void => {
-        throw new Error(`expected the source error listener to be registered before piping: ${String(error)}`);
-    };
-    const extractStream = {
-        once() {
-            return extractStream;
-        },
-        [Symbol.asyncIterator](): AsyncIterator<unknown> {
-            return {
-                next: async (): Promise<IteratorResult<unknown>> => {
-                    return await new Promise<IteratorResult<unknown>>(() => {
-                        // keep pending so the error race decides the outcome
-                    });
-                }
-            };
-        }
-    };
-    const gunzip = {
-        once() {
-            return gunzip;
-        },
-        pipe() {
-            return extractStream;
-        }
-    };
-    const source = {
-        once(_eventName: 'error', listener: (error: unknown) => void) {
-            sourceErrorListener = listener;
-            return source;
-        },
-        pipe() {
-            queueMicrotask(() => {
-                sourceErrorListener(new Error('source boom'));
-            });
-            return gunzip;
-        }
-    };
-
-    await expectFailure(async () => {
-        await withPromiseDeadline(
-            extractTarEntries(Buffer.from('unused'), {
-                createSource: () => source as unknown as Readable
-            }),
-            'source stream error event'
-        );
-    }, /^Error: source boom$/u);
+        await expectFailure(async () => {
+            await withPromiseDeadline(
+                extractTarEntries(Buffer.from('unused'), {
+                    createSource: () => source as unknown as Readable
+                }),
+                'source stream error event'
+            );
+        }, /^Error: source boom$/u);
+    });
 });

--- a/source/tar/tarball-builder.test.ts
+++ b/source/tar/tarball-builder.test.ts
@@ -1,147 +1,152 @@
 import assert from 'node:assert';
 import zlib from 'node:zlib';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import sinon from 'sinon';
 import { withPromiseDeadline } from '../test-libraries/promise-with-deadline.ts';
 import { extractTarEntries } from './extract-tar.ts';
 import { createTarballBuilder } from './tarball-builder.ts';
 
-test('creates an empty tarball', async () => {
-    const builder = createTarballBuilder();
-    const tarballBuffer = await builder.build([]);
-    const entries = await withPromiseDeadline(extractTarEntries(tarballBuffer), 'empty tarball builder extraction');
+suite('tarball-builder', function () {
+    test('creates an empty tarball', async function () {
+        const builder = createTarballBuilder();
+        const tarballBuffer = await builder.build([]);
+        const entries = await withPromiseDeadline(extractTarEntries(tarballBuffer), 'empty tarball builder extraction');
 
-    assert.deepStrictEqual(entries, []);
-});
-
-test('creates a tarball with one file', async () => {
-    const builder = createTarballBuilder();
-
-    const tarballBuffer = await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
-    const entries = await withPromiseDeadline(
-        extractTarEntries(tarballBuffer),
-        'single-file tarball builder extraction'
-    );
-
-    assert.deepStrictEqual(entries, [
-        {
-            header: {
-                devmajor: 0,
-                devminor: 0,
-                gid: 0,
-                gname: '',
-                linkname: null,
-                mode: 420,
-                mtime: new Date(0),
-                name: 'foo.txt',
-                pax: null,
-                size: 3,
-                type: 'file',
-                uid: 0,
-                uname: ''
-            },
-            content: 'bar'
-        }
-    ]);
-});
-
-test('sets the file mode in the tar header correctly when the file is executable', async () => {
-    const builder = createTarballBuilder();
-
-    const tarballBuffer = await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: true }]);
-    const entries = await withPromiseDeadline(
-        extractTarEntries(tarballBuffer),
-        'executable tarball builder extraction'
-    );
-
-    assert.deepStrictEqual(entries, [
-        {
-            header: {
-                devmajor: 0,
-                devminor: 0,
-                gid: 0,
-                gname: '',
-                linkname: null,
-                mode: 493,
-                mtime: new Date(0),
-                name: 'foo.txt',
-                pax: null,
-                size: 3,
-                type: 'file',
-                uid: 0,
-                uname: ''
-            },
-            content: 'bar'
-        }
-    ]);
-});
-
-test('creates a tarball with many nested files', async () => {
-    const builder = createTarballBuilder();
-
-    const tarballBuffer = await builder.build([
-        { filePath: '1.txt', content: '1', isExecutable: false },
-        { filePath: 'foo/2.txt', content: '2', isExecutable: false },
-        { filePath: 'foo/bar/3.txt', content: '3', isExecutable: false },
-        { filePath: 'foo/bar/baz/4.txt', content: '4', isExecutable: false }
-    ]);
-    const entries = await withPromiseDeadline(extractTarEntries(tarballBuffer), 'nested tarball builder extraction');
-    const expectedBaseHeaders = {
-        devmajor: 0,
-        devminor: 0,
-        gid: 0,
-        gname: '',
-        linkname: null,
-        mode: 420,
-        mtime: new Date(0),
-        pax: null,
-        uid: 0,
-        uname: '',
-        type: 'file'
-    } as const;
-
-    assert.deepStrictEqual(entries, [
-        {
-            header: {
-                ...expectedBaseHeaders,
-                name: '1.txt',
-                size: 1
-            },
-            content: '1'
-        },
-        {
-            header: {
-                ...expectedBaseHeaders,
-                name: 'foo/2.txt',
-                size: 1
-            },
-            content: '2'
-        },
-        {
-            header: {
-                ...expectedBaseHeaders,
-                name: 'foo/bar/3.txt',
-                size: 1
-            },
-            content: '3'
-        },
-        {
-            header: {
-                ...expectedBaseHeaders,
-                name: 'foo/bar/baz/4.txt',
-                size: 1
-            },
-            content: '4'
-        }
-    ]);
-});
-
-test('creates gzip streams with the maximum compression level', async () => {
-    const createGzip = sinon.spy((options?: zlib.ZlibOptions) => {
-        return zlib.createGzip(options);
+        assert.deepStrictEqual(entries, []);
     });
-    const builder = createTarballBuilder({ createGzip });
-    await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
 
-    assert.deepStrictEqual(createGzip.firstCall.args, [{ level: 9 }]);
+    test('creates a tarball with one file', async function () {
+        const builder = createTarballBuilder();
+
+        const tarballBuffer = await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
+        const entries = await withPromiseDeadline(
+            extractTarEntries(tarballBuffer),
+            'single-file tarball builder extraction'
+        );
+
+        assert.deepStrictEqual(entries, [
+            {
+                header: {
+                    devmajor: 0,
+                    devminor: 0,
+                    gid: 0,
+                    gname: '',
+                    linkname: null,
+                    mode: 420,
+                    mtime: new Date(0),
+                    name: 'foo.txt',
+                    pax: null,
+                    size: 3,
+                    type: 'file',
+                    uid: 0,
+                    uname: ''
+                },
+                content: 'bar'
+            }
+        ]);
+    });
+
+    test('sets the file mode in the tar header correctly when the file is executable', async function () {
+        const builder = createTarballBuilder();
+
+        const tarballBuffer = await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: true }]);
+        const entries = await withPromiseDeadline(
+            extractTarEntries(tarballBuffer),
+            'executable tarball builder extraction'
+        );
+
+        assert.deepStrictEqual(entries, [
+            {
+                header: {
+                    devmajor: 0,
+                    devminor: 0,
+                    gid: 0,
+                    gname: '',
+                    linkname: null,
+                    mode: 493,
+                    mtime: new Date(0),
+                    name: 'foo.txt',
+                    pax: null,
+                    size: 3,
+                    type: 'file',
+                    uid: 0,
+                    uname: ''
+                },
+                content: 'bar'
+            }
+        ]);
+    });
+
+    test('creates a tarball with many nested files', async function () {
+        const builder = createTarballBuilder();
+
+        const tarballBuffer = await builder.build([
+            { filePath: '1.txt', content: '1', isExecutable: false },
+            { filePath: 'foo/2.txt', content: '2', isExecutable: false },
+            { filePath: 'foo/bar/3.txt', content: '3', isExecutable: false },
+            { filePath: 'foo/bar/baz/4.txt', content: '4', isExecutable: false }
+        ]);
+        const entries = await withPromiseDeadline(
+            extractTarEntries(tarballBuffer),
+            'nested tarball builder extraction'
+        );
+        const expectedBaseHeaders = {
+            devmajor: 0,
+            devminor: 0,
+            gid: 0,
+            gname: '',
+            linkname: null,
+            mode: 420,
+            mtime: new Date(0),
+            pax: null,
+            uid: 0,
+            uname: '',
+            type: 'file'
+        } as const;
+
+        assert.deepStrictEqual(entries, [
+            {
+                header: {
+                    ...expectedBaseHeaders,
+                    name: '1.txt',
+                    size: 1
+                },
+                content: '1'
+            },
+            {
+                header: {
+                    ...expectedBaseHeaders,
+                    name: 'foo/2.txt',
+                    size: 1
+                },
+                content: '2'
+            },
+            {
+                header: {
+                    ...expectedBaseHeaders,
+                    name: 'foo/bar/3.txt',
+                    size: 1
+                },
+                content: '3'
+            },
+            {
+                header: {
+                    ...expectedBaseHeaders,
+                    name: 'foo/bar/baz/4.txt',
+                    size: 1
+                },
+                content: '4'
+            }
+        ]);
+    });
+
+    test('creates gzip streams with the maximum compression level', async function () {
+        const createGzip = sinon.spy((options?: zlib.ZlibOptions) => {
+            return zlib.createGzip(options);
+        });
+        const builder = createTarballBuilder({ createGzip });
+        await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
+
+        assert.deepStrictEqual(createGzip.firstCall.args, [{ level: 9 }]);
+    });
 });

--- a/source/version-manager/dependencies/bundle-dependency-grouping.test.ts
+++ b/source/version-manager/dependencies/bundle-dependency-grouping.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
 import { groupBundleDependencies } from './bundle-dependency-grouping.ts';
 
@@ -7,51 +7,60 @@ function externalDep(name: string): ExternalDependency {
     return { name, referencedFrom: ['/src/a.ts'] };
 }
 
-test('groupBundleDependencies returns empty groups when the bundle has no linked dependencies', () => {
-    assert.deepStrictEqual(groupBundleDependencies({ linkedBundleDependencies: new Map() }, [], []), {
-        dependencies: {},
-        peerDependencies: {}
+suite('bundle-dependency-grouping', function () {
+    test('groupBundleDependencies returns empty groups when the bundle has no linked dependencies', function () {
+        assert.deepStrictEqual(groupBundleDependencies({ linkedBundleDependencies: new Map() }, [], []), {
+            dependencies: {},
+            peerDependencies: {}
+        });
     });
-});
 
-test('groupBundleDependencies routes a linked dep to dependencies when it is in bundleDependencies', () => {
-    assert.deepStrictEqual(
-        groupBundleDependencies(
-            { linkedBundleDependencies: new Map([['my-dep', externalDep('my-dep')]]) },
-            [],
-            [{ name: 'my-dep', version: '2.0.0' }]
-        ),
-        { dependencies: { 'my-dep': '2.0.0' }, peerDependencies: {} }
-    );
-});
+    test('groupBundleDependencies routes a linked dep to dependencies when it is in bundleDependencies', function () {
+        assert.deepStrictEqual(
+            groupBundleDependencies(
+                { linkedBundleDependencies: new Map([['my-dep', externalDep('my-dep')]]) },
+                [],
+                [{ name: 'my-dep', version: '2.0.0' }]
+            ),
+            { dependencies: { 'my-dep': '2.0.0' }, peerDependencies: {} }
+        );
+    });
 
-test('groupBundleDependencies routes a linked dep to peerDependencies when it is in bundlePeerDependencies', () => {
-    assert.deepStrictEqual(
-        groupBundleDependencies(
-            { linkedBundleDependencies: new Map([['my-peer', externalDep('my-peer')]]) },
-            [{ name: 'my-peer', version: '3.0.0' }],
-            []
-        ),
-        { dependencies: {}, peerDependencies: { 'my-peer': '3.0.0' } }
-    );
-});
+    test('groupBundleDependencies routes a linked dep to peerDependencies when it is in bundlePeerDependencies', function () {
+        assert.deepStrictEqual(
+            groupBundleDependencies(
+                { linkedBundleDependencies: new Map([['my-peer', externalDep('my-peer')]]) },
+                [{ name: 'my-peer', version: '3.0.0' }],
+                []
+            ),
+            { dependencies: {}, peerDependencies: { 'my-peer': '3.0.0' } }
+        );
+    });
 
-test('groupBundleDependencies prefers the peer entry when a name appears in both peers and deps', () => {
-    assert.deepStrictEqual(
-        groupBundleDependencies(
-            { linkedBundleDependencies: new Map([['shared', externalDep('shared')]]) },
-            [{ name: 'shared', version: '3.0.0' }],
-            [{ name: 'shared', version: '2.0.0' }]
-        ),
-        { dependencies: {}, peerDependencies: { shared: '3.0.0' } }
-    );
-});
+    test('groupBundleDependencies prefers the peer entry when a name appears in both peers and deps', function () {
+        assert.deepStrictEqual(
+            groupBundleDependencies(
+                { linkedBundleDependencies: new Map([['shared', externalDep('shared')]]) },
+                [{ name: 'shared', version: '3.0.0' }],
+                [{ name: 'shared', version: '2.0.0' }]
+            ),
+            { dependencies: {}, peerDependencies: { shared: '3.0.0' } }
+        );
+    });
 
-test('groupBundleDependencies throws when a linked dep is in neither peers nor deps', () => {
-    try {
-        groupBundleDependencies({ linkedBundleDependencies: new Map([['unknown', externalDep('unknown')]]) }, [], []);
-        assert.fail('Expected groupBundleDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Couldn’t determine version number of bundle dependency unknown');
-    }
+    test('groupBundleDependencies throws when a linked dep is in neither peers nor deps', function () {
+        try {
+            groupBundleDependencies(
+                { linkedBundleDependencies: new Map([['unknown', externalDep('unknown')]]) },
+                [],
+                []
+            );
+            assert.fail('Expected groupBundleDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Couldn’t determine version number of bundle dependency unknown'
+            );
+        }
+    });
 });

--- a/source/version-manager/dependencies/dependency-groups.test.ts
+++ b/source/version-manager/dependencies/dependency-groups.test.ts
@@ -1,34 +1,39 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { mergeDependencyGroups } from './dependency-groups.ts';
 
-test('mergeDependencyGroups returns empty groups when called with no arguments', () => {
-    assert.deepStrictEqual(mergeDependencyGroups(), { dependencies: {}, peerDependencies: {} });
-});
-
-test('mergeDependencyGroups returns a single group unchanged', () => {
-    assert.deepStrictEqual(mergeDependencyGroups({ dependencies: { a: '1.0.0' }, peerDependencies: { b: '2.0.0' } }), {
-        dependencies: { a: '1.0.0' },
-        peerDependencies: { b: '2.0.0' }
+suite('dependency-groups', function () {
+    test('mergeDependencyGroups returns empty groups when called with no arguments', function () {
+        assert.deepStrictEqual(mergeDependencyGroups(), { dependencies: {}, peerDependencies: {} });
     });
-});
 
-test('mergeDependencyGroups merges non-overlapping groups across dependencies and peerDependencies', () => {
-    assert.deepStrictEqual(
-        mergeDependencyGroups(
-            { dependencies: { a: '1.0.0' }, peerDependencies: {} },
-            { dependencies: { b: '2.0.0' }, peerDependencies: { c: '3.0.0' } }
-        ),
-        { dependencies: { a: '1.0.0', b: '2.0.0' }, peerDependencies: { c: '3.0.0' } }
-    );
-});
+    test('mergeDependencyGroups returns a single group unchanged', function () {
+        assert.deepStrictEqual(
+            mergeDependencyGroups({ dependencies: { a: '1.0.0' }, peerDependencies: { b: '2.0.0' } }),
+            {
+                dependencies: { a: '1.0.0' },
+                peerDependencies: { b: '2.0.0' }
+            }
+        );
+    });
 
-test('mergeDependencyGroups lets the later group override the earlier group for the same dependency name', () => {
-    assert.deepStrictEqual(
-        mergeDependencyGroups(
-            { dependencies: { a: '1.0.0' }, peerDependencies: {} },
+    test('mergeDependencyGroups merges non-overlapping groups across dependencies and peerDependencies', function () {
+        assert.deepStrictEqual(
+            mergeDependencyGroups(
+                { dependencies: { a: '1.0.0' }, peerDependencies: {} },
+                { dependencies: { b: '2.0.0' }, peerDependencies: { c: '3.0.0' } }
+            ),
+            { dependencies: { a: '1.0.0', b: '2.0.0' }, peerDependencies: { c: '3.0.0' } }
+        );
+    });
+
+    test('mergeDependencyGroups lets the later group override the earlier group for the same dependency name', function () {
+        assert.deepStrictEqual(
+            mergeDependencyGroups(
+                { dependencies: { a: '1.0.0' }, peerDependencies: {} },
+                { dependencies: { a: '2.0.0' }, peerDependencies: {} }
+            ),
             { dependencies: { a: '2.0.0' }, peerDependencies: {} }
-        ),
-        { dependencies: { a: '2.0.0' }, peerDependencies: {} }
-    );
+        );
+    });
 });

--- a/source/version-manager/dependencies/external-dependency-classification.test.ts
+++ b/source/version-manager/dependencies/external-dependency-classification.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
 import type { MainPackageJson } from '../../config/package-json.ts';
 import { groupExternalDependencies } from './external-dependency-classification.ts';
@@ -13,167 +13,172 @@ const workspaceMalformedReason =
     'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace,' +
     ' not valid in a published manifest';
 
-test('groupExternalDependencies returns empty groups when the bundle has no external dependencies', () => {
-    assert.deepStrictEqual(groupExternalDependencies({ externalDependencies: new Map() }, baseMainPackageJson, []), {
-        dependencies: {},
-        peerDependencies: {}
+suite('external-dependency-classification', function () {
+    test('groupExternalDependencies returns empty groups when the bundle has no external dependencies', function () {
+        assert.deepStrictEqual(
+            groupExternalDependencies({ externalDependencies: new Map() }, baseMainPackageJson, []),
+            {
+                dependencies: {},
+                peerDependencies: {}
+            }
+        );
     });
-});
 
-test('groupExternalDependencies routes a direct dependency version to dependencies', () => {
-    assert.deepStrictEqual(
-        groupExternalDependencies(
-            { externalDependencies: new Map([['left-pad', externalDep('left-pad')]]) },
-            { ...baseMainPackageJson, dependencies: { 'left-pad': '^1.0.0' } },
-            []
-        ),
-        { dependencies: { 'left-pad': '^1.0.0' }, peerDependencies: {} }
-    );
-});
-
-test('groupExternalDependencies routes a peer dependency version to peerDependencies', () => {
-    assert.deepStrictEqual(
-        groupExternalDependencies(
-            { externalDependencies: new Map([['react', externalDep('react')]]) },
-            { ...baseMainPackageJson, peerDependencies: { react: '^19.0.0' } },
-            []
-        ),
-        { dependencies: {}, peerDependencies: { react: '^19.0.0' } }
-    );
-});
-
-test('groupExternalDependencies prefers peerDependencies over dependencies when the dep is in both', () => {
-    assert.deepStrictEqual(
-        groupExternalDependencies(
-            { externalDependencies: new Map([['react', externalDep('react')]]) },
-            {
-                ...baseMainPackageJson,
-                dependencies: { react: '^18.0.0' },
-                peerDependencies: { react: '^19.0.0' }
-            },
-            []
-        ),
-        { dependencies: {}, peerDependencies: { react: '^19.0.0' } }
-    );
-});
-
-test('groupExternalDependencies throws when an external dependency is missing from the main package.json', () => {
-    try {
-        groupExternalDependencies(
-            { externalDependencies: new Map([['left-pad', externalDep('left-pad')]]) },
-            baseMainPackageJson,
-            []
+    test('groupExternalDependencies routes a direct dependency version to dependencies', function () {
+        assert.deepStrictEqual(
+            groupExternalDependencies(
+                { externalDependencies: new Map([['left-pad', externalDep('left-pad')]]) },
+                { ...baseMainPackageJson, dependencies: { 'left-pad': '^1.0.0' } },
+                []
+            ),
+            { dependencies: { 'left-pad': '^1.0.0' }, peerDependencies: {} }
         );
-        assert.fail('Expected groupExternalDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Couldn’t determine version number of left-pad, because it is not listed in the main package.json'
-        );
-    }
-});
+    });
 
-test('groupExternalDependencies throws a mutable-specifier message when a dep uses a git url', () => {
-    const expected = [
-        "Refusing to publish: 1 dependency uses a mutable specifier, which bypasses the npm registry's integrity guarantees:",
-        '  - "react" → "git+https://github.com/our-fork/react#v18.0.0" (git)',
-        'Add the dep name to dependencyPolicy.allowMutableSpecifiers to allow this on purpose.'
-    ].join('\n');
-    try {
-        groupExternalDependencies(
-            { externalDependencies: new Map([['react', externalDep('react')]]) },
-            { ...baseMainPackageJson, dependencies: { react: 'git+https://github.com/our-fork/react#v18.0.0' } },
-            []
+    test('groupExternalDependencies routes a peer dependency version to peerDependencies', function () {
+        assert.deepStrictEqual(
+            groupExternalDependencies(
+                { externalDependencies: new Map([['react', externalDep('react')]]) },
+                { ...baseMainPackageJson, peerDependencies: { react: '^19.0.0' } },
+                []
+            ),
+            { dependencies: {}, peerDependencies: { react: '^19.0.0' } }
         );
-        assert.fail('Expected groupExternalDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, expected);
-    }
-});
+    });
 
-test('groupExternalDependencies throws a malformed-specifier message when a dep uses workspace:', () => {
-    const expected = [
-        'Refusing to publish: 1 dependency has a specifier that npm cannot publish:',
-        `  - "shared-utils" → "workspace:*" (${workspaceMalformedReason})`,
-        'Replace with a registry version (e.g. "^1.2.3"). Mutable-specifier allow-listing does not apply here.'
-    ].join('\n');
-    try {
-        groupExternalDependencies(
-            { externalDependencies: new Map([['shared-utils', externalDep('shared-utils')]]) },
-            { ...baseMainPackageJson, dependencies: { 'shared-utils': 'workspace:*' } },
-            []
+    test('groupExternalDependencies prefers peerDependencies over dependencies when the dep is in both', function () {
+        assert.deepStrictEqual(
+            groupExternalDependencies(
+                { externalDependencies: new Map([['react', externalDep('react')]]) },
+                {
+                    ...baseMainPackageJson,
+                    dependencies: { react: '^18.0.0' },
+                    peerDependencies: { react: '^19.0.0' }
+                },
+                []
+            ),
+            { dependencies: {}, peerDependencies: { react: '^19.0.0' } }
         );
-        assert.fail('Expected groupExternalDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, expected);
-    }
-});
+    });
 
-test('groupExternalDependencies prefers a malformed-specifier error over a mutable one', () => {
-    try {
-        groupExternalDependencies(
-            {
-                externalDependencies: new Map([
-                    ['shared-utils', externalDep('shared-utils')],
-                    ['react', externalDep('react')]
-                ])
-            },
-            {
-                ...baseMainPackageJson,
-                dependencies: {
-                    'shared-utils': 'workspace:*',
-                    react: 'git+https://github.com/foo/bar#v1'
-                }
-            },
-            []
-        );
-        assert.fail('Expected groupExternalDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.match((error as Error).message, /npm cannot publish/u);
-    }
-});
-
-test('groupExternalDependencies lets a mutable specifier through when its name is in allowMutableSpecifiers', () => {
-    assert.deepStrictEqual(
-        groupExternalDependencies(
-            { externalDependencies: new Map([['react', externalDep('react')]]) },
-            { ...baseMainPackageJson, dependencies: { react: 'git+https://github.com/our-fork/react#v18.0.0' } },
-            ['react']
-        ),
-        {
-            dependencies: { react: 'git+https://github.com/our-fork/react#v18.0.0' },
-            peerDependencies: {}
+    test('groupExternalDependencies throws when an external dependency is missing from the main package.json', function () {
+        try {
+            groupExternalDependencies(
+                { externalDependencies: new Map([['left-pad', externalDep('left-pad')]]) },
+                baseMainPackageJson,
+                []
+            );
+            assert.fail('Expected groupExternalDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Couldn’t determine version number of left-pad, because it is not listed in the main package.json'
+            );
         }
-    );
-});
+    });
 
-test('groupExternalDependencies throws when an allowMutableSpecifiers entry matches no rejected dep', () => {
-    const expected = [
-        'Refusing to publish: 1 entry in dependencyPolicy.allowMutableSpecifiers is not in use:',
-        '  - "old-vendored-pkg"',
-        'Remove unused entries — they reflect stale exceptions to the integrity policy.'
-    ].join('\n');
-    try {
-        groupExternalDependencies(
-            { externalDependencies: new Map([['left-pad', externalDep('left-pad')]]) },
-            { ...baseMainPackageJson, dependencies: { 'left-pad': '^1.0.0' } },
-            ['old-vendored-pkg']
-        );
-        assert.fail('Expected groupExternalDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, expected);
-    }
-});
+    test('groupExternalDependencies throws a mutable-specifier message when a dep uses a git url', function () {
+        const expected = [
+            "Refusing to publish: 1 dependency uses a mutable specifier, which bypasses the npm registry's integrity guarantees:",
+            '  - "react" → "git+https://github.com/our-fork/react#v18.0.0" (git)',
+            'Add the dep name to dependencyPolicy.allowMutableSpecifiers to allow this on purpose.'
+        ].join('\n');
+        try {
+            groupExternalDependencies(
+                { externalDependencies: new Map([['react', externalDep('react')]]) },
+                { ...baseMainPackageJson, dependencies: { react: 'git+https://github.com/our-fork/react#v18.0.0' } },
+                []
+            );
+            assert.fail('Expected groupExternalDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, expected);
+        }
+    });
 
-test('groupExternalDependencies prefers a mutable error over an unused-allow-list error', () => {
-    try {
-        groupExternalDependencies(
-            { externalDependencies: new Map([['react', externalDep('react')]]) },
-            { ...baseMainPackageJson, dependencies: { react: 'git+https://github.com/foo/bar#v1' } },
-            ['old-vendored-pkg']
+    test('groupExternalDependencies throws a malformed-specifier message when a dep uses workspace:', function () {
+        const expected = [
+            'Refusing to publish: 1 dependency has a specifier that npm cannot publish:',
+            `  - "shared-utils" → "workspace:*" (${workspaceMalformedReason})`,
+            'Replace with a registry version (e.g. "^1.2.3"). Mutable-specifier allow-listing does not apply here.'
+        ].join('\n');
+        try {
+            groupExternalDependencies(
+                { externalDependencies: new Map([['shared-utils', externalDep('shared-utils')]]) },
+                { ...baseMainPackageJson, dependencies: { 'shared-utils': 'workspace:*' } },
+                []
+            );
+            assert.fail('Expected groupExternalDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, expected);
+        }
+    });
+
+    test('groupExternalDependencies prefers a malformed-specifier error over a mutable one', function () {
+        try {
+            groupExternalDependencies(
+                {
+                    externalDependencies: new Map([
+                        ['shared-utils', externalDep('shared-utils')],
+                        ['react', externalDep('react')]
+                    ])
+                },
+                {
+                    ...baseMainPackageJson,
+                    dependencies: {
+                        'shared-utils': 'workspace:*',
+                        react: 'git+https://github.com/foo/bar#v1'
+                    }
+                },
+                []
+            );
+            assert.fail('Expected groupExternalDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.match((error as Error).message, /npm cannot publish/u);
+        }
+    });
+
+    test('groupExternalDependencies lets a mutable specifier through when its name is in allowMutableSpecifiers', function () {
+        assert.deepStrictEqual(
+            groupExternalDependencies(
+                { externalDependencies: new Map([['react', externalDep('react')]]) },
+                { ...baseMainPackageJson, dependencies: { react: 'git+https://github.com/our-fork/react#v18.0.0' } },
+                ['react']
+            ),
+            {
+                dependencies: { react: 'git+https://github.com/our-fork/react#v18.0.0' },
+                peerDependencies: {}
+            }
         );
-        assert.fail('Expected groupExternalDependencies() to throw but it did not');
-    } catch (error: unknown) {
-        assert.match((error as Error).message, /uses a mutable specifier/u);
-    }
+    });
+
+    test('groupExternalDependencies throws when an allowMutableSpecifiers entry matches no rejected dep', function () {
+        const expected = [
+            'Refusing to publish: 1 entry in dependencyPolicy.allowMutableSpecifiers is not in use:',
+            '  - "old-vendored-pkg"',
+            'Remove unused entries — they reflect stale exceptions to the integrity policy.'
+        ].join('\n');
+        try {
+            groupExternalDependencies(
+                { externalDependencies: new Map([['left-pad', externalDep('left-pad')]]) },
+                { ...baseMainPackageJson, dependencies: { 'left-pad': '^1.0.0' } },
+                ['old-vendored-pkg']
+            );
+            assert.fail('Expected groupExternalDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, expected);
+        }
+    });
+
+    test('groupExternalDependencies prefers a mutable error over an unused-allow-list error', function () {
+        try {
+            groupExternalDependencies(
+                { externalDependencies: new Map([['react', externalDep('react')]]) },
+                { ...baseMainPackageJson, dependencies: { react: 'git+https://github.com/foo/bar#v1' } },
+                ['old-vendored-pkg']
+            );
+            assert.fail('Expected groupExternalDependencies() to throw but it did not');
+        } catch (error: unknown) {
+            assert.match((error as Error).message, /uses a mutable specifier/u);
+        }
+    });
 });

--- a/source/version-manager/dependencies/versioned-bundle-dependencies.test.ts
+++ b/source/version-manager/dependencies/versioned-bundle-dependencies.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { ExternalDependency } from '../../dependency-scanner/external-dependencies.ts';
 import { distributeDependencies } from './versioned-bundle-dependencies.ts';
 
@@ -7,34 +7,36 @@ function externalDep(name: string): ExternalDependency {
     return { name, referencedFrom: ['/src/a.ts'] };
 }
 
-test('distributeDependencies returns empty groups when bundle and main package.json contribute nothing', () => {
-    assert.deepStrictEqual(
-        distributeDependencies({
-            bundle: { externalDependencies: new Map(), linkedBundleDependencies: new Map() },
-            mainPackageJson: { type: 'module' },
-            bundleDependencies: [],
-            bundlePeerDependencies: [],
-            allowMutableSpecifiers: []
-        }),
-        { dependencies: {}, peerDependencies: {} }
-    );
-});
+suite('versioned-bundle-dependencies', function () {
+    test('distributeDependencies returns empty groups when bundle and main package.json contribute nothing', function () {
+        assert.deepStrictEqual(
+            distributeDependencies({
+                bundle: { externalDependencies: new Map(), linkedBundleDependencies: new Map() },
+                mainPackageJson: { type: 'module' },
+                bundleDependencies: [],
+                bundlePeerDependencies: [],
+                allowMutableSpecifiers: []
+            }),
+            { dependencies: {}, peerDependencies: {} }
+        );
+    });
 
-test('distributeDependencies merges bundle-linked and external dependency groups', () => {
-    assert.deepStrictEqual(
-        distributeDependencies({
-            bundle: {
-                externalDependencies: new Map([['left-pad', externalDep('left-pad')]]),
-                linkedBundleDependencies: new Map([['my-bundle-dep', externalDep('my-bundle-dep')]])
-            },
-            mainPackageJson: { type: 'module', dependencies: { 'left-pad': '^1.0.0' } },
-            bundleDependencies: [{ name: 'my-bundle-dep', version: '2.0.0' }],
-            bundlePeerDependencies: [],
-            allowMutableSpecifiers: []
-        }),
-        {
-            dependencies: { 'left-pad': '^1.0.0', 'my-bundle-dep': '2.0.0' },
-            peerDependencies: {}
-        }
-    );
+    test('distributeDependencies merges bundle-linked and external dependency groups', function () {
+        assert.deepStrictEqual(
+            distributeDependencies({
+                bundle: {
+                    externalDependencies: new Map([['left-pad', externalDep('left-pad')]]),
+                    linkedBundleDependencies: new Map([['my-bundle-dep', externalDep('my-bundle-dep')]])
+                },
+                mainPackageJson: { type: 'module', dependencies: { 'left-pad': '^1.0.0' } },
+                bundleDependencies: [{ name: 'my-bundle-dep', version: '2.0.0' }],
+                bundlePeerDependencies: [],
+                allowMutableSpecifiers: []
+            }),
+            {
+                dependencies: { 'left-pad': '^1.0.0', 'my-bundle-dep': '2.0.0' },
+                peerDependencies: {}
+            }
+        );
+    });
 });

--- a/source/version-manager/imports/hash-import-scanner.test.ts
+++ b/source/version-manager/imports/hash-import-scanner.test.ts
@@ -1,47 +1,49 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { codeResource } from '../../test-libraries/analyzed-resource-fixtures.ts';
 import { collectHashImportSpecifiers } from './hash-import-scanner.ts';
 
-test('collectHashImportSpecifiers returns an empty set when the bundle has no contents', () => {
-    assert.deepStrictEqual(collectHashImportSpecifiers({ contents: [] }), new Set<string>());
-});
+suite('hash-import-scanner', function () {
+    test('collectHashImportSpecifiers returns an empty set when the bundle has no contents', function () {
+        assert.deepStrictEqual(collectHashImportSpecifiers({ contents: [] }), new Set<string>());
+    });
 
-test('collectHashImportSpecifiers returns an empty set when a code file uses no hash specifiers', () => {
-    assert.deepStrictEqual(
-        collectHashImportSpecifiers({ contents: [codeResource('a.js', "import './local.js';")] }),
-        new Set<string>()
-    );
-});
+    test('collectHashImportSpecifiers returns an empty set when a code file uses no hash specifiers', function () {
+        assert.deepStrictEqual(
+            collectHashImportSpecifiers({ contents: [codeResource('a.js', "import './local.js';")] }),
+            new Set<string>()
+        );
+    });
 
-test('collectHashImportSpecifiers collects a single hash specifier from a code file', () => {
-    assert.deepStrictEqual(
-        collectHashImportSpecifiers({ contents: [codeResource('a.js', "import '#foo';")] }),
-        new Set(['#foo'])
-    );
-});
+    test('collectHashImportSpecifiers collects a single hash specifier from a code file', function () {
+        assert.deepStrictEqual(
+            collectHashImportSpecifiers({ contents: [codeResource('a.js', "import '#foo';")] }),
+            new Set(['#foo'])
+        );
+    });
 
-test('collectHashImportSpecifiers collects every distinct hash specifier across multiple files', () => {
-    assert.deepStrictEqual(
-        collectHashImportSpecifiers({
-            contents: [codeResource('a.js', "import '#foo';"), codeResource('b.js', "import '#bar/baz';")]
-        }),
-        new Set(['#foo', '#bar/baz'])
-    );
-});
+    test('collectHashImportSpecifiers collects every distinct hash specifier across multiple files', function () {
+        assert.deepStrictEqual(
+            collectHashImportSpecifiers({
+                contents: [codeResource('a.js', "import '#foo';"), codeResource('b.js', "import '#bar/baz';")]
+            }),
+            new Set(['#foo', '#bar/baz'])
+        );
+    });
 
-test('collectHashImportSpecifiers deduplicates a hash specifier referenced from multiple files', () => {
-    assert.deepStrictEqual(
-        collectHashImportSpecifiers({
-            contents: [codeResource('a.js', "import '#foo';"), codeResource('b.js', "import '#foo';")]
-        }),
-        new Set(['#foo'])
-    );
-});
+    test('collectHashImportSpecifiers deduplicates a hash specifier referenced from multiple files', function () {
+        assert.deepStrictEqual(
+            collectHashImportSpecifiers({
+                contents: [codeResource('a.js', "import '#foo';"), codeResource('b.js', "import '#foo';")]
+            }),
+            new Set(['#foo'])
+        );
+    });
 
-test('collectHashImportSpecifiers ignores hash specifiers in non-code files', () => {
-    assert.deepStrictEqual(
-        collectHashImportSpecifiers({ contents: [codeResource('a.md', "import '#foo';")] }),
-        new Set<string>()
-    );
+    test('collectHashImportSpecifiers ignores hash specifiers in non-code files', function () {
+        assert.deepStrictEqual(
+            collectHashImportSpecifiers({ contents: [codeResource('a.md', "import '#foo';")] }),
+            new Set<string>()
+        );
+    });
 });

--- a/source/version-manager/imports/imports-key-matcher.test.ts
+++ b/source/version-manager/imports/imports-key-matcher.test.ts
@@ -1,49 +1,51 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { findMatchingImportEntryKey } from './imports-key-matcher.ts';
 
-test('findMatchingImportEntryKey returns undefined when the imports field is empty', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#foo', {}), undefined);
-});
+suite('imports-key-matcher', function () {
+    test('findMatchingImportEntryKey returns undefined when the imports field is empty', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#foo', {}), undefined);
+    });
 
-test('findMatchingImportEntryKey returns undefined when no entry matches the specifier', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#foo', { '#bar': './bar.js' }), undefined);
-});
+    test('findMatchingImportEntryKey returns undefined when no entry matches the specifier', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#foo', { '#bar': './bar.js' }), undefined);
+    });
 
-test('findMatchingImportEntryKey returns the exact key when one matches the specifier verbatim', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#foo', { '#foo': './foo.js' }), '#foo');
-});
+    test('findMatchingImportEntryKey returns the exact key when one matches the specifier verbatim', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#foo', { '#foo': './foo.js' }), '#foo');
+    });
 
-test('findMatchingImportEntryKey returns the wildcard key when the specifier matches its pattern', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#foo/bar', { '#foo/*': './foo/*.js' }), '#foo/*');
-});
+    test('findMatchingImportEntryKey returns the wildcard key when the specifier matches its pattern', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#foo/bar', { '#foo/*': './foo/*.js' }), '#foo/*');
+    });
 
-test('findMatchingImportEntryKey prefers the longer wildcard key when several patterns match', () => {
-    assert.strictEqual(
-        findMatchingImportEntryKey('#foo/bar/baz', { '#foo/*': './foo/*.js', '#foo/bar/*': './foo/bar/*.js' }),
-        '#foo/bar/*'
-    );
-});
+    test('findMatchingImportEntryKey prefers the longer wildcard key when several patterns match', function () {
+        assert.strictEqual(
+            findMatchingImportEntryKey('#foo/bar/baz', { '#foo/*': './foo/*.js', '#foo/bar/*': './foo/bar/*.js' }),
+            '#foo/bar/*'
+        );
+    });
 
-test('findMatchingImportEntryKey prefers an exact key over wildcard keys that also match', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#foo', { '#*': './*.js', '#foo': './foo.js' }), '#foo');
-});
+    test('findMatchingImportEntryKey prefers an exact key over wildcard keys that also match', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#foo', { '#*': './*.js', '#foo': './foo.js' }), '#foo');
+    });
 
-test('findMatchingImportEntryKey prefers an exact key over wildcards regardless of insertion order', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#foo', { '#foo': './foo.js', '#*': './*.js' }), '#foo');
-});
+    test('findMatchingImportEntryKey prefers an exact key over wildcards regardless of insertion order', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#foo', { '#foo': './foo.js', '#*': './*.js' }), '#foo');
+    });
 
-test('findMatchingImportEntryKey prefers an exact key over a longer wildcard that also matches', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#a', { '#a*': './long.js', '#a': './exact.js' }), '#a');
-});
+    test('findMatchingImportEntryKey prefers an exact key over a longer wildcard that also matches', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#a', { '#a*': './long.js', '#a': './exact.js' }), '#a');
+    });
 
-test('findMatchingImportEntryKey prefers an exact key listed before a longer wildcard that also matches', () => {
-    assert.strictEqual(findMatchingImportEntryKey('#a', { '#a': './exact.js', '#a*': './long.js' }), '#a');
-});
+    test('findMatchingImportEntryKey prefers an exact key listed before a longer wildcard that also matches', function () {
+        assert.strictEqual(findMatchingImportEntryKey('#a', { '#a': './exact.js', '#a*': './long.js' }), '#a');
+    });
 
-test('findMatchingImportEntryKey prefers the longer wildcard when neither matches the specifier exactly and the longer one is listed first', () => {
-    assert.strictEqual(
-        findMatchingImportEntryKey('#foo/bar/baz', { '#foo/bar/*': './long.js', '#foo/*': './short.js' }),
-        '#foo/bar/*'
-    );
+    test('findMatchingImportEntryKey prefers the longer wildcard when neither matches the specifier exactly and the longer one is listed first', function () {
+        assert.strictEqual(
+            findMatchingImportEntryKey('#foo/bar/baz', { '#foo/bar/*': './long.js', '#foo/*': './short.js' }),
+            '#foo/bar/*'
+        );
+    });
 });

--- a/source/version-manager/imports/versioned-bundle-imports.test.ts
+++ b/source/version-manager/imports/versioned-bundle-imports.test.ts
@@ -1,76 +1,78 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { codeResource } from '../../test-libraries/analyzed-resource-fixtures.ts';
 import { buildImportsField } from './versioned-bundle-imports.ts';
 
-test('buildImportsField returns undefined when no surviving #imports specifiers are referenced', () => {
-    assert.strictEqual(buildImportsField({ contents: [] }, { type: 'module' }), undefined);
-});
+suite('versioned-bundle-imports', function () {
+    test('buildImportsField returns undefined when no surviving #imports specifiers are referenced', function () {
+        assert.strictEqual(buildImportsField({ contents: [] }, { type: 'module' }), undefined);
+    });
 
-test('buildImportsField returns only the configured imports entries that are referenced by surviving code', () => {
-    assert.deepStrictEqual(
-        buildImportsField(
-            { contents: [codeResource('a.js', "import '#used';")] },
-            {
-                type: 'module',
-                imports: { '#used': './used.js', '#unused': './unused.js' }
-            }
-        ),
-        { '#used': './used.js' }
-    );
-});
+    test('buildImportsField returns only the configured imports entries that are referenced by surviving code', function () {
+        assert.deepStrictEqual(
+            buildImportsField(
+                { contents: [codeResource('a.js', "import '#used';")] },
+                {
+                    type: 'module',
+                    imports: { '#used': './used.js', '#unused': './unused.js' }
+                }
+            ),
+            { '#used': './used.js' }
+        );
+    });
 
-test('buildImportsField picks the most specific wildcard imports entry for a specifier', () => {
-    assert.deepStrictEqual(
-        buildImportsField(
-            { contents: [codeResource('a.js', "import '#foo/bar';")] },
-            {
-                type: 'module',
-                imports: { '#foo/*': './foo/*.js', '#foo/bar/*': './foo/bar/*.js' }
-            }
-        ),
-        { '#foo/*': './foo/*.js' }
-    );
-});
+    test('buildImportsField picks the most specific wildcard imports entry for a specifier', function () {
+        assert.deepStrictEqual(
+            buildImportsField(
+                { contents: [codeResource('a.js', "import '#foo/bar';")] },
+                {
+                    type: 'module',
+                    imports: { '#foo/*': './foo/*.js', '#foo/bar/*': './foo/bar/*.js' }
+                }
+            ),
+            { '#foo/*': './foo/*.js' }
+        );
+    });
 
-test('buildImportsField throws when surviving #imports exist but mainPackageJson.imports is missing', () => {
-    try {
-        buildImportsField({ contents: [codeResource('a.js', "import '#foo';")] }, { type: 'module' });
-        assert.fail('Expected buildImportsField() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Found surviving package.json imports specifier "#foo" but mainPackageJson.imports is not configured'
-        );
-    }
-});
+    test('buildImportsField throws when surviving #imports exist but mainPackageJson.imports is missing', function () {
+        try {
+            buildImportsField({ contents: [codeResource('a.js', "import '#foo';")] }, { type: 'module' });
+            assert.fail('Expected buildImportsField() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Found surviving package.json imports specifier "#foo" but mainPackageJson.imports is not configured'
+            );
+        }
+    });
 
-test('buildImportsField throws when a surviving specifier has no matching imports entry', () => {
-    try {
-        buildImportsField(
-            { contents: [codeResource('a.js', "import '#foo/bar';")] },
-            { type: 'module', imports: { '#baz': './baz.js' } }
-        );
-        assert.fail('Expected buildImportsField() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Found surviving package.json imports specifier "#foo/bar" but no matching mainPackageJson.imports entry'
-        );
-    }
-});
+    test('buildImportsField throws when a surviving specifier has no matching imports entry', function () {
+        try {
+            buildImportsField(
+                { contents: [codeResource('a.js', "import '#foo/bar';")] },
+                { type: 'module', imports: { '#baz': './baz.js' } }
+            );
+            assert.fail('Expected buildImportsField() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Found surviving package.json imports specifier "#foo/bar" but no matching mainPackageJson.imports entry'
+            );
+        }
+    });
 
-test('buildImportsField throws when the matching imports entry is explicitly undefined', () => {
-    try {
-        buildImportsField(
-            { contents: [codeResource('a.js', "import '#foo';")] },
-            { type: 'module', imports: { '#foo': undefined } as unknown as Record<string, never> }
-        );
-        assert.fail('Expected buildImportsField() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Found surviving package.json imports specifier "#foo" but matching mainPackageJson.imports entry "#foo" is undefined'
-        );
-    }
+    test('buildImportsField throws when the matching imports entry is explicitly undefined', function () {
+        try {
+            buildImportsField(
+                { contents: [codeResource('a.js', "import '#foo';")] },
+                { type: 'module', imports: { '#foo': undefined } as unknown as Record<string, never> }
+            );
+            assert.fail('Expected buildImportsField() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Found surviving package.json imports specifier "#foo" but matching mainPackageJson.imports entry "#foo" is undefined'
+            );
+        }
+    });
 });

--- a/source/version-manager/manager.test.ts
+++ b/source/version-manager/manager.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
 import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
 import {
@@ -18,223 +18,225 @@ function createAnalyzedBundle(): AnalyzedBundle {
     });
 }
 
-test('addVersion() creates the versioned bundle and manifest file', () => {
-    const manager = createVersionManager({
-        progressBroadcaster: {
-            emit: (): void => undefined,
-            hasSubscribers: (): boolean => false
-        }
-    });
-
-    const result = manager.addVersion({
-        bundle: createAnalyzedBundle(),
-        version: '1.2.3',
-        mainPackageJson: { type: 'module', dependencies: { 'left-pad': '^1.0.0' } },
-        bundleDependencies: [
-            versionedBundle({
-                name: 'bundle-dependency',
-                version: '4.5.6',
-                mainFile: { sourceFilePath: '/src/dep.js', targetFilePath: 'dep.js' }
-            })
-        ],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes: { publishConfig: { access: 'public' } },
-        allowMutableSpecifiers: []
-    });
-
-    assert.deepStrictEqual(result.packageJson, {
-        name: 'package-a',
-        version: '1.2.3',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
+suite('manager', function () {
+    test('addVersion() creates the versioned bundle and manifest file', function () {
+        const manager = createVersionManager({
+            progressBroadcaster: {
+                emit: (): void => undefined,
+                hasSubscribers: (): boolean => false
             }
-        },
-        type: 'module',
-        dependencies: { 'bundle-dependency': '4.5.6', 'left-pad': '^1.0.0' },
-        publishConfig: { access: 'public' }
-    });
-    assert.deepStrictEqual(result.manifestFile, {
-        filePath: 'package.json',
-        isExecutable: false,
-        content: [
-            '{',
-            '    "dependencies": {',
-            '        "bundle-dependency": "4.5.6",',
-            '        "left-pad": "^1.0.0"',
-            '    },',
-            '    "exports": {',
-            '        ".": {',
-            '            "import": "./index.js",',
-            '            "types": "./index.d.ts"',
-            '        }',
-            '    },',
-            '    "name": "package-a",',
-            '    "publishConfig": {',
-            '        "access": "public"',
-            '    },',
-            '    "type": "module",',
-            '    "version": "1.2.3"',
-            '}'
-        ].join('\n')
-    });
-});
+        });
 
-test('increaseVersion() bumps the patch version and rebuilds the package manifest', () => {
-    const manager = createVersionManager({
-        progressBroadcaster: {
-            emit: (): void => undefined,
-            hasSubscribers: (): boolean => false
-        }
+        const result = manager.addVersion({
+            bundle: createAnalyzedBundle(),
+            version: '1.2.3',
+            mainPackageJson: { type: 'module', dependencies: { 'left-pad': '^1.0.0' } },
+            bundleDependencies: [
+                versionedBundle({
+                    name: 'bundle-dependency',
+                    version: '4.5.6',
+                    mainFile: { sourceFilePath: '/src/dep.js', targetFilePath: 'dep.js' }
+                })
+            ],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: { publishConfig: { access: 'public' } },
+            allowMutableSpecifiers: []
+        });
+
+        assert.deepStrictEqual(result.packageJson, {
+            name: 'package-a',
+            version: '1.2.3',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module',
+            dependencies: { 'bundle-dependency': '4.5.6', 'left-pad': '^1.0.0' },
+            publishConfig: { access: 'public' }
+        });
+        assert.deepStrictEqual(result.manifestFile, {
+            filePath: 'package.json',
+            isExecutable: false,
+            content: [
+                '{',
+                '    "dependencies": {',
+                '        "bundle-dependency": "4.5.6",',
+                '        "left-pad": "^1.0.0"',
+                '    },',
+                '    "exports": {',
+                '        ".": {',
+                '            "import": "./index.js",',
+                '            "types": "./index.d.ts"',
+                '        }',
+                '    },',
+                '    "name": "package-a",',
+                '    "publishConfig": {',
+                '        "access": "public"',
+                '    },',
+                '    "type": "module",',
+                '    "version": "1.2.3"',
+                '}'
+            ].join('\n')
+        });
     });
 
-    const result = manager.increaseVersion(
-        standardVersionedBundle({
+    test('increaseVersion() bumps the patch version and rebuilds the package manifest', function () {
+        const manager = createVersionManager({
+            progressBroadcaster: {
+                emit: (): void => undefined,
+                hasSubscribers: (): boolean => false
+            }
+        });
+
+        const result = manager.increaseVersion(
+            standardVersionedBundle({
+                dependencies: { dep: '^1.0.0' },
+                peerDependencies: { react: '^19.0.0' }
+            })
+        );
+
+        assert.strictEqual(result.version, '1.2.4');
+        assert.deepStrictEqual(result.packageJson, {
+            name: 'package-a',
+            version: '1.2.4',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module',
             dependencies: { dep: '^1.0.0' },
             peerDependencies: { react: '^19.0.0' }
-        })
-    );
+        });
+        assert.deepStrictEqual(result.manifestFile, {
+            filePath: 'package.json',
+            isExecutable: false,
+            content: [
+                '{',
+                '    "dependencies": {',
+                '        "dep": "^1.0.0"',
+                '    },',
+                '    "exports": {',
+                '        ".": {',
+                '            "import": "./index.js",',
+                '            "types": "./index.d.ts"',
+                '        }',
+                '    },',
+                '    "name": "package-a",',
+                '    "peerDependencies": {',
+                '        "react": "^19.0.0"',
+                '    },',
+                '    "type": "module",',
+                '    "version": "1.2.4"',
+                '}'
+            ].join('\n')
+        });
+    });
 
-    assert.strictEqual(result.version, '1.2.4');
-    assert.deepStrictEqual(result.packageJson, {
-        name: 'package-a',
-        version: '1.2.4',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
+    test('increaseVersion() throws when the given version is invalid', function () {
+        const manager = createVersionManager({
+            progressBroadcaster: {
+                emit: (): void => undefined,
+                hasSubscribers: (): boolean => false
             }
-        },
-        type: 'module',
-        dependencies: { dep: '^1.0.0' },
-        peerDependencies: { react: '^19.0.0' }
-    });
-    assert.deepStrictEqual(result.manifestFile, {
-        filePath: 'package.json',
-        isExecutable: false,
-        content: [
-            '{',
-            '    "dependencies": {',
-            '        "dep": "^1.0.0"',
-            '    },',
-            '    "exports": {',
-            '        ".": {',
-            '            "import": "./index.js",',
-            '            "types": "./index.d.ts"',
-            '        }',
-            '    },',
-            '    "name": "package-a",',
-            '    "peerDependencies": {',
-            '        "react": "^19.0.0"',
-            '    },',
-            '    "type": "module",',
-            '    "version": "1.2.4"',
-            '}'
-        ].join('\n')
-    });
-});
+        });
 
-test('increaseVersion() throws when the given version is invalid', () => {
-    const manager = createVersionManager({
-        progressBroadcaster: {
-            emit: (): void => undefined,
-            hasSubscribers: (): boolean => false
+        try {
+            manager.increaseVersion({
+                name: 'package-a',
+                version: 'not-a-semver',
+                contents: [],
+                roots: {
+                    main: {
+                        js: {
+                            sourceFilePath: '/src/index.js',
+                            targetFilePath: 'index.js',
+                            content: '',
+                            isExecutable: false
+                        }
+                    }
+                },
+                surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+                dependencies: {},
+                peerDependencies: {},
+                additionalAttributes: {},
+                exportsField: {
+                    '.': {
+                        import: './index.js'
+                    }
+                },
+                mainFile: {
+                    sourceFilePath: '/src/index.js',
+                    targetFilePath: 'index.js',
+                    content: '',
+                    isExecutable: false
+                },
+                packageType: 'module',
+                sideEffectsField: undefined
+            });
+            assert.fail('Expected increaseVersion() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Failed to increase version');
         }
     });
 
-    try {
-        manager.increaseVersion({
-            name: 'package-a',
-            version: 'not-a-semver',
-            contents: [],
-            roots: {
-                main: {
-                    js: {
-                        sourceFilePath: '/src/index.js',
-                        targetFilePath: 'index.js',
-                        content: '',
-                        isExecutable: false
-                    }
-                }
-            },
-            surface: { mode: 'implicit', defaultModuleRoot: 'main' },
-            dependencies: {},
-            peerDependencies: {},
-            additionalAttributes: {},
-            exportsField: {
-                '.': {
-                    import: './index.js'
-                }
-            },
-            mainFile: {
-                sourceFilePath: '/src/index.js',
-                targetFilePath: 'index.js',
-                content: '',
-                isExecutable: false
-            },
-            packageType: 'module',
-            sideEffectsField: undefined
+    function callAddVersionWithProvider(
+        progressBroadcaster: Parameters<typeof createVersionManager>[0]['progressBroadcaster'],
+        additionalPackageJsonAttributes: Parameters<
+            ReturnType<typeof createVersionManager>['addVersion']
+        >[0]['additionalPackageJsonAttributes'] = {}
+    ): void {
+        const manager = createVersionManager({ progressBroadcaster });
+        manager.addVersion({
+            bundle: analyzedBundle({}),
+            version: '1.0.0',
+            mainPackageJson: { type: 'module' },
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes,
+            allowMutableSpecifiers: []
         });
-        assert.fail('Expected increaseVersion() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Failed to increase version');
     }
-});
 
-function callAddVersionWithProvider(
-    progressBroadcaster: Parameters<typeof createVersionManager>[0]['progressBroadcaster'],
-    additionalPackageJsonAttributes: Parameters<
-        ReturnType<typeof createVersionManager>['addVersion']
-    >[0]['additionalPackageJsonAttributes'] = {}
-): void {
-    const manager = createVersionManager({ progressBroadcaster });
-    manager.addVersion({
-        bundle: analyzedBundle({}),
-        version: '1.0.0',
-        mainPackageJson: { type: 'module' },
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
-        additionalPackageJsonAttributes,
-        allowMutableSpecifiers: []
-    });
-}
+    test('addVersion() emits a packageJsonAssembled event with the package name when subscribed', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: { packageName: string }[] = [];
+        broadcaster.consumer.on('packageJsonAssembled', (payload) => {
+            received.push({ packageName: payload.packageName });
+        });
 
-test('addVersion() emits a packageJsonAssembled event with the package name when subscribed', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: { packageName: string }[] = [];
-    broadcaster.consumer.on('packageJsonAssembled', (payload) => {
-        received.push({ packageName: payload.packageName });
+        callAddVersionWithProvider(broadcaster.provider);
+
+        assert.deepStrictEqual(received, [{ packageName: 'package-a' }]);
     });
 
-    callAddVersionWithProvider(broadcaster.provider);
+    test('addVersion() emits packageJsonAssembled fields with provenance classification', function () {
+        const broadcaster = createProgressBroadcaster();
+        const received: Readonly<Record<string, { source: string }>>[] = [];
+        broadcaster.consumer.on('packageJsonAssembled', (payload) => {
+            received.push(payload.fields as Readonly<Record<string, { source: string }>>);
+        });
 
-    assert.deepStrictEqual(received, [{ packageName: 'package-a' }]);
-});
+        callAddVersionWithProvider(broadcaster.provider, { publishConfig: { access: 'public' } });
 
-test('addVersion() emits packageJsonAssembled fields with provenance classification', () => {
-    const broadcaster = createProgressBroadcaster();
-    const received: Readonly<Record<string, { source: string }>>[] = [];
-    broadcaster.consumer.on('packageJsonAssembled', (payload) => {
-        received.push(payload.fields as Readonly<Record<string, { source: string }>>);
+        const [fields] = received;
+        if (fields === undefined) {
+            assert.fail('expected packageJsonAssembled to fire once');
+        }
+        assert.deepStrictEqual(fields.type, { source: 'mainPackageJson' });
+        assert.deepStrictEqual(fields.publishConfig, { source: 'additionalAttributes' });
+        assert.deepStrictEqual(fields.name, { source: 'derived' });
+        assert.deepStrictEqual(fields.version, { source: 'derived' });
     });
 
-    callAddVersionWithProvider(broadcaster.provider, { publishConfig: { access: 'public' } });
+    test('addVersion() does NOT emit packageJsonAssembled when no subscriber is registered', function () {
+        const wrapped = createSpyingBroadcaster();
 
-    const [fields] = received;
-    if (fields === undefined) {
-        assert.fail('expected packageJsonAssembled to fire once');
-    }
-    assert.deepStrictEqual(fields.type, { source: 'mainPackageJson' });
-    assert.deepStrictEqual(fields.publishConfig, { source: 'additionalAttributes' });
-    assert.deepStrictEqual(fields.name, { source: 'derived' });
-    assert.deepStrictEqual(fields.version, { source: 'derived' });
-});
+        callAddVersionWithProvider(wrapped.provider);
 
-test('addVersion() does NOT emit packageJsonAssembled when no subscriber is registered', () => {
-    const wrapped = createSpyingBroadcaster();
-
-    callAddVersionWithProvider(wrapped.provider);
-
-    assert.strictEqual(wrapped.emitSpy.callCount, 0);
+        assert.strictEqual(wrapped.emitSpy.callCount, 0);
+    });
 });

--- a/source/version-manager/manifest/builder.property.ts
+++ b/source/version-manager/manifest/builder.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { hasProp } from 'remeda';
 import type { AdditionalPackageJsonAttributes } from '../../config/package-json.ts';
 import type { VersionedBundle } from '../versioned-bundle.ts';
@@ -109,46 +109,48 @@ const bundleArbitrary: fc.Arbitrary<VersionedBundle> = fc
         } satisfies VersionedBundle;
     });
 
-test('buildPackageManifest() keeps generated manifest fields coherent with the bundle inputs', () => {
-    fc.assert(
-        fc.property(bundleArbitrary, (bundle) => {
-            const manifest = buildPackageManifest(bundle);
+suite('builder', function () {
+    test('buildPackageManifest() keeps generated manifest fields coherent with the bundle inputs', function () {
+        fc.assert(
+            fc.property(bundleArbitrary, (bundle) => {
+                const manifest = buildPackageManifest(bundle);
 
-            assert.strictEqual(manifest.name, bundle.name);
-            assert.strictEqual(manifest.version, bundle.version);
-            assert.deepStrictEqual(manifest.exports, bundle.exportsField);
-            assert.strictEqual(manifest.type, bundle.packageType);
+                assert.strictEqual(manifest.name, bundle.name);
+                assert.strictEqual(manifest.version, bundle.version);
+                assert.deepStrictEqual(manifest.exports, bundle.exportsField);
+                assert.strictEqual(manifest.type, bundle.packageType);
 
-            if (Object.keys(bundle.dependencies).length === 0) {
-                assert.strictEqual('dependencies' in manifest, false);
-            } else {
-                assert.deepStrictEqual(manifest.dependencies, bundle.dependencies);
-            }
+                if (Object.keys(bundle.dependencies).length === 0) {
+                    assert.strictEqual('dependencies' in manifest, false);
+                } else {
+                    assert.deepStrictEqual(manifest.dependencies, bundle.dependencies);
+                }
 
-            if (Object.keys(bundle.peerDependencies).length === 0) {
-                assert.strictEqual('peerDependencies' in manifest, false);
-            } else {
-                assert.deepStrictEqual(manifest.peerDependencies, bundle.peerDependencies);
-            }
-        })
-    );
-});
+                if (Object.keys(bundle.peerDependencies).length === 0) {
+                    assert.strictEqual('peerDependencies' in manifest, false);
+                } else {
+                    assert.deepStrictEqual(manifest.peerDependencies, bundle.peerDependencies);
+                }
+            })
+        );
+    });
 
-test('buildPackageManifest() preserves additional attributes without leaking dependency groups into each other', () => {
-    fc.assert(
-        fc.property(bundleArbitrary, (bundle) => {
-            const manifest = buildPackageManifest(bundle);
+    test('buildPackageManifest() preserves additional attributes without leaking dependency groups into each other', function () {
+        fc.assert(
+            fc.property(bundleArbitrary, (bundle) => {
+                const manifest = buildPackageManifest(bundle);
 
-            Object.entries(bundle.additionalAttributes).forEach(([key, value]) => {
-                assert.deepStrictEqual(manifest[key], value);
-            });
+                Object.entries(bundle.additionalAttributes).forEach(([key, value]) => {
+                    assert.deepStrictEqual(manifest[key], value);
+                });
 
-            Object.keys(bundle.dependencies).forEach((dependencyName) => {
-                assert.strictEqual(hasProp(manifest.peerDependencies ?? {}, dependencyName), false);
-            });
-            Object.keys(bundle.peerDependencies).forEach((dependencyName) => {
-                assert.strictEqual(hasProp(manifest.dependencies ?? {}, dependencyName), false);
-            });
-        })
-    );
+                Object.keys(bundle.dependencies).forEach((dependencyName) => {
+                    assert.strictEqual(hasProp(manifest.peerDependencies ?? {}, dependencyName), false);
+                });
+                Object.keys(bundle.peerDependencies).forEach((dependencyName) => {
+                    assert.strictEqual(hasProp(manifest.dependencies ?? {}, dependencyName), false);
+                });
+            })
+        );
+    });
 });

--- a/source/version-manager/manifest/builder.test.ts
+++ b/source/version-manager/manifest/builder.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { VersionedBundle } from '../versioned-bundle.ts';
 import { standardVersionedBundle } from '../../test-libraries/bundle-fixtures.ts';
 import { buildPackageManifest } from './builder.ts';
@@ -8,205 +8,207 @@ function createBundle(overrides: Parameters<typeof standardVersionedBundle>[0] =
     return standardVersionedBundle(overrides);
 }
 
-test('buildPackageManifest() omits optional fields when they are empty or undefined', () => {
-    const result = buildPackageManifest(createBundle());
+suite('builder', function () {
+    test('buildPackageManifest() omits optional fields when they are empty or undefined', function () {
+        const result = buildPackageManifest(createBundle());
 
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        type: 'module'
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module'
+        });
     });
-});
 
-test('buildPackageManifest() includes dependency, peer dependency, type, and exports fields', () => {
-    const result = buildPackageManifest(
-        createBundle({
+    test('buildPackageManifest() includes dependency, peer dependency, type, and exports fields', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                dependencies: { leftPad: '^1.0.0' },
+                peerDependencies: { react: '^19.0.0' },
+                packageType: 'module',
+                typesMainFile: {
+                    sourceFilePath: '/src/index.d.ts',
+                    targetFilePath: 'index.d.ts',
+                    content: '',
+                    isExecutable: false
+                }
+            })
+        );
+
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
             dependencies: { leftPad: '^1.0.0' },
             peerDependencies: { react: '^19.0.0' },
-            packageType: 'module',
-            typesMainFile: {
-                sourceFilePath: '/src/index.d.ts',
-                targetFilePath: 'index.d.ts',
-                content: '',
-                isExecutable: false
-            }
-        })
-    );
-
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        dependencies: { leftPad: '^1.0.0' },
-        peerDependencies: { react: '^19.0.0' },
-        type: 'module'
+            type: 'module'
+        });
     });
-});
 
-test('buildPackageManifest() includes generated imports when present', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            importsField: {
+    test('buildPackageManifest() includes generated imports when present', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                importsField: {
+                    '#foo': './src/foo.js',
+                    '#bar/*': { default: ['./src/bar/*.js', './fallback/*.js'] }
+                }
+            })
+        );
+
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            imports: {
                 '#foo': './src/foo.js',
                 '#bar/*': { default: ['./src/bar/*.js', './fallback/*.js'] }
-            }
-        })
-    );
-
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        imports: {
-            '#foo': './src/foo.js',
-            '#bar/*': { default: ['./src/bar/*.js', './fallback/*.js'] }
-        },
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        type: 'module'
+            },
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module'
+        });
     });
-});
 
-test('buildPackageManifest() preserves string bin entries when present', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            binField: './cli.js'
-        })
-    );
+    test('buildPackageManifest() preserves string bin entries when present', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                binField: './cli.js'
+            })
+        );
 
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        bin: './cli.js',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        type: 'module'
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            bin: './cli.js',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module'
+        });
     });
-});
 
-test('buildPackageManifest() drops undefined entries from object bin fields', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            binField: { packageA: './cli.js', ignored: undefined } as unknown as NonNullable<
-                VersionedBundle['binField']
-            >
-        })
-    );
+    test('buildPackageManifest() drops undefined entries from object bin fields', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                binField: { packageA: './cli.js', ignored: undefined } as unknown as NonNullable<
+                    VersionedBundle['binField']
+                >
+            })
+        );
 
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        bin: { packageA: './cli.js' },
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        type: 'module'
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            bin: { packageA: './cli.js' },
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module'
+        });
     });
-});
 
-test('buildPackageManifest() passes through a scripts block from additional attributes', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            additionalAttributes: { scripts: { postinstall: 'echo hi' } }
-        })
-    );
+    test('buildPackageManifest() passes through a scripts block from additional attributes', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                additionalAttributes: { scripts: { postinstall: 'echo hi' } }
+            })
+        );
 
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        type: 'module',
-        scripts: { postinstall: 'echo hi' }
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module',
+            scripts: { postinstall: 'echo hi' }
+        });
     });
-});
 
-test('buildPackageManifest() lets generated manifest fields override conflicting additional attributes', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            additionalAttributes: {
-                name: 'wrong-name',
-                version: '0.0.0',
-                customField: true
-            }
-        })
-    );
+    test('buildPackageManifest() lets generated manifest fields override conflicting additional attributes', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                additionalAttributes: {
+                    name: 'wrong-name',
+                    version: '0.0.0',
+                    customField: true
+                }
+            })
+        );
 
-    assert.deepStrictEqual(result, {
-        name: 'package-a',
-        version: '1.2.3',
-        exports: {
-            '.': {
-                import: './index.js',
-                types: './index.d.ts'
-            }
-        },
-        type: 'module',
-        customField: true
+        assert.deepStrictEqual(result, {
+            name: 'package-a',
+            version: '1.2.3',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                }
+            },
+            type: 'module',
+            customField: true
+        });
     });
-});
 
-test('buildPackageManifest() omits sideEffects when the bundle has no auto-detected value', () => {
-    const result = buildPackageManifest(createBundle());
+    test('buildPackageManifest() omits sideEffects when the bundle has no auto-detected value', function () {
+        const result = buildPackageManifest(createBundle());
 
-    assert.strictEqual('sideEffects' in result, false);
-});
+        assert.strictEqual('sideEffects' in result, false);
+    });
 
-test('buildPackageManifest() emits "sideEffects": false when the auto-detected value is false', () => {
-    const result = buildPackageManifest(createBundle({ sideEffectsField: false }));
+    test('buildPackageManifest() emits "sideEffects": false when the auto-detected value is false', function () {
+        const result = buildPackageManifest(createBundle({ sideEffectsField: false }));
 
-    assert.strictEqual(result.sideEffects, false);
-});
+        assert.strictEqual(result.sideEffects, false);
+    });
 
-test('buildPackageManifest() emits the auto-detected file list as "sideEffects"', () => {
-    const result = buildPackageManifest(createBundle({ sideEffectsField: ['./impure.js'] }));
+    test('buildPackageManifest() emits the auto-detected file list as "sideEffects"', function () {
+        const result = buildPackageManifest(createBundle({ sideEffectsField: ['./impure.js'] }));
 
-    assert.deepStrictEqual(result.sideEffects, ['./impure.js']);
-});
+        assert.deepStrictEqual(result.sideEffects, ['./impure.js']);
+    });
 
-test('buildPackageManifest() prefers a user-provided sideEffects value in additionalAttributes over the auto-detected one', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            additionalAttributes: { sideEffects: true },
-            sideEffectsField: false
-        })
-    );
+    test('buildPackageManifest() prefers a user-provided sideEffects value in additionalAttributes over the auto-detected one', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                additionalAttributes: { sideEffects: true },
+                sideEffectsField: false
+            })
+        );
 
-    assert.strictEqual(result.sideEffects, true);
-});
+        assert.strictEqual(result.sideEffects, true);
+    });
 
-test('buildPackageManifest() preserves a user-provided sideEffects array even when auto-detection would emit different values', () => {
-    const result = buildPackageManifest(
-        createBundle({
-            additionalAttributes: { sideEffects: ['./vendor/setup.js'] },
-            sideEffectsField: ['./other.js']
-        })
-    );
+    test('buildPackageManifest() preserves a user-provided sideEffects array even when auto-detection would emit different values', function () {
+        const result = buildPackageManifest(
+            createBundle({
+                additionalAttributes: { sideEffects: ['./vendor/setup.js'] },
+                sideEffectsField: ['./other.js']
+            })
+        );
 
-    assert.deepStrictEqual(result.sideEffects, ['./vendor/setup.js']);
+        assert.deepStrictEqual(result.sideEffects, ['./vendor/setup.js']);
+    });
 });

--- a/source/version-manager/manifest/serialize.property.ts
+++ b/source/version-manager/manifest/serialize.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageJson } from 'type-fest';
 import { serializePackageJson } from './serialize.ts';
 
@@ -88,24 +88,26 @@ function canonicalizeValue(value: JsonValue, path: readonly string[] = []): Json
     return value;
 }
 
-test('serializePackageJson() returns valid JSON with recursively sorted object keys', () => {
-    fc.assert(
-        fc.property(packageJsonLikeArbitrary, (value) => {
-            const result = serializePackageJson(value as PackageJson);
-            const parsed = JSON.parse(result) as JsonValue;
+suite('serialize', function () {
+    test('serializePackageJson() returns valid JSON with recursively sorted object keys', function () {
+        fc.assert(
+            fc.property(packageJsonLikeArbitrary, (value) => {
+                const result = serializePackageJson(value as PackageJson);
+                const parsed = JSON.parse(result) as JsonValue;
 
-            assert.deepStrictEqual(parsed, canonicalizeValue(value));
-        })
-    );
-});
+                assert.deepStrictEqual(parsed, canonicalizeValue(value));
+            })
+        );
+    });
 
-test('serializePackageJson() is stable once a package json has been serialized', () => {
-    fc.assert(
-        fc.property(packageJsonLikeArbitrary, (value) => {
-            const serialized = serializePackageJson(value as PackageJson);
-            const reparsed = JSON.parse(serialized) as PackageJsonLike;
+    test('serializePackageJson() is stable once a package json has been serialized', function () {
+        fc.assert(
+            fc.property(packageJsonLikeArbitrary, (value) => {
+                const serialized = serializePackageJson(value as PackageJson);
+                const reparsed = JSON.parse(serialized) as PackageJsonLike;
 
-            assert.strictEqual(serializePackageJson(reparsed as PackageJson), serialized);
-        })
-    );
+                assert.strictEqual(serializePackageJson(reparsed as PackageJson), serialized);
+            })
+        );
+    });
 });

--- a/source/version-manager/manifest/serialize.test.ts
+++ b/source/version-manager/manifest/serialize.test.ts
@@ -1,211 +1,213 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { JsonValue, PackageJson } from 'type-fest';
 import { serializePackageJson } from './serialize.ts';
 
-test('serializes the given data with 4 spaces indentation', () => {
-    const result = serializePackageJson({ a: 'foo', b: 'bar' });
-    assert.strictEqual(result, '{\n    "a": "foo",\n    "b": "bar"\n}');
-});
+suite('serialize', function () {
+    test('serializes the given data with 4 spaces indentation', function () {
+        const result = serializePackageJson({ a: 'foo', b: 'bar' });
+        assert.strictEqual(result, '{\n    "a": "foo",\n    "b": "bar"\n}');
+    });
 
-test('serializes arrays correctly', () => {
-    const result = serializePackageJson({ foo: ['a', 'b'] });
-    assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "b"\n    ]\n}');
-});
+    test('serializes arrays correctly', function () {
+        const result = serializePackageJson({ foo: ['a', 'b'] });
+        assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "b"\n    ]\n}');
+    });
 
-test('sorts the top-level keys alphabetically', () => {
-    const result = serializePackageJson({ b: 'foo', a: 'bar' });
-    assert.strictEqual(result, '{\n    "a": "bar",\n    "b": "foo"\n}');
-});
+    test('sorts the top-level keys alphabetically', function () {
+        const result = serializePackageJson({ b: 'foo', a: 'bar' });
+        assert.strictEqual(result, '{\n    "a": "bar",\n    "b": "foo"\n}');
+    });
 
-test('sorts simple array correctly', () => {
-    const result = serializePackageJson({ foo: ['b', 'a', 0, true] });
-    assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "b",\n        0,\n        true\n    ]\n}');
-});
+    test('sorts simple array correctly', function () {
+        const result = serializePackageJson({ foo: ['b', 'a', 0, true] });
+        assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "b",\n        0,\n        true\n    ]\n}');
+    });
 
-test('sorts the keys of a top-level property alphabetically', () => {
-    const result = serializePackageJson({ b: 'foo', a: { d: 'bar', c: 'baz' } });
-    assert.strictEqual(
-        result,
-        ['{', '    "a": {', '        "c": "baz",', '        "d": "bar"', '    },', '    "b": "foo"', '}'].join('\n')
-    );
-});
+    test('sorts the keys of a top-level property alphabetically', function () {
+        const result = serializePackageJson({ b: 'foo', a: { d: 'bar', c: 'baz' } });
+        assert.strictEqual(
+            result,
+            ['{', '    "a": {', '        "c": "baz",', '        "d": "bar"', '    },', '    "b": "foo"', '}'].join('\n')
+        );
+    });
 
-test('sorts the keys of a nested property alphabetically', () => {
-    const result = serializePackageJson({ b: 'foo', a: { c: { e: 'bar', d: 'baz' } } });
-    assert.strictEqual(
-        result,
-        [
-            '{',
-            '    "a": {',
-            '        "c": {',
-            '            "d": "baz",',
-            '            "e": "bar"',
-            '        }',
-            '    },',
-            '    "b": "foo"',
-            '}'
-        ].join('\n')
-    );
-});
+    test('sorts the keys of a nested property alphabetically', function () {
+        const result = serializePackageJson({ b: 'foo', a: { c: { e: 'bar', d: 'baz' } } });
+        assert.strictEqual(
+            result,
+            [
+                '{',
+                '    "a": {',
+                '        "c": {',
+                '            "d": "baz",',
+                '            "e": "bar"',
+                '        }',
+                '    },',
+                '    "b": "foo"',
+                '}'
+            ].join('\n')
+        );
+    });
 
-test('throws when a circular structure is given', () => {
-    const secondEntry: JsonValue = {};
-    const firstEntry: JsonValue = { c: secondEntry };
-    secondEntry.d = firstEntry;
+    test('throws when a circular structure is given', function () {
+        const secondEntry: JsonValue = {};
+        const firstEntry: JsonValue = { c: secondEntry };
+        secondEntry.d = firstEntry;
 
-    try {
-        serializePackageJson({ b: 'foo', a: firstEntry });
-        assert.fail('Expected serializePackageJson() should fail but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual((error as Error).message, 'Circular structures are not supported');
-    }
-});
-
-test('sorts objects nested within array correctly', () => {
-    const result = serializePackageJson({ foo: ['f', { b: '1', a: '2', d: [3, 2] }, 'c'] });
-    assert.strictEqual(
-        result,
-        '{\n    "foo": [\n        "f",\n        {\n            "a": "2",\n            "b": "1",\n            "d": [\n                2,\n                3\n            ]\n        },\n        "c"\n    ]\n}'
-    );
-});
-
-test('sorts primitive array values so false stays before true and numbers stay ordered', () => {
-    const result = serializePackageJson({ foo: [true, false, 2, 1] });
-
-    assert.strictEqual(result, '{\n    "foo": [\n        false,\n        true,\n        1,\n        2\n    ]\n}');
-});
-
-test('preserves array order inside top-level imports entries', () => {
-    const result = serializePackageJson({
-        imports: {
-            '#foo': {
-                default: ['./z.js', './a.js']
-            }
+        try {
+            serializePackageJson({ b: 'foo', a: firstEntry });
+            assert.fail('Expected serializePackageJson() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Circular structures are not supported');
         }
     });
 
-    assert.strictEqual(
-        result,
-        [
-            '{',
-            '    "imports": {',
-            '        "#foo": {',
-            '            "default": [',
-            '                "./z.js",',
-            '                "./a.js"',
-            '            ]',
-            '        }',
-            '    }',
-            '}'
-        ].join('\n')
-    );
-});
+    test('sorts objects nested within array correctly', function () {
+        const result = serializePackageJson({ foo: ['f', { b: '1', a: '2', d: [3, 2] }, 'c'] });
+        assert.strictEqual(
+            result,
+            '{\n    "foo": [\n        "f",\n        {\n            "a": "2",\n            "b": "1",\n            "d": [\n                2,\n                3\n            ]\n        },\n        "c"\n    ]\n}'
+        );
+    });
 
-test('preserves nested array order inside top-level imports entries', () => {
-    const result = serializePackageJson(
-        JSON.parse('{ "imports": { "#foo": { "default": [["./z.js", "./a.js"]] } } }') as Readonly<PackageJson>
-    );
+    test('sorts primitive array values so false stays before true and numbers stay ordered', function () {
+        const result = serializePackageJson({ foo: [true, false, 2, 1] });
 
-    assert.strictEqual(
-        result,
-        [
-            '{',
-            '    "imports": {',
-            '        "#foo": {',
-            '            "default": [',
-            '                [',
-            '                    "./z.js",',
-            '                    "./a.js"',
-            '                ]',
-            '            ]',
-            '        }',
-            '    }',
-            '}'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(result, '{\n    "foo": [\n        false,\n        true,\n        1,\n        2\n    ]\n}');
+    });
 
-test('preserves array order inside top-level exports entries', () => {
-    const result = serializePackageJson({
-        exports: {
-            '.': {
-                import: ['./z.js', './a.js']
+    test('preserves array order inside top-level imports entries', function () {
+        const result = serializePackageJson({
+            imports: {
+                '#foo': {
+                    default: ['./z.js', './a.js']
+                }
             }
-        }
+        });
+
+        assert.strictEqual(
+            result,
+            [
+                '{',
+                '    "imports": {',
+                '        "#foo": {',
+                '            "default": [',
+                '                "./z.js",',
+                '                "./a.js"',
+                '            ]',
+                '        }',
+                '    }',
+                '}'
+            ].join('\n')
+        );
     });
 
-    assert.strictEqual(
-        result,
-        [
-            '{',
-            '    "exports": {',
-            '        ".": {',
-            '            "import": [',
-            '                "./z.js",',
-            '                "./a.js"',
-            '            ]',
-            '        }',
-            '    }',
-            '}'
-        ].join('\n')
-    );
-});
+    test('preserves nested array order inside top-level imports entries', function () {
+        const result = serializePackageJson(
+            JSON.parse('{ "imports": { "#foo": { "default": [["./z.js", "./a.js"]] } } }') as Readonly<PackageJson>
+        );
 
-test('keeps equal primitive values stable without collapsing them', () => {
-    const result = serializePackageJson({ foo: ['b', 'a', 'a'] });
-
-    assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "a",\n        "b"\n    ]\n}');
-});
-
-test('sorts descending string arrays into ascending order', () => {
-    const result = serializePackageJson({ foo: ['z', 'm', 'a'] });
-
-    assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "m",\n        "z"\n    ]\n}');
-});
-
-test('sorts descending numeric arrays into ascending order', () => {
-    const result = serializePackageJson({ foo: [3, 2, 1] });
-
-    assert.strictEqual(result, '{\n    "foo": [\n        1,\n        2,\n        3\n    ]\n}');
-});
-
-test('keeps object arrays in original order while sorting each object deeply', () => {
-    const result = serializePackageJson({
-        foo: [
-            { b: 2, a: 1 },
-            { d: 4, c: 3 }
-        ]
+        assert.strictEqual(
+            result,
+            [
+                '{',
+                '    "imports": {',
+                '        "#foo": {',
+                '            "default": [',
+                '                [',
+                '                    "./z.js",',
+                '                    "./a.js"',
+                '                ]',
+                '            ]',
+                '        }',
+                '    }',
+                '}'
+            ].join('\n')
+        );
     });
 
-    assert.strictEqual(
-        result,
-        '{\n    "foo": [\n        {\n            "a": 1,\n            "b": 2\n        },\n        {\n            "c": 3,\n            "d": 4\n        }\n    ]\n}'
-    );
-});
+    test('preserves array order inside top-level exports entries', function () {
+        const result = serializePackageJson({
+            exports: {
+                '.': {
+                    import: ['./z.js', './a.js']
+                }
+            }
+        });
 
-test('serializes null values inside arrays and nested records without reordering record keys incorrectly', () => {
-    const result = serializePackageJson({
-        foo: [{ z: null, a: [null, 'b', 'a'] }]
+        assert.strictEqual(
+            result,
+            [
+                '{',
+                '    "exports": {',
+                '        ".": {',
+                '            "import": [',
+                '                "./z.js",',
+                '                "./a.js"',
+                '            ]',
+                '        }',
+                '    }',
+                '}'
+            ].join('\n')
+        );
     });
 
-    assert.strictEqual(
-        result,
-        '{\n    "foo": [\n        {\n            "a": [\n                null,\n                "a",\n                "b"\n            ],\n            "z": null\n        }\n    ]\n}'
-    );
-});
+    test('keeps equal primitive values stable without collapsing them', function () {
+        const result = serializePackageJson({ foo: ['b', 'a', 'a'] });
 
-test('preserves own __proto__ keys while sorting nested objects', () => {
-    const result = serializePackageJson(JSON.parse('{ "": [{ "__proto__": {} }] }') as Readonly<PackageJson>);
+        assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "a",\n        "b"\n    ]\n}');
+    });
 
-    assert.strictEqual(result, '{\n    "": [\n        {\n            "__proto__": {}\n        }\n    ]\n}');
-});
+    test('sorts descending string arrays into ascending order', function () {
+        const result = serializePackageJson({ foo: ['z', 'm', 'a'] });
 
-test('throws for circular arrays as well as circular records', () => {
-    const circularArray: JsonValue[] = [];
-    circularArray.push(circularArray as unknown as JsonValue);
+        assert.strictEqual(result, '{\n    "foo": [\n        "a",\n        "m",\n        "z"\n    ]\n}');
+    });
 
-    assert.throws(() => {
-        serializePackageJson({ foo: circularArray });
-    }, /^Error: Circular structures are not supported$/);
+    test('sorts descending numeric arrays into ascending order', function () {
+        const result = serializePackageJson({ foo: [3, 2, 1] });
+
+        assert.strictEqual(result, '{\n    "foo": [\n        1,\n        2,\n        3\n    ]\n}');
+    });
+
+    test('keeps object arrays in original order while sorting each object deeply', function () {
+        const result = serializePackageJson({
+            foo: [
+                { b: 2, a: 1 },
+                { d: 4, c: 3 }
+            ]
+        });
+
+        assert.strictEqual(
+            result,
+            '{\n    "foo": [\n        {\n            "a": 1,\n            "b": 2\n        },\n        {\n            "c": 3,\n            "d": 4\n        }\n    ]\n}'
+        );
+    });
+
+    test('serializes null values inside arrays and nested records without reordering record keys incorrectly', function () {
+        const result = serializePackageJson({
+            foo: [{ z: null, a: [null, 'b', 'a'] }]
+        });
+
+        assert.strictEqual(
+            result,
+            '{\n    "foo": [\n        {\n            "a": [\n                null,\n                "a",\n                "b"\n            ],\n            "z": null\n        }\n    ]\n}'
+        );
+    });
+
+    test('preserves own __proto__ keys while sorting nested objects', function () {
+        const result = serializePackageJson(JSON.parse('{ "": [{ "__proto__": {} }] }') as Readonly<PackageJson>);
+
+        assert.strictEqual(result, '{\n    "": [\n        {\n            "__proto__": {}\n        }\n    ]\n}');
+    });
+
+    test('throws for circular arrays as well as circular records', function () {
+        const circularArray: JsonValue[] = [];
+        circularArray.push(circularArray as unknown as JsonValue);
+
+        assert.throws(() => {
+            serializePackageJson({ foo: circularArray });
+        }, /^Error: Circular structures are not supported$/);
+    });
 });

--- a/source/version-manager/manifest/sort-values.test.ts
+++ b/source/version-manager/manifest/sort-values.test.ts
@@ -1,29 +1,31 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { compareValues } from './sort-values.ts';
 
-test('compareValues() sorts strings ascending and keeps equal strings stable', () => {
-    assert.strictEqual(compareValues('a', 'b'), -1);
-    assert.strictEqual(compareValues('b', 'a'), 1);
-    assert.strictEqual(compareValues('a', 'a'), 0);
-});
+suite('sort-values', function () {
+    test('compareValues() sorts strings ascending and keeps equal strings stable', function () {
+        assert.strictEqual(compareValues('a', 'b'), -1);
+        assert.strictEqual(compareValues('b', 'a'), 1);
+        assert.strictEqual(compareValues('a', 'a'), 0);
+    });
 
-test('compareValues() sorts numbers ascending and keeps equal numbers stable', () => {
-    assert.strictEqual(compareValues(1, 2), -1);
-    assert.strictEqual(compareValues(2, 1), 1);
-    assert.strictEqual(compareValues(2, 2), 0);
-});
+    test('compareValues() sorts numbers ascending and keeps equal numbers stable', function () {
+        assert.strictEqual(compareValues(1, 2), -1);
+        assert.strictEqual(compareValues(2, 1), 1);
+        assert.strictEqual(compareValues(2, 2), 0);
+    });
 
-test('compareValues() sorts booleans with false before true', () => {
-    assert.strictEqual(compareValues(false, true), -1);
-    assert.strictEqual(compareValues(true, false), 1);
-    assert.strictEqual(compareValues(true, true), 0);
-});
+    test('compareValues() sorts booleans with false before true', function () {
+        assert.strictEqual(compareValues(false, true), -1);
+        assert.strictEqual(compareValues(true, false), 1);
+        assert.strictEqual(compareValues(true, true), 0);
+    });
 
-test('compareValues() keeps mixed primitive types and non-primitives in their relative order', () => {
-    assert.strictEqual(compareValues('a', 1), 0);
-    assert.strictEqual(compareValues(false, 1), -1);
-    assert.strictEqual(compareValues([], 1), 0);
-    assert.strictEqual(compareValues(1, []), 0);
-    assert.strictEqual(compareValues({}, []), 0);
+    test('compareValues() keeps mixed primitive types and non-primitives in their relative order', function () {
+        assert.strictEqual(compareValues('a', 1), 0);
+        assert.strictEqual(compareValues(false, 1), -1);
+        assert.strictEqual(compareValues([], 1), 0);
+        assert.strictEqual(compareValues(1, []), 0);
+        assert.strictEqual(compareValues({}, []), 0);
+    });
 });

--- a/source/version-manager/optional-bundle-fields.test.ts
+++ b/source/version-manager/optional-bundle-fields.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { buildOptionalVersionedBundleFields } from './optional-bundle-fields.ts';
 
 const fileDescription = {
@@ -9,57 +9,63 @@ const fileDescription = {
     isExecutable: false
 };
 
-test('buildOptionalVersionedBundleFields returns an empty object when every field is undefined', () => {
-    assert.deepStrictEqual(
-        buildOptionalVersionedBundleFields({ importsField: undefined, binField: undefined, typesMainFile: undefined }),
-        {}
-    );
-});
+suite('optional-bundle-fields', function () {
+    test('buildOptionalVersionedBundleFields returns an empty object when every field is undefined', function () {
+        assert.deepStrictEqual(
+            buildOptionalVersionedBundleFields({
+                importsField: undefined,
+                binField: undefined,
+                typesMainFile: undefined
+            }),
+            {}
+        );
+    });
 
-test('buildOptionalVersionedBundleFields includes importsField when it is defined', () => {
-    assert.deepStrictEqual(
-        buildOptionalVersionedBundleFields({
-            importsField: { '#foo': './foo.js' },
-            binField: undefined,
-            typesMainFile: undefined
-        }),
-        { importsField: { '#foo': './foo.js' } }
-    );
-});
+    test('buildOptionalVersionedBundleFields includes importsField when it is defined', function () {
+        assert.deepStrictEqual(
+            buildOptionalVersionedBundleFields({
+                importsField: { '#foo': './foo.js' },
+                binField: undefined,
+                typesMainFile: undefined
+            }),
+            { importsField: { '#foo': './foo.js' } }
+        );
+    });
 
-test('buildOptionalVersionedBundleFields includes binField when it is defined', () => {
-    assert.deepStrictEqual(
-        buildOptionalVersionedBundleFields({
-            importsField: undefined,
-            binField: { 'pkg-a': './cli.js' },
-            typesMainFile: undefined
-        }),
-        { binField: { 'pkg-a': './cli.js' } }
-    );
-});
+    test('buildOptionalVersionedBundleFields includes binField when it is defined', function () {
+        assert.deepStrictEqual(
+            buildOptionalVersionedBundleFields({
+                importsField: undefined,
+                binField: { 'pkg-a': './cli.js' },
+                typesMainFile: undefined
+            }),
+            { binField: { 'pkg-a': './cli.js' } }
+        );
+    });
 
-test('buildOptionalVersionedBundleFields includes typesMainFile when it is defined', () => {
-    assert.deepStrictEqual(
-        buildOptionalVersionedBundleFields({
-            importsField: undefined,
-            binField: undefined,
-            typesMainFile: fileDescription
-        }),
-        { typesMainFile: fileDescription }
-    );
-});
+    test('buildOptionalVersionedBundleFields includes typesMainFile when it is defined', function () {
+        assert.deepStrictEqual(
+            buildOptionalVersionedBundleFields({
+                importsField: undefined,
+                binField: undefined,
+                typesMainFile: fileDescription
+            }),
+            { typesMainFile: fileDescription }
+        );
+    });
 
-test('buildOptionalVersionedBundleFields includes every defined field together', () => {
-    assert.deepStrictEqual(
-        buildOptionalVersionedBundleFields({
-            importsField: { '#foo': './foo.js' },
-            binField: { 'pkg-a': './cli.js' },
-            typesMainFile: fileDescription
-        }),
-        {
-            importsField: { '#foo': './foo.js' },
-            binField: { 'pkg-a': './cli.js' },
-            typesMainFile: fileDescription
-        }
-    );
+    test('buildOptionalVersionedBundleFields includes every defined field together', function () {
+        assert.deepStrictEqual(
+            buildOptionalVersionedBundleFields({
+                importsField: { '#foo': './foo.js' },
+                binField: { 'pkg-a': './cli.js' },
+                typesMainFile: fileDescription
+            }),
+            {
+                importsField: { '#foo': './foo.js' },
+                binField: { 'pkg-a': './cli.js' },
+                typesMainFile: fileDescription
+            }
+        );
+    });
 });

--- a/source/version-manager/representative-root.test.ts
+++ b/source/version-manager/representative-root.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import type { PackageInterface } from '../config/package-interface.ts';
 import type { RootFileDescription } from '../resource-resolver/resolved-bundle.ts';
 import { resolveRepresentativeRoot } from './representative-root.ts';
@@ -27,76 +27,78 @@ const cliRoot: RootFileDescription = {
     }
 };
 
-test('resolveRepresentativeRoot returns the implicit defaultModuleRoot for an implicit surface', () => {
-    assert.deepStrictEqual(
-        resolveRepresentativeRoot({
-            name: 'pkg-a',
-            roots: { main: indexRoot },
-            surface: { mode: 'implicit', defaultModuleRoot: 'main' }
-        }),
-        indexRoot
-    );
-});
-
-test('resolveRepresentativeRoot returns the first explicit module root', () => {
-    assert.deepStrictEqual(
-        resolveRepresentativeRoot({
-            name: 'pkg-a',
-            roots: { main: indexRoot, feature: featureRoot },
-            surface: {
-                mode: 'explicit',
-                packageInterface: { modules: [{ root: 'feature', export: '.' }] }
-            }
-        }),
-        featureRoot
-    );
-});
-
-test('resolveRepresentativeRoot falls back to the first explicit bin root when no modules are declared', () => {
-    assert.deepStrictEqual(
-        resolveRepresentativeRoot({
-            name: 'pkg-a',
-            roots: { cli: cliRoot },
-            surface: {
-                mode: 'explicit',
-                packageInterface: { bins: [{ root: 'cli', name: 'pkg-a' }] }
-            }
-        }),
-        cliRoot
-    );
-});
-
-test('resolveRepresentativeRoot falls back to bins when the modules array is empty', () => {
-    const packageInterface = {
-        modules: [],
-        bins: [{ root: 'cli', name: 'pkg-a' }]
-    } as unknown as PackageInterface;
-    assert.deepStrictEqual(
-        resolveRepresentativeRoot({
-            name: 'pkg-a',
-            roots: { cli: cliRoot },
-            surface: { mode: 'explicit', packageInterface }
-        }),
-        cliRoot
-    );
-});
-
-test('resolveRepresentativeRoot throws when an explicit surface declares neither modules nor bins', () => {
-    try {
-        resolveRepresentativeRoot({
-            name: 'pkg-a',
-            roots: {},
-            surface: {
-                mode: 'explicit',
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentionally malformed surface
-                packageInterface: {} as never
-            }
-        });
-        assert.fail('Expected resolveRepresentativeRoot() to throw but it did not');
-    } catch (error: unknown) {
-        assert.strictEqual(
-            (error as Error).message,
-            'Package "pkg-a" explicit surface declares neither modules nor bins'
+suite('representative-root', function () {
+    test('resolveRepresentativeRoot returns the implicit defaultModuleRoot for an implicit surface', function () {
+        assert.deepStrictEqual(
+            resolveRepresentativeRoot({
+                name: 'pkg-a',
+                roots: { main: indexRoot },
+                surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+            }),
+            indexRoot
         );
-    }
+    });
+
+    test('resolveRepresentativeRoot returns the first explicit module root', function () {
+        assert.deepStrictEqual(
+            resolveRepresentativeRoot({
+                name: 'pkg-a',
+                roots: { main: indexRoot, feature: featureRoot },
+                surface: {
+                    mode: 'explicit',
+                    packageInterface: { modules: [{ root: 'feature', export: '.' }] }
+                }
+            }),
+            featureRoot
+        );
+    });
+
+    test('resolveRepresentativeRoot falls back to the first explicit bin root when no modules are declared', function () {
+        assert.deepStrictEqual(
+            resolveRepresentativeRoot({
+                name: 'pkg-a',
+                roots: { cli: cliRoot },
+                surface: {
+                    mode: 'explicit',
+                    packageInterface: { bins: [{ root: 'cli', name: 'pkg-a' }] }
+                }
+            }),
+            cliRoot
+        );
+    });
+
+    test('resolveRepresentativeRoot falls back to bins when the modules array is empty', function () {
+        const packageInterface = {
+            modules: [],
+            bins: [{ root: 'cli', name: 'pkg-a' }]
+        } as unknown as PackageInterface;
+        assert.deepStrictEqual(
+            resolveRepresentativeRoot({
+                name: 'pkg-a',
+                roots: { cli: cliRoot },
+                surface: { mode: 'explicit', packageInterface }
+            }),
+            cliRoot
+        );
+    });
+
+    test('resolveRepresentativeRoot throws when an explicit surface declares neither modules nor bins', function () {
+        try {
+            resolveRepresentativeRoot({
+                name: 'pkg-a',
+                roots: {},
+                surface: {
+                    mode: 'explicit',
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentionally malformed surface
+                    packageInterface: {} as never
+                }
+            });
+            assert.fail('Expected resolveRepresentativeRoot() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'Package "pkg-a" explicit surface declares neither modules nor bins'
+            );
+        }
+    });
 });

--- a/source/version-manager/specifier-classifier.property.ts
+++ b/source/version-manager/specifier-classifier.property.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import fc from 'fast-check';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { classifySpecifier } from './specifier-classifier.ts';
 
 const packageNameArbitrary = fc.stringMatching(/^[a-z][\da-z-]{0,8}$/u);
@@ -22,13 +22,20 @@ const registrySubSpecArbitrary = fc.oneof(
     fc.constantFrom('latest', 'next', 'beta')
 );
 
-test('classify(alias) bucket matches classify(subSpec) bucket for registry sub-specs', () => {
-    fc.assert(
-        fc.property(packageNameArbitrary, packageNameArbitrary, registrySubSpecArbitrary, (alias, target, subSpec) => {
-            const aliasResult = classifySpecifier(alias, `npm:${target}@${subSpec}`);
-            const directResult = classifySpecifier(target, subSpec);
+suite('specifier-classifier', function () {
+    test('classify(alias) bucket matches classify(subSpec) bucket for registry sub-specs', function () {
+        fc.assert(
+            fc.property(
+                packageNameArbitrary,
+                packageNameArbitrary,
+                registrySubSpecArbitrary,
+                (alias, target, subSpec) => {
+                    const aliasResult = classifySpecifier(alias, `npm:${target}@${subSpec}`);
+                    const directResult = classifySpecifier(target, subSpec);
 
-            assert.strictEqual(aliasResult.kind, directResult.kind);
-        })
-    );
+                    assert.strictEqual(aliasResult.kind, directResult.kind);
+                }
+            )
+        );
+    });
 });

--- a/source/version-manager/specifier-classifier.test.ts
+++ b/source/version-manager/specifier-classifier.test.ts
@@ -1,97 +1,99 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import { classifySpecifier } from './specifier-classifier.ts';
 
-test('classifies an exact version as registry', () => {
-    assert.deepStrictEqual(classifySpecifier('left-pad', '1.2.3'), { kind: 'registry' });
-});
-
-test('classifies a range as registry', () => {
-    assert.deepStrictEqual(classifySpecifier('left-pad', '^1.0.0'), { kind: 'registry' });
-});
-
-test('classifies a tag as registry', () => {
-    assert.deepStrictEqual(classifySpecifier('left-pad', 'latest'), { kind: 'registry' });
-});
-
-test('classifies git+https as mutable git', () => {
-    assert.deepStrictEqual(classifySpecifier('react', 'git+https://github.com/our-fork/react#v18.0.0'), {
-        kind: 'mutable',
-        npaType: 'git'
+suite('specifier-classifier', function () {
+    test('classifies an exact version as registry', function () {
+        assert.deepStrictEqual(classifySpecifier('left-pad', '1.2.3'), { kind: 'registry' });
     });
-});
 
-test('classifies git:// as mutable git', () => {
-    assert.deepStrictEqual(classifySpecifier('react', 'git://github.com/our-fork/react#main'), {
-        kind: 'mutable',
-        npaType: 'git'
+    test('classifies a range as registry', function () {
+        assert.deepStrictEqual(classifySpecifier('left-pad', '^1.0.0'), { kind: 'registry' });
     });
-});
 
-test('classifies git+ssh:// as mutable git', () => {
-    assert.deepStrictEqual(classifySpecifier('react', 'git+ssh://git@github.com/our-fork/react#main'), {
-        kind: 'mutable',
-        npaType: 'git'
+    test('classifies a tag as registry', function () {
+        assert.deepStrictEqual(classifySpecifier('left-pad', 'latest'), { kind: 'registry' });
     });
-});
 
-test('classifies an http url as mutable remote', () => {
-    assert.deepStrictEqual(classifySpecifier('thing', 'https://example.test/thing.tgz'), {
-        kind: 'mutable',
-        npaType: 'remote'
+    test('classifies git+https as mutable git', function () {
+        assert.deepStrictEqual(classifySpecifier('react', 'git+https://github.com/our-fork/react#v18.0.0'), {
+            kind: 'mutable',
+            npaType: 'git'
+        });
     });
-});
 
-test('classifies a file:tarball as mutable file', () => {
-    assert.deepStrictEqual(classifySpecifier('internal-tool', 'file:./vendor/internal-tool.tgz'), {
-        kind: 'mutable',
-        npaType: 'file'
+    test('classifies git:// as mutable git', function () {
+        assert.deepStrictEqual(classifySpecifier('react', 'git://github.com/our-fork/react#main'), {
+            kind: 'mutable',
+            npaType: 'git'
+        });
     });
-});
 
-test('classifies a file: directory as mutable directory', () => {
-    assert.deepStrictEqual(classifySpecifier('internal-tool', 'file:./vendor/internal-tool'), {
-        kind: 'mutable',
-        npaType: 'directory'
+    test('classifies git+ssh:// as mutable git', function () {
+        assert.deepStrictEqual(classifySpecifier('react', 'git+ssh://git@github.com/our-fork/react#main'), {
+            kind: 'mutable',
+            npaType: 'git'
+        });
     });
-});
 
-test('classifies an alias of a registry version as registry', () => {
-    assert.deepStrictEqual(classifySpecifier('aliased', 'npm:other-pkg@^2.0.0'), { kind: 'registry' });
-});
-
-test('classifies a non-registry alias as malformed because npa rejects it', () => {
-    const result = classifySpecifier('aliased', 'npm:other-pkg@git+https://github.com/foo/bar#main');
-
-    if (result.kind !== 'malformed') {
-        assert.fail(`Expected malformed, got ${result.kind}`);
-    }
-    assert.match(result.reason, /aliases only work for registry deps/u);
-});
-
-test('classifies an alias of a registry tag as registry', () => {
-    assert.deepStrictEqual(classifySpecifier('aliased', 'npm:other-pkg@latest'), { kind: 'registry' });
-});
-
-test('classifies workspace: protocol as malformed with the workspace reason', () => {
-    assert.deepStrictEqual(classifySpecifier('shared-utils', 'workspace:*'), {
-        kind: 'malformed',
-        reason: 'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace, not valid in a published manifest'
+    test('classifies an http url as mutable remote', function () {
+        assert.deepStrictEqual(classifySpecifier('thing', 'https://example.test/thing.tgz'), {
+            kind: 'mutable',
+            npaType: 'remote'
+        });
     });
-});
 
-test('classifies portal: protocol as malformed with the portal reason', () => {
-    assert.deepStrictEqual(classifySpecifier('shared-utils', 'portal:./packages/shared'), {
-        kind: 'malformed',
-        reason: 'portal protocol is yarn-specific; resolved as a local symlink, not valid in a published manifest'
+    test('classifies a file:tarball as mutable file', function () {
+        assert.deepStrictEqual(classifySpecifier('internal-tool', 'file:./vendor/internal-tool.tgz'), {
+            kind: 'mutable',
+            npaType: 'file'
+        });
     });
-});
 
-test('classifies a specifier that npa cannot parse as malformed using the npa error message', () => {
-    const result = classifySpecifier('shared-utils', 'whatever:~~~broken');
+    test('classifies a file: directory as mutable directory', function () {
+        assert.deepStrictEqual(classifySpecifier('internal-tool', 'file:./vendor/internal-tool'), {
+            kind: 'mutable',
+            npaType: 'directory'
+        });
+    });
 
-    if (result.kind !== 'malformed') {
-        assert.fail(`Expected malformed, got ${result.kind}`);
-    }
-    assert.match(result.reason, /Unsupported URL Type/u);
+    test('classifies an alias of a registry version as registry', function () {
+        assert.deepStrictEqual(classifySpecifier('aliased', 'npm:other-pkg@^2.0.0'), { kind: 'registry' });
+    });
+
+    test('classifies a non-registry alias as malformed because npa rejects it', function () {
+        const result = classifySpecifier('aliased', 'npm:other-pkg@git+https://github.com/foo/bar#main');
+
+        if (result.kind !== 'malformed') {
+            assert.fail(`Expected malformed, got ${result.kind}`);
+        }
+        assert.match(result.reason, /aliases only work for registry deps/u);
+    });
+
+    test('classifies an alias of a registry tag as registry', function () {
+        assert.deepStrictEqual(classifySpecifier('aliased', 'npm:other-pkg@latest'), { kind: 'registry' });
+    });
+
+    test('classifies workspace: protocol as malformed with the workspace reason', function () {
+        assert.deepStrictEqual(classifySpecifier('shared-utils', 'workspace:*'), {
+            kind: 'malformed',
+            reason: 'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace, not valid in a published manifest'
+        });
+    });
+
+    test('classifies portal: protocol as malformed with the portal reason', function () {
+        assert.deepStrictEqual(classifySpecifier('shared-utils', 'portal:./packages/shared'), {
+            kind: 'malformed',
+            reason: 'portal protocol is yarn-specific; resolved as a local symlink, not valid in a published manifest'
+        });
+    });
+
+    test('classifies a specifier that npa cannot parse as malformed using the npa error message', function () {
+        const result = classifySpecifier('shared-utils', 'whatever:~~~broken');
+
+        if (result.kind !== 'malformed') {
+            assert.fail(`Expected malformed, got ${result.kind}`);
+        }
+        assert.match(result.reason, /Unsupported URL Type/u);
+    });
 });

--- a/source/version-manager/specifier-errors.test.ts
+++ b/source/version-manager/specifier-errors.test.ts
@@ -1,102 +1,104 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     renderMalformedSpecifierMessage,
     renderMutableSpecifierMessage,
     renderUnusedAllowListMessage
 } from './specifier-errors.ts';
 
-test('renderMutableSpecifierMessage formats a multi-offender message exactly', () => {
-    const message = renderMutableSpecifierMessage([
-        { name: 'react', specifier: 'git+https://github.com/our-fork/react#v18.0.0', npaType: 'git' },
-        { name: 'internal-tool', specifier: 'file:./vendor/internal-tool', npaType: 'file' }
-    ]);
+suite('specifier-errors', function () {
+    test('renderMutableSpecifierMessage formats a multi-offender message exactly', function () {
+        const message = renderMutableSpecifierMessage([
+            { name: 'react', specifier: 'git+https://github.com/our-fork/react#v18.0.0', npaType: 'git' },
+            { name: 'internal-tool', specifier: 'file:./vendor/internal-tool', npaType: 'file' }
+        ]);
 
-    assert.strictEqual(
-        message,
-        [
-            "Refusing to publish: 2 dependencies use mutable specifiers, which bypass the npm registry's integrity guarantees:",
-            '  - "react" → "git+https://github.com/our-fork/react#v18.0.0" (git)',
-            '  - "internal-tool" → "file:./vendor/internal-tool" (file)',
-            'Add the dep name to dependencyPolicy.allowMutableSpecifiers to allow this on purpose.'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            message,
+            [
+                "Refusing to publish: 2 dependencies use mutable specifiers, which bypass the npm registry's integrity guarantees:",
+                '  - "react" → "git+https://github.com/our-fork/react#v18.0.0" (git)',
+                '  - "internal-tool" → "file:./vendor/internal-tool" (file)',
+                'Add the dep name to dependencyPolicy.allowMutableSpecifiers to allow this on purpose.'
+            ].join('\n')
+        );
+    });
 
-test('renderMutableSpecifierMessage uses the singular noun for a single offender', () => {
-    const message = renderMutableSpecifierMessage([
-        { name: 'react', specifier: 'git+https://github.com/foo/bar#v1', npaType: 'git' }
-    ]);
+    test('renderMutableSpecifierMessage uses the singular noun for a single offender', function () {
+        const message = renderMutableSpecifierMessage([
+            { name: 'react', specifier: 'git+https://github.com/foo/bar#v1', npaType: 'git' }
+        ]);
 
-    assert.strictEqual(
-        message,
-        [
-            "Refusing to publish: 1 dependency uses a mutable specifier, which bypasses the npm registry's integrity guarantees:",
-            '  - "react" → "git+https://github.com/foo/bar#v1" (git)',
-            'Add the dep name to dependencyPolicy.allowMutableSpecifiers to allow this on purpose.'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            message,
+            [
+                "Refusing to publish: 1 dependency uses a mutable specifier, which bypasses the npm registry's integrity guarantees:",
+                '  - "react" → "git+https://github.com/foo/bar#v1" (git)',
+                'Add the dep name to dependencyPolicy.allowMutableSpecifiers to allow this on purpose.'
+            ].join('\n')
+        );
+    });
 
-test('renderMalformedSpecifierMessage formats a single-offender message exactly', () => {
-    const message = renderMalformedSpecifierMessage([
-        {
-            name: 'shared-utils',
-            specifier: 'workspace:*',
-            reason: 'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace, not valid in a published manifest'
-        }
-    ]);
+    test('renderMalformedSpecifierMessage formats a single-offender message exactly', function () {
+        const message = renderMalformedSpecifierMessage([
+            {
+                name: 'shared-utils',
+                specifier: 'workspace:*',
+                reason: 'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace, not valid in a published manifest'
+            }
+        ]);
 
-    assert.strictEqual(
-        message,
-        [
-            'Refusing to publish: 1 dependency has a specifier that npm cannot publish:',
-            '  - "shared-utils" → "workspace:*" (workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace, not valid in a published manifest)',
-            'Replace with a registry version (e.g. "^1.2.3"). Mutable-specifier allow-listing does not apply here.'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            message,
+            [
+                'Refusing to publish: 1 dependency has a specifier that npm cannot publish:',
+                '  - "shared-utils" → "workspace:*" (workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace, not valid in a published manifest)',
+                'Replace with a registry version (e.g. "^1.2.3"). Mutable-specifier allow-listing does not apply here.'
+            ].join('\n')
+        );
+    });
 
-test('renderMalformedSpecifierMessage uses the plural verb for multiple offenders', () => {
-    const message = renderMalformedSpecifierMessage([
-        { name: 'a', specifier: 'workspace:*', reason: 'workspace reason' },
-        { name: 'b', specifier: 'portal:./b', reason: 'portal reason' }
-    ]);
+    test('renderMalformedSpecifierMessage uses the plural verb for multiple offenders', function () {
+        const message = renderMalformedSpecifierMessage([
+            { name: 'a', specifier: 'workspace:*', reason: 'workspace reason' },
+            { name: 'b', specifier: 'portal:./b', reason: 'portal reason' }
+        ]);
 
-    assert.strictEqual(
-        message,
-        [
-            'Refusing to publish: 2 dependencies have a specifier that npm cannot publish:',
-            '  - "a" → "workspace:*" (workspace reason)',
-            '  - "b" → "portal:./b" (portal reason)',
-            'Replace with a registry version (e.g. "^1.2.3"). Mutable-specifier allow-listing does not apply here.'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            message,
+            [
+                'Refusing to publish: 2 dependencies have a specifier that npm cannot publish:',
+                '  - "a" → "workspace:*" (workspace reason)',
+                '  - "b" → "portal:./b" (portal reason)',
+                'Replace with a registry version (e.g. "^1.2.3"). Mutable-specifier allow-listing does not apply here.'
+            ].join('\n')
+        );
+    });
 
-test('renderUnusedAllowListMessage formats a single-entry message exactly', () => {
-    const message = renderUnusedAllowListMessage(['old-vendored-pkg']);
+    test('renderUnusedAllowListMessage formats a single-entry message exactly', function () {
+        const message = renderUnusedAllowListMessage(['old-vendored-pkg']);
 
-    assert.strictEqual(
-        message,
-        [
-            'Refusing to publish: 1 entry in dependencyPolicy.allowMutableSpecifiers is not in use:',
-            '  - "old-vendored-pkg"',
-            'Remove unused entries — they reflect stale exceptions to the integrity policy.'
-        ].join('\n')
-    );
-});
+        assert.strictEqual(
+            message,
+            [
+                'Refusing to publish: 1 entry in dependencyPolicy.allowMutableSpecifiers is not in use:',
+                '  - "old-vendored-pkg"',
+                'Remove unused entries — they reflect stale exceptions to the integrity policy.'
+            ].join('\n')
+        );
+    });
 
-test('renderUnusedAllowListMessage uses the plural noun and verb for multiple entries', () => {
-    const message = renderUnusedAllowListMessage(['old-vendored-pkg', 'still-clean-now']);
+    test('renderUnusedAllowListMessage uses the plural noun and verb for multiple entries', function () {
+        const message = renderUnusedAllowListMessage(['old-vendored-pkg', 'still-clean-now']);
 
-    assert.strictEqual(
-        message,
-        [
-            'Refusing to publish: 2 entries in dependencyPolicy.allowMutableSpecifiers are not in use:',
-            '  - "old-vendored-pkg"',
-            '  - "still-clean-now"',
-            'Remove unused entries — they reflect stale exceptions to the integrity policy.'
-        ].join('\n')
-    );
+        assert.strictEqual(
+            message,
+            [
+                'Refusing to publish: 2 entries in dependencyPolicy.allowMutableSpecifiers are not in use:',
+                '  - "old-vendored-pkg"',
+                '  - "still-clean-now"',
+                'Remove unused entries — they reflect stale exceptions to the integrity policy.'
+            ].join('\n')
+        );
+    });
 });

--- a/source/version-manager/versioned-bundle.test.ts
+++ b/source/version-manager/versioned-bundle.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { test } from 'mocha';
+import { suite, test } from 'mocha';
 import {
     analyzedBundle as createAnalyzedBundle,
     analyzedBundleResource,
@@ -56,103 +56,105 @@ function assertCliMainFile(result: ReturnType<typeof buildVersionedBundle>): voi
     });
 }
 
-test('buildVersionedBundle() uses the representative root as the main and types files', () => {
-    const result = buildVersionedBundle(buildOptions({ additionalPackageJsonAttributes: { custom: true } }));
+suite('versioned-bundle', function () {
+    test('buildVersionedBundle() uses the representative root as the main and types files', function () {
+        const result = buildVersionedBundle(buildOptions({ additionalPackageJsonAttributes: { custom: true } }));
 
-    assert.deepStrictEqual(result, standardVersionedBundle({ additionalAttributes: { custom: true } }));
-});
+        assert.deepStrictEqual(result, standardVersionedBundle({ additionalAttributes: { custom: true } }));
+    });
 
-test('buildVersionedBundle() groups bundle dependencies and peer dependencies by package name', () => {
-    const result = buildVersionedBundle(
-        buildOptions({
-            bundle: createAnalyzedBundle({
-                linkedBundleDependencies: new Map([
-                    ['bundle-dependency', createReferencedDependency('bundle-dependency')],
-                    ['peer-dependency', createReferencedDependency('peer-dependency')]
-                ])
-            }),
-            bundleDependencies: [
-                versionedBundle({
-                    name: 'bundle-dependency',
-                    version: '2.0.0',
-                    mainFile: { sourceFilePath: '/src/dep.js', targetFilePath: 'dep.js' }
-                })
-            ],
-            bundlePeerDependencies: [
-                versionedBundle({
-                    name: 'peer-dependency',
-                    version: '3.0.0',
-                    mainFile: { sourceFilePath: '/src/peer.js', targetFilePath: 'peer.js' }
-                })
-            ]
-        })
-    );
-
-    assert.deepStrictEqual(result.dependencies, { 'bundle-dependency': '2.0.0' });
-    assert.deepStrictEqual(result.peerDependencies, { 'peer-dependency': '3.0.0' });
-});
-
-test('buildVersionedBundle() omits the importsField when no #imports survive', () => {
-    const result = buildVersionedBundle(buildOptions());
-
-    assert.strictEqual(result.importsField, undefined);
-});
-
-test('buildVersionedBundle() exposes the bin field and omits typesMainFile for an explicit bin-only surface', () => {
-    const result = buildVersionedBundle(
-        buildOptions({
-            bundle: explicitCliBundle({ bins: [{ root: 'cli', name: 'package-a' }] })
-        })
-    );
-
-    assertCliMainFile(result);
-    assert.deepStrictEqual(result.binField, { 'package-a': './cli.js' });
-    assert.strictEqual(Object.hasOwn(result, 'binField'), true);
-    assert.strictEqual(Object.hasOwn(result, 'typesMainFile'), false);
-});
-
-test('buildVersionedBundle() throws when an implicit surface references an unknown defaultModuleRoot', () => {
-    assert.throws(() => {
-        buildVersionedBundle(
+    test('buildVersionedBundle() groups bundle dependencies and peer dependencies by package name', function () {
+        const result = buildVersionedBundle(
             buildOptions({
                 bundle: createAnalyzedBundle({
-                    roots: {},
-                    surface: { mode: 'implicit', defaultModuleRoot: 'missing' }
-                })
-            })
-        );
-    }, /^Error: Package "package-a" references unknown root "missing"$/u);
-});
-
-test('buildVersionedBundle() throws when an explicit module entry references an unknown root', () => {
-    assert.throws(() => {
-        buildVersionedBundle(
-            buildOptions({
-                bundle: createAnalyzedBundle({
-                    roots: {},
-                    surface: {
-                        mode: 'explicit',
-                        packageInterface: { modules: [{ root: 'missing', export: '.' }] }
-                    }
-                })
-            })
-        );
-    }, /^Error: Package "package-a" references unknown root "missing"$/u);
-});
-
-test('buildVersionedBundle() exposes the imports field for surviving #imports specifiers', () => {
-    const result = buildVersionedBundle(
-        buildOptions({
-            bundle: createAnalyzedBundle({
-                contents: [
-                    analyzedBundleResource('/src/index.js', {
-                        content: 'export { foo } from "#foo";\n'
+                    linkedBundleDependencies: new Map([
+                        ['bundle-dependency', createReferencedDependency('bundle-dependency')],
+                        ['peer-dependency', createReferencedDependency('peer-dependency')]
+                    ])
+                }),
+                bundleDependencies: [
+                    versionedBundle({
+                        name: 'bundle-dependency',
+                        version: '2.0.0',
+                        mainFile: { sourceFilePath: '/src/dep.js', targetFilePath: 'dep.js' }
+                    })
+                ],
+                bundlePeerDependencies: [
+                    versionedBundle({
+                        name: 'peer-dependency',
+                        version: '3.0.0',
+                        mainFile: { sourceFilePath: '/src/peer.js', targetFilePath: 'peer.js' }
                     })
                 ]
-            }),
-            mainPackageJson: { type: 'module', imports: { '#foo': './src/foo.js' } }
-        })
-    );
+            })
+        );
 
-    assert.deepStrictEqual(result.importsField, { '#foo': './src/foo.js' });
+        assert.deepStrictEqual(result.dependencies, { 'bundle-dependency': '2.0.0' });
+        assert.deepStrictEqual(result.peerDependencies, { 'peer-dependency': '3.0.0' });
+    });
+
+    test('buildVersionedBundle() omits the importsField when no #imports survive', function () {
+        const result = buildVersionedBundle(buildOptions());
+
+        assert.strictEqual(result.importsField, undefined);
+    });
+
+    test('buildVersionedBundle() exposes the bin field and omits typesMainFile for an explicit bin-only surface', function () {
+        const result = buildVersionedBundle(
+            buildOptions({
+                bundle: explicitCliBundle({ bins: [{ root: 'cli', name: 'package-a' }] })
+            })
+        );
+
+        assertCliMainFile(result);
+        assert.deepStrictEqual(result.binField, { 'package-a': './cli.js' });
+        assert.strictEqual(Object.hasOwn(result, 'binField'), true);
+        assert.strictEqual(Object.hasOwn(result, 'typesMainFile'), false);
+    });
+
+    test('buildVersionedBundle() throws when an implicit surface references an unknown defaultModuleRoot', function () {
+        assert.throws(() => {
+            buildVersionedBundle(
+                buildOptions({
+                    bundle: createAnalyzedBundle({
+                        roots: {},
+                        surface: { mode: 'implicit', defaultModuleRoot: 'missing' }
+                    })
+                })
+            );
+        }, /^Error: Package "package-a" references unknown root "missing"$/u);
+    });
+
+    test('buildVersionedBundle() throws when an explicit module entry references an unknown root', function () {
+        assert.throws(() => {
+            buildVersionedBundle(
+                buildOptions({
+                    bundle: createAnalyzedBundle({
+                        roots: {},
+                        surface: {
+                            mode: 'explicit',
+                            packageInterface: { modules: [{ root: 'missing', export: '.' }] }
+                        }
+                    })
+                })
+            );
+        }, /^Error: Package "package-a" references unknown root "missing"$/u);
+    });
+
+    test('buildVersionedBundle() exposes the imports field for surviving #imports specifiers', function () {
+        const result = buildVersionedBundle(
+            buildOptions({
+                bundle: createAnalyzedBundle({
+                    contents: [
+                        analyzedBundleResource('/src/index.js', {
+                            content: 'export { foo } from "#foo";\n'
+                        })
+                    ]
+                }),
+                mainPackageJson: { type: 'module', imports: { '#foo': './src/foo.js' } }
+            })
+        );
+
+        assert.deepStrictEqual(result.importsField, { '#foo': './src/foo.js' });
+    });
 });


### PR DESCRIPTION
The mocha settings override in eslint.config.js set `interface: 'TDD'` while every test file uses exports-style imports (`import { test } from 'mocha'`). `eslint-plugin-mocha` switches discovery strategies on that setting and only matches imported references when interface is `'exports'`, so the entire mocha rule set silently no-op'd — including `no-global-tests`, which is why no error was ever raised for the 2,550+ top-level `test()` calls across 295 files.

Drop the bogus override (the preset already configures `'exports'`), wrap every test file in `suite('<basename>', function () {...})`, and mirror the upcoming `@enormora/eslint-config-mocha` default by disabling `mocha/no-setup-in-describe` locally — the codebase's `checkValidationSuccess({...})` factory pattern is intentionally describe-time work that builds closures, and that rule will be off by default in the next preset release.