### PR TITLE
Add pack command for tar, zip, and folder artifacts

### DIFF
--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert';
+import { stripVTControlCharacters } from 'node:util';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import type { Packtory } from '../../packtory/packtory.ts';
+import { createConfigLoaderStub } from '../../test-libraries/handler-stub-fixtures.ts';
+import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import { runPackHandler, type PackHandlerDeps } from './pack-handler.ts';
+
+type PackFlags = PackHandlerDeps['flags'];
+
+type PackOutcome = Awaited<ReturnType<Packtory['packPackage']>>;
+
+function spinnerRendererCapturing(stopAll: SinonSpy): TerminalSpinnerRenderer {
+    return { stopAll } as unknown as TerminalSpinnerRenderer;
+}
+
+function packtoryStub(outcome: PackOutcome, spy: SinonSpy): Packtory {
+    return {
+        packPackage: async (...args: unknown[]) => {
+            spy(...args);
+            return outcome;
+        }
+    } as unknown as Packtory;
+}
+
+function makeOutcome(result: PackOutcome['result']): PackOutcome {
+    return { result };
+}
+
+function defaultFlags(overrides: Partial<PackFlags> = {}): PackFlags {
+    return {
+        packageName: 'pkg-a',
+        format: 'zip',
+        outputPath: '/out/pkg-a.zip',
+        version: '0.0.0',
+        ...overrides
+    };
+}
+
+function setup(
+    outcome: PackOutcome,
+    overrides: Partial<PackFlags> = {}
+): {
+    readonly deps: PackHandlerDeps;
+    readonly logSpy: SinonSpy;
+    readonly stopAllSpy: SinonSpy;
+    readonly packPackageSpy: SinonSpy;
+} {
+    const logSpy = fake();
+    const stopAllSpy = fake();
+    const packPackageSpy = fake();
+    const flags = defaultFlags(overrides);
+    return {
+        deps: {
+            log: (message) => {
+                logSpy(stripVTControlCharacters(message));
+            },
+            packtory: packtoryStub(outcome, packPackageSpy),
+            spinnerRenderer: spinnerRendererCapturing(stopAllSpy),
+            configLoader: createConfigLoaderStub(),
+            flags
+        },
+        logSpy,
+        stopAllSpy,
+        packPackageSpy
+    };
+}
+
+suite('pack-handler', function () {
+    test('returns 0 and logs a success line when the pack outcome is Ok', async function () {
+        const { deps, logSpy } = setup(
+            makeOutcome({ isOk: true, isErr: false, value: undefined } as PackOutcome['result'])
+        );
+
+        const code = await runPackHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(logSpy.callCount, 1);
+        assert.match(logSpy.firstCall.args[0] as string, /Packed "pkg-a" as zip to \/out\/pkg-a\.zip/u);
+    });
+
+    test('forwards the flag values into packtory.packPackage', async function () {
+        const { deps, packPackageSpy } = setup(
+            makeOutcome({ isOk: true, isErr: false, value: undefined } as PackOutcome['result']),
+            { packageName: 'pkg-b', format: 'tar', outputPath: '/out/pkg-b.tgz', version: '1.2.3' }
+        );
+
+        await runPackHandler(deps);
+
+        assert.strictEqual(packPackageSpy.callCount, 1);
+        const args = packPackageSpy.firstCall.args as readonly unknown[];
+        const options = args[1];
+        assert.deepStrictEqual(options, {
+            packageName: 'pkg-b',
+            format: 'tar',
+            outputPath: '/out/pkg-b.tgz',
+            version: '1.2.3'
+        });
+    });
+
+    async function expectFailure(error: unknown, patterns: readonly RegExp[]): Promise<void> {
+        const { deps, logSpy } = setup(
+            makeOutcome({ isOk: false, isErr: true, error } as unknown as PackOutcome['result'])
+        );
+
+        const code = await runPackHandler(deps);
+
+        assert.strictEqual(code, 1);
+        const message = logSpy.firstCall.args[0] as string;
+        for (const pattern of patterns) {
+            assert.match(message, pattern);
+        }
+    }
+
+    test('returns 1 and prints the config issues separated by newlines with the total issue count', async function () {
+        await expectFailure({ type: 'config', issues: ['bad-one', 'bad-two'] }, [
+            /config is invalid/u,
+            /2 issue\(s\)/u,
+            /- bad-one\n- bad-two/u
+        ]);
+    });
+
+    test('returns 1 and prints the check issues separated by newlines with the total issue count', async function () {
+        await expectFailure({ type: 'checks', issues: ['rule-a', 'rule-b'] }, [
+            /Checks failed/u,
+            /2 issue\(s\)/u,
+            /- rule-a\n- rule-b/u
+        ]);
+    });
+
+    test('returns 1 and prints a package-not-found message when packPackage returns that failure', async function () {
+        await expectFailure({ type: 'package-not-found', packageName: 'missing-pkg' }, [
+            /Package "missing-pkg" is not declared/u
+        ]);
+    });
+
+    test('returns 1 and explains the missing vendor flag when bundle-dependencies-unsupported is reported', async function () {
+        await expectFailure({ type: 'bundle-dependencies-unsupported', packageName: 'pkg-a' }, [
+            /bundleDependencies which pack does not yet support/u
+        ]);
+    });
+
+    test('returns 1 and summarises partial resolve failures with one line per failure', async function () {
+        await expectFailure(
+            { type: 'partial', error: { succeeded: [], failures: [new Error('resolve A'), new Error('resolve B')] } },
+            [/2 package\(s\) failed to resolve/u, /- resolve A\n- resolve B/u]
+        );
+    });
+
+    test('stops spinners both immediately after the call and again in the finally block', async function () {
+        const { deps, stopAllSpy } = setup(
+            makeOutcome({ isOk: true, isErr: false, value: undefined } as PackOutcome['result'])
+        );
+
+        await runPackHandler(deps);
+
+        assert.strictEqual(stopAllSpy.callCount, 2);
+    });
+});

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -1,0 +1,76 @@
+import type { PackOutcome, Packtory } from '../../packtory/packtory.ts';
+import type { PackFailure } from '../../packtory/packtory-results.ts';
+import type { ConfigLoader } from '../config-loader.ts';
+import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import { getErrorSymbol, getSuccessSymbol } from './runner-symbols.ts';
+
+type Logger = (message: string) => void;
+
+type PackFlags = {
+    readonly packageName: string;
+    readonly format: 'folder' | 'tar' | 'zip';
+    readonly outputPath: string;
+    readonly version: string;
+};
+
+export type PackHandlerDeps = {
+    readonly log: Logger;
+    readonly packtory: Packtory;
+    readonly spinnerRenderer: TerminalSpinnerRenderer;
+    readonly configLoader: ConfigLoader;
+    readonly flags: PackFlags;
+};
+
+function formatIssueList(prefix: string, issues: readonly string[]): string {
+    const issueCount = `${issues.length} issue(s)`;
+    return `${getErrorSymbol()} ${prefix}, there are ${issueCount}\n\n- ${issues.join('\n- ')}`;
+}
+
+function formatPartialResolveFailure(error: PackFailure & { readonly type: 'partial' }): string {
+    const messages = error.error.failures.map((failure) => {
+        return `- ${failure.message}`;
+    });
+    return [`${getErrorSymbol()} ${messages.length} package(s) failed to resolve`, ...messages].join('\n');
+}
+
+function formatPackFailure(error: PackFailure): string {
+    if (error.type === 'config') {
+        return formatIssueList('The provided config is invalid', error.issues);
+    }
+    if (error.type === 'checks') {
+        return formatIssueList('Checks failed', error.issues);
+    }
+    if (error.type === 'package-not-found') {
+        return `${getErrorSymbol()} Package "${error.packageName}" is not declared in the packtory configuration`;
+    }
+    if (error.type === 'bundle-dependencies-unsupported') {
+        const note = 'declares bundleDependencies which pack does not yet support without --vendor-dependencies';
+        return `${getErrorSymbol()} Package "${error.packageName}" ${note}`;
+    }
+    return formatPartialResolveFailure(error);
+}
+
+function reportOutcome(log: Logger, outcome: PackOutcome, flags: PackFlags): number {
+    if (outcome.result.isErr) {
+        log(formatPackFailure(outcome.result.error));
+        return 1;
+    }
+    log(`${getSuccessSymbol()} Packed "${flags.packageName}" as ${flags.format} to ${flags.outputPath}`);
+    return 0;
+}
+
+export async function runPackHandler(deps: PackHandlerDeps): Promise<number> {
+    const { log, packtory, spinnerRenderer, configLoader, flags } = deps;
+    try {
+        const outcome = await packtory.packPackage(await configLoader.load(), {
+            packageName: flags.packageName,
+            format: flags.format,
+            outputPath: flags.outputPath,
+            version: flags.version
+        });
+        spinnerRenderer.stopAll();
+        return reportOutcome(log, outcome, flags);
+    } finally {
+        spinnerRenderer.stopAll();
+    }
+}

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -22,6 +22,7 @@ import {
 type Overrides = {
     readonly buildAndPublishAll?: SinonSpy;
     readonly diffAgainstLatestPublished?: SinonSpy;
+    readonly packPackage?: SinonSpy;
     readonly loadConfig?: SinonSpy;
     readonly log?: SinonSpy;
     readonly fileManager?: FakeFileManager;
@@ -78,7 +79,10 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
             diffAgainstLatestPublished: createSpy(overrides.diffAgainstLatestPublished, () => {
                 return fake.resolves(toReleaseDiffOutcome(Result.ok([])));
             }),
-            resolveAndLinkAll: fake.resolves(toOutcome(Result.ok([])))
+            resolveAndLinkAll: fake.resolves(toOutcome(Result.ok([]))),
+            packPackage: createSpy(overrides.packPackage, () => {
+                return fake.resolves(toOutcome(Result.ok(undefined)));
+            })
         },
         log: (message) => {
             log(stripVTControlCharacters(message));
@@ -756,5 +760,113 @@ suite('runner', function () {
 
         const helpText = String(log.firstCall.args[0]);
         assert.match(helpText, /Compares the next dry-run build against the latest published version, per package\./u);
+    });
+
+    test('pack command loads the config and forwards the flags into packPackage', async function () {
+        const loadConfig = fake.resolves('the-config');
+        const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
+        const runner = runnerFactory({ loadConfig, packPackage });
+
+        const exitCode = await runner.run([
+            'foo',
+            'bar',
+            'pack',
+            'pkg-a',
+            '--format',
+            'zip',
+            '--out',
+            '/tmp/pkg-a.zip',
+            '--version',
+            '1.2.3'
+        ]);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(loadConfig.callCount, 1);
+        assert.strictEqual(packPackage.callCount, 1);
+        assert.strictEqual(packPackage.firstCall.args[0], 'the-config');
+        assert.deepStrictEqual(packPackage.firstCall.args[1], {
+            packageName: 'pkg-a',
+            format: 'zip',
+            outputPath: '/tmp/pkg-a.zip',
+            version: '1.2.3'
+        });
+    });
+
+    test('pack command defaults the version to 0.0.0 when --version is omitted', async function () {
+        const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
+        const runner = runnerFactory({ packPackage });
+
+        await runner.run(['foo', 'bar', 'pack', 'pkg-a', '--format', 'zip', '--out', '/tmp/pkg-a.zip']);
+
+        assert.deepStrictEqual(packPackage.firstCall.args[1], {
+            packageName: 'pkg-a',
+            format: 'zip',
+            outputPath: '/tmp/pkg-a.zip',
+            version: '0.0.0'
+        });
+    });
+
+    test('pack command returns exit code 1 when packPackage reports an Err', async function () {
+        const packPackage = fake.resolves(toOutcome(Result.err({ type: 'package-not-found', packageName: 'pkg-a' })));
+        const runner = runnerFactory({ packPackage });
+
+        const exitCode = await runner.run([
+            'foo',
+            'bar',
+            'pack',
+            'pkg-a',
+            '--format',
+            'tar',
+            '--out',
+            '/tmp/pkg-a.tgz'
+        ]);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(packPackage.callCount, 1);
+    });
+
+    test('pack command accepts each of the zip, tar, and folder format values and forwards them to packPackage', async function () {
+        for (const format of ['zip', 'tar', 'folder'] as const) {
+            const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
+            const runner = runnerFactory({ packPackage });
+
+            await runner.run(['foo', 'bar', 'pack', 'pkg-a', '--format', format, '--out', '/tmp/pkg-a.archive']);
+
+            assert.strictEqual(packPackage.callCount, 1);
+            const forwarded = packPackage.firstCall.args[1] as { readonly format: string };
+            assert.strictEqual(forwarded.format, format);
+        }
+    });
+
+    test('pack --help advertises the command, positional <package>, --format, --out, and --version flags', async function () {
+        const log = fake();
+        const runner = runnerFactory({ log });
+
+        await runner.run(['foo', 'bar', 'pack', '--help']);
+
+        const helpText = String(log.firstCall.args[0]);
+        assert.match(helpText, /Builds a single configured package and writes it as a zip, tar, or folder artifact\./u);
+        assert.match(helpText, /<package>/u);
+        assert.match(helpText, /--format/u);
+        assert.match(helpText, /--out/u);
+        assert.match(helpText, /--version/u);
+    });
+
+    test('pack command rejects --format values outside of zip, tar, or folder', async function () {
+        const log = fake();
+        const runner = runnerFactory({ log });
+
+        const exitCode = await runner.run([
+            'foo',
+            'bar',
+            'pack',
+            'pkg-a',
+            '--format',
+            'rar',
+            '--out',
+            '/tmp/pkg-a.rar'
+        ]);
+
+        assert.strictEqual(exitCode, 1);
     });
 });

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -1,11 +1,12 @@
-/* eslint-disable import/max-dependencies -- the CLI runner wires three subcommands plus shared dependencies */
-import { binary, command, flag, runSafely, subcommands } from 'cmd-ts';
+/* eslint-disable import/max-dependencies -- the CLI runner wires four subcommands plus shared dependencies */
+import { binary, command, flag, oneOf, option, positional, runSafely, string, subcommands } from 'cmd-ts';
 import type { FileManager } from '../../file-manager/file-manager.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
 import type { ProgressBroadcastConsumer } from '../../progress/progress-broadcaster.ts';
 import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import { getParseExitCode } from './command-parsing.ts';
