### PR TITLE
Document the packtory pack feature across all doc surfaces

### DIFF
--- a/documentation/how-it-works.md
+++ b/documentation/how-it-works.md
@@ -1,10 +1,10 @@
 # How it works under the hood
 
-This document explains the pipeline, the data structures, and the algorithms that drive bundling, dead-code elimination, import rewriting, automatic versioning, and parallel scheduling. It is written for engineers who want to contribute, debug, or simply understand the trade-offs — not for end users (read the [readme](../readme.md) for that).
+This document explains the pipeline, the data structures, and the algorithms that drive bundling, dead-code elimination, import rewriting, automatic versioning, on-disk artifact emission, and parallel scheduling. It is written for engineers who want to contribute, debug, or simply understand the trade-offs — not for end users (read the [readme](../readme.md) for that).
 
 ## 1. The pipeline
 
-A single `packtory publish` run is a chain of seven stages. Each stage produces an immutable artifact consumed by the next.
+A single `packtory publish` run is a chain of seven stages. Each stage produces an immutable artifact consumed by the next. `packtory pack` (§10) reuses every stage up through the version manager and swaps the bundle emitter for a disk-writing variant.
 
 ```mermaid
 flowchart LR
@@ -394,7 +394,50 @@ Key properties:
 
 If `publishSettings.access === 'public'` and `provenance.type === 'auto'`, the emitter asserts that the CI environment's repository URL matches `package.json#repository.url` _before_ publishing (`assertRepositoryCoherence`), then delegates the actual sigstore signing to `libnpmpublish`. The npm trusted-publishing token exchange is a separate OIDC resolver. Neither is on the hot path for this doc; see [supply-chain.md](./supply-chain.md) for the full story.
 
