### PR TITLE
Materialize bundle dependencies and check peer dependencies on vendor pack

### DIFF
--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -143,6 +143,23 @@ suite('pack-handler', function () {
         ]);
     });
 
+    test('returns 1 and lists each unsatisfied peer dependency on its own line when the closure is incomplete', async function () {
+        await expectFailure(
+            {
+                type: 'peer-dependencies-unsatisfied',
+                packageName: 'pkg-a',
+                items: [
+                    { packageName: 'react-dom', peer: 'react' },
+                    { packageName: 'styled-components', peer: 'react' }
+                ]
+            },
+            [
+                /Pack of "pkg-a" is missing 2 peer dependency\(ies\)/u,
+                /- "react-dom" needs peer "react"\n- "styled-components" needs peer "react"/u
+            ]
+        );
+    });
+
     test('returns 1 and summarises partial resolve failures with one line per failure', async function () {
         await expectFailure(
             { type: 'partial', error: { succeeded: [], failures: [new Error('resolve A'), new Error('resolve B')] } },

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -34,19 +34,64 @@ function formatPartialResolveFailure(error: PackFailure & { readonly type: 'part
     return [`${getErrorSymbol()} ${messages.length} package(s) failed to resolve`, ...messages].join('\n');
 }
 
-function formatPackFailure(error: PackFailure): string {
+function formatPeerFailure(error: PackFailure & { readonly type: 'peer-dependencies-unsatisfied' }): string {
+    const lines = error.items.map((item) => {
+        return `- "${item.packageName}" needs peer "${item.peer}"`;
+    });
+    const count = error.items.length;
+    const header = `${getErrorSymbol()} Pack of "${error.packageName}" is missing ${count} peer dependency(ies)`;
+    return [header, ...lines].join('\n');
+}
+
+function formatBundleDepFailure(packageName: string): string {
+    const note = 'declares bundleDependencies which pack does not yet support without --vendor-dependencies';
+    return `${getErrorSymbol()} Package "${packageName}" ${note}`;
+}
+
+function formatPackageNotFound(packageName: string): string {
+    return `${getErrorSymbol()} Package "${packageName}" is not declared in the packtory configuration`;
+}
+
+type ConfigOrCheckError = PackFailure & { readonly type: 'checks' | 'config' };
+type PackPackageError = PackFailure & {
+    readonly type: 'bundle-dependencies-unsupported' | 'package-not-found' | 'peer-dependencies-unsatisfied';
+};
+
+function formatIssueListFailure(error: ConfigOrCheckError): string {
     if (error.type === 'config') {
         return formatIssueList('The provided config is invalid', error.issues);
     }
-    if (error.type === 'checks') {
-        return formatIssueList('Checks failed', error.issues);
-    }
+    return formatIssueList('Checks failed', error.issues);
+}
+
+function formatPackPackageFailure(error: PackPackageError): string {
     if (error.type === 'package-not-found') {
-        return `${getErrorSymbol()} Package "${error.packageName}" is not declared in the packtory configuration`;
+        return formatPackageNotFound(error.packageName);
     }
     if (error.type === 'bundle-dependencies-unsupported') {
-        const note = 'declares bundleDependencies which pack does not yet support without --vendor-dependencies';
-        return `${getErrorSymbol()} Package "${error.packageName}" ${note}`;
+        return formatBundleDepFailure(error.packageName);
+    }
+    return formatPeerFailure(error);
+}
+
+function isConfigOrCheckError(error: PackFailure): error is ConfigOrCheckError {
+    return error.type === 'config' || error.type === 'checks';
+}
+
+function isPackPackageError(error: PackFailure): error is PackPackageError {
+    return (
+        error.type === 'package-not-found' ||
+        error.type === 'bundle-dependencies-unsupported' ||
+        error.type === 'peer-dependencies-unsatisfied'
+    );
+}
+
+function formatPackFailure(error: PackFailure): string {
+    if (isConfigOrCheckError(error)) {
+        return formatIssueListFailure(error);
+    }
+    if (isPackPackageError(error)) {
+        return formatPackPackageFailure(error);
     }
     return formatPartialResolveFailure(error);
 }

--- a/source/pack-emitter/pack-emitter.test.ts
+++ b/source/pack-emitter/pack-emitter.test.ts
@@ -38,10 +38,10 @@ suite('pack-emitter', function () {
         const emitter = createPackEmitter(deps);
         const bundle = makeBundle();
 
-        await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip', vendorEntries: [] });
+        await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip', vendorEntries: [], extraFiles: [] });
 
         assert.strictEqual(buildZip.callCount, 1);
-        assert.deepStrictEqual(buildZip.firstCall.args, [bundle, undefined, []]);
+        assert.deepStrictEqual(buildZip.firstCall.args, [bundle, [], []]);
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
             filePath: '/out/fn.zip',
@@ -56,10 +56,10 @@ suite('pack-emitter', function () {
         const emitter = createPackEmitter(deps);
         const bundle = makeBundle();
 
-        await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz', vendorEntries: [] });
+        await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz', vendorEntries: [], extraFiles: [] });
 
         assert.strictEqual(buildTarball.callCount, 1);
-        assert.deepStrictEqual(buildTarball.firstCall.args, [bundle, undefined, []]);
+        assert.deepStrictEqual(buildTarball.firstCall.args, [bundle, [], []]);
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
             filePath: '/out/pkg.tgz',
@@ -73,10 +73,16 @@ suite('pack-emitter', function () {
         const emitter = createPackEmitter(deps);
         const bundle = makeBundle();
 
-        await emitter.pack({ bundle, format: 'folder', outputPath: '/out/extracted', vendorEntries: [] });
+        await emitter.pack({
+            bundle,
+            format: 'folder',
+            outputPath: '/out/extracted',
+            vendorEntries: [],
+            extraFiles: []
+        });
 
         assert.strictEqual(buildFolder.callCount, 1);
-        assert.deepStrictEqual(buildFolder.firstCall.args, [bundle, '/out/extracted', undefined, []]);
+        assert.deepStrictEqual(buildFolder.firstCall.args, [bundle, '/out/extracted', [], []]);
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 0);
     });
 });

--- a/source/pack-emitter/pack-emitter.ts
+++ b/source/pack-emitter/pack-emitter.ts
@@ -1,4 +1,5 @@
 import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
+import type { FileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
 import type { ArtifactSourcePackage } from '../published-package/published-package.ts';
 import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
@@ -10,6 +11,7 @@ type PackOptions = {
     readonly format: PackFormat;
     readonly outputPath: string;
     readonly vendorEntries: readonly VendorEntry[];
+    readonly extraFiles: readonly FileDescription[];
 };
 
 export type PackEmitter = {
@@ -25,17 +27,26 @@ export function createPackEmitter(dependencies: PackEmitterDependencies): PackEm
     const { artifactsBuilder, fileManager } = dependencies;
 
     async function packZip(options: PackOptions): Promise<void> {
-        const { zipData } = await artifactsBuilder.buildZip(options.bundle, undefined, options.vendorEntries);
+        const { zipData } = await artifactsBuilder.buildZip(options.bundle, options.extraFiles, options.vendorEntries);
         await fileManager.writeBinaryFile(options.outputPath, zipData);
     }
 
     async function packTarball(options: PackOptions): Promise<void> {
-        const { tarData } = await artifactsBuilder.buildTarball(options.bundle, undefined, options.vendorEntries);
+        const { tarData } = await artifactsBuilder.buildTarball(
+            options.bundle,
+            options.extraFiles,
+            options.vendorEntries
+        );
         await fileManager.writeBinaryFile(options.outputPath, tarData);
     }
 
     async function packFolder(options: PackOptions): Promise<void> {
-        await artifactsBuilder.buildFolder(options.bundle, options.outputPath, undefined, options.vendorEntries);
+        await artifactsBuilder.buildFolder(
+            options.bundle,
+            options.outputPath,
+            options.extraFiles,
+            options.vendorEntries
+        );
     }
 
     return {

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -16,6 +16,20 @@ import type { ResolvedPackage } from './resolved-package.ts';
 
 const validatedConfig = {} as unknown as ValidConfigWithoutRegistryResult;
 
+type FakeVersionedBundle = {
+    readonly name: string;
+    readonly version: string;
+    readonly manifestFile: { readonly content: string; readonly isExecutable: boolean; readonly filePath: string };
+    readonly contents: readonly {
+        readonly fileDescription: {
+            readonly targetFilePath: string;
+            readonly content: string;
+            readonly isExecutable: boolean;
+        };
+    }[];
+    readonly peerDependencies: Readonly<Record<string, string>>;
+};
+
 const baseOptions: PackOptions = {
     packageName: 'pkg-a',
     format: 'zip',
@@ -29,7 +43,9 @@ function makeResolvedPackage(
         readonly name?: string;
         readonly bundleDependencies?: readonly unknown[];
         readonly externalDependencyNames?: readonly string[];
+        readonly bundleDependencyNames?: readonly string[];
         readonly sourcesFolder?: string;
+        readonly contents?: readonly unknown[];
     } = {}
 ): ResolvedPackage {
     const externalDependencies = new Map(
@@ -37,11 +53,19 @@ function makeResolvedPackage(
             return [name, { name, referencedFrom: ['/x'] as const }];
         })
     );
+    const linkedBundleDependencies = new Map(
+        (overrides.bundleDependencyNames ?? []).map((name) => {
+            return [name, { name, referencedFrom: ['/x'] as const }];
+        })
+    );
+    const packageName = overrides.name ?? 'pkg-a';
     return {
-        name: overrides.name ?? 'pkg-a',
+        name: packageName,
         analyzedBundle: {
-            contents: [],
-            externalDependencies
+            name: packageName,
+            contents: overrides.contents ?? [],
+            externalDependencies,
+            linkedBundleDependencies
         } as unknown as ResolvedPackage['analyzedBundle'],
         resolveOptions: {
             mainPackageJson: { type: 'module' },
@@ -96,7 +120,12 @@ function createDependencies(overrides: {
     };
     const resolveAndLinkAll = fake.resolves(overrides.resolveResult ?? Result.ok([makeResolvedPackage()]));
     const materializeExternals =
-        overrides.materializerSpy ?? fake.resolves({ entries: overrides.vendorEntries ?? [], packageNames: [] });
+        overrides.materializerSpy ??
+        fake.resolves({
+            entries: overrides.vendorEntries ?? [],
+            packageNames: [],
+            peerRequirements: new Map<string, readonly string[]>()
+        });
     const vendorMaterializer = {
         materializeExternals:
             materializeExternals as unknown as PackRunDependencies['vendorMaterializer']['materializeExternals']
@@ -112,6 +141,51 @@ function expectErr(result: Result<undefined, InternalPackFailure>): InternalPack
         assert.fail('expected Err result');
     }
     return result.error;
+}
+
+function buildDependenciesWith(
+    addVersionFake: SinonSpy,
+    packEmitterPackFake: SinonSpy,
+    materializerOverride?: SinonSpy
+): PackRunDependencies {
+    return {
+        versionManager: {
+            addVersion: addVersionFake as never,
+            increaseVersion: fake() as never
+        },
+        packEmitter: { pack: packEmitterPackFake as never },
+        vendorMaterializer: {
+            materializeExternals: (materializerOverride ??
+                fake.resolves({
+                    entries: [],
+                    packageNames: [],
+                    peerRequirements: new Map<string, readonly string[]>()
+                })) as never
+        }
+    };
+}
+
+function makeBareVersionedBundle(name: string): FakeVersionedBundle {
+    return {
+        name,
+        version: '0.0.0',
+        manifestFile: { content: '{}', isExecutable: false, filePath: 'package.json' },
+        contents: [],
+        peerDependencies: {}
+    };
+}
+
+async function runVendorAndExpectExtraFiles(
+    runPack: ReturnType<typeof createRunPackValidated>,
+    resolveAndLinkAll: SinonSpy,
+    packEmitterPack: SinonSpy
+): Promise<readonly { readonly filePath: string; readonly content: string }[]> {
+    const result = await runPack(validatedConfig, { ...baseOptions, vendorDependencies: true }, resolveAndLinkAll);
+    assert.deepStrictEqual(result.isOk ? result.value : 'errored', undefined);
+    const emitOptions = packEmitterPack.firstCall.args[0] as {
+        readonly extraFiles: readonly { readonly filePath: string; readonly content: string }[];
+    };
+    return emitOptions.extraFiles;
 }
 
 suite('packtory-pack', function () {
@@ -137,7 +211,7 @@ suite('packtory-pack', function () {
         assert.deepStrictEqual(expectErr(result), { type: 'package-not-found', packageName: 'pkg-a' });
     });
 
-    test('returns a bundle-dependencies-unsupported failure when the target package declares bundle dependencies', async function () {
+    test('returns a bundle-dependencies-unsupported failure when the target package declares bundle dependencies in non-vendor mode', async function () {
         const { dependencies, fakes } = createDependencies({
             resolveResult: Result.ok([makeResolvedPackage({ bundleDependencies: [{ name: 'dep' }] })])
         });
@@ -146,6 +220,174 @@ suite('packtory-pack', function () {
         const result = await runPack(validatedConfig, baseOptions, fakes.resolveAndLinkAll);
 
         assert.deepStrictEqual(expectErr(result), { type: 'bundle-dependencies-unsupported', packageName: 'pkg-a' });
+    });
+
+    test('materializes a transitive bundle dependency closure as node_modules/<dep>/ extras when vendoring is enabled', async function () {
+        const versionedTarget = makeBareVersionedBundle('pkg-a');
+        const versionedShared: FakeVersionedBundle = {
+            ...makeBareVersionedBundle('shared'),
+            manifestFile: {
+                content: JSON.stringify({ name: 'shared', version: '0.0.0' }),
+                isExecutable: false,
+                filePath: 'package.json'
+            },
+            contents: [
+                { fileDescription: { targetFilePath: 'index.js', content: 'export const x = 1;', isExecutable: false } }
+            ]
+        };
+        const versionedTooling: FakeVersionedBundle = {
+            ...makeBareVersionedBundle('tooling'),
+            manifestFile: {
+                content: JSON.stringify({ name: 'tooling', version: '0.0.0' }),
+                isExecutable: false,
+                filePath: 'package.json'
+            },
+            contents: [
+                { fileDescription: { targetFilePath: 'lib.js', content: 'export const y = 2;', isExecutable: false } }
+            ]
+        };
+        const lookup = new Map<string, FakeVersionedBundle>([
+            ['pkg-a', versionedTarget],
+            ['shared', versionedShared],
+            ['tooling', versionedTooling]
+        ]);
+        const addVersion = fake((options: { bundle: { name: string } }) => {
+            return lookup.get(options.bundle.name) ?? versionedTarget;
+        });
+        const packEmitterPack = fake.resolves(undefined);
+        const target = makeResolvedPackage({ bundleDependencyNames: ['shared'] });
+        const shared = makeResolvedPackage({ name: 'shared', bundleDependencyNames: ['tooling'] });
+        const tooling = makeResolvedPackage({ name: 'tooling' });
+        const resolveAndLinkAll = fake.resolves(Result.ok([target, shared, tooling]));
+        const runPack = createRunPackValidated(buildDependenciesWith(addVersion, packEmitterPack));
+
+        const extraFiles = await runVendorAndExpectExtraFiles(runPack, resolveAndLinkAll, packEmitterPack);
+        const sortedPaths = extraFiles
+            .map((entry) => {
+                return entry.filePath;
+            })
+            .toSorted((a, b) => {
+                return a.localeCompare(b);
+            });
+        assert.deepStrictEqual(sortedPaths, [
+            'node_modules/shared/index.js',
+            'node_modules/shared/package.json',
+            'node_modules/tooling/lib.js',
+            'node_modules/tooling/package.json'
+        ]);
+    });
+
+    test('deduplicates bundle dependencies that are reachable through multiple paths in the closure', async function () {
+        const versionedBundle = makeBareVersionedBundle('pkg-a');
+        const versionedShared = makeBareVersionedBundle('shared');
+        const versionedLeftAndRight: FakeVersionedBundle = {
+            ...versionedShared,
+            contents: [{ fileDescription: { targetFilePath: 'index.js', content: 'export {};', isExecutable: false } }]
+        };
+        const lookup = new Map<string, FakeVersionedBundle>([
+            ['pkg-a', versionedBundle],
+            ['left', { ...versionedLeftAndRight, name: 'left' }],
+            ['right', { ...versionedLeftAndRight, name: 'right' }],
+            ['shared', versionedShared]
+        ]);
+        const addVersion = fake((options: { bundle: { name: string } }) => {
+            return lookup.get(options.bundle.name) ?? versionedBundle;
+        });
+        const packEmitterPack = fake.resolves(undefined);
+        const target = makeResolvedPackage({ bundleDependencyNames: ['left', 'right'] });
+        const left = makeResolvedPackage({ name: 'left', bundleDependencyNames: ['shared'] });
+        const right = makeResolvedPackage({ name: 'right', bundleDependencyNames: ['shared'] });
+        const shared = makeResolvedPackage({ name: 'shared' });
+        const resolveAndLinkAll = fake.resolves(Result.ok([target, left, right, shared]));
+        const runPack = createRunPackValidated(buildDependenciesWith(addVersion, packEmitterPack));
+
+        await runPack(validatedConfig, { ...baseOptions, vendorDependencies: true }, resolveAndLinkAll);
+
+        const emitOptions = packEmitterPack.firstCall.args[0] as {
+            readonly extraFiles: readonly { readonly filePath: string }[];
+        };
+        const sharedEntries = emitOptions.extraFiles.filter((entry) => {
+            return entry.filePath.startsWith('node_modules/shared/');
+        });
+        // Each package contributes its manifest; 'shared' has no other content so exactly one entry.
+        assert.strictEqual(sharedEntries.length, 1);
+    });
+
+    test('silently skips bundle dependencies whose names are not present in the resolved package list', async function () {
+        const versionedBundle: FakeVersionedBundle = {
+            name: 'pkg-a',
+            version: '0.0.0',
+            manifestFile: { content: '{}', isExecutable: false, filePath: 'package.json' },
+            contents: [],
+            peerDependencies: {}
+        };
+        const addVersion = fake.returns(versionedBundle);
+        const packEmitterPack = fake.resolves(undefined);
+        // target references 'missing' as a bundle dependency, but it's not in the resolve list
+        const target = makeResolvedPackage({ bundleDependencyNames: ['missing'] });
+        const resolveAndLinkAll = fake.resolves(Result.ok([target]));
+        const runPack = createRunPackValidated(buildDependenciesWith(addVersion, packEmitterPack));
+
+        const extraFiles = await runVendorAndExpectExtraFiles(runPack, resolveAndLinkAll, packEmitterPack);
+        assert.deepStrictEqual(extraFiles, []);
+    });
+
+    test('returns a peer-dependencies-unsatisfied failure listing only the peers that are missing from the closure', async function () {
+        // 'react' is in the closure (satisfied), 'react-router' is not (unsatisfied).
+        const materializerSpy = fake.resolves({
+            entries: [],
+            packageNames: ['react-dom', 'react'],
+            peerRequirements: new Map<string, readonly string[]>([['react-dom', ['react', 'react-router']]])
+        });
+        const { dependencies, fakes } = createDependencies({
+            materializerSpy,
+            resolveResult: Result.ok([
+                makeResolvedPackage({ externalDependencyNames: ['react-dom'], sourcesFolder: '/repo/source' })
+            ])
+        });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(
+            validatedConfig,
+            { ...baseOptions, vendorDependencies: true },
+            fakes.resolveAndLinkAll
+        );
+
+        assert.deepStrictEqual(expectErr(result), {
+            type: 'peer-dependencies-unsatisfied',
+            packageName: 'pkg-a',
+            items: [{ packageName: 'react-dom', peer: 'react-router' }]
+        });
+        assert.strictEqual(fakes.packEmitterPack.callCount, 0);
+    });
+
+    test('aggregates peer requirements from both the bundle-dep closure and the external vendor closure', async function () {
+        const versionedTarget = makeBareVersionedBundle('pkg-a');
+        const versionedShared: FakeVersionedBundle = {
+            ...makeBareVersionedBundle('shared'),
+            peerDependencies: { 'styled-components': '^6.0.0' }
+        };
+        const lookup = new Map<string, FakeVersionedBundle>([
+            ['pkg-a', versionedTarget],
+            ['shared', versionedShared]
+        ]);
+        const addVersion = fake((options: { bundle: { name: string } }) => {
+            return lookup.get(options.bundle.name) ?? versionedTarget;
+        });
+        const packEmitterPack = fake.resolves(undefined);
+        const target = makeResolvedPackage({ bundleDependencyNames: ['shared'] });
+        const shared = makeResolvedPackage({ name: 'shared' });
+        const resolveAndLinkAll = fake.resolves(Result.ok([target, shared]));
+        const runPack = createRunPackValidated(buildDependenciesWith(addVersion, packEmitterPack));
+
+        const result = await runPack(validatedConfig, { ...baseOptions, vendorDependencies: true }, resolveAndLinkAll);
+
+        // 'styled-components' from the bundle-dep ('shared') is not in any closure, so it surfaces.
+        assert.deepStrictEqual(expectErr(result), {
+            type: 'peer-dependencies-unsatisfied',
+            packageName: 'pkg-a',
+            items: [{ packageName: 'shared', peer: 'styled-components' }]
+        });
     });
 
     test('builds a versioned bundle and emits it via the pack emitter on success', async function () {
@@ -171,7 +413,13 @@ suite('packtory-pack', function () {
         assert.deepStrictEqual(addVersionOptions.bundleDependencies, []);
         assert.deepStrictEqual(addVersionOptions.bundlePeerDependencies, []);
         assert.deepStrictEqual(fakes.packEmitterPack.firstCall.args, [
-            { bundle: versionedBundle, format: 'tar', outputPath: '/out/pkg-a.tgz', vendorEntries: [] }
+            {
+                bundle: versionedBundle,
+                format: 'tar',
+                outputPath: '/out/pkg-a.tgz',
+                vendorEntries: [],
+                extraFiles: []
+            }
         ]);
     });
 
@@ -218,7 +466,11 @@ suite('packtory-pack', function () {
                 isExecutable: false
             }
         ];
-        const materializerSpy = fake.resolves({ entries: vendorEntries, packageNames: ['left-pad'] });
+        const materializerSpy = fake.resolves({
+            entries: vendorEntries,
+            packageNames: ['left-pad'],
+            peerRequirements: new Map<string, readonly string[]>()
+        });
         const { dependencies, fakes } = createDependencies({
             versionedBundle,
             materializerSpy,

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -3,6 +3,7 @@ import { Result } from 'true-myth';
 import { safeParse } from '@schema-hub/zod-error-formatter';
 import type { PackageJson } from 'type-fest';
 import { z } from 'zod/mini';
+import type { FileDescription } from '../file-manager/file-description.ts';
 import type { PackEmitter, PackFormat } from '../pack-emitter/pack-emitter.ts';
 import { serializePackageJson } from '../version-manager/manifest/serialize.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
@@ -12,7 +13,7 @@ import type { VendorMaterializer } from '../vendor-materializer/vendor-materiali
 import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 import type { ResolvedPackage } from './resolved-package.ts';
 import type { InternalResolveAndLinkFailure } from './packtory-resolve.ts';
-import type { PackPackageFailure } from './packtory-results.ts';
+import type { PackPackageFailure, UnsatisfiedPeerDependency } from './packtory-results.ts';
 
 export type PackOptions = {
     readonly packageName: string;
@@ -35,6 +36,7 @@ export type PackRunDependencies = {
 };
 
 const manifestSchema = z.record(z.string(), z.unknown());
+const nodeModulesFolderName = 'node_modules';
 
 function findPackage(
     resolved: readonly ResolvedPackage[],
@@ -45,13 +47,6 @@ function findPackage(
     });
     if (target === undefined) {
         return Result.err({ type: 'package-not-found', packageName });
-    }
-    return Result.ok(target);
-}
-
-function ensureNoBundleDependencies(target: ResolvedPackage): Result<ResolvedPackage, PackPackageFailure> {
-    if (target.resolveOptions.bundleDependencies.length > 0) {
-        return Result.err({ type: 'bundle-dependencies-unsupported', packageName: target.name });
     }
     return Result.ok(target);
 }
@@ -101,34 +96,221 @@ function buildVersionedBundle(
     });
 }
 
-async function vendorExternalsFor(
-    vendorMaterializer: VendorMaterializer,
-    target: ResolvedPackage
-): Promise<readonly VendorEntry[]> {
-    const initialDependencyNames = Array.from(target.analyzedBundle.externalDependencies.keys());
-    const materialized = await vendorMaterializer.materializeExternals({
-        initialDependencyNames,
+function bundleDependencyAsExtraFiles(versioned: VersionedBundleWithManifest): readonly FileDescription[] {
+    const prefix = `${nodeModulesFolderName}/${versioned.name}`;
+    const manifest: FileDescription = {
+        filePath: `${prefix}/${versioned.manifestFile.filePath}`,
+        content: versioned.manifestFile.content,
+        isExecutable: versioned.manifestFile.isExecutable
+    };
+    const sources = versioned.contents.map((entry) => {
+        return {
+            filePath: `${prefix}/${entry.fileDescription.targetFilePath}`,
+            content: entry.fileDescription.content,
+            isExecutable: entry.fileDescription.isExecutable
+        };
+    });
+    return [manifest, ...sources];
+}
+
+type BundleDepClosure = {
+    readonly extraFiles: readonly FileDescription[];
+    readonly packageNames: ReadonlySet<string>;
+    readonly peerRequirements: ReadonlyMap<string, readonly string[]>;
+};
+
+type BundleDepClosureBuilder = {
+    readonly extraFiles: FileDescription[];
+    readonly packageNames: Set<string>;
+    readonly peerRequirements: Map<string, readonly string[]>;
+    readonly resolvedByName: ReadonlyMap<string, ResolvedPackage>;
+};
+
+function recordVisitedBundleDependency(
+    builder: BundleDepClosureBuilder,
+    versionManager: VersionManager,
+    fallbackVersion: string,
+    pkg: ResolvedPackage
+): void {
+    builder.packageNames.add(pkg.name);
+    const versioned = buildVersionedBundle(versionManager, pkg, fallbackVersion);
+    builder.extraFiles.push(...bundleDependencyAsExtraFiles(versioned));
+    builder.peerRequirements.set(pkg.name, Object.keys(versioned.peerDependencies));
+}
+
+function visitBundleDependency(
+    builder: BundleDepClosureBuilder,
+    versionManager: VersionManager,
+    fallbackVersion: string,
+    name: string
+): void {
+    if (builder.packageNames.has(name)) {
+        return;
+    }
+    const pkg = builder.resolvedByName.get(name);
+    if (pkg === undefined) {
+        return;
+    }
+    recordVisitedBundleDependency(builder, versionManager, fallbackVersion, pkg);
+    for (const transitiveName of pkg.analyzedBundle.linkedBundleDependencies.keys()) {
+        visitBundleDependency(builder, versionManager, fallbackVersion, transitiveName);
+    }
+}
+
+function collectBundleDependencies(
+    target: ResolvedPackage,
+    resolvedPackages: readonly ResolvedPackage[],
+    versionManager: VersionManager,
+    fallbackVersion: string
+): BundleDepClosure {
+    const builder: BundleDepClosureBuilder = {
+        extraFiles: [],
+        packageNames: new Set<string>(),
+        peerRequirements: new Map<string, readonly string[]>(),
+        resolvedByName: new Map(
+            resolvedPackages.map((resolvedPackage) => {
+                return [resolvedPackage.name, resolvedPackage];
+            })
+        )
+    };
+    for (const name of target.analyzedBundle.linkedBundleDependencies.keys()) {
+        visitBundleDependency(builder, versionManager, fallbackVersion, name);
+    }
+    return {
+        extraFiles: builder.extraFiles,
+        packageNames: builder.packageNames,
+        peerRequirements: builder.peerRequirements
+    };
+}
+
+function findUnsatisfiedPeers(
+    closurePackageNames: ReadonlySet<string>,
+    peerRequirements: ReadonlyMap<string, readonly string[]>
+): readonly UnsatisfiedPeerDependency[] {
+    const unsatisfied: UnsatisfiedPeerDependency[] = [];
+    for (const [packageName, peers] of peerRequirements) {
+        for (const peer of peers) {
+            if (!closurePackageNames.has(peer)) {
+                unsatisfied.push({ packageName, peer });
+            }
+        }
+    }
+    return unsatisfied;
+}
+
+type VendoredArtifact = {
+    readonly bundle: VersionedBundleWithManifest;
+    readonly vendorEntries: readonly VendorEntry[];
+    readonly extraFiles: readonly FileDescription[];
+};
+
+function mergePeerRequirements(
+    left: ReadonlyMap<string, readonly string[]>,
+    right: ReadonlyMap<string, readonly string[]>
+): Map<string, readonly string[]> {
+    const merged = new Map<string, readonly string[]>();
+    for (const [name, peers] of left) {
+        merged.set(name, peers);
+    }
+    for (const [name, peers] of right) {
+        merged.set(name, peers);
+    }
+    return merged;
+}
+
+type VendoredInputs = {
+    readonly target: ResolvedPackage;
+    readonly resolved: readonly ResolvedPackage[];
+    readonly built: VersionedBundleWithManifest;
+    readonly version: string;
+};
+
+async function prepareVendoredArtifact(
+    dependencies: PackRunDependencies,
+    inputs: VendoredInputs
+): Promise<Result<VendoredArtifact, PackPackageFailure>> {
+    const { target, resolved, built, version } = inputs;
+    const bundleClosure = collectBundleDependencies(target, resolved, dependencies.versionManager, version);
+    const externalsMaterialized = await dependencies.vendorMaterializer.materializeExternals({
+        initialDependencyNames: Array.from(target.analyzedBundle.externalDependencies.keys()),
         projectFolder: target.resolveOptions.sourcesFolder
     });
-    return materialized.entries;
+    const closurePackageNames = new Set<string>([...bundleClosure.packageNames, ...externalsMaterialized.packageNames]);
+    const allPeerRequirements = mergePeerRequirements(
+        bundleClosure.peerRequirements,
+        externalsMaterialized.peerRequirements
+    );
+    const unsatisfiedPeers = findUnsatisfiedPeers(closurePackageNames, allPeerRequirements);
+    if (unsatisfiedPeers.length > 0) {
+        return Result.err({
+            type: 'peer-dependencies-unsatisfied',
+            packageName: target.name,
+            items: unsatisfiedPeers
+        });
+    }
+    return Result.ok({
+        bundle: slimManifestForVendoredArtifact(built),
+        vendorEntries: externalsMaterialized.entries,
+        extraFiles: bundleClosure.extraFiles
+    });
 }
 
 type PreparedArtifact = {
     readonly bundle: VersionedBundleWithManifest;
     readonly vendorEntries: readonly VendorEntry[];
+    readonly extraFiles: readonly FileDescription[];
 };
 
 async function prepareArtifact(
     dependencies: PackRunDependencies,
     target: ResolvedPackage,
+    resolved: readonly ResolvedPackage[],
     options: PackOptions
-): Promise<PreparedArtifact> {
+): Promise<Result<PreparedArtifact, PackPackageFailure>> {
     const built = buildVersionedBundle(dependencies.versionManager, target, options.version);
     if (!options.vendorDependencies) {
-        return { bundle: built, vendorEntries: [] };
+        if (target.resolveOptions.bundleDependencies.length > 0) {
+            return Result.err({ type: 'bundle-dependencies-unsupported', packageName: target.name });
+        }
+        return Result.ok({ bundle: built, vendorEntries: [], extraFiles: [] });
     }
-    const vendorEntries = await vendorExternalsFor(dependencies.vendorMaterializer, target);
-    return { bundle: slimManifestForVendoredArtifact(built), vendorEntries };
+    return await prepareVendoredArtifact(dependencies, {
+        target,
+        resolved,
+        built,
+        version: options.version
+    });
+}
+
+async function emitPreparedArtifact(
+    packEmitter: PackEmitter,
+    prepared: PreparedArtifact,
+    options: PackOptions
+): Promise<void> {
+    await packEmitter.pack({
+        bundle: prepared.bundle,
+        format: options.format,
+        outputPath: options.outputPath,
+        vendorEntries: prepared.vendorEntries,
+        extraFiles: prepared.extraFiles
+    });
+}
+
+async function packWithResolved(
+    dependencies: PackRunDependencies,
+    resolved: readonly ResolvedPackage[],
+    options: PackOptions
+): Promise<Result<undefined, InternalPackFailure>> {
+    const targetResult = findPackage(resolved, options.packageName);
+    if (targetResult.isErr) {
+        return Result.err(targetResult.error);
+    }
+    const preparedResult = await prepareArtifact(dependencies, targetResult.value, resolved, options);
+    if (preparedResult.isErr) {
+        return Result.err(preparedResult.error);
+    }
+    await emitPreparedArtifact(dependencies.packEmitter, preparedResult.value, options);
+    return Result.ok(undefined);
 }
 
 export function createRunPackValidated(
@@ -143,20 +325,6 @@ export function createRunPackValidated(
         if (resolveResult.isErr) {
             return Result.err(resolveResult.error);
         }
-
-        const targetResult = findPackage(resolveResult.value, options.packageName).andThen(ensureNoBundleDependencies);
-        if (targetResult.isErr) {
-            return Result.err(targetResult.error);
-        }
-
-        const prepared = await prepareArtifact(dependencies, targetResult.value, options);
-        await dependencies.packEmitter.pack({
-            bundle: prepared.bundle,
-            format: options.format,
-            outputPath: options.outputPath,
-            vendorEntries: prepared.vendorEntries
-        });
-
-        return Result.ok(undefined);
+        return await packWithResolved(dependencies, resolveResult.value, options);
     };
 }

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -7,7 +7,19 @@ import type { BuildAndPublishResult } from './package-processor.ts';
 import type { CheckError, ResolvedPackage } from './resolved-package.ts';
 import type { PartialError } from './scheduler.ts';
 
+export type UnsatisfiedPeerDependency = {
+    readonly packageName: string;
+    readonly peer: string;
+};
+
+type PeerDependenciesUnsatisfiedFailure = {
+    readonly type: 'peer-dependencies-unsatisfied';
+    readonly packageName: string;
+    readonly items: readonly UnsatisfiedPeerDependency[];
+};
+
 export type PackPackageFailure =
+    | PeerDependenciesUnsatisfiedFailure
     | { readonly type: 'bundle-dependencies-unsupported'; readonly packageName: string }
     | { readonly type: 'package-not-found'; readonly packageName: string };
 

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -242,7 +242,11 @@ function createPacktoryUnderTest(
             },
             vendorMaterializer: {
                 materializeExternals: async () => {
-                    return { entries: [], packageNames: [] };
+                    return {
+                        entries: [],
+                        packageNames: [],
+                        peerRequirements: new Map<string, readonly string[]>()
+                    };
                 }
             }
         }),

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -39,6 +39,7 @@ async function runWith(
         readonly isExecutable: boolean;
     }[];
     readonly packageNames: readonly string[];
+    readonly peerRequirements: ReadonlyMap<string, readonly string[]>;
 }> {
     const fileManager = setupFileManager(setup);
     const materializer = createVendorMaterializer({ fileManager });
@@ -46,7 +47,7 @@ async function runWith(
 }
 
 suite('vendor-materializer', function () {
-    test('treats a package.json with malformed dependency maps as having no transitive dependencies and only collects its own files', async function () {
+    test('treats a package.json with malformed dependency maps as having no transitive dependencies and no peer requirements', async function () {
         const result = await runWith(
             {
                 readabilities: [{ value: { isReadable: true } }],
@@ -65,6 +66,7 @@ suite('vendor-materializer', function () {
                 isExecutable: false
             }
         ]);
+        assert.deepStrictEqual(Array.from(result.peerRequirements.entries()), [['broken', []]]);
     });
 
     test('returns an empty result when no initial dependencies are requested', async function () {

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -7,6 +7,7 @@ import type { VendorEntry } from './vendor-entry.ts';
 type MaterializedExternals = {
     readonly entries: readonly VendorEntry[];
     readonly packageNames: readonly string[];
+    readonly peerRequirements: ReadonlyMap<string, readonly string[]>;
 };
 
 export type VendorMaterializerDependencies = {
@@ -39,6 +40,7 @@ type Closure = {
     readonly visited: Set<string>;
     readonly entries: VendorEntry[];
     readonly queue: QueueItem[];
+    readonly peerRequirements: Map<string, readonly string[]>;
 };
 
 function ancestorFolders(startFolder: string): readonly string[] {
@@ -65,12 +67,22 @@ function enqueueDependencies(closure: Closure, fromFolder: string, dependencyNam
     }
 }
 
-function parseManifestDependencies(content: string): readonly string[] {
+type ParsedManifestSummary = {
+    readonly transitiveDependencyNames: readonly string[];
+    readonly peerDependencyNames: readonly string[];
+};
+
+function parseManifestSummary(content: string): ParsedManifestSummary {
     const parsed = safeParse(packageManifestSchema, JSON.parse(content));
     if (!parsed.success) {
-        return [];
+        return { transitiveDependencyNames: [], peerDependencyNames: [] };
     }
-    return [...Object.keys(parsed.data.dependencies ?? {}), ...Object.keys(parsed.data.peerDependencies ?? {})];
+    const dependencyNames = Object.keys(parsed.data.dependencies ?? {});
+    const peerDependencyNames = Object.keys(parsed.data.peerDependencies ?? {});
+    return {
+        transitiveDependencyNames: [...dependencyNames, ...peerDependencyNames],
+        peerDependencyNames
+    };
 }
 
 export function createVendorMaterializer(dependencies: VendorMaterializerDependencies): VendorMaterializer {
@@ -95,10 +107,10 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
         return undefined;
     }
 
-    async function readDependencyNames(packageDirectory: string): Promise<readonly string[]> {
+    async function readManifestSummary(packageDirectory: string): Promise<ParsedManifestSummary> {
         const manifestPath = path.join(packageDirectory, 'package.json');
         const content = await fileManager.readFile(manifestPath);
-        return parseManifestDependencies(content);
+        return parseManifestSummary(content);
     }
 
     async function collectPackageFiles(rootDirectory: string, packageName: string): Promise<readonly VendorEntry[]> {
@@ -124,6 +136,15 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
         return collected;
     }
 
+    async function ingestResolvedPackage(closure: Closure, name: string, realPath: string): Promise<void> {
+        closure.visited.add(name);
+        const summary = await readManifestSummary(realPath);
+        enqueueDependencies(closure, realPath, summary.transitiveDependencyNames);
+        closure.peerRequirements.set(name, summary.peerDependencyNames);
+        const packageEntries = await collectPackageFiles(realPath, name);
+        closure.entries.push(...packageEntries);
+    }
+
     async function processQueueItem(closure: Closure, item: QueueItem): Promise<void> {
         if (closure.visited.has(item.name)) {
             return;
@@ -132,11 +153,7 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
         if (realPath === undefined) {
             return;
         }
-        closure.visited.add(item.name);
-        const dependencyNames = await readDependencyNames(realPath);
-        enqueueDependencies(closure, realPath, dependencyNames);
-        const packageEntries = await collectPackageFiles(realPath, item.name);
-        closure.entries.push(...packageEntries);
+        await ingestResolvedPackage(closure, item.name, realPath);
     }
 
     async function drainQueue(closure: Closure): Promise<void> {
@@ -155,10 +172,15 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
                 entries: [],
                 queue: options.initialDependencyNames.map((name) => {
                     return { name, fromFolder: options.projectFolder };
-                })
+                }),
+                peerRequirements: new Map<string, readonly string[]>()
             };
             await drainQueue(closure);
-            return { entries: closure.entries, packageNames: Array.from(closure.visited) };
+            return {
+                entries: closure.entries,
+                packageNames: Array.from(closure.visited),
+                peerRequirements: closure.peerRequirements
+            };
         }
     };
 }


### PR DESCRIPTION
## Summary

Slice 4 closes out the `packtory pack` feature. Builds on PR #615.

After this PR:

- **`--vendor-dependencies` now materializes the bundle-dependency closure too.** When packtory's per-package linker has already built the source bundles, pack walks the target package's `linkedBundleDependencies` transitively and lays each one's already-linked output into the artifact at `node_modules/<dep>/<…>` (manifest + sources). Combined with slice 3's external vendoring, a Lambda zip is fully self-contained.
- **Strict peer-dependency check (`Q1`).** Every `peerDependency` declared by any package in the vendor closure — whether a bundle-dep or an external — must be present as a top-level package name in the closure; otherwise pack fails with the new `peer-dependencies-unsatisfied` error, listing each offending `(packageName, peer)` pair.

### How it composes

`packtory-pack.ts` gains a `collectBundleDependencies` walker that:

1. Resolves each transitive bundle-dep from the existing `resolveAndLinkAll` output (no extra build pass).
2. Builds a versioned bundle for it via the existing `versionManager.addVersion` machinery.
3. Converts the bundle's `manifestFile` + each `contents[].fileDescription` into `FileDescription`s with paths prefixed by `node_modules/<dep>/`. These flow through the existing `extraFiles` channel into the artifact builders, so the tar/zip/folder writers don't need new code paths.
4. Records the bundle's `peerDependencies` in the closure's peer-requirement map.

The vendor-materializer (externals) was extended in this PR to also surface `peerRequirements` per package. The peer-check unions both maps against the closure of vendored package names.

### Non-vendor mode behaviour

Unchanged from slice 2/3 — `bundleDependencies` are still rejected with the `bundle-dependencies-unsupported` error. The flag is what makes them deployable, since declared bundle-deps in a non-vendor artifact have no install step to resolve them.

## Test plan
- [x] `just compile`
- [x] `just lint` — all gates green
- [x] `just test-unit-with-coverage` — 100% statements/branches/functions/lines
- [x] `just test-mutation` — 100.00 mutation score, zero timeout mutants
- [x] Local `packtory publish` dry-run still passes