+import { runPackHandler } from './pack-handler.ts';
 import { runPreviewHandler } from './preview-handler.ts';
 import { runReleaseDiffHandler } from './release-diff-handler.ts';
 import { registerProgressListeners } from './progress-wiring.ts';
@@ -45,6 +46,8 @@ export function createCommandLineInterfaceRunner(
     const publishCommandName = 'publish';
     const previewCommandName = 'preview';
     const releaseDiffCommandName = 'release-diff';
+    const packCommandName = 'pack';
+    const defaultPackVersion = '0.0.0';
     const baseCommand = subcommands({
         name: 'packtory',
         cmds: {
@@ -96,6 +99,31 @@ export function createCommandLineInterfaceRunner(
                         packtory,
                         spinnerRenderer,
                         configLoader
+                    });
+                }
+            }),
+            [packCommandName]: command({
+                name: packCommandName,
+                description: 'Builds a single configured package and writes it as a zip, tar, or folder artifact.',
+                args: {
+                    packageName: positional({ type: string, displayName: 'package' }),
+                    format: option({ long: 'format', type: oneOf(['zip', 'tar', 'folder']) }),
+                    outputPath: option({ long: 'out', type: string }),
+                    version: option({
+                        long: 'version',
+                        type: string,
+                        defaultValue: () => {
+                            return defaultPackVersion;
+                        }
+                    })
+                },
+                async handler({ packageName, format, outputPath, version }) {
+                    exitCode = await runPackHandler({
+                        log,
+                        packtory,
+                        spinnerRenderer,
+                        configLoader,
+                        flags: { packageName, format, outputPath, version }
                     });
                 }
             })

