### PR TITLE
Add --vendor-dependencies to pack for external materialization

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -18,6 +18,13 @@
         "canonicalizer",
         "fflate",
         "Flate",
-        "Zippable"
+        "Zippable",
+        "Materializer",
+        "materializer",
+        "materializers",
+        "materialize",
+        "materializing",
+        "materialized",
+        "materializes"
     ]
 }

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -124,7 +124,8 @@ suite('artifacts-builder', function () {
                 { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
                 { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
                 { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
-            ]
+            ],
+            []
         ]);
     });
 
@@ -269,7 +270,34 @@ suite('artifacts-builder', function () {
                 { filePath: 'package/package.json', content: '{}', isExecutable: false },
                 { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
                 { filePath: 'package/sbom.cdx.json', content: '{"bomFormat":"CycloneDX"}', isExecutable: false }
+            ],
+            []
+        ]);
+    });
+
+    test('buildTarball() prefixes each vendor entry target path with "package/" so the tarball mirrors the npm publish layout', async function () {
+        const tarballBuilder = { build: fake.resolves(Buffer.from([])) };
+        const { builder } = artifactsBuilderFactory({ tarballBuilder });
+        await builder.buildTarball(
+            bundleWithContents([], 'package.json'),
+            [],
+            [
+                {
+                    sourceAbsolutePath: '/host/node_modules/pkg/index.js',
+                    targetRelativePath: 'node_modules/pkg/index.js',
+                    isExecutable: false
+                }
             ]
+        );
+
+        const args = tarballBuilder.build.firstCall.args as readonly unknown[];
+        const vendorArgs = args[1];
+        assert.deepStrictEqual(vendorArgs, [
+            {
+                sourceAbsolutePath: '/host/node_modules/pkg/index.js',
+                targetRelativePath: 'package/node_modules/pkg/index.js',
+                isExecutable: false
+            }
         ]);
     });
 
@@ -300,7 +328,8 @@ suite('artifacts-builder', function () {
                 { filePath: 'handler.js', content: 'handler', isExecutable: false },
                 { filePath: 'lib/helper.js', content: 'helper', isExecutable: false },
                 { filePath: 'lib/cli.js', content: 'cli', isExecutable: false }
-            ]
+            ],
+            []
         ]);
     });
 
@@ -316,7 +345,8 @@ suite('artifacts-builder', function () {
                 { filePath: 'manifest.json', content: '{}', isExecutable: false },
                 { filePath: 'handler.js', content: 'handler', isExecutable: false },
                 { filePath: 'extra.json', content: '{"kind":"extra"}', isExecutable: false }
-            ]
+            ],
+            []
         ]);
     });
 

--- a/source/artifacts/artifacts-builder.ts
+++ b/source/artifacts/artifacts-builder.ts
@@ -4,6 +4,7 @@ import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster
 import type { ArtifactSourcePackage } from '../published-package/published-package.ts';
 import { inspectArtifactSizes } from '../report/inspectors/inspect-artifact-sizes.ts';
 import type { TarballBuilder } from '../tar/tarball-builder.ts';
+import { applyPrefixToVendorEntry, type VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 import type { ZipBuilder } from '../zip/zip-builder.ts';
 import { collectArtifactContents, describeArtifactsForReport } from './content-collection.ts';
 import { writeArtifactsToFolder } from './folder-writer.ts';
@@ -29,12 +30,21 @@ export type ArtifactsBuilder = {
         prefix?: string,
         extraFiles?: readonly FileDescription[]
     ) => readonly FileDescription[];
-    buildTarball: (bundle: ArtifactSourcePackage, extraFiles?: readonly FileDescription[]) => Promise<TarballArtifact>;
-    buildZip: (bundle: ArtifactSourcePackage, extraFiles?: readonly FileDescription[]) => Promise<ZipArtifact>;
+    buildTarball: (
+        bundle: ArtifactSourcePackage,
+        extraFiles?: readonly FileDescription[],
+        vendorEntries?: readonly VendorEntry[]
+    ) => Promise<TarballArtifact>;
+    buildZip: (
+        bundle: ArtifactSourcePackage,
+        extraFiles?: readonly FileDescription[],
+        vendorEntries?: readonly VendorEntry[]
+    ) => Promise<ZipArtifact>;
     buildFolder: (
         bundle: ArtifactSourcePackage,
         targetFolder: string,
-        extraFiles?: readonly FileDescription[]
+        extraFiles?: readonly FileDescription[],
+        vendorEntries?: readonly VendorEntry[]
     ) => Promise<void>;
 };
 
@@ -61,21 +71,24 @@ export function createArtifactsBuilder(dependencies: ArtifactsBuilderDependencie
     return {
         collectContents,
 
-        async buildTarball(bundle, extraFiles) {
+        async buildTarball(bundle, extraFiles, vendorEntries = []) {
             const contents = collectContents(bundle, 'package', extraFiles);
-            const tarData = await tarballBuilder.build(contents);
+            const prefixedVendor = vendorEntries.map((entry) => {
+                return applyPrefixToVendorEntry('package', entry);
+            });
+            const tarData = await tarballBuilder.build(contents, prefixedVendor);
             return { tarData };
         },
 
-        async buildZip(bundle, extraFiles) {
+        async buildZip(bundle, extraFiles, vendorEntries = []) {
             const contents = collectContents(bundle, undefined, extraFiles);
-            const zipData = await zipBuilder.build(contents);
+            const zipData = await zipBuilder.build(contents, vendorEntries);
             return { zipData };
         },
 
-        async buildFolder(bundle, targetFolder, extraFiles) {
+        async buildFolder(bundle, targetFolder, extraFiles, vendorEntries = []) {
             const contents = collectContents(bundle, undefined, extraFiles);
-            await writeArtifactsToFolder(fileManager, targetFolder, contents);
+            await writeArtifactsToFolder(fileManager, targetFolder, contents, vendorEntries);
         }
     };
 }

--- a/source/artifacts/folder-writer.test.ts
+++ b/source/artifacts/folder-writer.test.ts
@@ -48,4 +48,29 @@ suite('folder-writer', function () {
         });
         assert.deepStrictEqual(fileManager.getWriteFileCall(1), { filePath: '/target/data.txt', content: 'data' });
     });
+
+    test('writeArtifactsToFolder copies vendor entries byte-for-byte after writing inline contents', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }]
+        });
+
+        await writeArtifactsToFolder(
+            fileManager,
+            '/target',
+            [{ filePath: 'inline.txt', content: 'inline', isExecutable: false }],
+            [
+                {
+                    sourceAbsolutePath: '/repo/node_modules/pkg/index.js',
+                    targetRelativePath: 'node_modules/pkg/index.js',
+                    isExecutable: false
+                }
+            ]
+        );
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+        assert.deepStrictEqual(fileManager.getCopyFileBytesCall(0), {
+            from: '/repo/node_modules/pkg/index.js',
+            to: '/target/node_modules/pkg/index.js'
+        });
+    });
 });

--- a/source/artifacts/folder-writer.ts
+++ b/source/artifacts/folder-writer.ts
@@ -1,20 +1,42 @@
 import path from 'node:path';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
+import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
-export async function writeArtifactsToFolder(
+async function writeFileDescriptions(
     fileManager: FileManager,
     targetFolder: string,
     contents: readonly FileDescription[]
 ): Promise<void> {
-    const readability = await fileManager.checkReadability(targetFolder);
-    if (readability.isReadable) {
-        throw new Error(`Folder ${targetFolder} already exists`);
-    }
-
     for (const entry of contents) {
         const targetFilePath = path.join(targetFolder, entry.filePath);
         await fileManager.writeFile(targetFilePath, entry.content);
         await fileManager.setExecutable(targetFilePath, entry.isExecutable);
     }
+}
+
+async function copyVendorEntries(
+    fileManager: FileManager,
+    targetFolder: string,
+    vendorEntries: readonly VendorEntry[]
+): Promise<void> {
+    for (const vendorEntry of vendorEntries) {
+        const targetFilePath = path.join(targetFolder, vendorEntry.targetRelativePath);
+        await fileManager.copyFileBytes(vendorEntry.sourceAbsolutePath, targetFilePath);
+        await fileManager.setExecutable(targetFilePath, vendorEntry.isExecutable);
+    }
+}
+
+export async function writeArtifactsToFolder(
+    fileManager: FileManager,
+    targetFolder: string,
+    contents: readonly FileDescription[],
+    vendorEntries: readonly VendorEntry[] = []
+): Promise<void> {
+    const readability = await fileManager.checkReadability(targetFolder);
+    if (readability.isReadable) {
+        throw new Error(`Folder ${targetFolder} already exists`);
+    }
+    await writeFileDescriptions(fileManager, targetFolder, contents);
+    await copyVendorEntries(fileManager, targetFolder, vendorEntries);
 }

--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -34,6 +34,7 @@ function defaultFlags(overrides: Partial<PackFlags> = {}): PackFlags {
         format: 'zip',
         outputPath: '/out/pkg-a.zip',
         version: '0.0.0',
+        vendorDependencies: false,
         ...overrides
     };
 }
@@ -95,7 +96,8 @@ suite('pack-handler', function () {
             packageName: 'pkg-b',
             format: 'tar',
             outputPath: '/out/pkg-b.tgz',
-            version: '1.2.3'
+            version: '1.2.3',
+            vendorDependencies: false
         });
     });
 

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -11,6 +11,7 @@ type PackFlags = {
     readonly format: 'folder' | 'tar' | 'zip';
     readonly outputPath: string;
     readonly version: string;
+    readonly vendorDependencies: boolean;
 };
 
 export type PackHandlerDeps = {
@@ -66,7 +67,8 @@ export async function runPackHandler(deps: PackHandlerDeps): Promise<number> {
             packageName: flags.packageName,
             format: flags.format,
             outputPath: flags.outputPath,
-            version: flags.version
+            version: flags.version,
+            vendorDependencies: flags.vendorDependencies
         });
         spinnerRenderer.stopAll();
         return reportOutcome(log, outcome, flags);

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -788,7 +788,8 @@ suite('runner', function () {
             packageName: 'pkg-a',
             format: 'zip',
             outputPath: '/tmp/pkg-a.zip',
-            version: '1.2.3'
+            version: '1.2.3',
+            vendorDependencies: false
         });
     });
 
@@ -802,7 +803,8 @@ suite('runner', function () {
             packageName: 'pkg-a',
             format: 'zip',
             outputPath: '/tmp/pkg-a.zip',
-            version: '0.0.0'
+            version: '0.0.0',
+            vendorDependencies: false
         });
     });
 