-## 10. Putting it all together
+## 10. Stage: Pack Emitter — on-disk artifacts
+
+`packtory pack` and the programmatic `packPackage(config, options)` share the same pipeline as `publish` through every prior stage (validation, resource resolution, linking, dead-code elimination, checks, version manager). What changes is the terminal stage: instead of comparing against a registry tarball and uploading, the Pack emitter takes the produced `VersionedBundleWithManifest` for the requested package and writes it to disk in one of three formats.
+
+### Why it exists
+
+The bundle / link / DCE / checks pipeline produces an artifact that is correct, minimal, and tree-shaken — and that work is just as valuable when the destination isn't an npm registry. AWS Lambda functions want zips. Container builds want directories. Release archives want tarballs. `pack` exposes the same artifact through a different sink so none of that pipeline work has to be re-implemented per destination.
+
+`pack` is also intentionally decoupled from automatic versioning. The registry is the source of truth for "what version comes next" — once you take the artifact off the registry path, there is no source of truth, so the caller has to supply a version. The CLI defaults the stamp to `0.0.0`; the API requires it explicitly.
+
+### Formats
+
+Three writers, one interface (`packEmitter.pack({ bundle, format, outputPath, vendorEntries, extraFiles })`):
+
+- **`zip`** — produced via `fflate` with maximum compression. Entry metadata is fully deterministic: every file is stamped with a fixed 1980-01-01 modification time, the Unix OS marker, and a fixed mode (`0644` for regular files, `0755` for executables). This makes byte-identical inputs produce byte-identical archives, which matters for reproducible-build claims and for Lambda's content-hash-based deduplication.
+- **`tar`** — the same gzipped tarball shape the publish path would upload, just written to a path instead of streamed to a registry.
+- **`folder`** — the artifact expanded onto disk. `outputPath` is treated as the target directory; files are written via the file manager's `writeBinaryFile`, executables get their bit set, and the layout mirrors what would be inside the zip/tar.
+
+### Vendor materialization
+
+The `--vendor-dependencies` / `vendorDependencies: true` flag turns the artifact into a self-contained drop. The materializer walks the consuming project's `node_modules` starting from every external dependency the linker recorded for the target package. For each visited package:
+
+- Resolves the package's real on-disk path via `fs.realpath`, which transparently handles npm's flat-with-symlinks layout, yarn-classic's nested layout, and pnpm's `node_modules/.pnpm` store with the `node_modules/<name>` symlinks. Resolution walks ancestor folders from the package's `sourcesFolder` upward until a matching `node_modules/<name>` is found.
+- Reads the resolved package's `package.json` and extracts both `dependencies` and `peerDependencies` to enqueue. Both are followed so the closure ends up self-contained.
+- Records every file under the package as a `VendorEntry` — a `{ sourceAbsolutePath, targetRelativePath, isExecutable }` reference. Files are referenced by path, not slurped into memory, so binary assets, native modules, and large blobs flow through without ever being decoded. Nested `node_modules` directories inside a visited package are skipped — each transitive dependency is visited independently from the project's top-level layout.
+- Recurses until a fixed point (every reachable dependency visited exactly once).
+
+The collected entries are passed to the artifact writers alongside the bundle's own files; the writers copy them into `node_modules/<name>/...` inside the artifact (or write directly for `folder`).
+
+**Bundle-dependency materialization** uses the same mechanism. A package the linker had previously substituted via cross-package import rewriting (§5) would, in a publish flow, ship without that sibling's source — the consumer's `npm install` would pull it from the registry. In a pack-with-vendor flow there is no consumer install, so the sibling has to be inside the artifact. The materializer treats `bundleDependencies` like any other dependency and copies the resolved sibling's files into `node_modules/`. The cross-package imports the linker rewrote during §5 (`./lib/foo.js` → `pkg/foo.js`) then resolve naturally once the sibling exists under `node_modules/pkg/`.
+
+**Strict peer-dependency check.** When `vendorDependencies` is on, every `peerDependency` declared by a vendored package — whether the vendored package is a sibling bundle or a vendored external — must be satisfied by another package in the same vendor closure. Peers cannot fall through to an ambient install at runtime, because there is no install. An unsatisfied peer is reported as `peer-dependencies-unsatisfied` with the offending package and peer names, and pack exits 1. This is policy, not a transport limitation: silently shipping an artifact whose peer expectations are unmet would defer the failure to runtime in someone else's environment.
+
+### Failure modes specific to pack
+
+The pack outcome's `PackFailure` discriminated union carries the union of the inherited resolve/link/checks failures plus three pack-specific variants:
+
+- `package-not-found` — the `<package>` argument doesn't match any configured package name.
+- `bundle-dependencies-unsupported` — the target package declares `bundleDependencies` but `--vendor-dependencies` is off. Without vendoring there is nowhere to put the sibling, so the request is rejected up front instead of producing a broken artifact.
+- `peer-dependencies-unsatisfied` — see the strict peer check above.
+
+All three are produced before any bytes are written, so a failed `pack` never leaves a partial artifact behind.
+
+## 11. Putting it all together
 
 A worked example: `image-resizer-cli` bundles `image-resizer-lib`.
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Say goodbye to:
 - **Clean and Efficient Packaging**: Package only essential files, excluding devDependencies, CI configurations, and tests. Keep your npm package clean and efficient.
 - **Revolutionary Automatic Versioning**: Choose manual versioning or let packtory handle it. In automatic mode, it calculates versions intelligently, ensuring reproducibility without complexity.
 - **Seamless CI Pipeline Integration**: Easily integrate packtory into your CI pipelines for automatic publishing with every commit. No more intricate checks to decide what to publish.
+- **On-Disk Artifacts for Non-Registry Targets**: Produce a single configured package as a zip, tarball, or expanded folder — ideal for AWS Lambda deployments, container builds, and any workflow where the destination isn't an npm registry.
 
 ## Quick Start
 
@@ -115,6 +116,23 @@ Packtory supports two versioning modes:
 
 2. **Manual Versioning:**
     - Provide the exact version number in the configuration.