--- a/source/file-manager/file-manager.test.ts
+++ b/source/file-manager/file-manager.test.ts
@@ -89,6 +89,33 @@ suite('file-manager', function () {
         assert.deepStrictEqual(writeFile.args, [['/foo/bar.txt', 'the-content', { encoding: 'utf8' }]]);
     });
 
+    async function runWriteBinaryFile(
+        access: SinonSpy
+    ): Promise<{ readonly writeFile: SinonSpy; readonly mkdir: SinonSpy; readonly payload: Buffer }> {
+        const writeFile = fake.resolves(undefined);
+        const mkdir = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ access, writeFile, mkdir });
+        const payload = Buffer.from([7, 8, 9]);
+        await fileManager.writeBinaryFile('/dist/archive.zip', payload);
+        return { writeFile, mkdir, payload };
+    }
+
+    test('writeBinaryFile() writes the binary payload without applying utf-8 encoding when the parent folder is already readable', async function () {
+        const access = fake.resolves(undefined);
+        const { writeFile, mkdir, payload } = await runWriteBinaryFile(access);
+
+        assert.strictEqual(mkdir.callCount, 0);
+        assert.deepStrictEqual(access.args, [['/dist', fs.constants.R_OK]]);
+        assert.deepStrictEqual(writeFile.args, [['/dist/archive.zip', payload]]);
+    });
+
+    test('writeBinaryFile() recursively creates the parent folder before writing when the folder is missing', async function () {
+        const { writeFile, mkdir, payload } = await runWriteBinaryFile(fake.rejects(undefined));
+
+        assert.deepStrictEqual(mkdir.args, [['/dist', { recursive: true }]]);
+        assert.deepStrictEqual(writeFile.args, [['/dist/archive.zip', payload]]);
+    });
+
     test('readFile() reads the given file and returns its content', async function () {
         const readFile = fake.resolves('the-content');
         const fileManager = fileManagerFactory({ readFile });

--- a/source/file-manager/file-manager.ts
+++ b/source/file-manager/file-manager.ts
@@ -15,6 +15,7 @@ export type FileManager = {
     checkReadability: (fileOrFolderPath: string) => Promise<FileOrFolderReadability>;
     readFile: (filePath: string) => Promise<string>;
     writeFile: (filePath: string, content: string) => Promise<void>;
+    writeBinaryFile: (filePath: string, content: Buffer) => Promise<void>;
     setExecutable: (filePath: string, executable: boolean) => Promise<void>;
     copyFile: (from: string, to: string) => Promise<void>;
     getTransferableFileDescriptionFromPath: (
@@ -38,15 +39,23 @@ export function createFileManager(dependencies: FileManagerDependencies): FileMa
         }
     }
 
-    async function writeFile(filePath: string, content: string): Promise<void> {
+    async function ensureContainingFolder(filePath: string): Promise<void> {
         const containingFolder = path.dirname(filePath);
         const parentReadability = await checkReadability(containingFolder);
 
         if (!parentReadability.isReadable) {
             await hostFileSystem.mkdir(containingFolder, { recursive: true });
         }
+    }
 
+    async function writeFile(filePath: string, content: string): Promise<void> {
+        await ensureContainingFolder(filePath);
         await hostFileSystem.writeFile(filePath, content, { encoding: 'utf8' });
+    }
+
+    async function writeBinaryFile(filePath: string, content: Buffer): Promise<void> {
+        await ensureContainingFolder(filePath);
+        await hostFileSystem.writeFile(filePath, content);
     }
 
     async function readFile(filePath: string): Promise<string> {
@@ -67,6 +76,8 @@ export function createFileManager(dependencies: FileManagerDependencies): FileMa
         checkReadability,
 
         writeFile,
+
+        writeBinaryFile,
 
         setExecutable,
 

--- a/source/pack-emitter/pack-emitter.test.ts
+++ b/source/pack-emitter/pack-emitter.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
+import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
+import { createPackEmitter, type PackEmitterDependencies } from './pack-emitter.ts';
+
+function makeBundle(): ReturnType<typeof versionedBundleWithManifest> {
+    return versionedBundleWithManifest({
+        contents: [],
+        packageJson: { name: 'the-pkg', version: '1.0.0' },
+        name: 'the-pkg',
+        manifestFile: { content: '{}', isExecutable: false, filePath: 'package.json' }
+    });
+}
+
+function createDependencies(overrides: Partial<PackEmitterDependencies['artifactsBuilder']> = {}): {
+    readonly deps: PackEmitterDependencies;
+    readonly fileManager: ReturnType<typeof createFakeFileManager>;
+} {
+    const fileManager = createFakeFileManager();
+    const artifactsBuilder = {
+        buildZip: overrides.buildZip ?? fake.resolves({ zipData: Buffer.from([80, 75]) }),
+        buildTarball: overrides.buildTarball ?? fake.resolves({ tarData: Buffer.from([31, 139]) }),
+        buildFolder: overrides.buildFolder ?? fake.resolves(undefined)
+    };
+    return {
+        deps: { artifactsBuilder, fileManager },
+        fileManager
+    };
+}
+
+suite('pack-emitter', function () {
+    test('writes the zip artifact bytes returned by buildZip to the output path', async function () {
+        const zipData = Buffer.from([80, 75, 5, 6]);
+        const buildZip = fake.resolves({ zipData });
+        const { deps, fileManager } = createDependencies({ buildZip });
+        const emitter = createPackEmitter(deps);
+        const bundle = makeBundle();
+
+        await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip' });
+
+        assert.strictEqual(buildZip.callCount, 1);
+        assert.deepStrictEqual(buildZip.firstCall.args, [bundle]);
+        assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
+            filePath: '/out/fn.zip',
+            content: zipData
+        });
+    });
+
+    test('writes the tarball artifact bytes returned by buildTarball to the output path', async function () {
+        const tarData = Buffer.from([31, 139, 8, 0]);
+        const buildTarball = fake.resolves({ tarData });
+        const { deps, fileManager } = createDependencies({ buildTarball });
+        const emitter = createPackEmitter(deps);
+        const bundle = makeBundle();
+
+        await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz' });
+
+        assert.strictEqual(buildTarball.callCount, 1);
+        assert.deepStrictEqual(buildTarball.firstCall.args, [bundle]);
+        assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
+            filePath: '/out/pkg.tgz',
+            content: tarData
+        });
+    });
+
+    test('delegates folder writes to buildFolder with the requested output path', async function () {
+        const buildFolder = fake.resolves(undefined);
+        const { deps, fileManager } = createDependencies({ buildFolder });
+        const emitter = createPackEmitter(deps);
+        const bundle = makeBundle();
+
+        await emitter.pack({ bundle, format: 'folder', outputPath: '/out/extracted' });
+
+        assert.strictEqual(buildFolder.callCount, 1);
+        assert.deepStrictEqual(buildFolder.firstCall.args, [bundle, '/out/extracted']);
+        assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 0);
+    });
+});