@@ -823,6 +825,15 @@ suite('runner', function () {
 
         assert.strictEqual(exitCode, 1);
         assert.strictEqual(packPackage.callCount, 1);
+    });
+
+    test('pack command forwards --vendor-dependencies as true when the flag is supplied', async function () {
+        const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
+        const argv = 'foo,bar,pack,pkg-a,--format,zip,--out,/tmp/pkg-a.zip,--vendor-dependencies'.split(',');
+        await runnerFactory({ packPackage }).run(argv);
+
+        const forwarded = packPackage.firstCall.args[1] as { readonly vendorDependencies: boolean };
+        assert.strictEqual(forwarded.vendorDependencies, true);
     });
 
     test('pack command accepts each of the zip, tar, and folder format values and forwards them to packPackage', async function () {

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -115,15 +115,16 @@ export function createCommandLineInterfaceRunner(
                         defaultValue: () => {
                             return defaultPackVersion;
                         }
-                    })
+                    }),
+                    vendorDependencies: flag({ long: 'vendor-dependencies' })
                 },
-                async handler({ packageName, format, outputPath, version }) {
+                async handler({ packageName, format, outputPath, version, vendorDependencies }) {
                     exitCode = await runPackHandler({
                         log,
                         packtory,
                         spinnerRenderer,
                         configLoader,
-                        flags: { packageName, format, outputPath, version }
+                        flags: { packageName, format, outputPath, version, vendorDependencies }
                     });
                 }
             })

