### PR TITLE
Add zip artifact builder

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -15,6 +15,9 @@
         "sonarjs",
         "EUSAGE",
         "cyclonedx",
-        "canonicalizer"
+        "canonicalizer",
+        "fflate",
+        "Flate",
+        "Zippable"
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "cmd-ts": "0.15.0",
                 "common-tags": "1.8.2",
                 "diff": "9.0.0",
+                "fflate": "0.8.3",
                 "hosted-git-info": "10.1.1",
                 "libnpmpublish": "11.2.0",
                 "npm-package-arg": "14.0.0",
@@ -3034,9 +3035,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3054,9 +3052,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3074,9 +3069,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3094,9 +3086,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3114,9 +3103,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3134,9 +3120,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3154,9 +3137,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3174,9 +3154,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3389,9 +3366,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3406,9 +3380,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3423,9 +3394,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3440,9 +3408,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3457,9 +3422,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3474,9 +3436,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3491,9 +3450,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3508,9 +3464,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4648,9 +4601,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4665,9 +4615,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4682,9 +4629,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4699,9 +4643,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4716,9 +4657,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4733,9 +4671,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4750,9 +4685,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4767,9 +4699,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -8628,6 +8557,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+            "license": "MIT"
         },
         "node_modules/figures": {
             "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "cmd-ts": "0.15.0",
         "common-tags": "1.8.2",
         "diff": "9.0.0",
+        "fflate": "0.8.3",
         "hosted-git-info": "10.1.1",
         "libnpmpublish": "11.2.0",
         "npm-package-arg": "14.0.0",

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { AnalyzedBundleResource } from '../dead-code-eliminator/analyzed-bundle.ts';
-import { createProgressBroadcaster } from '../progress/progress-broadcaster.ts';
+import { createProgressBroadcaster, type ArtifactEntry } from '../progress/progress-broadcaster.ts';
 import { createSpyingBroadcaster } from '../test-libraries/result-helpers.ts';
 import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
@@ -334,18 +334,37 @@ suite('artifacts-builder', function () {
         });
     });
 