--- a/source/pack-emitter/pack-emitter.ts
+++ b/source/pack-emitter/pack-emitter.ts
@@ -1,0 +1,53 @@
+import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
+import type { ArtifactSourcePackage } from '../published-package/published-package.ts';
+
+export type PackFormat = 'folder' | 'tar' | 'zip';
+
+type PackOptions = {
+    readonly bundle: ArtifactSourcePackage;
+    readonly format: PackFormat;
+    readonly outputPath: string;
+};
+
+export type PackEmitter = {
+    pack: (options: PackOptions) => Promise<void>;
+};
+
+export type PackEmitterDependencies = {
+    readonly artifactsBuilder: Pick<ArtifactsBuilder, 'buildFolder' | 'buildTarball' | 'buildZip'>;
+    readonly fileManager: Pick<FileManager, 'writeBinaryFile'>;
+};
+
+export function createPackEmitter(dependencies: PackEmitterDependencies): PackEmitter {
+    const { artifactsBuilder, fileManager } = dependencies;
+
+    async function packZip(bundle: ArtifactSourcePackage, outputPath: string): Promise<void> {
+        const { zipData } = await artifactsBuilder.buildZip(bundle);
+        await fileManager.writeBinaryFile(outputPath, zipData);
+    }
+
+    async function packTarball(bundle: ArtifactSourcePackage, outputPath: string): Promise<void> {
+        const { tarData } = await artifactsBuilder.buildTarball(bundle);
+        await fileManager.writeBinaryFile(outputPath, tarData);
+    }
+
+    async function packFolder(bundle: ArtifactSourcePackage, outputPath: string): Promise<void> {
+        await artifactsBuilder.buildFolder(bundle, outputPath);
+    }
+
+    return {
+        async pack(options) {
+            const { bundle, format, outputPath } = options;
+            if (format === 'zip') {
+                await packZip(bundle, outputPath);
+                return;
+            }
+            if (format === 'tar') {
+                await packTarball(bundle, outputPath);
+                return;
+            }
+            await packFolder(bundle, outputPath);
+        }
+    };
+}

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -61,7 +61,7 @@ const promptForOneTimePassword = createOneTimePasswordPrompt({
     }
 });
 