+
+### Pack (on-disk artifacts)
+
+`packtory publish` is the registry-driven workflow; `packtory pack` is the disk-driven complement. Use it whenever you need the same bundled, dead-code-eliminated, linked output as a published package, but the destination is something other than an npm registry — AWS Lambda functions, Docker build contexts, OCI image layers, archived release artifacts, or local inspection of what would have been published.
+
+`pack` reuses the same validate → resolve → link → checks pipeline as the other commands. What changes is the emit stage:
+
+- **Format**: `zip` (the format AWS Lambda accepts directly, with deterministic metadata for byte-identical builds), `tar` (the same gzipped tarball shape `publish` would upload), or `folder` (the artifact expanded into a directory).
+- **Output path**: where to write the archive or, for `folder`, the directory to populate.
+- **Version**: stamped into the generated manifest. Defaults to `0.0.0` — `pack` is intentionally decoupled from the registry-driven automatic versioning, so the caller decides the version (often the CI build's release tag).
+- **Vendor dependencies**: an opt-in `--vendor-dependencies` (CLI) / `vendorDependencies: true` (API) flag materializes every transitive runtime dependency from the local `node_modules` directly into `node_modules/` inside the artifact. This is what makes the output self-contained for runtimes that cannot run `npm install` (AWS Lambda, distroless containers). Symlink layouts created by npm, yarn-classic, and pnpm are all handled. Packages declared in `bundleDependencies` are materialized too, with their original cross-package import paths preserved.
+
+```bash
+npx packtory pack image-resizer-cli --format zip --out ./dist/image-resizer-cli.zip --vendor-dependencies
+```
+
+See the [CLI documentation](./source/packages/command-line-interface/README.md) for the full flag reference and the programmatic API in [`packtory`](./source/packages/packtory/README.md) for `packPackage(config, options)`.
 
 For a deeper look at the pipeline, the package graph, parallel scheduling, the tree-shaking algorithm, import-path rewriting, and automatic version detection, see [How it works under the hood](./documentation/how-it-works.md).
 

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -21,6 +21,7 @@ packtory <command> [options]
 - **preview:** Runs a fresh dry-run build with report collection enabled and shows a human-oriented preview of the emitted package contents, file statuses, and changed-file diffs.
 - **release-diff:** Runs the same dry-run build as `preview` and shows, per package, the changes between the latest version currently published on the configured registry and the bundle the next run would publish.
 - **publish:** Bundles and publishes npm packages based on the configuration in `packtory.config.js`.
+- **pack:** Builds a single configured package and writes it to disk as a zip archive, tarball, or expanded folder. Intended for ad-hoc artifact use cases such as AWS Lambda deployments, container builds, or local inspection — `pack` never talks to a registry.
 
 **Options:**
 
@@ -28,6 +29,9 @@ packtory <command> [options]
 - **preview --open:** Generates the same fresh preview report as `packtory preview`, writes a temporary HTML file, and opens it with the platform opener.
 - **publish --report-json:** Writes `packtory-report.json`, the machine-readable `BuildReport`.
 - **publish --report-html:** Writes `packtory-report.html`, the rich HTML report used by `packtory preview --open`.
+- **pack &lt;package&gt; --format &lt;zip|tar|folder&gt; --out &lt;path&gt;:** Selects which package from the configuration to build and where to write it. `--format` and `--out` are required.
+- **pack --version &lt;version&gt;:** Stamps the produced manifest with the given version. Defaults to `0.0.0` when omitted, since `pack` is decoupled from the registry-driven automatic versioning used by `publish`.
+- **pack --vendor-dependencies:** Resolves every external (and bundle) dependency from the local `node_modules` and materializes them next to the package files inside the artifact. Use this for self-contained deployments where the runtime cannot run `npm install` (e.g. AWS Lambda zips). Without the flag, dependencies are recorded in the generated `package.json` only.
 
 **Preview behavior:**
 
@@ -48,6 +52,18 @@ packtory <command> [options]
 - Previewable runs are shown through `$PAGER` when possible, otherwise `less -R`, otherwise standard output. Failure-only runs go directly to standard output.
 - `packtory release-diff` exits with code `0` on a clean run and `1` on config errors, check failures, or partial failures.
 - `release-diff` is read-only: it never publishes and never writes to the registry. It is currently terminal-only; an HTML/`--open` variant and an `--against <version>` selector are not part of this release.
+
+**Pack behavior:**
+
+- `packtory pack` runs the same validate → resolve → link → checks pipeline as the other commands, then emits the selected package's bundle to the path given by `--out`. It never reads from or writes to the configured registry.
+- Format choices:
+    - `zip` — single-file zip archive. The format AWS Lambda accepts directly. Uses static metadata (1980-01-01 entries, deterministic ordering) so byte-identical inputs yield byte-identical archives.
+    - `tar` — single-file gzipped tarball, the same shape `publish` would upload, but written to disk instead of the registry.
+    - `folder` — expanded directory; `--out` is treated as the directory path. Useful for inspecting the artifact, for `docker build` contexts, or for piping the contents through another tool.
+- `--vendor-dependencies` walks the local `node_modules` (resolving symlinks with `fs.realpath`, so npm, yarn-classic, and pnpm layouts all work) and copies every transitive runtime dependency into `node_modules/` inside the artifact. Files are streamed by path rather than read into memory, so binary assets and executables survive intact. Anything declared in `bundleDependencies` is materialized the same way without import-path rewriting, so cross-package imports keep their original form.
+- Strict peer-dependency check: when `--vendor-dependencies` is set, every `peerDependency` declared by a vendored package must be satisfied by another vendored package (or by the target package itself). An unsatisfied peer is reported as `peer-dependencies-unsatisfied` and pack exits with code 1.
+- Without `--vendor-dependencies`, packages that declare `bundleDependencies` are rejected with `bundle-dependencies-unsupported`. The flag is the only path that knows how to put a sibling package inside the artifact.
+- An unknown `<package>` argument is reported as `package-not-found`.
 
 **Preview vs release-diff:**
 

--- a/source/packages/packtory/readme.md
+++ b/source/packages/packtory/readme.md
@@ -2,10 +2,12 @@
 
 **API Package for packtory**
 
-This package provides an API for the `packtory` tool, enabling programmatic usage. It exposes two functions:
+This package provides an API for the `packtory` tool, enabling programmatic usage. It exposes the following functions:
 
 - `buildAndPublishAll(config, options)` – validates the configuration, builds every package, runs the enabled checks, and (optionally) publishes the results.
 - `resolveAndLinkAll(config)` – performs the validation, resolve, link, and checks phases without publishing. This is useful for custom workflows and integration tests that only need the prepared bundles.
+- `diffAgainstLatestPublished(config)` – validates and builds every package without publishing, then per package computes the file-level diff between the bundle the next publish would produce and the version currently tagged `latest` on the configured registry.
+- `packPackage(config, options)` – validates the configuration, runs the same resolve / link / checks pipeline as `buildAndPublishAll`, and writes a single configured package to disk as a zip, tarball, or expanded folder. Useful when you need an artifact you control (Lambda zip, container build context, local inspection) instead of a registry publish.
 
 **Installation:**
 
@@ -16,30 +18,43 @@ npm install packtory
 **Usage:**
 
 ```javascript
-import { buildAndPublishAll, resolveAndLinkAll } from 'packtory';
+import { buildAndPublishAll, resolveAndLinkAll, packPackage } from 'packtory';
 
 const config = {
     /* your packtory configuration */
 };
-const options = { dryRun: true }; // Example options
 
 (async () => {
-    const publishResult = await buildAndPublishAll(config, options);
-    console.log(publishResult);
+    const publishOutcome = await buildAndPublishAll(config, { dryRun: true });
+    console.log(publishOutcome.result);
 
-    const resolvedResult = await resolveAndLinkAll(config);
-    console.log(resolvedResult);
+    const resolvedOutcome = await resolveAndLinkAll(config);
+    console.log(resolvedOutcome.result);
+
+    const packOutcome = await packPackage(config, {
+        packageName: 'image-resizer-cli',
+        format: 'zip',
+        outputPath: './dist/image-resizer-cli.zip',
+        version: '1.4.0',
+        vendorDependencies: true
+    });
+    console.log(packOutcome.result);
 })();
 ```
 
 **Parameters:**
 
 - **config:** The packtory configuration object.
-- **options:** An options object, currently supporting a `dryRun` boolean (only required for `buildAndPublishAll`).
+- **options:** Per-function options object:
+    - `buildAndPublishAll`: `{ dryRun: boolean; collectReport?: boolean }`.
+    - `resolveAndLinkAll`: optional `{ collectReport?: boolean }`.
+    - `packPackage`: `{ packageName, format, outputPath, version, vendorDependencies }`. `format` is `'zip' | 'tar' | 'folder'`. `version` stamps the generated manifest (no automatic versioning is performed). `vendorDependencies` toggles materializing the resolved `node_modules` tree (including any `bundleDependencies`) into the artifact for self-contained deployments.
 
 **Return Values:**
 
-- `buildAndPublishAll` returns a `PublishAllResult` containing either a list of successful publish results or a partial error if some packages failed.
-- `resolveAndLinkAll` returns a `ResolveAndLinkAllResult` with either the resolved package information or details about the failure (validation errors, check failures, or partial execution issues).
+- `buildAndPublishAll` returns a `PublishAllOutcome` whose `result` is either a list of successful publish results or a partial error if some packages failed.
+- `resolveAndLinkAll` returns a `ResolveAndLinkAllOutcome` whose `result` carries the resolved package information or details about the failure (validation errors, check failures, or partial execution issues).
+- `diffAgainstLatestPublished` returns a `ReleaseDiffAllOutcome` whose `result` carries the per-package release diff list or a failure variant.
+- `packPackage` returns a `PackOutcome` whose `result` is `Ok(undefined)` on success or a `PackFailure`. `PackFailure` is a discriminated union covering configuration errors, check failures, partial resolve failures, and the pack-specific variants `package-not-found`, `bundle-dependencies-unsupported` (rejected when `vendorDependencies` is `false` and the target declares `bundleDependencies`), and `peer-dependencies-unsatisfied` (raised when a vendored dependency declares a peer that no other vendored package satisfies).
 
-**Note:** Refer to the [full documentation](https://github.com/enormora/packtory/blob/main/readme.md) for additional details.
+**Note:** Refer to the [full documentation](../../../readme.md) for additional details.


### PR DESCRIPTION
## Summary
- Audit the repository's documentation concept — root README (user-facing concept), `documentation/how-it-works.md` (mechanism), `@packtory/cli` README (commands and flags), `packtory` README (programmatic API) — and extend every surface that the `packtory pack` feature touches.
- Root README: new "Pack (on-disk artifacts)" section and feature bullet, with a worked CLI example linking to the per-package docs.
- `how-it-works`: add §10 "Stage: Pack Emitter — on-disk artifacts" describing format-specific writers, vendor materialization (real-path resolution that handles npm / yarn-classic / pnpm layouts), bundle-dependency materialization, and the strict peer-dependency policy.
- `@packtory/cli` README: document the `pack` subcommand, the `--format` / `--out` / `--version` / `--vendor-dependencies` flags, expected behavior, and the pack-specific failure modes.
- `packtory` README: list `packPackage` in the API surface, document `PackPublicOptions` and `PackOutcome` / `PackFailure`, and switch the existing absolute link to the relative pattern the other package READMEs use.

This is a follow-up to PRs #612, #614, #615, #616 (the feature itself). No code changes, no test changes — purely documentation.