+    function buildEmptyArtifactDependencies(
+        progressBroadcaster: ArtifactsBuilderDependencies['progressBroadcaster']
+    ): ArtifactsBuilderDependencies {
+        return {
+            fileManager: createFakeFileManager(),
+            tarballBuilder: { build: fake.resolves(Buffer.from([])) },
+            zipBuilder: { build: fake.resolves(Buffer.from([])) },
+            progressBroadcaster
+        };
+    }
+
+    function captureArtifactEntries<TProjected>(
+        broadcaster: ReturnType<typeof createProgressBroadcaster>,
+        project: (entry: ArtifactEntry) => TProjected
+    ): readonly { readonly entries: readonly TProjected[] }[] {
+        const received: { readonly entries: readonly TProjected[] }[] = [];
+        broadcaster.consumer.on('artifactsCollected', (payload) => {
+            received.push({ entries: payload.entries.map(project) });
+        });
+        return received;
+    }
+
     function artifactsBuilderWithBroadcaster(): {
         readonly builder: ArtifactsBuilder;
         readonly broadcaster: ReturnType<typeof createProgressBroadcaster>;
     } {
         const broadcaster = createProgressBroadcaster();
-        const dependencies: ArtifactsBuilderDependencies = {
-            fileManager: createFakeFileManager(),
-            tarballBuilder: { build: fake.resolves(Buffer.from([])) },
-            zipBuilder: { build: fake.resolves(Buffer.from([])) },
-            progressBroadcaster: broadcaster.provider
+        return {
+            builder: createArtifactsBuilder(buildEmptyArtifactDependencies(broadcaster.provider)),
+            broadcaster
         };
-        return { builder: createArtifactsBuilder(dependencies), broadcaster };
     }
 
     test('collectContents() emits an artifactsCollected event with the package name when a subscriber is registered', function () {
@@ -362,29 +381,15 @@ suite('artifacts-builder', function () {
 
     test('collectContents() emits artifact entries with size and kind classification', function () {
         const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
-        const received: {
-            entries: readonly {
-                path: string;
-                sizeBytes: number;
-                kind: string;
-                sourcePath?: string;
-                status: string;
-                badges: readonly string[];
-            }[];
-        }[] = [];
-        broadcaster.consumer.on('artifactsCollected', (payload) => {
-            received.push({
-                entries: payload.entries.map((entry) => {
-                    return {
-                        path: entry.path,
-                        sizeBytes: entry.sizeBytes,
-                        kind: entry.kind,
-                        ...(entry.sourcePath === undefined ? {} : { sourcePath: entry.sourcePath }),
-                        status: entry.status,
-                        badges: entry.badges
-                    };
-                })
-            });
+        const received = captureArtifactEntries(broadcaster, (entry) => {
+            return {
+                path: entry.path,
+                sizeBytes: entry.sizeBytes,
+                kind: entry.kind,
+                ...(entry.sourcePath === undefined ? {} : { sourcePath: entry.sourcePath }),
+                status: entry.status,
+                badges: entry.badges
+            };
         });
 
         builder.collectContents(bundleWithContents([makeContent('a.js', 'abc', true)], 'package.json'));
@@ -408,15 +413,8 @@ suite('artifacts-builder', function () {
 
     test('collectContents() emits extra generated files in artifactsCollected when subscribed', function () {
         const { builder, broadcaster } = artifactsBuilderWithBroadcaster();
-        const received: {
-            entries: readonly { path: string; status: string; kind: string }[];
-        }[] = [];
-        broadcaster.consumer.on('artifactsCollected', (payload) => {
-            received.push({
-                entries: payload.entries.map((entry) => {
-                    return { path: entry.path, status: entry.status, kind: entry.kind };
-                })
-            });
+        const received = captureArtifactEntries(broadcaster, (entry) => {
+            return { path: entry.path, status: entry.status, kind: entry.kind };
         });
 
         builder.collectContents(bundleWithContents([], 'package.json'), undefined, [
@@ -435,13 +433,7 @@ suite('artifacts-builder', function () {
 
     test('collectContents() does NOT emit artifactsCollected when no subscriber is registered', function () {
         const spying = createSpyingBroadcaster();
-        const dependencies: ArtifactsBuilderDependencies = {
-            fileManager: createFakeFileManager(),
-            tarballBuilder: { build: fake.resolves(Buffer.from([])) },
-            zipBuilder: { build: fake.resolves(Buffer.from([])) },
-            progressBroadcaster: spying.provider
-        };
-        const builder = createArtifactsBuilder(dependencies);
+        const builder = createArtifactsBuilder(buildEmptyArtifactDependencies(spying.provider));
 
         builder.collectContents(bundleWithContents([], 'package.json'));
 

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -40,11 +40,10 @@ function bundleWithExplicitBin(
 type Overrides = {
     readonly fileManager?: FakeFileManager;
     readonly tarballBuilder?: { readonly build?: SinonSpy };
+    readonly zipBuilder?: { readonly build?: SinonSpy };
 };
 
-function createTarballBuilderDependencies(overrides: Overrides['tarballBuilder'] = {}): {
-    readonly build: SinonSpy;
-} {
+function createBuildStub(overrides: { readonly build?: SinonSpy } = {}): { readonly build: SinonSpy } {
     return {
         build: overrides.build ?? fake.resolves(Buffer.from([-1]))
     };
@@ -57,7 +56,8 @@ function artifactsBuilderFactory(overrides: Overrides = {}): {
     const fileManager = overrides.fileManager ?? createFakeFileManager();
     const dependencies: ArtifactsBuilderDependencies = {
         fileManager,
-        tarballBuilder: createTarballBuilderDependencies(overrides.tarballBuilder),
+        tarballBuilder: createBuildStub(overrides.tarballBuilder),
+        zipBuilder: createBuildStub(overrides.zipBuilder),
         progressBroadcaster: {
             emit: (): void => undefined,
             hasSubscribers: (): boolean => false
@@ -273,6 +273,53 @@ suite('artifacts-builder', function () {
         ]);
     });
 
+    test('buildZip() returns the zipData', async function () {
+        const zipBuilder = { build: fake.resolves(Buffer.from([42])) };
+        const { builder } = artifactsBuilderFactory({ zipBuilder });
+        const result = await builder.buildZip(bundleWithContents([]));
+
+        assert.deepStrictEqual(result, {
+            zipData: Buffer.from([42])
+        });
+    });
+
+    test('buildZip() passes all given contents to the zipBuilder without applying a path prefix', async function () {
+        const zipBuilder = { build: fake.resolves(Buffer.from([])) };
+        const { builder } = artifactsBuilderFactory({ zipBuilder });
+        const contents: AnalyzedBundleResource[] = [
+            makeContent('handler.js', 'handler'),
+            makeContent('lib/helper.js', 'helper'),
+            makeContent('lib/cli.js', 'cli', true)
+        ];
+        await builder.buildZip(bundleWithContents(contents, 'manifest.json'));
+
+        assert.strictEqual(zipBuilder.build.callCount, 1);
+        assert.deepStrictEqual(zipBuilder.build.firstCall.args, [
+            [
+                { filePath: 'manifest.json', content: '{}', isExecutable: false },
+                { filePath: 'handler.js', content: 'handler', isExecutable: false },
+                { filePath: 'lib/helper.js', content: 'helper', isExecutable: false },
+                { filePath: 'lib/cli.js', content: 'cli', isExecutable: false }
+            ]
+        ]);
+    });
+
+    test('buildZip() forwards extra files to the zip builder alongside the bundle contents', async function () {
+        const zipBuilder = { build: fake.resolves(Buffer.from([])) };
+        const { builder } = artifactsBuilderFactory({ zipBuilder });
+        await builder.buildZip(bundleWithContents([makeContent('handler.js', 'handler')], 'manifest.json'), [
+            { filePath: 'extra.json', content: '{"kind":"extra"}', isExecutable: false }
+        ]);
+
+        assert.deepStrictEqual(zipBuilder.build.firstCall.args, [
+            [
+                { filePath: 'manifest.json', content: '{}', isExecutable: false },
+                { filePath: 'handler.js', content: 'handler', isExecutable: false },
+                { filePath: 'extra.json', content: '{"kind":"extra"}', isExecutable: false }
+            ]
+        ]);
+    });
+
     test('buildFolder() writes extra files alongside the bundle contents into the target folder', async function () {
         const { builder, fileManager } = builderWithUnreadableTargetFolder();
 
@@ -295,6 +342,7 @@ suite('artifacts-builder', function () {
         const dependencies: ArtifactsBuilderDependencies = {
             fileManager: createFakeFileManager(),
             tarballBuilder: { build: fake.resolves(Buffer.from([])) },
+            zipBuilder: { build: fake.resolves(Buffer.from([])) },
             progressBroadcaster: broadcaster.provider
         };
         return { builder: createArtifactsBuilder(dependencies), broadcaster };
@@ -390,6 +438,7 @@ suite('artifacts-builder', function () {
         const dependencies: ArtifactsBuilderDependencies = {
             fileManager: createFakeFileManager(),
             tarballBuilder: { build: fake.resolves(Buffer.from([])) },
+            zipBuilder: { build: fake.resolves(Buffer.from([])) },
             progressBroadcaster: spying.provider
         };
         const builder = createArtifactsBuilder(dependencies);

--- a/source/artifacts/artifacts-builder.ts
+++ b/source/artifacts/artifacts-builder.ts
@@ -4,17 +4,23 @@ import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster
 import type { ArtifactSourcePackage } from '../published-package/published-package.ts';
 import { inspectArtifactSizes } from '../report/inspectors/inspect-artifact-sizes.ts';
 import type { TarballBuilder } from '../tar/tarball-builder.ts';
+import type { ZipBuilder } from '../zip/zip-builder.ts';
 import { collectArtifactContents, describeArtifactsForReport } from './content-collection.ts';
 import { writeArtifactsToFolder } from './folder-writer.ts';
 
 export type ArtifactsBuilderDependencies = {
     readonly fileManager: FileManager;
     readonly tarballBuilder: TarballBuilder;
+    readonly zipBuilder: ZipBuilder;
     readonly progressBroadcaster: ProgressBroadcastProvider;
 };
 
 type TarballArtifact = {
     readonly tarData: Buffer;
+};
+
+type ZipArtifact = {
+    readonly zipData: Buffer;
 };
 
 export type ArtifactsBuilder = {
@@ -24,6 +30,7 @@ export type ArtifactsBuilder = {
         extraFiles?: readonly FileDescription[]
     ) => readonly FileDescription[];
     buildTarball: (bundle: ArtifactSourcePackage, extraFiles?: readonly FileDescription[]) => Promise<TarballArtifact>;
+    buildZip: (bundle: ArtifactSourcePackage, extraFiles?: readonly FileDescription[]) => Promise<ZipArtifact>;
     buildFolder: (
         bundle: ArtifactSourcePackage,
         targetFolder: string,
@@ -32,7 +39,7 @@ export type ArtifactsBuilder = {
 };
 
 export function createArtifactsBuilder(dependencies: ArtifactsBuilderDependencies): ArtifactsBuilder {
-    const { fileManager, tarballBuilder, progressBroadcaster } = dependencies;
+    const { fileManager, tarballBuilder, zipBuilder, progressBroadcaster } = dependencies;
 
     function collectContents(
         bundle: ArtifactSourcePackage,
@@ -58,6 +65,12 @@ export function createArtifactsBuilder(dependencies: ArtifactsBuilderDependencie
             const contents = collectContents(bundle, 'package', extraFiles);
             const tarData = await tarballBuilder.build(contents);
             return { tarData };
+        },
+
+        async buildZip(bundle, extraFiles) {
+            const contents = collectContents(bundle, undefined, extraFiles);
+            const zipData = await zipBuilder.build(contents);
+            return { zipData };
         },
 
         async buildFolder(bundle, targetFolder, extraFiles) {

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -37,7 +37,8 @@ function emitterFactory(overrides: Overrides = {}): BundleEmitter {
             collectContents: createSpy(overrides.collectContents, () => {
                 return fake.resolves([]);
             }),
-            buildFolder: fake()
+            buildFolder: fake(),
+            buildZip: fake()
         },
         registryClient: {
             publishPackage: createSpy(overrides.publishPackage, fake),

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -21,6 +21,7 @@ import { createProgressBroadcaster, type ProgressBroadcaster } from '../progress
 import { withStageTimings } from '../report/decorators.ts';
 import { createResourceResolver, type ResourceResolver } from '../resource-resolver/resource-resolver.ts';
 import { createTarballBuilder } from '../tar/tarball-builder.ts';
+import { createZipBuilder } from '../zip/zip-builder.ts';
 import { createVersionManager } from '../version-manager/manager.ts';
 import { createClock, type Clock } from '../common/clock.ts';
 import { createNpmOidcIdTokenResolver } from '../npm-oidc-id-token-resolver.ts';
@@ -133,6 +134,7 @@ function buildCompositionParts(options: PackageProcessorCompositionOptions): Com
     const artifactsBuilder = createArtifactsBuilder({
         fileManager,
         tarballBuilder: createTarballBuilder(),
+        zipBuilder: createZipBuilder(),
         progressBroadcaster: progressBroadcaster.provider
     });
     return {

--- a/source/test-libraries/extract-zip.ts
+++ b/source/test-libraries/extract-zip.ts
@@ -1,0 +1,101 @@
+import { unzip, type FlateError, type Unzipped } from 'fflate';
+
+export type ZipEntry = {
+    readonly name: string;
+    readonly content: string;
+    readonly unixMode: number;
+    readonly osOfOrigin: number;
+};
+
+type CentralDirectoryEntry = {
+    readonly name: string;
+    readonly osOfOrigin: number;
+    readonly unixMode: number;
+    readonly nextOffset: number;
+};
+
+const endOfCentralDirectorySignature = 101_010_256;
+const centralDirectoryEntrySignature = 33_639_248;
+const endOfCentralDirectoryLength = 22;
+const centralDirectoryEntryHeaderLength = 46;
+const totalEntriesOffset = 10;
+const centralDirectoryStartOffset = 16;
+const versionMadeByHighByteOffset = 5;
+const fileNameLengthOffset = 28;
+const extraFieldLengthOffset = 30;
+const fileCommentLengthOffset = 32;
+const externalAttributesOffset = 38;
+const highBytesScale = 65_536;
+
+function findEndOfCentralDirectory(buffer: Buffer): number {
+    for (let offset = buffer.length - endOfCentralDirectoryLength; offset >= 0; offset -= 1) {
+        if (buffer.readUInt32LE(offset) === endOfCentralDirectorySignature) {
+            return offset;
+        }
+    }
+    throw new Error('end of central directory record not found in zip buffer');
+}
+
+function readCentralDirectoryEntry(buffer: Buffer, offset: number): CentralDirectoryEntry {
+    if (buffer.readUInt32LE(offset) !== centralDirectoryEntrySignature) {
+        throw new Error(`invalid central directory entry signature at offset ${offset}`);
+    }
+    const osOfOrigin = buffer.readUInt8(offset + versionMadeByHighByteOffset);
+    const fileNameLength = buffer.readUInt16LE(offset + fileNameLengthOffset);
+    const extraFieldLength = buffer.readUInt16LE(offset + extraFieldLengthOffset);
+    const fileCommentLength = buffer.readUInt16LE(offset + fileCommentLengthOffset);
+    const externalFileAttributes = buffer.readUInt32LE(offset + externalAttributesOffset);
+    const nameStart = offset + centralDirectoryEntryHeaderLength;
+    const name = buffer.toString('utf8', nameStart, nameStart + fileNameLength);
+    return {
+        name,
+        osOfOrigin,
+        unixMode: Math.floor(externalFileAttributes / highBytesScale),
+        nextOffset: nameStart + fileNameLength + extraFieldLength + fileCommentLength
+    };
+}
+
+function readCentralDirectoryMetadata(buffer: Buffer): Map<string, CentralDirectoryEntry> {
+    const endOfCentralDirectoryOffset = findEndOfCentralDirectory(buffer);
+    const numberOfEntries = buffer.readUInt16LE(endOfCentralDirectoryOffset + totalEntriesOffset);
+    const centralDirectoryOffset = buffer.readUInt32LE(endOfCentralDirectoryOffset + centralDirectoryStartOffset);
+
+    const metadataByName = new Map<string, CentralDirectoryEntry>();
+    let offset = centralDirectoryOffset;
+    for (let index = 0; index < numberOfEntries; index += 1) {
+        const entry = readCentralDirectoryEntry(buffer, offset);
+        metadataByName.set(entry.name, entry);
+        offset = entry.nextOffset;
+    }
+    return metadataByName;
+}
+
+async function decodeZipContents(buffer: Buffer): Promise<Unzipped> {
+    return await new Promise<Unzipped>((resolve, reject) => {
+        const data = new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+        unzip(data, (error: FlateError | null, decoded: Unzipped) => {
+            if (error === null) {
+                resolve(decoded);
+                return;
+            }
+            reject(error);
+        });
+    });
+}
+
+export async function extractZipEntries(buffer: Buffer): Promise<readonly ZipEntry[]> {
+    const decoded = await decodeZipContents(buffer);
+    const metadataByName = readCentralDirectoryMetadata(buffer);
+    return Object.entries(decoded).map(([name, data]) => {
+        const metadata = metadataByName.get(name);
+        if (metadata === undefined) {
+            throw new Error(`zip entry "${name}" is missing from the central directory`);
+        }
+        return {
+            name,
+            content: new TextDecoder().decode(data),
+            unixMode: metadata.unixMode,
+            osOfOrigin: metadata.osOfOrigin
+        };
+    });
+}

--- a/source/zip/zip-builder.test.ts
+++ b/source/zip/zip-builder.test.ts
@@ -94,8 +94,9 @@ suite('zip-builder', function () {
     });
 
     test('passes the static modification time, unix os marker and maximum compression to fflate', async function () {
-        const zip =
-            sinon.spy<(data: AsyncZippable, options: AsyncZipOptions, callback: FlateCallback) => unknown>(fflateZip);
+        const zip = sinon.spy((data: AsyncZippable, options: AsyncZipOptions, callback: FlateCallback): void => {
+            fflateZip(data, options, callback);
+        });
         const builder = createZipBuilder({ zip });
 
         await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);

--- a/source/zip/zip-builder.test.ts
+++ b/source/zip/zip-builder.test.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import sinon from 'sinon';
+import {
+    zip as fflateZip,
+    type AsyncZippable,
+    type AsyncZipOptions,
+    type FlateCallback,
+    type FlateError
+} from 'fflate';
+import { extractZipEntries } from '../test-libraries/extract-zip.ts';
+import { createZipBuilder } from './zip-builder.ts';
+
+const nonExecutableUnixMode = 0o10_0644;
+const executableUnixMode = 0o10_0755;
+const unixOperatingSystem = 3;
+const staticFileModificationTime = new Date(Date.UTC(1980, 0, 1, 12, 0, 0));
+const maxCompressionLevel = 9;
+const highBytesScale = 65_536;
+
+suite('zip-builder', function () {
+    test('creates an empty zip', async function () {
+        const builder = createZipBuilder();
+        const zipBuffer = await builder.build([]);
+        const entries = await extractZipEntries(zipBuffer);
+
+        assert.deepStrictEqual(entries, []);
+    });
+
+    test('creates a zip with one file', async function () {
+        const builder = createZipBuilder();
+
+        const zipBuffer = await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
+        const entries = await extractZipEntries(zipBuffer);
+
+        assert.deepStrictEqual(entries, [
+            {
+                name: 'foo.txt',
+                content: 'bar',
+                unixMode: nonExecutableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            }
+        ]);
+    });
+
+    test('marks executable files with the executable unix mode', async function () {
+        const builder = createZipBuilder();
+
+        const zipBuffer = await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: true }]);
+        const entries = await extractZipEntries(zipBuffer);
+
+        assert.deepStrictEqual(entries, [
+            {
+                name: 'foo.txt',
+                content: 'bar',
+                unixMode: executableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            }
+        ]);
+    });
+
+    test('creates a zip with many nested files', async function () {
+        const builder = createZipBuilder();
+
+        const zipBuffer = await builder.build([
+            { filePath: 'root.md', content: 'root', isExecutable: false },
+            { filePath: 'docs/intro.md', content: 'intro', isExecutable: false },
+            { filePath: 'docs/api/index.md', content: 'index', isExecutable: false },
+            { filePath: 'docs/api/v1/get.md', content: 'get', isExecutable: false }
+        ]);
+        const entries = await extractZipEntries(zipBuffer);
+
+        assert.deepStrictEqual(entries, [
+            { name: 'root.md', content: 'root', unixMode: nonExecutableUnixMode, osOfOrigin: unixOperatingSystem },
+            {
+                name: 'docs/intro.md',
+                content: 'intro',
+                unixMode: nonExecutableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            },
+            {
+                name: 'docs/api/index.md',
+                content: 'index',
+                unixMode: nonExecutableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            },
+            {
+                name: 'docs/api/v1/get.md',
+                content: 'get',
+                unixMode: nonExecutableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            }
+        ]);
+    });
+
+    test('passes the static modification time, unix os marker and maximum compression to fflate', async function () {
+        const zip =
+            sinon.spy<(data: AsyncZippable, options: AsyncZipOptions, callback: FlateCallback) => unknown>(fflateZip);
+        const builder = createZipBuilder({ zip });
+
+        await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
+
+        const [data, options] = zip.firstCall.args;
+        assert.deepStrictEqual(data, {
+            'foo.txt': [
+                new TextEncoder().encode('bar'),
+                {
+                    os: unixOperatingSystem,
+                    attrs: nonExecutableUnixMode * highBytesScale,
+                    mtime: staticFileModificationTime,
+                    level: maxCompressionLevel
+                }
+            ]
+        });
+        assert.deepStrictEqual(options, {});
+    });
+
+    test('rejects when fflate reports an error', async function () {
+        const errorFromFflate: FlateError = Object.assign(new Error('fflate-failure'), {
+            code: 99 as FlateError['code']
+        });
+        const failingZip = (_data: AsyncZippable, _options: AsyncZipOptions, callback: FlateCallback): void => {
+            queueMicrotask(() => {
+                callback(errorFromFflate, new Uint8Array());
+            });
+        };
+        const builder = createZipBuilder({ zip: failingZip });
+
+        try {
+            await builder.build([{ filePath: 'foo.txt', content: 'bar', isExecutable: false }]);
+            assert.fail('Expected build() to reject but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(error, errorFromFflate);
+        }
+    });
+});

--- a/source/zip/zip-builder.test.ts
+++ b/source/zip/zip-builder.test.ts
@@ -14,7 +14,7 @@ import { createZipBuilder } from './zip-builder.ts';
 const nonExecutableUnixMode = 0o10_0644;
 const executableUnixMode = 0o10_0755;
 const unixOperatingSystem = 3;
-const staticFileModificationTime = new Date(Date.UTC(1980, 0, 1, 12, 0, 0));
+const staticFileModificationTimestamp = 315_576_000_000;
 const maxCompressionLevel = 9;
 const highBytesScale = 65_536;
 
@@ -108,7 +108,7 @@ suite('zip-builder', function () {
                 {
                     os: unixOperatingSystem,
                     attrs: nonExecutableUnixMode * highBytesScale,
-                    mtime: staticFileModificationTime,
+                    mtime: staticFileModificationTimestamp,
                     level: maxCompressionLevel
                 }
             ]

--- a/source/zip/zip-builder.ts
+++ b/source/zip/zip-builder.ts
@@ -1,0 +1,62 @@
+import { promisify } from 'node:util';
+import { zip as fflateZip, type AsyncZippable, type AsyncZipOptions, type FlateCallback } from 'fflate';
+import type { FileDescription } from '../file-manager/file-description.ts';
+
+type AsyncZipFunction = (data: AsyncZippable, options: AsyncZipOptions, callback: FlateCallback) => void;
+type PromisifiedZip = (data: AsyncZippable, options: AsyncZipOptions) => Promise<Uint8Array>;
+
+export type ZipBuilder = {
+    build: (fileDescriptions: readonly FileDescription[]) => Promise<Buffer>;
+};
+
+type ZipBuilderDependencies = {
+    readonly zip: AsyncZipFunction;
+};
+
+const unixOperatingSystem = 3;
+const regularFileMarker = 0o10_0000;
+const executablePermissionBits = 0o755;
+const nonExecutablePermissionBits = 0o644;
+const executableUnixMode = regularFileMarker + executablePermissionBits;
+const nonExecutableUnixMode = regularFileMarker + nonExecutablePermissionBits;
+const highBytesScale = 65_536;
+const maxCompressionLevel = 9;
+const minimumDosYear = 1980;
+const safeUtcHour = 12;
+const staticFileModificationTime = new Date(Date.UTC(minimumDosYear, 0, 1, safeUtcHour, 0, 0));
+
+function externalAttributes(isExecutable: boolean): number {
+    return (isExecutable ? executableUnixMode : nonExecutableUnixMode) * highBytesScale;
+}
+
+function buildFileEntry(fileDescription: FileDescription): [Uint8Array, AsyncZipOptions] {
+    return [
+        new TextEncoder().encode(fileDescription.content),
+        {
+            os: unixOperatingSystem,
+            attrs: externalAttributes(fileDescription.isExecutable),
+            mtime: staticFileModificationTime,
+            level: maxCompressionLevel
+        }
+    ];
+}
+
+function toFileMap(fileDescriptions: readonly FileDescription[]): AsyncZippable {
+    const fileMap: AsyncZippable = {};
+    for (const fileDescription of fileDescriptions) {
+        fileMap[fileDescription.filePath] = buildFileEntry(fileDescription);
+    }
+    return fileMap;
+}
+
+export function createZipBuilder(dependencies: Partial<ZipBuilderDependencies> = {}): ZipBuilder {
+    const zip = dependencies.zip ?? fflateZip;
+    const runZip: PromisifiedZip = promisify(zip);
+
+    return {
+        async build(fileDescriptions) {
+            const data = await runZip(toFileMap(fileDescriptions), {});
+            return Buffer.from(data);
+        }
+    };
+}

--- a/source/zip/zip-builder.ts
+++ b/source/zip/zip-builder.ts
@@ -14,16 +14,14 @@ type ZipBuilderDependencies = {
 };
 
 const unixOperatingSystem = 3;
-const regularFileMarker = 0o10_0000;
-const executablePermissionBits = 0o755;
-const nonExecutablePermissionBits = 0o644;
-const executableUnixMode = regularFileMarker + executablePermissionBits;
-const nonExecutableUnixMode = regularFileMarker + nonExecutablePermissionBits;
+const executableUnixMode = 0o10_0755;
+const nonExecutableUnixMode = 0o10_0644;
 const highBytesScale = 65_536;
 const maxCompressionLevel = 9;
-const minimumDosYear = 1980;
-const safeUtcHour = 12;
-const staticFileModificationTime = new Date(Date.UTC(minimumDosYear, 0, 1, safeUtcHour, 0, 0));
+// 1980-01-01T12:00:00Z. Zip's DOS time format requires year >= 1980; the noon offset keeps
+// `getFullYear()` at 1980 across all timezones. Kept as a plain literal so the module has no
+// load-time side effects (tree-shake-friendly).
+const staticFileModificationTimestamp = 315_576_000_000;
 
 function externalAttributes(isExecutable: boolean): number {
     return (isExecutable ? executableUnixMode : nonExecutableUnixMode) * highBytesScale;
@@ -35,7 +33,7 @@ function buildFileEntry(fileDescription: FileDescription): [Uint8Array, AsyncZip
         {
             os: unixOperatingSystem,
             attrs: externalAttributes(fileDescription.isExecutable),
-            mtime: staticFileModificationTime,
+            mtime: staticFileModificationTimestamp,
             level: maxCompressionLevel
         }
     ];


### PR DESCRIPTION
## Summary

First slice of the `packtory pack` feature (planned: `pack <name> --format {zip|tar|folder} --out <path>`). Adds a zip byte producer alongside the existing tarball and folder writers.

- New `source/zip/zip-builder.ts` — fflate-backed, deterministic output: 644/755 unix file mode, `os: 3` (Unix), zip-safe static mtime (1980-01-01T12:00Z to stay valid across timezones), maximum compression.
- New `buildZip` method on `ArtifactsBuilder`. Lays out files at the artifact root (no `package/` prefix), so future Lambda/deploy emit targets can consume it directly.
- `source/test-libraries/extract-zip.ts` — minimal central-directory reader for round-trip tests (parses unix mode + os from external attributes; content via fflate's async unzip).

Slice 1 is intentionally isolated: no orchestration changes, no CLI surface yet, no vendoring. The new builder isn't wired to any user-facing command — it's a primitive for the upcoming `pack-emitter`.

## Test plan
- [x] `just compile` — type check clean
- [x] `just lint` — eslint, prettier-check, dep-cruiser, ls-lint, knip, jscpd all green
- [x] `just test-unit-with-coverage` — 2664 passing, 100% statements/branches/functions/lines
- [x] `just test-unit-property` — 33 property tests passing
- [x] `just test-types` — tstyche passing
- [x] `just test-mutation` — 100.00 mutation score, zero timeout mutants