-const { packageProcessor, progressBroadcaster, deadCodeEliminator, artifactsBuilder } =
+const { packageProcessor, progressBroadcaster, deadCodeEliminator, artifactsBuilder, versionManager, packEmitter } =
     buildPackageProcessorComposition({
         promptForOneTimePassword,
         ciEnvironment: readCiEnvironment(process.env)
@@ -75,7 +75,9 @@ const packtory = createPacktory({
     packageProcessor,
     deadCodeEliminator,
     progressBroadcaster,
-    artifactsBuilder
+    artifactsBuilder,
+    versionManager,
+    packEmitter
 });
 
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -6,6 +6,7 @@ import { ModuleKind, ModuleResolutionKind, Project, ScriptTarget } from 'ts-morp
 import { createArtifactsBuilder, type ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
 import { createBundleEmitter, type BundleEmitter } from '../bundle-emitter/emitter.ts';
 import { createRegistryClient, type RegistryClient } from '../bundle-emitter/registry/registry-client.ts';
+import { createPackEmitter, type PackEmitter } from '../pack-emitter/pack-emitter.ts';
 import { getCiRepositoryUrl, type CiEnvironment } from '../bundle-emitter/repository-coherence.ts';
 import type { DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
 import { createDeadCodeEliminator } from '../dead-code-eliminator/eliminator.ts';
@@ -39,6 +40,8 @@ export type PackageProcessorComposition = {
     readonly progressBroadcaster: ProgressBroadcaster;
     readonly deadCodeEliminator: DeadCodeEliminator;
     readonly artifactsBuilder: ArtifactsBuilder;
+    readonly versionManager: ReturnType<typeof createVersionManager>;
+    readonly packEmitter: PackEmitter;
 };
 
 export type PackageProcessorCompositionOptions = {
@@ -152,9 +155,10 @@ export function buildPackageProcessorComposition(
     options: PackageProcessorCompositionOptions
 ): PackageProcessorComposition {
     const parts = buildCompositionParts(options);
+    const versionManager = createVersionManager({ progressBroadcaster: parts.progressBroadcaster.provider });
     const basePackageProcessor = createPackageProcessor({
         progressBroadcaster: parts.progressBroadcaster.provider,
-        versionManager: createVersionManager({ progressBroadcaster: parts.progressBroadcaster.provider }),
+        versionManager,
         bundleEmitter: parts.bundleEmitter,
         linker: createBundleLinker(),
         resourceResolver: parts.resourceResolver,
@@ -162,11 +166,17 @@ export function buildPackageProcessorComposition(
         deadCodeEliminator: parts.deadCodeEliminator
     });
     const packageProcessor = withStageTimings(basePackageProcessor, parts.progressBroadcaster.provider);
+    const packEmitter = createPackEmitter({
+        artifactsBuilder: parts.artifactsBuilder,
+        fileManager: parts.fileManager
+    });
 
     return {
         packageProcessor,
         progressBroadcaster: parts.progressBroadcaster,
         deadCodeEliminator: parts.deadCodeEliminator,
-        artifactsBuilder: parts.artifactsBuilder
+        artifactsBuilder: parts.artifactsBuilder,
+        versionManager,
+        packEmitter
     };
 }

--- a/source/packages/packtory/packtory.entry-point.ts
+++ b/source/packages/packtory/packtory.entry-point.ts
@@ -3,6 +3,9 @@ import {
     createPacktory,
     type BuildAndPublishAllOptions as PublicBuildAndPublishAllOptions,
     type BuildReport as PublicBuildReport,
+    type PackOutcome as PublicPackOutcome,
+    type PackPublicOptions as PublicPackPublicOptions,
+    type PackResult as PublicPackResult,
     type PublishAllOutcome as PublicPublishAllOutcome,
     type PublishAllResult as PublicPublishAllResult,
     type ReleaseDiffAllOutcome as PublicReleaseDiffAllOutcome,
@@ -18,7 +21,7 @@ import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts'
 import type { PublicProgressBroadcastConsumer } from '../../progress/progress-broadcaster.ts';
 import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
 
-const { packageProcessor, progressBroadcaster, deadCodeEliminator, artifactsBuilder } =
+const { packageProcessor, progressBroadcaster, deadCodeEliminator, artifactsBuilder, versionManager, packEmitter } =
     buildPackageProcessorComposition({
         ciEnvironment: readCiEnvironment(process.env)
     });
@@ -32,15 +35,20 @@ const packtory = createPacktory({
     packageProcessor,
     deadCodeEliminator,
     progressBroadcaster,
-    artifactsBuilder
+    artifactsBuilder,
+    versionManager,
+    packEmitter
 });
 
-export const { buildAndPublishAll, diffAgainstLatestPublished, resolveAndLinkAll } = packtory;
+export const { buildAndPublishAll, diffAgainstLatestPublished, resolveAndLinkAll, packPackage } = packtory;
 export const progressBroadcastConsumer: PublicProgressBroadcastConsumer = progressBroadcaster.consumer;
 
 export type PacktoryConfig = PublicPacktoryConfig;
 export type BuildAndPublishAllOptions = PublicBuildAndPublishAllOptions;
 export type BuildReport = PublicBuildReport;
+export type PackOutcome = PublicPackOutcome;
+export type PackPublicOptions = PublicPackPublicOptions;
+export type PackResult = PublicPackResult;
 export type PublishAllOutcome = PublicPublishAllOutcome;
 export type PublishAllResult = PublicPublishAllResult;
 export type ReleaseDiffAllOutcome = PublicReleaseDiffAllOutcome;

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import { Result } from 'true-myth';
+import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
+import type { PackEmitter } from '../pack-emitter/pack-emitter.ts';
+import type { VersionManager } from '../version-manager/manager.ts';
+import {
+    createRunPackValidated,
+    type InternalPackFailure,
+    type PackOptions,
+    type PackRunDependencies
+} from './packtory-pack.ts';
+import type { InternalResolveAndLinkFailure } from './packtory-resolve.ts';
+import type { ResolvedPackage } from './resolved-package.ts';
+
+const validatedConfig = {} as unknown as ValidConfigWithoutRegistryResult;
+
+const baseOptions: PackOptions = {
+    packageName: 'pkg-a',
+    format: 'zip',
+    outputPath: '/out/pkg-a.zip',
+    version: '0.0.0'
+};
+
+function makeResolvedPackage(
+    overrides: { readonly name?: string; readonly bundleDependencies?: readonly unknown[] } = {}
+): ResolvedPackage {
+    return {
+        name: overrides.name ?? 'pkg-a',
+        analyzedBundle: { contents: [] } as unknown as ResolvedPackage['analyzedBundle'],
+        resolveOptions: {
+            mainPackageJson: { type: 'module' },
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            bundleDependencies: overrides.bundleDependencies ?? [],
+            bundlePeerDependencies: [],
+            roots: { main: { js: 'index.js' } },
+            surface: { kind: 'implicit' }
+        } as unknown as ResolvedPackage['resolveOptions']
+    };
+}
+
+type RunPackDependenciesFakes = {
+    readonly versionManagerAddVersion: SinonSpy;
+    readonly packEmitterPack: SinonSpy;
+    readonly resolveAndLinkAll: SinonSpy;
+};
+
+function createDependencies(overrides: {
+    readonly versionedBundle?: unknown;
+    readonly resolveResult?: Result<readonly ResolvedPackage[], InternalResolveAndLinkFailure>;
+}): { readonly dependencies: PackRunDependencies; readonly fakes: RunPackDependenciesFakes } {
+    const versionedBundle = overrides.versionedBundle ?? { name: 'pkg-a', version: '0.0.0' };
+    const versionManagerAddVersion = fake.returns(versionedBundle);
+    const packEmitterPack = fake.resolves(undefined);
+    const versionManager: VersionManager = {
+        addVersion: versionManagerAddVersion as unknown as VersionManager['addVersion'],
+        increaseVersion: fake.returns(versionedBundle) as unknown as VersionManager['increaseVersion']
+    };
+    const packEmitter: PackEmitter = {
+        pack: packEmitterPack as unknown as PackEmitter['pack']
+    };
+    const resolveAndLinkAll = fake.resolves(overrides.resolveResult ?? Result.ok([makeResolvedPackage()]));
+    return {
+        dependencies: { versionManager, packEmitter },
+        fakes: { versionManagerAddVersion, packEmitterPack, resolveAndLinkAll }
+    };
+}
+
+function expectErr(result: Result<undefined, InternalPackFailure>): InternalPackFailure {
+    if (result.isOk) {
+        assert.fail('expected Err result');
+    }
+    return result.error;
+}
+
+suite('packtory-pack', function () {
+    test('passes the resolve-and-link failure through unchanged when resolve fails', async function () {
+        const resolveFailure: InternalResolveAndLinkFailure = { type: 'checks', issues: ['boom'] };
+        const { dependencies, fakes } = createDependencies({ resolveResult: Result.err(resolveFailure) });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(validatedConfig, baseOptions, fakes.resolveAndLinkAll);
+
+        const error = expectErr(result);
+        assert.deepStrictEqual(error, resolveFailure);
+    });
+
+    test('returns a package-not-found failure when no resolved package matches the requested name', async function () {
+        const { dependencies, fakes } = createDependencies({
+            resolveResult: Result.ok([makeResolvedPackage({ name: 'pkg-other' })])
+        });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(validatedConfig, baseOptions, fakes.resolveAndLinkAll);
+
+        assert.deepStrictEqual(expectErr(result), { type: 'package-not-found', packageName: 'pkg-a' });
+    });
+
+    test('returns a bundle-dependencies-unsupported failure when the target package declares bundle dependencies', async function () {
+        const { dependencies, fakes } = createDependencies({
+            resolveResult: Result.ok([makeResolvedPackage({ bundleDependencies: [{ name: 'dep' }] })])
+        });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(validatedConfig, baseOptions, fakes.resolveAndLinkAll);
+
+        assert.deepStrictEqual(expectErr(result), { type: 'bundle-dependencies-unsupported', packageName: 'pkg-a' });
+    });
+
+    test('builds a versioned bundle and emits it via the pack emitter on success', async function () {
+        const versionedBundle = { name: 'pkg-a', version: '1.2.3' };
+        const { dependencies, fakes } = createDependencies({ versionedBundle });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(
+            validatedConfig,
+            { ...baseOptions, version: '1.2.3', format: 'tar', outputPath: '/out/pkg-a.tgz' },
+            fakes.resolveAndLinkAll
+        );
+
+        assert.deepStrictEqual(result.isOk ? result.value : 'errored', undefined);
+        assert.strictEqual(fakes.versionManagerAddVersion.callCount, 1);
+        const args = fakes.versionManagerAddVersion.firstCall.args as readonly unknown[];
+        const addVersionOptions = args[0] as {
+            readonly version: string;
+            readonly bundleDependencies: readonly unknown[];
+            readonly bundlePeerDependencies: readonly unknown[];
+        };
+        assert.strictEqual(addVersionOptions.version, '1.2.3');
+        assert.deepStrictEqual(addVersionOptions.bundleDependencies, []);
+        assert.deepStrictEqual(addVersionOptions.bundlePeerDependencies, []);
+        assert.deepStrictEqual(fakes.packEmitterPack.firstCall.args, [
+            { bundle: versionedBundle, format: 'tar', outputPath: '/out/pkg-a.tgz' }
+        ]);
+    });
+});

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -1,0 +1,84 @@
+import { Result } from 'true-myth';
+import type { PackEmitter, PackFormat } from '../pack-emitter/pack-emitter.ts';
+import type { VersionManager } from '../version-manager/manager.ts';
+import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
+import type { ResolvedPackage } from './resolved-package.ts';
+import type { InternalResolveAndLinkFailure } from './packtory-resolve.ts';
+import type { PackPackageFailure } from './packtory-results.ts';
+
+export type PackOptions = {
+    readonly packageName: string;
+    readonly format: PackFormat;
+    readonly outputPath: string;
+    readonly version: string;
+};
+
+export type InternalPackFailure = InternalResolveAndLinkFailure | PackPackageFailure;
+
+type ResolveAndLinkAllValidated = (
+    config: ValidConfigWithoutRegistryResult
+) => Promise<Result<readonly ResolvedPackage[], InternalResolveAndLinkFailure>>;
+
+export type PackRunDependencies = {
+    readonly versionManager: VersionManager;
+    readonly packEmitter: PackEmitter;
+};
+
+function findPackage(
+    resolved: readonly ResolvedPackage[],
+    packageName: string
+): Result<ResolvedPackage, PackPackageFailure> {
+    const target = resolved.find((resolvedPackage) => {
+        return resolvedPackage.name === packageName;
+    });
+    if (target === undefined) {
+        return Result.err({ type: 'package-not-found', packageName });
+    }
+    return Result.ok(target);
+}
+
+function ensureNoBundleDependencies(target: ResolvedPackage): Result<ResolvedPackage, PackPackageFailure> {
+    if (target.resolveOptions.bundleDependencies.length > 0) {
+        return Result.err({ type: 'bundle-dependencies-unsupported', packageName: target.name });
+    }
+    return Result.ok(target);
+}
+
+export function createRunPackValidated(
+    dependencies: PackRunDependencies
+): (
+    validated: ValidConfigWithoutRegistryResult,
+    options: PackOptions,
+    resolveAndLinkAllValidated: ResolveAndLinkAllValidated
+) => Promise<Result<undefined, InternalPackFailure>> {
+    return async function runPackValidated(validated, options, resolveAndLinkAllValidated) {
+        const resolveResult = await resolveAndLinkAllValidated(validated);
+        if (resolveResult.isErr) {
+            return Result.err(resolveResult.error);
+        }
+
+        const targetResult = findPackage(resolveResult.value, options.packageName).andThen(ensureNoBundleDependencies);
+        if (targetResult.isErr) {
+            return Result.err(targetResult.error);
+        }
+
+        const target = targetResult.value;
+        const versionedBundle = dependencies.versionManager.addVersion({
+            bundle: target.analyzedBundle,
+            version: options.version,
+            mainPackageJson: target.resolveOptions.mainPackageJson,
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: target.resolveOptions.additionalPackageJsonAttributes,
+            allowMutableSpecifiers: target.resolveOptions.allowMutableSpecifiers
+        });
+
+        await dependencies.packEmitter.pack({
+            bundle: versionedBundle,
+            format: options.format,
+            outputPath: options.outputPath
+        });
+
+        return Result.ok(undefined);
+    };
+}

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -1,10 +1,15 @@
 import type { Result } from 'true-myth';
+import type { PackFormat } from '../pack-emitter/pack-emitter.ts';
 import type { ProgressBroadcaster as ProgressBroadcasterBase } from '../progress/progress-broadcaster.ts';
 import type { BuildReport as ReportBuildReport } from '../report/aggregator/report-types.ts';
 import type { PackageReleaseDiff } from '../report/release-diff/file-set-diff.ts';
 import type { BuildAndPublishResult } from './package-processor.ts';
 import type { CheckError, ResolvedPackage } from './resolved-package.ts';
 import type { PartialError } from './scheduler.ts';
+
+export type PackPackageFailure =
+    | { readonly type: 'bundle-dependencies-unsupported'; readonly packageName: string }
+    | { readonly type: 'package-not-found'; readonly packageName: string };
 
 export type BuildAndPublishAllOptions = {
     readonly dryRun: boolean;
@@ -89,10 +94,30 @@ export function releaseDiffPartialFailure(error: PartialError<PackageReleaseDiff
     return { type: 'partial', ...error };
 }
 
+export type PackPublicOptions = {
+    readonly packageName: string;
+    readonly format: PackFormat;
+    readonly outputPath: string;
+    readonly version: string;
+};
+
+export type PackFailure = CheckError | ConfigError | PackPackageFailure | PartialErrorResult;
+
+export type PackResult = Result<undefined, PackFailure>;
+
+export type PackOutcome = {
+    readonly result: PackResult;
+};
+
+export function createPackOutcome(result: PackResult): PackOutcome {
+    return { result };
+}
+
 export type Packtory = {
     buildAndPublishAll: (config: unknown, options: BuildAndPublishAllOptions) => Promise<PublishAllOutcome>;
     diffAgainstLatestPublished: (config: unknown) => Promise<ReleaseDiffAllOutcome>;
     resolveAndLinkAll: (config: unknown, options?: ResolveAndLinkAllOptions) => Promise<ResolveAndLinkAllOutcome>;
+    packPackage: (config: unknown, options: PackPublicOptions) => Promise<PackOutcome>;
 };
 
 export type ProgressBroadcaster = ProgressBroadcasterBase;

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -143,6 +143,8 @@ function createPacktoryUnderTest(
         readonly tryBuildAndPublish?: SinonSpy;
         readonly buildAndPublish?: SinonSpy;
         readonly deadCodeEliminator?: ReturnType<typeof createTestEliminator>;
+        readonly packEmitterPack?: SinonSpy;
+        readonly versionManagerAddVersion?: SinonSpy;
     } = {}
 ): PacktoryUnderTest {
     const resolveAndLink =
@@ -222,7 +224,22 @@ function createPacktoryUnderTest(
             scheduler: scheduler as never,
             deadCodeEliminator: overrides.deadCodeEliminator ?? createTestEliminator(),
             progressBroadcaster,
-            artifactsBuilder: { collectContents: () => [] }
+            artifactsBuilder: { collectContents: () => [] },
+            versionManager: {
+                addVersion: (overrides.versionManagerAddVersion ??
+                    (() => {
+                        throw new Error('versionManager.addVersion not implemented in tests');
+                    })) as never,
+                increaseVersion: () => {
+                    throw new Error('versionManager.increaseVersion not implemented in tests');
+                }
+            },
+            packEmitter: {
+                pack: (overrides.packEmitterPack ??
+                    (async () => {
+                        throw new Error('packEmitter.pack not implemented in tests');
+                    })) as never
+            }
         }),
         resolveAndLink,
         tryBuildAndPublish,
@@ -558,5 +575,33 @@ suite('packtory', function () {
         await packtory.diffAgainstLatestPublished(createConfig());
 
         assert.strictEqual(progressBroadcaster.provider.hasSubscribers('versionDetermined'), false);
+    });
+
+    const packPublicOptions = {
+        packageName: 'package-a',
+        format: 'zip' as const,
+        outputPath: '/out/package-a.zip',
+        version: '1.0.0'
+    };
+
+    test('packPackage() returns a config failure when the supplied config is invalid', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const { result } = await packtory.packPackage({ invalid: true }, packPublicOptions);
+
+        const error = getErrResult(result, 'expected packPackage() to fail with a config error');
+        assert.strictEqual(error.type, 'config');
+    });
+
+    test('packPackage() returns Ok and forwards the bundle to packEmitter.pack when the config validates and the package is resolvable', async function () {
+        const versionManagerAddVersion = fake.returns(createVersionedBundle('package-a'));
+        const packEmitterPack = fake.resolves(undefined);
+        const { packtory } = createPacktoryUnderTest({ versionManagerAddVersion, packEmitterPack });
+
+        const { result } = await packtory.packPackage(createConfigWithoutRegistry(), packPublicOptions);
+
+        getOkResult(result, 'expected packPackage() to succeed');
+        assert.strictEqual(versionManagerAddVersion.callCount, 1);
+        assert.strictEqual(packEmitterPack.callCount, 1);
     });
 });

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -1,19 +1,26 @@
-/* eslint-disable import/max-dependencies -- the packtory facade legitimately stitches together validation, resolve+link, publish, release-diff, and report attachment */
+/* eslint-disable import/max-dependencies -- the packtory facade legitimately stitches together validation, resolve+link, publish, release-diff, pack, and report attachment */
 import { Result } from 'true-myth';
 import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
 import { validateConfig, validateConfigWithoutRegistry, type ValidConfigResult } from '../config/validation.ts';
 import type { DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
+import type { PackEmitter } from '../pack-emitter/pack-emitter.ts';
+import type { VersionManager } from '../version-manager/manager.ts';
 import { createDiffAgainstLatestPublishedValidated } from './packtory-release-diff.ts';
+import { createRunPackValidated } from './packtory-pack.ts';
 import { attachAggregator, emitEffectiveConfigPerPackage, maybeAttachAggregator } from './report-attachment.ts';
 import { createResolveAndLinkAllValidated } from './packtory-resolve.ts';
 import { createRunBuildAndPublishValidated } from './packtory-publish.ts';
 import {
     configError,
+    createPackOutcome,
     createPublishAllOutcome,
     createReleaseDiffAllOutcome,
     createResolveAndLinkAllOutcome,
     type BuildAndPublishAllOptions as BuildAndPublishAllOptionsBase,
     type BuildReport as BuildReportBase,
+    type PackOutcome as PackOutcomeBase,
+    type PackPublicOptions as PackPublicOptionsBase,
+    type PackResult as PackResultBase,
     type Packtory as PacktoryBase,
     type ProgressBroadcaster,
     type PublishAllOutcome as PublishAllOutcomeBase,
@@ -34,6 +41,9 @@ export type BuildReport = BuildReportBase;
 export type PublishAllOutcome = PublishAllOutcomeBase;
 export type ResolveAndLinkAllOutcome = ResolveAndLinkAllOutcomeBase;
 export type ReleaseDiffAllOutcome = ReleaseDiffAllOutcomeBase;
+export type PackOutcome = PackOutcomeBase;
+export type PackResult = PackResultBase;
+export type PackPublicOptions = PackPublicOptionsBase;
 export type PublishAllResult = PublishAllResultBase;
 export type ResolveAndLinkAllResult = ResolveAndLinkAllResultBase;
 export type ReleaseDiffAllResult = ReleaseDiffAllResultBase;
@@ -46,13 +56,34 @@ type PacktoryDependencies = {
     readonly deadCodeEliminator: DeadCodeEliminator;
     readonly progressBroadcaster: ProgressBroadcaster;
     readonly artifactsBuilder: Pick<ArtifactsBuilder, 'collectContents'>;
+    readonly versionManager: VersionManager;
+    readonly packEmitter: PackEmitter;
 };
+
+type ValidatedRunners = {
+    readonly resolveAndLinkAllValidated: ReturnType<typeof createResolveAndLinkAllValidated>;
+    readonly runBuildAndPublishValidated: ReturnType<typeof createRunBuildAndPublishValidated>;
+    readonly diffAgainstLatestPublishedValidated: ReturnType<typeof createDiffAgainstLatestPublishedValidated>;
+    readonly runPackValidated: ReturnType<typeof createRunPackValidated>;
+};
+
+function createValidatedRunners(dependencies: PacktoryDependencies): ValidatedRunners {
+    return {
+        resolveAndLinkAllValidated: createResolveAndLinkAllValidated(dependencies),
+        runBuildAndPublishValidated: createRunBuildAndPublishValidated(dependencies),
+        diffAgainstLatestPublishedValidated: createDiffAgainstLatestPublishedValidated(dependencies),
+        runPackValidated: createRunPackValidated(dependencies)
+    };
+}
 
 export function createPacktory(dependencies: PacktoryDependencies): Packtory {
     const { progressBroadcaster } = dependencies;
-    const resolveAndLinkAllValidated = createResolveAndLinkAllValidated(dependencies);
-    const runBuildAndPublishValidated = createRunBuildAndPublishValidated(dependencies);
-    const diffAgainstLatestPublishedValidated = createDiffAgainstLatestPublishedValidated(dependencies);
+    const {
+        resolveAndLinkAllValidated,
+        runBuildAndPublishValidated,
+        diffAgainstLatestPublishedValidated,
+        runPackValidated
+    } = createValidatedRunners(dependencies);
 
     async function resolveAndLinkAllPublic(
         config: unknown,
@@ -101,6 +132,16 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         }
     }
 
+    async function packPackagePublic(config: unknown, options: PackPublicOptions): Promise<PackOutcome> {
+        const validation = validateConfigWithoutRegistry(config);
+        if (validation.isErr) {
+            return createPackOutcome(Result.err(configError(validation.error)));
+        }
+
+        const result = await runPackValidated(validation.value, options, resolveAndLinkAllValidated);
+        return createPackOutcome(result);
+    }
+
     async function diffAgainstLatestPublishedPublic(config: unknown): Promise<ReleaseDiffAllOutcome> {
         const reporting = attachAggregator(progressBroadcaster);
         try {
@@ -120,6 +161,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
     return {
         buildAndPublishAll: buildAndPublishAllPublic,
         diffAgainstLatestPublished: diffAgainstLatestPublishedPublic,
-        resolveAndLinkAll: resolveAndLinkAllPublic
+        resolveAndLinkAll: resolveAndLinkAllPublic,
+        packPackage: packPackagePublic
     };
 }

--- a/source/test-libraries/fake-file-manager.ts
+++ b/source/test-libraries/fake-file-manager.ts
@@ -27,6 +27,11 @@ type WriteFileCall = {
     readonly content: string;
 };
 
+type WriteBinaryFileCall = {
+    readonly filePath: string;
+    readonly content: Buffer;
+};
+
 type CopyFileCall = {
     readonly from: string;
     readonly to: string;
@@ -52,6 +57,7 @@ type FakeFileManagerOptions = {
     readonly simulatedTransferableFileDescriptionResponses?: readonly SimulatedResponse<TransferableFileDescription>[];
     readonly transferableFileDescriptionResponder?: TransferableFileDescriptionResponder;
     readonly simulatedWriteFileResponses?: readonly SimulatedVoidResponse[];
+    readonly simulatedWriteBinaryFileResponses?: readonly SimulatedVoidResponse[];
     readonly simulatedCopyFileResponses?: readonly SimulatedVoidResponse[];
 };
 
@@ -63,6 +69,10 @@ export type FakeFileManager = FileManager & {
     readonly getWriteFileCallCount: () => number;
     readonly getWriteFileCall: (index: number) => WriteFileCall;
     readonly getAllWriteFileCalls: () => readonly WriteFileCall[];
+
+    readonly getWriteBinaryFileCallCount: () => number;
+    readonly getWriteBinaryFileCall: (index: number) => WriteBinaryFileCall;
+    readonly getAllWriteBinaryFileCalls: () => readonly WriteBinaryFileCall[];
 
     readonly getCopyFileCallCount: () => number;
     readonly getCopyFileCall: (index: number) => CopyFileCall;
@@ -111,11 +121,13 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
         simulatedTransferableFileDescriptionResponses = [],
         transferableFileDescriptionResponder,
         simulatedWriteFileResponses = [],
+        simulatedWriteBinaryFileResponses = [],
         simulatedCopyFileResponses = []
     } = options;
 
     const readFileCalls: ReadFileCall[] = [];
     const writeFileCalls: WriteFileCall[] = [];
+    const writeBinaryFileCalls: WriteBinaryFileCall[] = [];
     const copyFileCalls: CopyFileCall[] = [];
     const checkReadabilityCalls: CheckReadabilityCall[] = [];
     const transferableFileDescriptionCalls: TransferableFileDescriptionCall[] = [];
@@ -130,6 +142,12 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
         async writeFile(filePath, content) {
             const response = simulatedWriteFileResponses[writeFileCalls.length] ?? defaultVoidResponse;
             writeFileCalls.push({ filePath, content });
+            resolveVoidResponse(response);
+        },
+
+        async writeBinaryFile(filePath, content) {
+            const response = simulatedWriteBinaryFileResponses[writeBinaryFileCalls.length] ?? defaultVoidResponse;
+            writeBinaryFileCalls.push({ filePath, content });
             resolveVoidResponse(response);
         },
 
@@ -181,6 +199,16 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
         },
         getAllWriteFileCalls() {
             return writeFileCalls;
+        },
+
+        getWriteBinaryFileCallCount() {
+            return writeBinaryFileCalls.length;
+        },
+        getWriteBinaryFileCall(index) {
+            return getCallAtIndex(writeBinaryFileCalls, 'writeBinaryFile', index);
+        },
+        getAllWriteBinaryFileCalls() {
+            return writeBinaryFileCalls;
         },
 
         getCopyFileCallCount() {


### PR DESCRIPTION
## Summary

Slice 2 of the `packtory pack` feature. Builds on PR #612.

After this PR, the CLI exposes:

```
packtory pack <package-name> \
  --format {zip|tar|folder} \
  --out <path> \
  [--version <semver>]
```

It runs the same validation + resolve-and-link + checks pipeline as `publish`, and writes the named package's bundle either as an npm-shaped tarball, a zip (files at the root, no `package/` prefix), or unpacked into a target folder.

### Architecture

- `source/pack-emitter/pack-emitter.ts` — orchestrates format → artifact dispatch. For `tar`/`zip` it calls the existing `ArtifactsBuilder` (gaining `buildZip` in PR #612) and writes bytes via the new `FileManager.writeBinaryFile`. For `folder` it delegates to the existing `buildFolder`.
- `source/packtory/packtory-pack.ts` — finds the named package after resolve-and-link and feeds the analyzed bundle into `versionManager.addVersion`, then to the emitter.
- `source/command-line-interface/runner/pack-handler.ts` — CLI handler with the failure-printing surface for each `PackFailure` variant.
- New `pack` subcommand wired into `runner.ts` alongside `publish`/`preview`/`release-diff`.
- `FileManager.writeBinaryFile` — sibling to the existing UTF-8 `writeFile`, needed because zip/tar payloads must not be re-encoded.

### Slice 2 scope (deliberate omissions)

- **`bundleDependencies` not yet supported.** A package that declares any bundle deps is rejected with a clear `bundle-dependencies-unsupported` error. The vendor-mode slice will materialize them under `node_modules/<dep>/`.
- **Version is always written.** `--version` defaults to `0.0.0`. The agreed "omit `version` from the manifest entirely" behavior touches the manifest builder and is a planned follow-up.
- **Always overwrites** the output path without prompting. CI-friendly; matches the agreed default.

## Test plan
- [x] `just compile`
- [x] `just lint`
- [x] `just test-unit-with-coverage` — 100% statements/branches/functions/lines, 2691 passing
- [x] `just test-unit-property` & `just test-types`
- [x] `just test-mutation` — 100.00 mutation score, zero timeout mutants
- [x] Local `packtory publish` dry-run still passes (no-side-effects check green)