--- a/source/file-manager/file-manager.test.ts
+++ b/source/file-manager/file-manager.test.ts
@@ -11,6 +11,9 @@ type Overrides = {
     readonly readFile?: SinonSpy;
     readonly stat?: SinonSpy;
     readonly chmod?: SinonSpy;
+    readonly copyFile?: SinonSpy;
+    readonly readdir?: SinonSpy;
+    readonly realpath?: SinonSpy;
 };
 
 function createSpy<TSpy extends SinonSpy>(spy: TSpy | undefined, fallback: () => TSpy): TSpy {
@@ -25,7 +28,10 @@ function fileManagerFactory(overrides: Overrides = {}): FileManager {
         writeFile: createSpy(overrides.writeFile, fake),
         readFile: createSpy(overrides.readFile, fake),
         stat: createSpy(overrides.stat, fake),
-        chmod: createSpy(overrides.chmod, fake)
+        chmod: createSpy(overrides.chmod, fake),
+        copyFile: createSpy(overrides.copyFile, fake),
+        readdir: createSpy(overrides.readdir, fake),
+        realpath: createSpy(overrides.realpath, fake)
     };
     const dependencies: FileManagerDependencies = { hostFileSystem };
 
@@ -114,6 +120,70 @@ suite('file-manager', function () {
 
         assert.deepStrictEqual(mkdir.args, [['/dist', { recursive: true }]]);
         assert.deepStrictEqual(writeFile.args, [['/dist/archive.zip', payload]]);
+    });
+
+    test('readFileBytes() reads the given file as a Buffer without applying utf-8 decoding', async function () {
+        const expected = Buffer.from([222, 173, 190, 239]);
+        const readFile = fake.resolves(expected);
+        const fileManager = fileManagerFactory({ readFile });
+
+        const result = await fileManager.readFileBytes('/foo/native.node');
+
+        assert.strictEqual(readFile.callCount, 1);
+        assert.deepStrictEqual(readFile.firstCall.args, ['/foo/native.node']);
+        assert.strictEqual(result, expected);
+    });
+
+    test('copyFileBytes() copies the source file to the target via the host fs.copyFile primitive', async function () {
+        const access = fake.resolves(undefined);
+        const copyFile = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ access, copyFile });
+
+        await fileManager.copyFileBytes('/src/lib.node', '/dest/lib.node');
+
+        assert.strictEqual(access.callCount, 1);
+        assert.deepStrictEqual(access.firstCall.args, ['/dest', fs.constants.R_OK]);
+        assert.deepStrictEqual(copyFile.args, [['/src/lib.node', '/dest/lib.node']]);
+    });
+
+    test('copyFileBytes() creates the destination folder when it does not exist before copying', async function () {
+        const access = fake.rejects(undefined);
+        const copyFile = fake.resolves(undefined);
+        const mkdir = fake.resolves(undefined);
+        const fileManager = fileManagerFactory({ access, copyFile, mkdir });
+
+        await fileManager.copyFileBytes('/src/data.bin', '/out/extracted/data.bin');
+
+        assert.deepStrictEqual(mkdir.args, [['/out/extracted', { recursive: true }]]);
+        assert.deepStrictEqual(copyFile.args, [['/src/data.bin', '/out/extracted/data.bin']]);
+    });
+
+    test('listDirectoryEntries() returns the entries from host readdir tagged with type information', async function () {
+        const readdir = fake.resolves([
+            { name: 'file.txt', isDirectory: () => false, isSymbolicLink: () => false },
+            { name: 'sub', isDirectory: () => true, isSymbolicLink: () => false },
+            { name: 'linked', isDirectory: () => false, isSymbolicLink: () => true }
+        ]);
+        const fileManager = fileManagerFactory({ readdir });
+
+        const result = await fileManager.listDirectoryEntries('/some/folder');
+
+        assert.deepStrictEqual(readdir.firstCall.args, ['/some/folder', { withFileTypes: true }]);
+        assert.deepStrictEqual(result, [
+            { name: 'file.txt', isDirectory: false, isSymbolicLink: false },
+            { name: 'sub', isDirectory: true, isSymbolicLink: false },
+            { name: 'linked', isDirectory: false, isSymbolicLink: true }
+        ]);
+    });
+
+    test('getRealPath() delegates to host realpath', async function () {
+        const realpath = fake.resolves('/real/path/somewhere');
+        const fileManager = fileManagerFactory({ realpath });
+
+        const result = await fileManager.getRealPath('/symlinked/path');
+
+        assert.deepStrictEqual(realpath.firstCall.args, ['/symlinked/path']);
+        assert.strictEqual(result, '/real/path/somewhere');
     });
 
     test('readFile() reads the given file and returns its content', async function () {

--- a/source/file-manager/file-manager.ts
+++ b/source/file-manager/file-manager.ts
@@ -11,13 +11,23 @@ type FileOrFolderReadability = {
     readonly isReadable: boolean;
 };
 
+type DirectoryEntry = {
+    readonly name: string;
+    readonly isDirectory: boolean;
+    readonly isSymbolicLink: boolean;
+};
+
 export type FileManager = {
     checkReadability: (fileOrFolderPath: string) => Promise<FileOrFolderReadability>;
     readFile: (filePath: string) => Promise<string>;
+    readFileBytes: (filePath: string) => Promise<Buffer>;
     writeFile: (filePath: string, content: string) => Promise<void>;
     writeBinaryFile: (filePath: string, content: Buffer) => Promise<void>;
     setExecutable: (filePath: string, executable: boolean) => Promise<void>;
     copyFile: (from: string, to: string) => Promise<void>;
+    copyFileBytes: (from: string, to: string) => Promise<void>;
+    listDirectoryEntries: (directoryPath: string) => Promise<readonly DirectoryEntry[]>;
+    getRealPath: (filePath: string) => Promise<string>;
     getTransferableFileDescriptionFromPath: (
         sourceFilePath: string,
         targetFilePath: string
@@ -62,6 +72,10 @@ export function createFileManager(dependencies: FileManagerDependencies): FileMa
         return hostFileSystem.readFile(filePath, { encoding: 'utf8' });
     }
 
+    async function readFileBytes(filePath: string): Promise<Buffer> {
+        return hostFileSystem.readFile(filePath);
+    }
+
     async function getFileMode(filePath: string): Promise<number> {
         const stats = await hostFileSystem.stat(filePath);
         return stats.mode;
@@ -83,6 +97,8 @@ export function createFileManager(dependencies: FileManagerDependencies): FileMa
 
         readFile,
 
+        readFileBytes,
+
         async getTransferableFileDescriptionFromPath(sourceFilePath, targetFilePath) {
             const mode = await getFileMode(sourceFilePath);
 
@@ -97,6 +113,26 @@ export function createFileManager(dependencies: FileManagerDependencies): FileMa
         async copyFile(from, to) {
             const content = await readFile(from);
             await writeFile(to, content);
+        },
+
+        async copyFileBytes(from, to) {
+            await ensureContainingFolder(to);
+            await hostFileSystem.copyFile(from, to);
+        },
+
+        async listDirectoryEntries(directoryPath) {
+            const entries = await hostFileSystem.readdir(directoryPath, { withFileTypes: true });
+            return entries.map((entry) => {
+                return {
+                    name: entry.name,
+                    isDirectory: entry.isDirectory(),
+                    isSymbolicLink: entry.isSymbolicLink()
+                };
+            });
+        },
+
+        async getRealPath(filePath) {
+            return hostFileSystem.realpath(filePath);
         }
     };
 }

--- a/source/pack-emitter/pack-emitter.test.ts
+++ b/source/pack-emitter/pack-emitter.test.ts
@@ -38,10 +38,10 @@ suite('pack-emitter', function () {
         const emitter = createPackEmitter(deps);
         const bundle = makeBundle();
 
-        await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip' });
+        await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip', vendorEntries: [] });
 
         assert.strictEqual(buildZip.callCount, 1);
-        assert.deepStrictEqual(buildZip.firstCall.args, [bundle]);
+        assert.deepStrictEqual(buildZip.firstCall.args, [bundle, undefined, []]);
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
             filePath: '/out/fn.zip',
@@ -56,10 +56,10 @@ suite('pack-emitter', function () {
         const emitter = createPackEmitter(deps);
         const bundle = makeBundle();
 
-        await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz' });
+        await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz', vendorEntries: [] });
 
         assert.strictEqual(buildTarball.callCount, 1);
-        assert.deepStrictEqual(buildTarball.firstCall.args, [bundle]);
+        assert.deepStrictEqual(buildTarball.firstCall.args, [bundle, undefined, []]);
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
             filePath: '/out/pkg.tgz',
@@ -73,10 +73,10 @@ suite('pack-emitter', function () {
         const emitter = createPackEmitter(deps);
         const bundle = makeBundle();
 
-        await emitter.pack({ bundle, format: 'folder', outputPath: '/out/extracted' });
+        await emitter.pack({ bundle, format: 'folder', outputPath: '/out/extracted', vendorEntries: [] });
 
         assert.strictEqual(buildFolder.callCount, 1);
-        assert.deepStrictEqual(buildFolder.firstCall.args, [bundle, '/out/extracted']);
+        assert.deepStrictEqual(buildFolder.firstCall.args, [bundle, '/out/extracted', undefined, []]);
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 0);
     });
 });

--- a/source/pack-emitter/pack-emitter.ts
+++ b/source/pack-emitter/pack-emitter.ts
@@ -1,6 +1,7 @@
 import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
 import type { ArtifactSourcePackage } from '../published-package/published-package.ts';
+import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
 export type PackFormat = 'folder' | 'tar' | 'zip';
 
@@ -8,6 +9,7 @@ type PackOptions = {
     readonly bundle: ArtifactSourcePackage;
     readonly format: PackFormat;
     readonly outputPath: string;
+    readonly vendorEntries: readonly VendorEntry[];
 };
 
 export type PackEmitter = {
@@ -22,32 +24,31 @@ export type PackEmitterDependencies = {
 export function createPackEmitter(dependencies: PackEmitterDependencies): PackEmitter {
     const { artifactsBuilder, fileManager } = dependencies;
 
-    async function packZip(bundle: ArtifactSourcePackage, outputPath: string): Promise<void> {
-        const { zipData } = await artifactsBuilder.buildZip(bundle);
-        await fileManager.writeBinaryFile(outputPath, zipData);
+    async function packZip(options: PackOptions): Promise<void> {
+        const { zipData } = await artifactsBuilder.buildZip(options.bundle, undefined, options.vendorEntries);
+        await fileManager.writeBinaryFile(options.outputPath, zipData);
     }
 
-    async function packTarball(bundle: ArtifactSourcePackage, outputPath: string): Promise<void> {
-        const { tarData } = await artifactsBuilder.buildTarball(bundle);
-        await fileManager.writeBinaryFile(outputPath, tarData);
+    async function packTarball(options: PackOptions): Promise<void> {
+        const { tarData } = await artifactsBuilder.buildTarball(options.bundle, undefined, options.vendorEntries);
+        await fileManager.writeBinaryFile(options.outputPath, tarData);
     }
 
-    async function packFolder(bundle: ArtifactSourcePackage, outputPath: string): Promise<void> {
-        await artifactsBuilder.buildFolder(bundle, outputPath);
+    async function packFolder(options: PackOptions): Promise<void> {
+        await artifactsBuilder.buildFolder(options.bundle, options.outputPath, undefined, options.vendorEntries);
     }
 
     return {
         async pack(options) {
-            const { bundle, format, outputPath } = options;
-            if (format === 'zip') {
-                await packZip(bundle, outputPath);
+            if (options.format === 'zip') {
+                await packZip(options);
                 return;
             }
-            if (format === 'tar') {
-                await packTarball(bundle, outputPath);
+            if (options.format === 'tar') {
+                await packTarball(options);
                 return;
             }
-            await packFolder(bundle, outputPath);
+            await packFolder(options);
         }
     };
 }

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -61,11 +61,18 @@ const promptForOneTimePassword = createOneTimePasswordPrompt({
     }
 });
 
-const { packageProcessor, progressBroadcaster, deadCodeEliminator, artifactsBuilder, versionManager, packEmitter } =
-    buildPackageProcessorComposition({
-        promptForOneTimePassword,
-        ciEnvironment: readCiEnvironment(process.env)
-    });
+const {
+    packageProcessor,
+    progressBroadcaster,
+    deadCodeEliminator,
+    artifactsBuilder,
+    versionManager,
+    packEmitter,
+    vendorMaterializer
+} = buildPackageProcessorComposition({
+    promptForOneTimePassword,
+    ciEnvironment: readCiEnvironment(process.env)
+});
 const scheduler = createScheduler({
     progressBroadcastProvider: progressBroadcaster.provider
 });
@@ -77,7 +84,8 @@ const packtory = createPacktory({
     progressBroadcaster,
     artifactsBuilder,
     versionManager,
-    packEmitter
+    packEmitter,
+    vendorMaterializer
 });
 
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -7,6 +7,7 @@ import { createArtifactsBuilder, type ArtifactsBuilder } from '../artifacts/arti
 import { createBundleEmitter, type BundleEmitter } from '../bundle-emitter/emitter.ts';
 import { createRegistryClient, type RegistryClient } from '../bundle-emitter/registry/registry-client.ts';
 import { createPackEmitter, type PackEmitter } from '../pack-emitter/pack-emitter.ts';
+import { createVendorMaterializer, type VendorMaterializer } from '../vendor-materializer/vendor-materializer.ts';
 import { getCiRepositoryUrl, type CiEnvironment } from '../bundle-emitter/repository-coherence.ts';
 import type { DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
 import { createDeadCodeEliminator } from '../dead-code-eliminator/eliminator.ts';
@@ -42,6 +43,7 @@ export type PackageProcessorComposition = {
     readonly artifactsBuilder: ArtifactsBuilder;
     readonly versionManager: ReturnType<typeof createVersionManager>;
     readonly packEmitter: PackEmitter;
+    readonly vendorMaterializer: VendorMaterializer;
 };
 
 export type PackageProcessorCompositionOptions = {
@@ -136,8 +138,8 @@ function buildCompositionParts(options: PackageProcessorCompositionOptions): Com
     const progressBroadcaster = createProgressBroadcaster();
     const artifactsBuilder = createArtifactsBuilder({
         fileManager,
-        tarballBuilder: createTarballBuilder(),
-        zipBuilder: createZipBuilder(),
+        tarballBuilder: createTarballBuilder({ fileManager }),
+        zipBuilder: createZipBuilder({ fileManager }),
         progressBroadcaster: progressBroadcaster.provider
     });
     return {
@@ -170,6 +172,7 @@ export function buildPackageProcessorComposition(
         artifactsBuilder: parts.artifactsBuilder,
         fileManager: parts.fileManager
     });
+    const vendorMaterializer = createVendorMaterializer({ fileManager: parts.fileManager });
 
     return {
         packageProcessor,
@@ -177,6 +180,7 @@ export function buildPackageProcessorComposition(
         deadCodeEliminator: parts.deadCodeEliminator,
         artifactsBuilder: parts.artifactsBuilder,
         versionManager,
-        packEmitter
+        packEmitter,
+        vendorMaterializer
     };
 }

--- a/source/packages/packtory/packtory.entry-point.ts
+++ b/source/packages/packtory/packtory.entry-point.ts
@@ -21,10 +21,17 @@ import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts'
 import type { PublicProgressBroadcastConsumer } from '../../progress/progress-broadcaster.ts';
 import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
 
-const { packageProcessor, progressBroadcaster, deadCodeEliminator, artifactsBuilder, versionManager, packEmitter } =
-    buildPackageProcessorComposition({
-        ciEnvironment: readCiEnvironment(process.env)
-    });
+const {
+    packageProcessor,
+    progressBroadcaster,
+    deadCodeEliminator,
+    artifactsBuilder,
+    versionManager,
+    packEmitter,
+    vendorMaterializer
+} = buildPackageProcessorComposition({
+    ciEnvironment: readCiEnvironment(process.env)
+});
 
 const scheduler = createScheduler({
     progressBroadcastProvider: progressBroadcaster.provider
@@ -37,7 +44,8 @@ const packtory = createPacktory({
     progressBroadcaster,
     artifactsBuilder,
     versionManager,
-    packEmitter
+    packEmitter,
+    vendorMaterializer
 });
 
 export const { buildAndPublishAll, diffAgainstLatestPublished, resolveAndLinkAll, packPackage } = packtory;

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -20,15 +20,29 @@ const baseOptions: PackOptions = {
     packageName: 'pkg-a',
     format: 'zip',
     outputPath: '/out/pkg-a.zip',
-    version: '0.0.0'
+    version: '0.0.0',
+    vendorDependencies: false
 };
 
 function makeResolvedPackage(
-    overrides: { readonly name?: string; readonly bundleDependencies?: readonly unknown[] } = {}
+    overrides: {
+        readonly name?: string;
+        readonly bundleDependencies?: readonly unknown[];
+        readonly externalDependencyNames?: readonly string[];
+        readonly sourcesFolder?: string;
+    } = {}
 ): ResolvedPackage {
+    const externalDependencies = new Map(
+        (overrides.externalDependencyNames ?? []).map((name) => {
+            return [name, { name, referencedFrom: ['/x'] as const }];
+        })
+    );
     return {
         name: overrides.name ?? 'pkg-a',
-        analyzedBundle: { contents: [] } as unknown as ResolvedPackage['analyzedBundle'],
+        analyzedBundle: {
+            contents: [],
+            externalDependencies
+        } as unknown as ResolvedPackage['analyzedBundle'],
         resolveOptions: {
             mainPackageJson: { type: 'module' },
             additionalPackageJsonAttributes: {},
@@ -36,7 +50,8 @@ function makeResolvedPackage(
             bundleDependencies: overrides.bundleDependencies ?? [],
             bundlePeerDependencies: [],
             roots: { main: { js: 'index.js' } },
-            surface: { kind: 'implicit' }
+            surface: { kind: 'implicit' },
+            sourcesFolder: overrides.sourcesFolder ?? '/repo'
         } as unknown as ResolvedPackage['resolveOptions']
     };
 }
@@ -50,8 +65,26 @@ type RunPackDependenciesFakes = {
 function createDependencies(overrides: {
     readonly versionedBundle?: unknown;
     readonly resolveResult?: Result<readonly ResolvedPackage[], InternalResolveAndLinkFailure>;
+    readonly materializerSpy?: SinonSpy;
+    readonly vendorEntries?: readonly {
+        readonly sourceAbsolutePath: string;
+        readonly targetRelativePath: string;
+        readonly isExecutable: boolean;
+    }[];
 }): { readonly dependencies: PackRunDependencies; readonly fakes: RunPackDependenciesFakes } {
-    const versionedBundle = overrides.versionedBundle ?? { name: 'pkg-a', version: '0.0.0' };
+    const versionedBundle = overrides.versionedBundle ?? {
+        name: 'pkg-a',
+        version: '0.0.0',
+        manifestFile: {
+            content: JSON.stringify({
+                name: 'pkg-a',
+                dependencies: { left: '1.0.0' },
+                peerDependencies: { right: '1.0.0' }
+            }),
+            isExecutable: false,
+            filePath: 'package.json'
+        }
+    };
     const versionManagerAddVersion = fake.returns(versionedBundle);
     const packEmitterPack = fake.resolves(undefined);
     const versionManager: VersionManager = {
@@ -62,8 +95,14 @@ function createDependencies(overrides: {
         pack: packEmitterPack as unknown as PackEmitter['pack']
     };
     const resolveAndLinkAll = fake.resolves(overrides.resolveResult ?? Result.ok([makeResolvedPackage()]));
+    const materializeExternals =
+        overrides.materializerSpy ?? fake.resolves({ entries: overrides.vendorEntries ?? [], packageNames: [] });
+    const vendorMaterializer = {
+        materializeExternals:
+            materializeExternals as unknown as PackRunDependencies['vendorMaterializer']['materializeExternals']
+    };
     return {
-        dependencies: { versionManager, packEmitter },
+        dependencies: { versionManager, packEmitter, vendorMaterializer },
         fakes: { versionManagerAddVersion, packEmitterPack, resolveAndLinkAll }
     };
 }
@@ -132,7 +171,86 @@ suite('packtory-pack', function () {
         assert.deepStrictEqual(addVersionOptions.bundleDependencies, []);
         assert.deepStrictEqual(addVersionOptions.bundlePeerDependencies, []);
         assert.deepStrictEqual(fakes.packEmitterPack.firstCall.args, [
-            { bundle: versionedBundle, format: 'tar', outputPath: '/out/pkg-a.tgz' }
+            { bundle: versionedBundle, format: 'tar', outputPath: '/out/pkg-a.tgz', vendorEntries: [] }
         ]);
+    });
+
+    test('falls back to the original manifest unchanged when vendoring is on but the manifest content is not a JSON object', async function () {
+        const malformedContent = JSON.stringify(['unexpected', 'array']);
+        const versionedBundle = {
+            name: 'pkg-a',
+            version: '0.0.0',
+            manifestFile: { content: malformedContent, isExecutable: false, filePath: 'package.json' }
+        };
+        const { dependencies, fakes } = createDependencies({ versionedBundle });
+        const result = await createRunPackValidated(dependencies)(
+            validatedConfig,
+            { ...baseOptions, vendorDependencies: true },
+            fakes.resolveAndLinkAll
+        );
+
+        assert.deepStrictEqual(result.isOk ? result.value : 'errored', undefined);
+        const emitted = fakes.packEmitterPack.firstCall.args[0] as {
+            readonly bundle: { readonly manifestFile: { readonly content: string } };
+        };
+        assert.strictEqual(emitted.bundle.manifestFile.content, malformedContent);
+    });
+
+    test('materializes externals and strips dependencies + peerDependencies from the manifest when vendorDependencies is enabled', async function () {
+        const versionedBundle = {
+            name: 'pkg-a',
+            version: '0.0.0',
+            manifestFile: {
+                content: JSON.stringify({
+                    name: 'pkg-a',
+                    version: '0.0.0',
+                    dependencies: { 'left-pad': '1.0.0' },
+                    peerDependencies: { react: '18.0.0' }
+                }),
+                isExecutable: false,
+                filePath: 'package.json'
+            }
+        };
+        const vendorEntries = [
+            {
+                sourceAbsolutePath: '/repo/node_modules/left-pad/index.js',
+                targetRelativePath: 'node_modules/left-pad/index.js',
+                isExecutable: false
+            }
+        ];
+        const materializerSpy = fake.resolves({ entries: vendorEntries, packageNames: ['left-pad'] });
+        const { dependencies, fakes } = createDependencies({
+            versionedBundle,
+            materializerSpy,
+            resolveResult: Result.ok([
+                makeResolvedPackage({
+                    externalDependencyNames: ['left-pad'],
+                    sourcesFolder: '/repo/source'
+                })
+            ])
+        });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(
+            validatedConfig,
+            { ...baseOptions, vendorDependencies: true },
+            fakes.resolveAndLinkAll
+        );
+
+        assert.deepStrictEqual(result.isOk ? result.value : 'errored', undefined);
+        assert.strictEqual(materializerSpy.callCount, 1);
+        assert.deepStrictEqual(materializerSpy.firstCall.args, [
+            { initialDependencyNames: ['left-pad'], projectFolder: '/repo/source' }
+        ]);
+        const emitArgs = fakes.packEmitterPack.firstCall.args as readonly unknown[];
+        const emitOptions = emitArgs[0] as {
+            readonly bundle: { readonly manifestFile: { readonly content: string } };
+            readonly vendorEntries: readonly unknown[];
+        };
+        const slimManifest = JSON.parse(emitOptions.bundle.manifestFile.content) as Record<string, unknown>;
+        assert.strictEqual('dependencies' in slimManifest, false);
+        assert.strictEqual('peerDependencies' in slimManifest, false);
+        assert.strictEqual(slimManifest.name, 'pkg-a');
+        assert.deepStrictEqual(emitOptions.vendorEntries, vendorEntries);
     });
 });

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -1,7 +1,15 @@
+/* eslint-disable import/max-dependencies -- the pack orchestrator wires resolve+link, version manager, vendor materializer, and pack emitter */
 import { Result } from 'true-myth';
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import type { PackageJson } from 'type-fest';
+import { z } from 'zod/mini';
 import type { PackEmitter, PackFormat } from '../pack-emitter/pack-emitter.ts';
+import { serializePackageJson } from '../version-manager/manifest/serialize.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
+import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
 import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
+import type { VendorMaterializer } from '../vendor-materializer/vendor-materializer.ts';
+import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 import type { ResolvedPackage } from './resolved-package.ts';
 import type { InternalResolveAndLinkFailure } from './packtory-resolve.ts';
 import type { PackPackageFailure } from './packtory-results.ts';
@@ -11,6 +19,7 @@ export type PackOptions = {
     readonly format: PackFormat;
     readonly outputPath: string;
     readonly version: string;
+    readonly vendorDependencies: boolean;
 };
 
 export type InternalPackFailure = InternalResolveAndLinkFailure | PackPackageFailure;
@@ -22,7 +31,10 @@ type ResolveAndLinkAllValidated = (
 export type PackRunDependencies = {
     readonly versionManager: VersionManager;
     readonly packEmitter: PackEmitter;
+    readonly vendorMaterializer: VendorMaterializer;
 };
+
+const manifestSchema = z.record(z.string(), z.unknown());
 
 function findPackage(
     resolved: readonly ResolvedPackage[],
@@ -44,6 +56,81 @@ function ensureNoBundleDependencies(target: ResolvedPackage): Result<ResolvedPac
     return Result.ok(target);
 }
 
+function stripVendoredManifestFields(manifest: Readonly<Record<string, unknown>>): Record<string, unknown> {
+    const slim: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(manifest)) {
+        if (key !== 'dependencies' && key !== 'peerDependencies') {
+            slim[key] = value;
+        }
+    }
+    return slim;
+}
+
+function asPackageJson(record: Readonly<Record<string, unknown>>): PackageJson {
+    // serializePackageJson sorts and stringifies any plain object; the PackageJson cast keeps
+    // the public seam without forcing every test fixture through type-fest's deep type.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- structural compat
+    return record as PackageJson;
+}
+
+function slimManifestForVendoredArtifact(bundle: VersionedBundleWithManifest): VersionedBundleWithManifest {
+    const parsed = safeParse(manifestSchema, JSON.parse(bundle.manifestFile.content));
+    if (!parsed.success) {
+        return bundle;
+    }
+    const content = serializePackageJson(asPackageJson(stripVendoredManifestFields(parsed.data)));
+    return {
+        ...bundle,
+        manifestFile: { ...bundle.manifestFile, content }
+    };
+}
+
+function buildVersionedBundle(
+    versionManager: VersionManager,
+    target: ResolvedPackage,
+    version: string
+): VersionedBundleWithManifest {
+    return versionManager.addVersion({
+        bundle: target.analyzedBundle,
+        version,
+        mainPackageJson: target.resolveOptions.mainPackageJson,
+        bundleDependencies: [],
+        bundlePeerDependencies: [],
+        additionalPackageJsonAttributes: target.resolveOptions.additionalPackageJsonAttributes,
+        allowMutableSpecifiers: target.resolveOptions.allowMutableSpecifiers
+    });
+}
+
+async function vendorExternalsFor(
+    vendorMaterializer: VendorMaterializer,
+    target: ResolvedPackage
+): Promise<readonly VendorEntry[]> {
+    const initialDependencyNames = Array.from(target.analyzedBundle.externalDependencies.keys());
+    const materialized = await vendorMaterializer.materializeExternals({
+        initialDependencyNames,
+        projectFolder: target.resolveOptions.sourcesFolder
+    });
+    return materialized.entries;
+}
+
+type PreparedArtifact = {
+    readonly bundle: VersionedBundleWithManifest;
+    readonly vendorEntries: readonly VendorEntry[];
+};
+
+async function prepareArtifact(
+    dependencies: PackRunDependencies,
+    target: ResolvedPackage,
+    options: PackOptions
+): Promise<PreparedArtifact> {
+    const built = buildVersionedBundle(dependencies.versionManager, target, options.version);
+    if (!options.vendorDependencies) {
+        return { bundle: built, vendorEntries: [] };
+    }
+    const vendorEntries = await vendorExternalsFor(dependencies.vendorMaterializer, target);
+    return { bundle: slimManifestForVendoredArtifact(built), vendorEntries };
+}
+
 export function createRunPackValidated(
     dependencies: PackRunDependencies
 ): (
@@ -62,21 +149,12 @@ export function createRunPackValidated(
             return Result.err(targetResult.error);
         }
 
-        const target = targetResult.value;
-        const versionedBundle = dependencies.versionManager.addVersion({
-            bundle: target.analyzedBundle,
-            version: options.version,
-            mainPackageJson: target.resolveOptions.mainPackageJson,
-            bundleDependencies: [],
-            bundlePeerDependencies: [],
-            additionalPackageJsonAttributes: target.resolveOptions.additionalPackageJsonAttributes,
-            allowMutableSpecifiers: target.resolveOptions.allowMutableSpecifiers
-        });
-
+        const prepared = await prepareArtifact(dependencies, targetResult.value, options);
         await dependencies.packEmitter.pack({
-            bundle: versionedBundle,
+            bundle: prepared.bundle,
             format: options.format,
-            outputPath: options.outputPath
+            outputPath: options.outputPath,
+            vendorEntries: prepared.vendorEntries
         });
 
         return Result.ok(undefined);

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -99,6 +99,7 @@ export type PackPublicOptions = {
     readonly format: PackFormat;
     readonly outputPath: string;
     readonly version: string;
+    readonly vendorDependencies: boolean;
 };
 
 export type PackFailure = CheckError | ConfigError | PackPackageFailure | PartialErrorResult;

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -239,6 +239,11 @@ function createPacktoryUnderTest(
                     (async () => {
                         throw new Error('packEmitter.pack not implemented in tests');
                     })) as never
+            },
+            vendorMaterializer: {
+                materializeExternals: async () => {
+                    return { entries: [], packageNames: [] };
+                }
             }
         }),
         resolveAndLink,
@@ -581,7 +586,8 @@ suite('packtory', function () {
         packageName: 'package-a',
         format: 'zip' as const,
         outputPath: '/out/package-a.zip',
-        version: '1.0.0'
+        version: '1.0.0',
+        vendorDependencies: false
     };
 
     test('packPackage() returns a config failure when the supplied config is invalid', async function () {

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -4,6 +4,7 @@ import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
 import { validateConfig, validateConfigWithoutRegistry, type ValidConfigResult } from '../config/validation.ts';
 import type { DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { PackEmitter } from '../pack-emitter/pack-emitter.ts';
+import type { VendorMaterializer } from '../vendor-materializer/vendor-materializer.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
 import { createDiffAgainstLatestPublishedValidated } from './packtory-release-diff.ts';
 import { createRunPackValidated } from './packtory-pack.ts';
@@ -58,6 +59,7 @@ type PacktoryDependencies = {
     readonly artifactsBuilder: Pick<ArtifactsBuilder, 'collectContents'>;
     readonly versionManager: VersionManager;
     readonly packEmitter: PackEmitter;
+    readonly vendorMaterializer: VendorMaterializer;
 };
 
 type ValidatedRunners = {

--- a/source/tar/tarball-builder.test.ts
+++ b/source/tar/tarball-builder.test.ts
@@ -149,4 +149,77 @@ suite('tarball-builder', function () {
 
         assert.deepStrictEqual(createGzip.firstCall.args, [{ level: 9 }]);
     });
+
+    test('includes vendor entries with raw bytes from the file manager alongside inline file descriptions', async function () {
+        const builder = createTarballBuilder({
+            fileManager: {
+                readFileBytes: async () => {
+                    return Buffer.from('vendored-bytes', 'utf8');
+                }
+            }
+        });
+
+        const tarballBuffer = await builder.build(
+            [{ filePath: 'index.js', content: 'console.log(0);', isExecutable: false }],
+            [
+                {
+                    sourceAbsolutePath: '/repo/node_modules/pkg/dist/main.js',
+                    targetRelativePath: 'node_modules/pkg/main.js',
+                    isExecutable: false
+                }
+            ]
+        );
+        const entries = await withPromiseDeadline(extractTarEntries(tarballBuffer), 'vendor tar extraction');
+
+        const names = entries.map((entry) => {
+            return entry.header.name;
+        });
+        assert.deepStrictEqual(names, ['index.js', 'node_modules/pkg/main.js']);
+        const vendorEntry = entries.find((entry) => {
+            return entry.header.name === 'node_modules/pkg/main.js';
+        });
+        assert.ok(vendorEntry);
+        assert.strictEqual(vendorEntry.content, 'vendored-bytes');
+    });
+
+    test('marks executable vendor entries with the executable mode in the tarball', async function () {
+        const builder = createTarballBuilder({
+            fileManager: {
+                readFileBytes: async () => {
+                    return Buffer.from('#!/bin/sh', 'utf8');
+                }
+            }
+        });
+
+        const tarballBuffer = await builder.build(
+            [],
+            [
+                {
+                    sourceAbsolutePath: '/repo/bin/run.sh',
+                    targetRelativePath: 'node_modules/pkg/bin/run.sh',
+                    isExecutable: true
+                }
+            ]
+        );
+        const [entry] = await withPromiseDeadline(extractTarEntries(tarballBuffer), 'executable vendor tar extraction');
+        assert.ok(entry);
+        assert.strictEqual(entry.header.mode, 493);
+    });
+
+    test('rejects vendor materialization when no file manager is wired into the tarball builder', async function () {
+        const builder = createTarballBuilder();
+        const vendorEntry = {
+            sourceAbsolutePath: '/missing',
+            targetRelativePath: 'node_modules/pkg/lib.js',
+            isExecutable: false
+        };
+        let capturedMessage = '';
+        try {
+            await builder.build([], [vendorEntry]);
+            assert.fail('expected build() to reject because the tarball builder lacks readFileBytes');
+        } catch (error: unknown) {
+            capturedMessage = (error as Error).message;
+        }
+        assert.strictEqual(capturedMessage, 'readFileBytes is required to materialize vendor entries into the tarball');
+    });
 });

--- a/source/tar/tarball-builder.ts
+++ b/source/tar/tarball-builder.ts
@@ -1,13 +1,16 @@
 import zlib from 'node:zlib';
 import tar, { type Pack } from 'tar-stream';
 import type { FileDescription } from '../file-manager/file-description.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
+import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
 export type TarballBuilder = {
-    build: (fileDescriptions: readonly FileDescription[]) => Promise<Buffer>;
+    build: (fileDescriptions: readonly FileDescription[], vendorEntries?: readonly VendorEntry[]) => Promise<Buffer>;
 };
 
 type TarballBuilderDependencies = {
     readonly createGzip: typeof zlib.createGzip;
+    readonly fileManager: Pick<FileManager, 'readFileBytes'>;
 };
 
 const gzipHeaderOperationSystemTypeFieldIndex = 9;
@@ -29,20 +32,36 @@ const nonExecutableFileMode = 420;
 
 export function createTarballBuilder(dependencies: Partial<TarballBuilderDependencies> = {}): TarballBuilder {
     const createGzip = dependencies.createGzip ?? zlib.createGzip;
+    const fileManager = dependencies.fileManager ?? {
+        async readFileBytes(): Promise<Buffer> {
+            throw new Error('readFileBytes is required to materialize vendor entries into the tarball');
+        }
+    };
 
-    function createPack(fileDescriptions: readonly FileDescription[]): Pack {
+    function addEntry(pack: Pack, filePath: string, isExecutable: boolean, payload: Buffer | string): void {
+        const entry = pack.entry(
+            {
+                name: filePath,
+                mtime: staticFileModificationTime,
+                mode: isExecutable ? executableFileMode : nonExecutableFileMode
+            },
+            payload
+        );
+        entry.end();
+    }
+
+    async function createPack(
+        fileDescriptions: readonly FileDescription[],
+        vendorEntries: readonly VendorEntry[]
+    ): Promise<Pack> {
         const pack = tar.pack();
 
         for (const fileDescription of fileDescriptions) {
-            const entry = pack.entry(
-                {
-                    name: fileDescription.filePath,
-                    mtime: staticFileModificationTime,
-                    mode: fileDescription.isExecutable ? executableFileMode : nonExecutableFileMode
-                },
-                fileDescription.content
-            );
-            entry.end();
+            addEntry(pack, fileDescription.filePath, fileDescription.isExecutable, fileDescription.content);
+        }
+        for (const vendorEntry of vendorEntries) {
+            const payload = await fileManager.readFileBytes(vendorEntry.sourceAbsolutePath);
+            addEntry(pack, vendorEntry.targetRelativePath, vendorEntry.isExecutable, payload);
         }
 
         pack.finalize();
@@ -51,8 +70,8 @@ export function createTarballBuilder(dependencies: Partial<TarballBuilderDepende
     }
 
     return {
-        async build(fileDescriptions) {
-            const pack = createPack(fileDescriptions);
+        async build(fileDescriptions, vendorEntries = []) {
+            const pack = await createPack(fileDescriptions, vendorEntries);
 
             const gzipStream = createGzip({ level: 9 });
             const tarballStream = pack.pipe(gzipStream);

--- a/source/test-libraries/fake-file-manager.ts
+++ b/source/test-libraries/fake-file-manager.ts
@@ -1,6 +1,8 @@
 import type { TransferableFileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
 
+type DirectoryEntry = Awaited<ReturnType<FileManager['listDirectoryEntries']>>[number];
+
 type SimulatedSuccess<TValue> = {
     readonly value: TValue;
     readonly error?: undefined;
@@ -22,6 +24,10 @@ type ReadFileCall = {
     readonly filePath: string;
 };
 
+type ReadFileBytesCall = {
+    readonly filePath: string;
+};
+
 type WriteFileCall = {
     readonly filePath: string;
     readonly content: string;
@@ -35,6 +41,19 @@ type WriteBinaryFileCall = {
 type CopyFileCall = {
     readonly from: string;
     readonly to: string;
+};
+
+type CopyFileBytesCall = {
+    readonly from: string;
+    readonly to: string;
+};
+
+type ListDirectoryCall = {
+    readonly directoryPath: string;
+};
+
+type RealPathCall = {
+    readonly filePath: string;
 };
 
 type CheckReadabilityCall = {
@@ -53,18 +72,26 @@ type TransferableFileDescriptionResponder = (
 
 type FakeFileManagerOptions = {
     readonly simulatedReadFileResponses?: readonly SimulatedResponse<string>[];
+    readonly simulatedReadFileBytesResponses?: readonly SimulatedResponse<Buffer>[];
     readonly simulatedCheckReadabilityResponses?: readonly SimulatedResponse<ReadabilityResult>[];
     readonly simulatedTransferableFileDescriptionResponses?: readonly SimulatedResponse<TransferableFileDescription>[];
     readonly transferableFileDescriptionResponder?: TransferableFileDescriptionResponder;
     readonly simulatedWriteFileResponses?: readonly SimulatedVoidResponse[];
     readonly simulatedWriteBinaryFileResponses?: readonly SimulatedVoidResponse[];
     readonly simulatedCopyFileResponses?: readonly SimulatedVoidResponse[];
+    readonly simulatedCopyFileBytesResponses?: readonly SimulatedVoidResponse[];
+    readonly simulatedListDirectoryResponses?: readonly SimulatedResponse<readonly DirectoryEntry[]>[];
+    readonly simulatedRealPathResponses?: readonly SimulatedResponse<string>[];
 };
 
 export type FakeFileManager = FileManager & {
     readonly getReadFileCallCount: () => number;
     readonly getReadFileCall: (index: number) => ReadFileCall;
     readonly getAllReadFileCalls: () => readonly ReadFileCall[];
+
+    readonly getReadFileBytesCallCount: () => number;
+    readonly getReadFileBytesCall: (index: number) => ReadFileBytesCall;
+    readonly getAllReadFileBytesCalls: () => readonly ReadFileBytesCall[];
 
     readonly getWriteFileCallCount: () => number;
     readonly getWriteFileCall: (index: number) => WriteFileCall;
@@ -78,6 +105,18 @@ export type FakeFileManager = FileManager & {
     readonly getCopyFileCall: (index: number) => CopyFileCall;
     readonly getAllCopyFileCalls: () => readonly CopyFileCall[];
 
+    readonly getCopyFileBytesCallCount: () => number;
+    readonly getCopyFileBytesCall: (index: number) => CopyFileBytesCall;
+    readonly getAllCopyFileBytesCalls: () => readonly CopyFileBytesCall[];
+
+    readonly getListDirectoryCallCount: () => number;
+    readonly getListDirectoryCall: (index: number) => ListDirectoryCall;
+    readonly getAllListDirectoryCalls: () => readonly ListDirectoryCall[];
+
+    readonly getRealPathCallCount: () => number;
+    readonly getRealPathCall: (index: number) => RealPathCall;
+    readonly getAllRealPathCalls: () => readonly RealPathCall[];
+
     readonly getCheckReadabilityCallCount: () => number;
     readonly getCheckReadabilityCall: (index: number) => CheckReadabilityCall;
     readonly getAllCheckReadabilityCalls: () => readonly CheckReadabilityCall[];
@@ -88,6 +127,7 @@ export type FakeFileManager = FileManager & {
 };
 
 const defaultReadFileResponse: SimulatedResponse<string> = { value: '' };
+const defaultReadFileBytesResponse: SimulatedResponse<Buffer> = { value: Buffer.alloc(0) };
 const defaultCheckReadabilityResponse: SimulatedResponse<ReadabilityResult> = { value: { isReadable: true } };
 const defaultVoidResponse: SimulatedVoidResponse = {};
 
@@ -117,18 +157,26 @@ function getCallAtIndex<TCall>(calls: readonly TCall[], methodName: string, inde
 export function createFakeFileManager(options: FakeFileManagerOptions = {}): FakeFileManager {
     const {
         simulatedReadFileResponses = [],
+        simulatedReadFileBytesResponses = [],
         simulatedCheckReadabilityResponses = [],
         simulatedTransferableFileDescriptionResponses = [],
         transferableFileDescriptionResponder,
         simulatedWriteFileResponses = [],
         simulatedWriteBinaryFileResponses = [],
-        simulatedCopyFileResponses = []
+        simulatedCopyFileResponses = [],
+        simulatedCopyFileBytesResponses = [],
+        simulatedListDirectoryResponses = [],
+        simulatedRealPathResponses = []
     } = options;
 
     const readFileCalls: ReadFileCall[] = [];
+    const readFileBytesCalls: ReadFileBytesCall[] = [];
     const writeFileCalls: WriteFileCall[] = [];
     const writeBinaryFileCalls: WriteBinaryFileCall[] = [];
     const copyFileCalls: CopyFileCall[] = [];
+    const copyFileBytesCalls: CopyFileBytesCall[] = [];
+    const listDirectoryCalls: ListDirectoryCall[] = [];
+    const realPathCalls: RealPathCall[] = [];
     const checkReadabilityCalls: CheckReadabilityCall[] = [];
     const transferableFileDescriptionCalls: TransferableFileDescriptionCall[] = [];
 
@@ -136,6 +184,12 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
         async readFile(filePath) {
             const response = simulatedReadFileResponses[readFileCalls.length] ?? defaultReadFileResponse;
             readFileCalls.push({ filePath });
+            return resolveValueResponse(response);
+        },
+
+        async readFileBytes(filePath) {
+            const response = simulatedReadFileBytesResponses[readFileBytesCalls.length] ?? defaultReadFileBytesResponse;
+            readFileBytesCalls.push({ filePath });
             return resolveValueResponse(response);
         },
 
@@ -159,6 +213,24 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
             const response = simulatedCopyFileResponses[copyFileCalls.length] ?? defaultVoidResponse;
             copyFileCalls.push({ from, to });
             resolveVoidResponse(response);
+        },
+
+        async copyFileBytes(from, to) {
+            const response = simulatedCopyFileBytesResponses[copyFileBytesCalls.length] ?? defaultVoidResponse;
+            copyFileBytesCalls.push({ from, to });
+            resolveVoidResponse(response);
+        },
+
+        async listDirectoryEntries(directoryPath) {
+            const response = simulatedListDirectoryResponses[listDirectoryCalls.length] ?? { value: [] };
+            listDirectoryCalls.push({ directoryPath });
+            return resolveValueResponse(response);
+        },
+
+        async getRealPath(filePath) {
+            const response = simulatedRealPathResponses[realPathCalls.length] ?? { value: filePath };
+            realPathCalls.push({ filePath });
+            return resolveValueResponse(response);
         },
 
         async checkReadability(fileOrFolderPath) {
@@ -191,6 +263,16 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
             return readFileCalls;
         },
 
+        getReadFileBytesCallCount() {
+            return readFileBytesCalls.length;
+        },
+        getReadFileBytesCall(index) {
+            return getCallAtIndex(readFileBytesCalls, 'readFileBytes', index);
+        },
+        getAllReadFileBytesCalls() {
+            return readFileBytesCalls;
+        },
+
         getWriteFileCallCount() {
             return writeFileCalls.length;
         },
@@ -219,6 +301,36 @@ export function createFakeFileManager(options: FakeFileManagerOptions = {}): Fak
         },
         getAllCopyFileCalls() {
             return copyFileCalls;
+        },
+
+        getCopyFileBytesCallCount() {
+            return copyFileBytesCalls.length;
+        },
+        getCopyFileBytesCall(index) {
+            return getCallAtIndex(copyFileBytesCalls, 'copyFileBytes', index);
+        },
+        getAllCopyFileBytesCalls() {
+            return copyFileBytesCalls;
+        },
+
+        getListDirectoryCallCount() {
+            return listDirectoryCalls.length;
+        },
+        getListDirectoryCall(index) {
+            return getCallAtIndex(listDirectoryCalls, 'listDirectoryEntries', index);
+        },
+        getAllListDirectoryCalls() {
+            return listDirectoryCalls;
+        },
+
+        getRealPathCallCount() {
+            return realPathCalls.length;
+        },
+        getRealPathCall(index) {
+            return getCallAtIndex(realPathCalls, 'getRealPath', index);
+        },
+        getAllRealPathCalls() {
+            return realPathCalls;
         },
 
         getCheckReadabilityCallCount() {

--- a/source/vendor-materializer/vendor-entry.test.ts
+++ b/source/vendor-materializer/vendor-entry.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { applyPrefixToVendorEntry } from './vendor-entry.ts';
+
+suite('applyPrefixToVendorEntry', function () {
+    test('prepends the supplied prefix to the target relative path while preserving the other fields', function () {
+        const prefixed = applyPrefixToVendorEntry('package', {
+            sourceAbsolutePath: '/src/index.js',
+            targetRelativePath: 'node_modules/pkg/index.js',
+            isExecutable: true
+        });
+
+        assert.deepStrictEqual(prefixed, {
+            sourceAbsolutePath: '/src/index.js',
+            targetRelativePath: 'package/node_modules/pkg/index.js',
+            isExecutable: true
+        });
+    });
+});

--- a/source/vendor-materializer/vendor-entry.ts
+++ b/source/vendor-materializer/vendor-entry.ts
@@ -1,0 +1,13 @@
+export type VendorEntry = {
+    readonly sourceAbsolutePath: string;
+    readonly targetRelativePath: string;
+    readonly isExecutable: boolean;
+};
+
+export function applyPrefixToVendorEntry(prefix: string, entry: VendorEntry): VendorEntry {
+    return {
+        sourceAbsolutePath: entry.sourceAbsolutePath,
+        targetRelativePath: `${prefix}/${entry.targetRelativePath}`,
+        isExecutable: entry.isExecutable
+    };
+}

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
+import { createVendorMaterializer } from './vendor-materializer.ts';
+
+type ReadabilityResponse = { readonly value: { readonly isReadable: boolean } };
+type StringResponse = { readonly value: string };
+type DirectoryEntriesResponse = {
+    readonly value: readonly {
+        readonly name: string;
+        readonly isDirectory: boolean;
+        readonly isSymbolicLink: boolean;
+    }[];
+};
+
+type FakeSetup = {
+    readonly readabilities: readonly ReadabilityResponse[];
+    readonly realPaths: readonly StringResponse[];
+    readonly listings: readonly DirectoryEntriesResponse[];
+    readonly fileReads: readonly StringResponse[];
+};
+
+function setupFileManager(setup: FakeSetup): ReturnType<typeof createFakeFileManager> {
+    return createFakeFileManager({
+        simulatedCheckReadabilityResponses: setup.readabilities,
+        simulatedRealPathResponses: setup.realPaths,
+        simulatedListDirectoryResponses: setup.listings,
+        simulatedReadFileResponses: setup.fileReads
+    });
+}
+
+async function runWith(
+    setup: FakeSetup,
+    request: { readonly initialDependencyNames: readonly string[]; readonly projectFolder: string }
+): Promise<{
+    readonly entries: readonly {
+        readonly targetRelativePath: string;
+        readonly sourceAbsolutePath: string;
+        readonly isExecutable: boolean;
+    }[];
+    readonly packageNames: readonly string[];
+}> {
+    const fileManager = setupFileManager(setup);
+    const materializer = createVendorMaterializer({ fileManager });
+    return await materializer.materializeExternals(request);
+}
+
+suite('vendor-materializer', function () {
+    test('treats a package.json with malformed dependency maps as having no transitive dependencies and only collects its own files', async function () {
+        const result = await runWith(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/broken' }],
+                listings: [{ value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }],
+                fileReads: [{ value: JSON.stringify({ dependencies: 'this should be an object' }) }]
+            },
+            { initialDependencyNames: ['broken'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(result.packageNames, ['broken']);
+        assert.deepStrictEqual(result.entries, [
+            {
+                sourceAbsolutePath: '/repo/node_modules/broken/index.js',
+                targetRelativePath: 'node_modules/broken/index.js',
+                isExecutable: false
+            }
+        ]);
+    });
+
+    test('returns an empty result when no initial dependencies are requested', async function () {
+        const fileManager = setupFileManager({ readabilities: [], realPaths: [], listings: [], fileReads: [] });
+        const materializer = createVendorMaterializer({ fileManager });
+
+        const result = await materializer.materializeExternals({
+            initialDependencyNames: [],
+            projectFolder: '/repo'
+        });
+
+        assert.deepStrictEqual(result.entries, []);
+        assert.deepStrictEqual(result.packageNames, []);
+    });
+
+    test('collects files for a single dependency by probing the start folder first and reads its package.json by exact name', async function () {
+        const fileManager = setupFileManager({
+            readabilities: [{ value: { isReadable: true } }],
+            realPaths: [{ value: '/repo/node_modules/leaf' }],
+            listings: [
+                {
+                    value: [
+                        { name: 'index.js', isDirectory: false, isSymbolicLink: false },
+                        { name: 'package.json', isDirectory: false, isSymbolicLink: false }
+                    ]
+                }
+            ],
+            fileReads: [{ value: '{}' }]
+        });
+        const materializer = createVendorMaterializer({ fileManager });
+
+        const result = await materializer.materializeExternals({
+            initialDependencyNames: ['leaf'],
+            projectFolder: '/repo'
+        });
+
+        assert.deepStrictEqual(result.packageNames, ['leaf']);
+        assert.deepStrictEqual(result.entries, [
+            {
+                sourceAbsolutePath: '/repo/node_modules/leaf/index.js',
+                targetRelativePath: 'node_modules/leaf/index.js',
+                isExecutable: false
+            },
+            {
+                sourceAbsolutePath: '/repo/node_modules/leaf/package.json',
+                targetRelativePath: 'node_modules/leaf/package.json',
+                isExecutable: false
+            }
+        ]);
+        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), {
+            fileOrFolderPath: '/repo/node_modules/leaf'
+        });
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/repo/node_modules/leaf/package.json' });
+    });
+
+    test('walks transitively into both dependencies and peerDependencies declared by each visited package', async function () {
+        const fileManager = setupFileManager({
+            readabilities: [
+                { value: { isReadable: true } },
+                { value: { isReadable: true } },
+                { value: { isReadable: true } }
+            ],
+            realPaths: [
+                { value: '/repo/node_modules/root' },
+                { value: '/repo/node_modules/dep' },
+                { value: '/repo/node_modules/peer' }
+            ],
+            listings: [
+                { value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] },
+                { value: [{ name: 'lib.js', isDirectory: false, isSymbolicLink: false }] },
+                { value: [{ name: 'peer.js', isDirectory: false, isSymbolicLink: false }] }
+            ],
+            fileReads: [
+                { value: JSON.stringify({ dependencies: { dep: '1.0.0' }, peerDependencies: { peer: '1.0.0' } }) },
+                { value: '{}' },
+                { value: '{}' }
+            ]
+        });
+        const materializer = createVendorMaterializer({ fileManager });
+
+        const result = await materializer.materializeExternals({
+            initialDependencyNames: ['root'],
+            projectFolder: '/repo'
+        });
+
+        assert.deepStrictEqual(result.packageNames, ['root', 'dep', 'peer']);
+        const targetPaths = result.entries.map((entry) => {
+            return entry.targetRelativePath;
+        });
+        assert.deepStrictEqual(targetPaths, [
+            'node_modules/root/index.js',
+            'node_modules/dep/lib.js',
+            'node_modules/peer/peer.js'
+        ]);
+    });
+
+    test('skips nested node_modules when walking files (nested packages are visited as separate closure entries instead)', async function () {
+        // If the materializer mistakenly recurses into the nested node_modules, this second listing
+        // would be consumed and "should-never-be-included.js" would appear in the result.
+        const result = await runWith(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }],
+                listings: [
+                    {
+                        value: [
+                            { name: 'index.js', isDirectory: false, isSymbolicLink: false },
+                            { name: 'node_modules', isDirectory: true, isSymbolicLink: false }
+                        ]
+                    },
+                    {
+                        value: [{ name: 'should-never-be-included.js', isDirectory: false, isSymbolicLink: false }]
+                    }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(
+            result.entries.map((entry) => {
+                return entry.targetRelativePath;
+            }),
+            ['node_modules/pkg/index.js']
+        );
+    });
+
+    test('recurses into non-node_modules subdirectories and preserves the relative path under the package root', async function () {
+        const result = await runWith(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }],
+                listings: [
+                    { value: [{ name: 'src', isDirectory: true, isSymbolicLink: false }] },
+                    { value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(result.entries, [
+            {
+                sourceAbsolutePath: '/repo/node_modules/pkg/src/index.js',
+                targetRelativePath: 'node_modules/pkg/src/index.js',
+                isExecutable: false
+            }
+        ]);
+    });
+
+    test('walks up parent folders to find a dependency when it is not under the starting folder', async function () {
+        const fileManager = setupFileManager({
+            readabilities: [
+                { value: { isReadable: false } },
+                { value: { isReadable: false } },
+                { value: { isReadable: true } }
+            ],
+            realPaths: [{ value: '/workspace/node_modules/hoisted' }],
+            listings: [{ value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }],
+            fileReads: [{ value: '{}' }]
+        });
+        const materializer = createVendorMaterializer({ fileManager });
+
+        const result = await materializer.materializeExternals({
+            initialDependencyNames: ['hoisted'],
+            projectFolder: '/workspace/packages/inner'
+        });
+
+        assert.deepStrictEqual(result.packageNames, ['hoisted']);
+        assert.deepStrictEqual(fileManager.getAllCheckReadabilityCalls(), [
+            { fileOrFolderPath: '/workspace/packages/inner/node_modules/hoisted' },
+            { fileOrFolderPath: '/workspace/packages/node_modules/hoisted' },
+            { fileOrFolderPath: '/workspace/node_modules/hoisted' }
+        ]);
+        assert.deepStrictEqual(result.entries, [
+            {
+                sourceAbsolutePath: '/workspace/node_modules/hoisted/index.js',
+                targetRelativePath: 'node_modules/hoisted/index.js',
+                isExecutable: false
+            }
+        ]);
+    });
+
+    test('skips dependencies that cannot be located in any reachable node_modules ancestor, probing every ancestor up to the filesystem root', async function () {
+        const fileManager = setupFileManager({
+            readabilities: Array.from({ length: 20 }, () => {
+                return { value: { isReadable: false } };
+            }),
+            realPaths: [],
+            listings: [],
+            fileReads: []
+        });
+        const materializer = createVendorMaterializer({ fileManager });
+
+        const result = await materializer.materializeExternals({
+            initialDependencyNames: ['missing'],
+            projectFolder: '/some/deep/folder'
+        });
+
+        assert.deepStrictEqual(result.entries, []);
+        assert.deepStrictEqual(result.packageNames, []);
+        assert.deepStrictEqual(fileManager.getAllCheckReadabilityCalls(), [
+            { fileOrFolderPath: '/some/deep/folder/node_modules/missing' },
+            { fileOrFolderPath: '/some/deep/node_modules/missing' },
+            { fileOrFolderPath: '/some/node_modules/missing' },
+            { fileOrFolderPath: '/node_modules/missing' }
+        ]);
+    });
+
+    test('deduplicates packages so the same name is materialized at most once even when referenced from multiple deps', async function () {
+        const truthyReadability = { value: { isReadable: true } } as const;
+        const result = await runWith(
+            {
+                readabilities: [truthyReadability, truthyReadability, truthyReadability],
+                realPaths: [
+                    { value: '/repo/node_modules/a' },
+                    { value: '/repo/node_modules/b' },
+                    { value: '/repo/node_modules/shared' }
+                ],
+                listings: [
+                    { value: [{ name: 'a.js', isDirectory: false, isSymbolicLink: false }] },
+                    { value: [{ name: 'b.js', isDirectory: false, isSymbolicLink: false }] },
+                    { value: [{ name: 'shared.js', isDirectory: false, isSymbolicLink: false }] }
+                ],
+                fileReads: [
+                    { value: JSON.stringify({ dependencies: { shared: '1.0.0' } }) },
+                    { value: JSON.stringify({ dependencies: { shared: '1.0.0' } }) },
+                    { value: '{}' }
+                ]
+            },
+            { initialDependencyNames: ['a', 'b'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(result.packageNames, ['a', 'b', 'shared']);
+        const sharedCount = result.entries.filter((entry) => {
+            return entry.targetRelativePath.startsWith('node_modules/shared/');
+        }).length;
+        assert.strictEqual(sharedCount, 1);
+    });
+});

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -1,0 +1,164 @@
+import path from 'node:path';
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import { z } from 'zod/mini';
+import type { FileManager } from '../file-manager/file-manager.ts';
+import type { VendorEntry } from './vendor-entry.ts';
+
+type MaterializedExternals = {
+    readonly entries: readonly VendorEntry[];
+    readonly packageNames: readonly string[];
+};
+
+export type VendorMaterializerDependencies = {
+    readonly fileManager: Pick<FileManager, 'checkReadability' | 'getRealPath' | 'listDirectoryEntries' | 'readFile'>;
+};
+
+type MaterializeExternalsOptions = {
+    readonly initialDependencyNames: readonly string[];
+    readonly projectFolder: string;
+};
+
+export type VendorMaterializer = {
+    materializeExternals: (options: MaterializeExternalsOptions) => Promise<MaterializedExternals>;
+};
+
+const nodeModulesFolderName = 'node_modules';
+
+const dependencyMapSchema = z.optional(z.record(z.string(), z.string()));
+const packageManifestSchema = z.object({
+    dependencies: dependencyMapSchema,
+    peerDependencies: dependencyMapSchema
+});
+
+type QueueItem = {
+    readonly name: string;
+    readonly fromFolder: string;
+};
+
+type Closure = {
+    readonly visited: Set<string>;
+    readonly entries: VendorEntry[];
+    readonly queue: QueueItem[];
+};
+
+function ancestorFolders(startFolder: string): readonly string[] {
+    const parts = startFolder.split(path.sep);
+    return parts.map((_segment, index, allSegments) => {
+        const prefixLength = allSegments.length - index;
+        const joined = allSegments.slice(0, prefixLength).join(path.sep);
+        return joined.length === 0 ? path.sep : joined;
+    });
+}
+
+function buildVendorEntry(rootDirectory: string, packageName: string, relativePath: string): VendorEntry {
+    const normalizedRelative = relativePath.split(path.sep).join('/');
+    return {
+        sourceAbsolutePath: path.join(rootDirectory, relativePath),
+        targetRelativePath: `${nodeModulesFolderName}/${packageName}/${normalizedRelative}`,
+        isExecutable: false
+    };
+}
+
+function enqueueDependencies(closure: Closure, fromFolder: string, dependencyNames: readonly string[]): void {
+    for (const dependencyName of dependencyNames) {
+        closure.queue.push({ name: dependencyName, fromFolder });
+    }
+}
+
+function parseManifestDependencies(content: string): readonly string[] {
+    const parsed = safeParse(packageManifestSchema, JSON.parse(content));
+    if (!parsed.success) {
+        return [];
+    }
+    return [...Object.keys(parsed.data.dependencies ?? {}), ...Object.keys(parsed.data.peerDependencies ?? {})];
+}
+
+export function createVendorMaterializer(dependencies: VendorMaterializerDependencies): VendorMaterializer {
+    const { fileManager } = dependencies;
+
+    async function probeCandidate(currentFolder: string, packageName: string): Promise<string | undefined> {
+        const candidate = path.join(currentFolder, nodeModulesFolderName, packageName);
+        const readability = await fileManager.checkReadability(candidate);
+        if (readability.isReadable) {
+            return await fileManager.getRealPath(candidate);
+        }
+        return undefined;
+    }
+
+    async function findPackageRealPath(packageName: string, startFolder: string): Promise<string | undefined> {
+        for (const folder of ancestorFolders(startFolder)) {
+            const found = await probeCandidate(folder, packageName);
+            if (found !== undefined) {
+                return found;
+            }
+        }
+        return undefined;
+    }
+
+    async function readDependencyNames(packageDirectory: string): Promise<readonly string[]> {
+        const manifestPath = path.join(packageDirectory, 'package.json');
+        const content = await fileManager.readFile(manifestPath);
+        return parseManifestDependencies(content);
+    }
+
+    async function collectPackageFiles(rootDirectory: string, packageName: string): Promise<readonly VendorEntry[]> {
+        const collected: VendorEntry[] = [];
+
+        async function walk(relativeDirectory: string): Promise<void> {
+            const absoluteDirectory = path.join(rootDirectory, relativeDirectory);
+            const entries = await fileManager.listDirectoryEntries(absoluteDirectory);
+            const includedEntries = entries.filter((entry) => {
+                return entry.name !== nodeModulesFolderName;
+            });
+            for (const entry of includedEntries) {
+                const relativeEntryPath = path.join(relativeDirectory, entry.name);
+                if (entry.isDirectory) {
+                    await walk(relativeEntryPath);
+                } else {
+                    collected.push(buildVendorEntry(rootDirectory, packageName, relativeEntryPath));
+                }
+            }
+        }
+
+        await walk('');
+        return collected;
+    }
+
+    async function processQueueItem(closure: Closure, item: QueueItem): Promise<void> {
+        if (closure.visited.has(item.name)) {
+            return;
+        }
+        const realPath = await findPackageRealPath(item.name, item.fromFolder);
+        if (realPath === undefined) {
+            return;
+        }
+        closure.visited.add(item.name);
+        const dependencyNames = await readDependencyNames(realPath);
+        enqueueDependencies(closure, realPath, dependencyNames);
+        const packageEntries = await collectPackageFiles(realPath, item.name);
+        closure.entries.push(...packageEntries);
+    }
+
+    async function drainQueue(closure: Closure): Promise<void> {
+        const item = closure.queue.shift();
+        if (item === undefined) {
+            return;
+        }
+        await processQueueItem(closure, item);
+        await drainQueue(closure);
+    }
+
+    return {
+        async materializeExternals(options) {
+            const closure: Closure = {
+                visited: new Set<string>(),
+                entries: [],
+                queue: options.initialDependencyNames.map((name) => {
+                    return { name, fromFolder: options.projectFolder };
+                })
+            };
+            await drainQueue(closure);
+            return { entries: closure.entries, packageNames: Array.from(closure.visited) };
+        }
+    };
+}

--- a/source/zip/zip-builder.test.ts
+++ b/source/zip/zip-builder.test.ts
@@ -116,6 +116,96 @@ suite('zip-builder', function () {
         assert.deepStrictEqual(options, {});
     });
 
+    test('includes vendor entries with raw bytes from the file manager alongside inline file descriptions', async function () {
+        const builder = createZipBuilder({
+            fileManager: {
+                readFileBytes: async () => {
+                    return Buffer.from('vendored-bytes', 'utf8');
+                }
+            }
+        });
+
+        const zipBuffer = await builder.build(
+            [{ filePath: 'index.js', content: 'console.log(0);', isExecutable: false }],
+            [
+                {
+                    sourceAbsolutePath: '/repo/node_modules/pkg/dist/main.js',
+                    targetRelativePath: 'node_modules/pkg/main.js',
+                    isExecutable: false
+                }
+            ]
+        );
+        const entries = await extractZipEntries(zipBuffer);
+
+        assert.deepStrictEqual(entries, [
+            {
+                name: 'index.js',
+                content: 'console.log(0);',
+                unixMode: nonExecutableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            },
+            {
+                name: 'node_modules/pkg/main.js',
+                content: 'vendored-bytes',
+                unixMode: nonExecutableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            }
+        ]);
+    });
+
+    test('marks executable vendor entries with the executable unix mode in the zip output', async function () {
+        const builder = createZipBuilder({
+            fileManager: {
+                readFileBytes: async () => {
+                    return Buffer.from('#!/bin/sh\necho hi', 'utf8');
+                }
+            }
+        });
+
+        const zipBuffer = await builder.build(
+            [],
+            [
+                {
+                    sourceAbsolutePath: '/repo/node_modules/pkg/bin/run.sh',
+                    targetRelativePath: 'node_modules/pkg/bin/run.sh',
+                    isExecutable: true
+                }
+            ]
+        );
+        const entries = await extractZipEntries(zipBuffer);
+
+        assert.deepStrictEqual(entries, [
+            {
+                name: 'node_modules/pkg/bin/run.sh',
+                content: '#!/bin/sh\necho hi',
+                unixMode: executableUnixMode,
+                osOfOrigin: unixOperatingSystem
+            }
+        ]);
+    });
+
+    test('throws a clear error when vendor entries are requested without a configured file manager', async function () {
+        const builder = createZipBuilder();
+        try {
+            await builder.build(
+                [],
+                [
+                    {
+                        sourceAbsolutePath: '/anywhere',
+                        targetRelativePath: 'node_modules/pkg/index.js',
+                        isExecutable: false
+                    }
+                ]
+            );
+            assert.fail('expected build() to reject because readFileBytes is not configured');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'readFileBytes is required to materialize vendor entries into the zip'
+            );
+        }
+    });
+
     test('rejects when fflate reports an error', async function () {
         const errorFromFflate: FlateError = Object.assign(new Error('fflate-failure'), {
             code: 99 as FlateError['code']

--- a/source/zip/zip-builder.ts
+++ b/source/zip/zip-builder.ts
@@ -1,16 +1,19 @@
 import { promisify } from 'node:util';
 import { zip as fflateZip, type AsyncZippable, type AsyncZipOptions, type FlateCallback } from 'fflate';
 import type { FileDescription } from '../file-manager/file-description.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
+import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
 type AsyncZipFunction = (data: AsyncZippable, options: AsyncZipOptions, callback: FlateCallback) => void;
 type PromisifiedZip = (data: AsyncZippable, options: AsyncZipOptions) => Promise<Uint8Array>;
 
 export type ZipBuilder = {
-    build: (fileDescriptions: readonly FileDescription[]) => Promise<Buffer>;
+    build: (fileDescriptions: readonly FileDescription[], vendorEntries?: readonly VendorEntry[]) => Promise<Buffer>;
 };
 
 type ZipBuilderDependencies = {
-    readonly zip: AsyncZipFunction;
+    readonly zip?: AsyncZipFunction;
+    readonly fileManager?: Pick<FileManager, 'readFileBytes'>;
 };
 
 const unixOperatingSystem = 3;
@@ -27,33 +30,52 @@ function externalAttributes(isExecutable: boolean): number {
     return (isExecutable ? executableUnixMode : nonExecutableUnixMode) * highBytesScale;
 }
 
-function buildFileEntry(fileDescription: FileDescription): [Uint8Array, AsyncZipOptions] {
+function buildFileEntry(payload: Uint8Array, isExecutable: boolean): [Uint8Array, AsyncZipOptions] {
     return [
-        new TextEncoder().encode(fileDescription.content),
+        payload,
         {
             os: unixOperatingSystem,
-            attrs: externalAttributes(fileDescription.isExecutable),
+            attrs: externalAttributes(isExecutable),
             mtime: staticFileModificationTimestamp,
             level: maxCompressionLevel
         }
     ];
 }
 
-function toFileMap(fileDescriptions: readonly FileDescription[]): AsyncZippable {
+async function toFileMap(
+    fileDescriptions: readonly FileDescription[],
+    vendorEntries: readonly VendorEntry[],
+    readFileBytes: (filePath: string) => Promise<Buffer>
+): Promise<AsyncZippable> {
     const fileMap: AsyncZippable = {};
     for (const fileDescription of fileDescriptions) {
-        fileMap[fileDescription.filePath] = buildFileEntry(fileDescription);
+        fileMap[fileDescription.filePath] = buildFileEntry(
+            new TextEncoder().encode(fileDescription.content),
+            fileDescription.isExecutable
+        );
+    }
+    for (const vendorEntry of vendorEntries) {
+        const payload = await readFileBytes(vendorEntry.sourceAbsolutePath);
+        fileMap[vendorEntry.targetRelativePath] = buildFileEntry(payload, vendorEntry.isExecutable);
     }
     return fileMap;
 }
 
-export function createZipBuilder(dependencies: Partial<ZipBuilderDependencies> = {}): ZipBuilder {
+export function createZipBuilder(dependencies: ZipBuilderDependencies = {}): ZipBuilder {
+    const fileManager = dependencies.fileManager ?? {
+        async readFileBytes(): Promise<Buffer> {
+            throw new Error('readFileBytes is required to materialize vendor entries into the zip');
+        }
+    };
     const zip = dependencies.zip ?? fflateZip;
     const runZip: PromisifiedZip = promisify(zip);
 
     return {
-        async build(fileDescriptions) {
-            const data = await runZip(toFileMap(fileDescriptions), {});
+        async build(fileDescriptions, vendorEntries = []) {
+            const fileMap = await toFileMap(fileDescriptions, vendorEntries, async (filePath) => {
+                return fileManager.readFileBytes(filePath);
+            });
+            const data = await runZip(fileMap, {});
             return Buffer.from(data);
         }
     };


### PR DESCRIPTION
## Summary

Slice 3 of the `packtory pack` feature. Builds on PR #614.

Adds `--vendor-dependencies` to `packtory pack`. When passed, the command walks the configured package's external dependency closure on the host's `node_modules/`, dereferences symlinks (so npm, yarn-classic, and pnpm all work), and copies each file into the artifact at `node_modules/<dep>/<...>`. The vendored manifest also drops `dependencies` and `peerDependencies` since the consumer never resolves them.

### How files travel

`FileDescription.content` stays string-typed and unchanged. Vendor entries are a parallel input — `{ sourceAbsolutePath, targetRelativePath, isExecutable }` references — that flow into the byte producers separately:

- **folder**: `fs.copyFile` per file (byte-for-byte, no decoding)
- **tar**: tar-stream's `pack.entry({...}, Buffer)` per file
- **zip**: fflate's `zip()` with `Buffer` per file

The bytes never round-trip through a UTF-8 string, so binary files (`.node`, fonts, prebuilt assets) survive intact.

### Architecture

- **`source/vendor-materializer/`** — Walks the dep+peerDep closure from a starting folder. Resolves each package to its real path (handles symlinks), reads `package.json` to find transitive deps, walks the package directory while skipping nested `node_modules/` (those become separate closure entries on their own).
- **`FileManager`** gains `readFileBytes`, `copyFileBytes`, `listDirectoryEntries`, `getRealPath`. The fake mirrors them so tests stay deterministic.
- **Pack-emitter** forwards `vendorEntries` to `ArtifactsBuilder`. For `tar` the prefix `package/` is applied to the vendor entries (preserving the npm tarball layout); `zip` and `folder` lay them at the root.
- **packtory-pack** calls the materializer when `vendorDependencies: true`, then slims the manifest before handing the bundle to the emitter.

### What's still missing (slice 4)

- `bundleDependencies` are still rejected with a clear error — slice 4 materializes them from packtory's own per-package output, alongside the host's `node_modules/`.
- Strict peer-dependency validation (the `(Q1)` policy we agreed on).
- Native-binary detection / target-platform mismatch — agreed `(N3)`: ignored, user-responsibility.

## Test plan
- [x] `just compile`
- [x] `just lint` — eslint, prettier-check, dep-cruiser, ls-lint, knip, jscpd all green
- [x] `just test-unit-with-coverage` — 100% statements/branches/functions/lines
- [x] `just test-mutation` — 100.00 mutation score, zero timeout mutants
- [x] Local `packtory publish` dry-run still passes
