### PR TITLE
Reject vendor entries whose symlinks escape the package directory

### DIFF
--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -160,6 +160,22 @@ suite('pack-handler', function () {
         );
     });
 
+    test('returns 1 and surfaces the vendored package, escaped entry path, and resolved target when a vendor symlink leaves its package directory', async function () {
+        await expectFailure(
+            {
+                type: 'vendor-symlink-target-outside-package',
+                packageName: 'pkg-a',
+                vendoredPackageName: 'evil-helper',
+                entryRelativePath: 'config/defaults.json',
+                resolvedTargetPath: '/Users/victim/.npmrc'
+            },
+            [
+                /Pack of "pkg-a" rejected a vendored dependency with a symlink that escapes its package directory/u,
+                /"evil-helper" contains "config\/defaults\.json" which resolves to "\/Users\/victim\/\.npmrc"/u
+            ]
+        );
+    });
+
     test('returns 1 and summarises partial resolve failures with one line per failure', async function () {
         await expectFailure(
             { type: 'partial', error: { succeeded: [], failures: [new Error('resolve A'), new Error('resolve B')] } },

--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -170,8 +170,7 @@ suite('pack-handler', function () {
                 resolvedTargetPath: '/Users/victim/.npmrc'
             },
             [
-                /Pack of "pkg-a" rejected a vendored dependency with a symlink that escapes its package directory/u,
-                /"evil-helper" contains "config\/defaults\.json" which resolves to "\/Users\/victim\/\.npmrc"/u
+                /escapes its package directory\n- "evil-helper" contains "config\/defaults\.json" which resolves to "\/Users\/victim\/\.npmrc"/u
             ]
         );
     });

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -52,9 +52,23 @@ function formatPackageNotFound(packageName: string): string {
     return `${getErrorSymbol()} Package "${packageName}" is not declared in the packtory configuration`;
 }
 
+function formatVendorSymlinkOutsidePackageFailure(
+    error: PackFailure & { readonly type: 'vendor-symlink-target-outside-package' }
+): string {
+    const reason = 'rejected a vendored dependency with a symlink that escapes its package directory';
+    const header = `${getErrorSymbol()} Pack of "${error.packageName}" ${reason}`;
+    const target = `which resolves to "${error.resolvedTargetPath}"`;
+    const details = `- "${error.vendoredPackageName}" contains "${error.entryRelativePath}" ${target}`;
+    return [header, details].join('\n');
+}
+
 type ConfigOrCheckError = PackFailure & { readonly type: 'checks' | 'config' };
 type PackPackageError = PackFailure & {
-    readonly type: 'bundle-dependencies-unsupported' | 'package-not-found' | 'peer-dependencies-unsatisfied';
+    readonly type:
+        | 'bundle-dependencies-unsupported'
+        | 'package-not-found'
+        | 'peer-dependencies-unsatisfied'
+        | 'vendor-symlink-target-outside-package';
 };
 
 function formatIssueListFailure(error: ConfigOrCheckError): string {
@@ -71,6 +85,9 @@ function formatPackPackageFailure(error: PackPackageError): string {
     if (error.type === 'bundle-dependencies-unsupported') {
         return formatBundleDepFailure(error.packageName);
     }
+    if (error.type === 'vendor-symlink-target-outside-package') {
+        return formatVendorSymlinkOutsidePackageFailure(error);
+    }
     return formatPeerFailure(error);
 }
 
@@ -82,7 +99,8 @@ function isPackPackageError(error: PackFailure): error is PackPackageError {
     return (
         error.type === 'package-not-found' ||
         error.type === 'bundle-dependencies-unsupported' ||
-        error.type === 'peer-dependencies-unsatisfied'
+        error.type === 'peer-dependencies-unsatisfied' ||
+        error.type === 'vendor-symlink-target-outside-package'
     );
 }
 

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -121,11 +121,13 @@ function createDependencies(overrides: {
     const resolveAndLinkAll = fake.resolves(overrides.resolveResult ?? Result.ok([makeResolvedPackage()]));
     const materializeExternals =
         overrides.materializerSpy ??
-        fake.resolves({
-            entries: overrides.vendorEntries ?? [],
-            packageNames: [],
-            peerRequirements: new Map<string, readonly string[]>()
-        });
+        fake.resolves(
+            Result.ok({
+                entries: overrides.vendorEntries ?? [],
+                packageNames: [],
+                peerRequirements: new Map<string, readonly string[]>()
+            })
+        );
     const vendorMaterializer = {
         materializeExternals:
             materializeExternals as unknown as PackRunDependencies['vendorMaterializer']['materializeExternals']
@@ -156,11 +158,13 @@ function buildDependenciesWith(
         packEmitter: { pack: packEmitterPackFake as never },
         vendorMaterializer: {
             materializeExternals: (materializerOverride ??
-                fake.resolves({
-                    entries: [],
-                    packageNames: [],
-                    peerRequirements: new Map<string, readonly string[]>()
-                })) as never
+                fake.resolves(
+                    Result.ok({
+                        entries: [],
+                        packageNames: [],
+                        peerRequirements: new Map<string, readonly string[]>()
+                    })
+                )) as never
         }
     };
 }
@@ -334,11 +338,13 @@ suite('packtory-pack', function () {
 
     test('returns a peer-dependencies-unsatisfied failure listing only the peers that are missing from the closure', async function () {
         // 'react' is in the closure (satisfied), 'react-router' is not (unsatisfied).
-        const materializerSpy = fake.resolves({
-            entries: [],
-            packageNames: ['react-dom', 'react'],
-            peerRequirements: new Map<string, readonly string[]>([['react-dom', ['react', 'react-router']]])
-        });
+        const materializerSpy = fake.resolves(
+            Result.ok({
+                entries: [],
+                packageNames: ['react-dom', 'react'],
+                peerRequirements: new Map<string, readonly string[]>([['react-dom', ['react', 'react-router']]])
+            })
+        );
         const { dependencies, fakes } = createDependencies({
             materializerSpy,
             resolveResult: Result.ok([
@@ -357,6 +363,39 @@ suite('packtory-pack', function () {
             type: 'peer-dependencies-unsatisfied',
             packageName: 'pkg-a',
             items: [{ packageName: 'react-dom', peer: 'react-router' }]
+        });
+        assert.strictEqual(fakes.packEmitterPack.callCount, 0);
+    });
+
+    test('maps a vendor symlink-target-outside-package failure to the corresponding pack failure and never emits an artifact', async function () {
+        const materializerSpy = fake.resolves(
+            Result.err({
+                type: 'symlink-target-outside-package',
+                packageName: 'evil',
+                entryRelativePath: 'leak.json',
+                resolvedTargetPath: '/Users/victim/.npmrc'
+            })
+        );
+        const { dependencies, fakes } = createDependencies({
+            materializerSpy,
+            resolveResult: Result.ok([
+                makeResolvedPackage({ externalDependencyNames: ['evil'], sourcesFolder: '/repo/source' })
+            ])
+        });
+        const runPack = createRunPackValidated(dependencies);
+
+        const result = await runPack(
+            validatedConfig,
+            { ...baseOptions, vendorDependencies: true },
+            fakes.resolveAndLinkAll
+        );
+
+        assert.deepStrictEqual(expectErr(result), {
+            type: 'vendor-symlink-target-outside-package',
+            packageName: 'pkg-a',
+            vendoredPackageName: 'evil',
+            entryRelativePath: 'leak.json',
+            resolvedTargetPath: '/Users/victim/.npmrc'
         });
         assert.strictEqual(fakes.packEmitterPack.callCount, 0);
     });
@@ -466,11 +505,13 @@ suite('packtory-pack', function () {
                 isExecutable: false
             }
         ];
-        const materializerSpy = fake.resolves({
-            entries: vendorEntries,
-            packageNames: ['left-pad'],
-            peerRequirements: new Map<string, readonly string[]>()
-        });
+        const materializerSpy = fake.resolves(
+            Result.ok({
+                entries: vendorEntries,
+                packageNames: ['left-pad'],
+                peerRequirements: new Map<string, readonly string[]>()
+            })
+        );
         const { dependencies, fakes } = createDependencies({
             versionedBundle,
             materializerSpy,

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -9,7 +9,10 @@ import { serializePackageJson } from '../version-manager/manifest/serialize.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
 import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
-import type { VendorMaterializer } from '../vendor-materializer/vendor-materializer.ts';
+import type {
+    SymlinkTargetOutsidePackageFailure,
+    VendorMaterializer
+} from '../vendor-materializer/vendor-materializer.ts';
 import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 import type { ResolvedPackage } from './resolved-package.ts';
 import type { InternalResolveAndLinkFailure } from './packtory-resolve.ts';
@@ -225,32 +228,52 @@ type VendoredInputs = {
     readonly version: string;
 };
 
+type MaterializedExternalsResult = Awaited<
+    ReturnType<PackRunDependencies['vendorMaterializer']['materializeExternals']>
+>;
+
+function mapMaterializerFailure(
+    packageName: string,
+    materializerFailure: SymlinkTargetOutsidePackageFailure
+): PackPackageFailure {
+    return {
+        type: 'vendor-symlink-target-outside-package',
+        packageName,
+        vendoredPackageName: materializerFailure.packageName,
+        entryRelativePath: materializerFailure.entryRelativePath,
+        resolvedTargetPath: materializerFailure.resolvedTargetPath
+    };
+}
+
+function checkClosurePeers(
+    bundleClosure: BundleDepClosure,
+    externals: MaterializedExternalsResult & { readonly isOk: true }
+): readonly UnsatisfiedPeerDependency[] {
+    const closurePackageNames = new Set<string>([...bundleClosure.packageNames, ...externals.value.packageNames]);
+    const allPeerRequirements = mergePeerRequirements(bundleClosure.peerRequirements, externals.value.peerRequirements);
+    return findUnsatisfiedPeers(closurePackageNames, allPeerRequirements);
+}
+
 async function prepareVendoredArtifact(
     dependencies: PackRunDependencies,
     inputs: VendoredInputs
 ): Promise<Result<VendoredArtifact, PackPackageFailure>> {
     const { target, resolved, built, version } = inputs;
     const bundleClosure = collectBundleDependencies(target, resolved, dependencies.versionManager, version);
-    const externalsMaterialized = await dependencies.vendorMaterializer.materializeExternals({
+    const materializationResult = await dependencies.vendorMaterializer.materializeExternals({
         initialDependencyNames: Array.from(target.analyzedBundle.externalDependencies.keys()),
         projectFolder: target.resolveOptions.sourcesFolder
     });
-    const closurePackageNames = new Set<string>([...bundleClosure.packageNames, ...externalsMaterialized.packageNames]);
-    const allPeerRequirements = mergePeerRequirements(
-        bundleClosure.peerRequirements,
-        externalsMaterialized.peerRequirements
-    );
-    const unsatisfiedPeers = findUnsatisfiedPeers(closurePackageNames, allPeerRequirements);
+    if (materializationResult.isErr) {
+        return Result.err(mapMaterializerFailure(target.name, materializationResult.error));
+    }
+    const unsatisfiedPeers = checkClosurePeers(bundleClosure, materializationResult);
     if (unsatisfiedPeers.length > 0) {
-        return Result.err({
-            type: 'peer-dependencies-unsatisfied',
-            packageName: target.name,
-            items: unsatisfiedPeers
-        });
+        return Result.err({ type: 'peer-dependencies-unsatisfied', packageName: target.name, items: unsatisfiedPeers });
     }
     return Result.ok({
         bundle: slimManifestForVendoredArtifact(built),
-        vendorEntries: externalsMaterialized.entries,
+        vendorEntries: materializationResult.value.entries,
         extraFiles: bundleClosure.extraFiles
     });
 }

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -18,8 +18,17 @@ type PeerDependenciesUnsatisfiedFailure = {
     readonly items: readonly UnsatisfiedPeerDependency[];
 };
 
+type VendorSymlinkOutsidePackageFailure = {
+    readonly type: 'vendor-symlink-target-outside-package';
+    readonly packageName: string;
+    readonly vendoredPackageName: string;
+    readonly entryRelativePath: string;
+    readonly resolvedTargetPath: string;
+};
+
 export type PackPackageFailure =
     | PeerDependenciesUnsatisfiedFailure
+    | VendorSymlinkOutsidePackageFailure
     | { readonly type: 'bundle-dependencies-unsupported'; readonly packageName: string }
     | { readonly type: 'package-not-found'; readonly packageName: string };
 

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -242,11 +242,11 @@ function createPacktoryUnderTest(
             },
             vendorMaterializer: {
                 materializeExternals: async () => {
-                    return {
+                    return Result.ok({
                         entries: [],
                         packageNames: [],
                         peerRequirements: new Map<string, readonly string[]>()
-                    };
+                    });
                 }
             }
         }),

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -398,6 +398,55 @@ suite('vendor-materializer', function () {
         });
     });
 
+    test('rejects a symlink whose resolved target is the immediate parent of the package directory', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }, { value: '/repo/node_modules' }],
+                listings: [
+                    {
+                        value: [{ name: 'parent-link', isDirectory: false, isSymbolicLink: true }]
+                    }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'symlink-target-outside-package',
+            packageName: 'pkg',
+            entryRelativePath: 'parent-link',
+            resolvedTargetPath: '/repo/node_modules'
+        });
+    });
+
+    test('reports a nested symlink-entry path with forward slashes regardless of platform separators', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }, { value: '/Users/victim/.ssh/id_rsa' }],
+                listings: [
+                    {
+                        value: [{ name: 'config', isDirectory: true, isSymbolicLink: false }]
+                    },
+                    {
+                        value: [{ name: 'secret-link', isDirectory: false, isSymbolicLink: true }]
+                    }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'symlink-target-outside-package',
+            packageName: 'pkg',
+            entryRelativePath: 'config/secret-link',
+            resolvedTargetPath: '/Users/victim/.ssh/id_rsa'
+        });
+    });
+
     test('rejects a symlink whose target cannot be resolved (broken symlink) so packtory never blindly trusts it', async function () {
         const failure = await runExpectingFailure(
             {

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -1,10 +1,14 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
-import { createVendorMaterializer } from './vendor-materializer.ts';
+import {
+    createVendorMaterializer,
+    type VendorMaterializer,
+    type SymlinkTargetOutsidePackageFailure
+} from './vendor-materializer.ts';
 
 type ReadabilityResponse = { readonly value: { readonly isReadable: boolean } };
-type StringResponse = { readonly value: string };
+type StringResponse = { readonly error: Error } | { readonly value: string };
 type DirectoryEntriesResponse = {
     readonly value: readonly {
         readonly name: string;
@@ -29,10 +33,7 @@ function setupFileManager(setup: FakeSetup): ReturnType<typeof createFakeFileMan
     });
 }
 
-async function runWith(
-    setup: FakeSetup,
-    request: { readonly initialDependencyNames: readonly string[]; readonly projectFolder: string }
-): Promise<{
+type MaterializedSnapshot = {
     readonly entries: readonly {
         readonly targetRelativePath: string;
         readonly sourceAbsolutePath: string;
@@ -40,10 +41,40 @@ async function runWith(
     }[];
     readonly packageNames: readonly string[];
     readonly peerRequirements: ReadonlyMap<string, readonly string[]>;
-}> {
+};
+
+function expectOk(result: Awaited<ReturnType<VendorMaterializer['materializeExternals']>>): MaterializedSnapshot {
+    if (result.isErr) {
+        assert.fail(`expected materializeExternals to succeed but it returned ${JSON.stringify(result.error)}`);
+    }
+    return result.value;
+}
+
+function expectErr(
+    result: Awaited<ReturnType<VendorMaterializer['materializeExternals']>>
+): SymlinkTargetOutsidePackageFailure {
+    if (result.isOk) {
+        assert.fail('expected materializeExternals to fail but it returned Ok');
+    }
+    return result.error;
+}
+
+async function runWith(
+    setup: FakeSetup,
+    request: { readonly initialDependencyNames: readonly string[]; readonly projectFolder: string }
+): Promise<MaterializedSnapshot> {
     const fileManager = setupFileManager(setup);
     const materializer = createVendorMaterializer({ fileManager });
-    return await materializer.materializeExternals(request);
+    return expectOk(await materializer.materializeExternals(request));
+}
+
+async function runExpectingFailure(
+    setup: FakeSetup,
+    request: { readonly initialDependencyNames: readonly string[]; readonly projectFolder: string }
+): Promise<SymlinkTargetOutsidePackageFailure> {
+    const fileManager = setupFileManager(setup);
+    const materializer = createVendorMaterializer({ fileManager });
+    return expectErr(await materializer.materializeExternals(request));
 }
 
 suite('vendor-materializer', function () {
@@ -73,10 +104,12 @@ suite('vendor-materializer', function () {
         const fileManager = setupFileManager({ readabilities: [], realPaths: [], listings: [], fileReads: [] });
         const materializer = createVendorMaterializer({ fileManager });
 
-        const result = await materializer.materializeExternals({
-            initialDependencyNames: [],
-            projectFolder: '/repo'
-        });
+        const result = expectOk(
+            await materializer.materializeExternals({
+                initialDependencyNames: [],
+                projectFolder: '/repo'
+            })
+        );
 
         assert.deepStrictEqual(result.entries, []);
         assert.deepStrictEqual(result.packageNames, []);
@@ -98,10 +131,12 @@ suite('vendor-materializer', function () {
         });
         const materializer = createVendorMaterializer({ fileManager });
 
-        const result = await materializer.materializeExternals({
-            initialDependencyNames: ['leaf'],
-            projectFolder: '/repo'
-        });
+        const result = expectOk(
+            await materializer.materializeExternals({
+                initialDependencyNames: ['leaf'],
+                projectFolder: '/repo'
+            })
+        );
 
         assert.deepStrictEqual(result.packageNames, ['leaf']);
         assert.deepStrictEqual(result.entries, [
@@ -147,10 +182,12 @@ suite('vendor-materializer', function () {
         });
         const materializer = createVendorMaterializer({ fileManager });
 
-        const result = await materializer.materializeExternals({
-            initialDependencyNames: ['root'],
-            projectFolder: '/repo'
-        });
+        const result = expectOk(
+            await materializer.materializeExternals({
+                initialDependencyNames: ['root'],
+                projectFolder: '/repo'
+            })
+        );
 
         assert.deepStrictEqual(result.packageNames, ['root', 'dep', 'peer']);
         const targetPaths = result.entries.map((entry) => {
@@ -230,10 +267,12 @@ suite('vendor-materializer', function () {
         });
         const materializer = createVendorMaterializer({ fileManager });
 
-        const result = await materializer.materializeExternals({
-            initialDependencyNames: ['hoisted'],
-            projectFolder: '/workspace/packages/inner'
-        });
+        const result = expectOk(
+            await materializer.materializeExternals({
+                initialDependencyNames: ['hoisted'],
+                projectFolder: '/workspace/packages/inner'
+            })
+        );
 
         assert.deepStrictEqual(result.packageNames, ['hoisted']);
         assert.deepStrictEqual(fileManager.getAllCheckReadabilityCalls(), [
@@ -261,10 +300,12 @@ suite('vendor-materializer', function () {
         });
         const materializer = createVendorMaterializer({ fileManager });
 
-        const result = await materializer.materializeExternals({
-            initialDependencyNames: ['missing'],
-            projectFolder: '/some/deep/folder'
-        });
+        const result = expectOk(
+            await materializer.materializeExternals({
+                initialDependencyNames: ['missing'],
+                projectFolder: '/some/deep/folder'
+            })
+        );
 
         assert.deepStrictEqual(result.entries, []);
         assert.deepStrictEqual(result.packageNames, []);
@@ -305,5 +346,81 @@ suite('vendor-materializer', function () {
             return entry.targetRelativePath.startsWith('node_modules/shared/');
         }).length;
         assert.strictEqual(sharedCount, 1);
+    });
+
+    test('vendors a symlink whose resolved target stays inside the package directory', async function () {
+        const result = await runWith(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }, { value: '/repo/node_modules/pkg/dist/index.js' }],
+                listings: [
+                    {
+                        value: [
+                            { name: 'dist', isDirectory: true, isSymbolicLink: false },
+                            { name: 'bin.js', isDirectory: false, isSymbolicLink: true }
+                        ]
+                    },
+                    {
+                        value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }]
+                    }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        const targetPaths = result.entries.map((entry) => {
+            return entry.targetRelativePath;
+        });
+        assert.deepStrictEqual(targetPaths, ['node_modules/pkg/dist/index.js', 'node_modules/pkg/bin.js']);
+    });
+
+    test('rejects a symlink whose resolved target escapes the package directory', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/evil' }, { value: '/Users/victim/.npmrc' }],
+                listings: [
+                    {
+                        value: [{ name: 'leak.json', isDirectory: false, isSymbolicLink: true }]
+                    }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['evil'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'symlink-target-outside-package',
+            packageName: 'evil',
+            entryRelativePath: 'leak.json',
+            resolvedTargetPath: '/Users/victim/.npmrc'
+        });
+    });
+
+    test('rejects a symlink whose target cannot be resolved (broken symlink) so packtory never blindly trusts it', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [
+                    { value: '/repo/node_modules/pkg' },
+                    { error: new Error('ENOENT: no such file or directory') }
+                ],
+                listings: [
+                    {
+                        value: [{ name: 'broken.json', isDirectory: false, isSymbolicLink: true }]
+                    }
+                ],
+                fileReads: [{ value: '{}' }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'symlink-target-outside-package',
+            packageName: 'pkg',
+            entryRelativePath: 'broken.json',
+            resolvedTargetPath: '/repo/node_modules/pkg/broken.json'
+        });
     });
 });

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -3,9 +3,11 @@ import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
     createVendorMaterializer,
-    type VendorMaterializer,
-    type SymlinkTargetOutsidePackageFailure
+    type SymlinkTargetOutsidePackageFailure,
+    type VendorMaterializer
 } from './vendor-materializer.ts';
+
+type VendorMaterializerFailure = SymlinkTargetOutsidePackageFailure;
 
 type ReadabilityResponse = { readonly value: { readonly isReadable: boolean } };
 type StringResponse = { readonly error: Error } | { readonly value: string };
@@ -398,20 +400,30 @@ suite('vendor-materializer', function () {
         });
     });
 
-    test('rejects a symlink whose resolved target is the immediate parent of the package directory', async function () {
-        const failure = await runExpectingFailure(
+    async function runSinglePackageSymlinkScenario(scenario: {
+        readonly initialName: string;
+        readonly packageRealPath: string;
+        readonly listings: FakeSetup['listings'];
+        readonly targetRealPath: { readonly error: Error } | { readonly value: string };
+    }): Promise<VendorMaterializerFailure> {
+        return await runExpectingFailure(
             {
                 readabilities: [{ value: { isReadable: true } }],
-                realPaths: [{ value: '/repo/node_modules/pkg' }, { value: '/repo/node_modules' }],
-                listings: [
-                    {
-                        value: [{ name: 'parent-link', isDirectory: false, isSymbolicLink: true }]
-                    }
-                ],
+                realPaths: [{ value: scenario.packageRealPath }, scenario.targetRealPath],
+                listings: scenario.listings,
                 fileReads: [{ value: '{}' }]
             },
-            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+            { initialDependencyNames: [scenario.initialName], projectFolder: '/repo' }
         );
+    }
+
+    test('rejects a symlink whose resolved target is the immediate parent of the package directory', async function () {
+        const failure = await runSinglePackageSymlinkScenario({
+            initialName: 'pkg',
+            packageRealPath: '/repo/node_modules/pkg',
+            listings: [{ value: [{ name: 'parent-link', isDirectory: false, isSymbolicLink: true }] }],
+            targetRealPath: { value: '/repo/node_modules' }
+        });
 
         assert.deepStrictEqual(failure, {
             type: 'symlink-target-outside-package',
@@ -422,22 +434,15 @@ suite('vendor-materializer', function () {
     });
 
     test('reports a nested symlink-entry path with forward slashes regardless of platform separators', async function () {
-        const failure = await runExpectingFailure(
-            {
-                readabilities: [{ value: { isReadable: true } }],
-                realPaths: [{ value: '/repo/node_modules/pkg' }, { value: '/Users/victim/.ssh/id_rsa' }],
-                listings: [
-                    {
-                        value: [{ name: 'config', isDirectory: true, isSymbolicLink: false }]
-                    },
-                    {
-                        value: [{ name: 'secret-link', isDirectory: false, isSymbolicLink: true }]
-                    }
-                ],
-                fileReads: [{ value: '{}' }]
-            },
-            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
-        );
+        const failure = await runSinglePackageSymlinkScenario({
+            initialName: 'pkg',
+            packageRealPath: '/repo/node_modules/pkg',
+            listings: [
+                { value: [{ name: 'config', isDirectory: true, isSymbolicLink: false }] },
+                { value: [{ name: 'secret-link', isDirectory: false, isSymbolicLink: true }] }
+            ],
+            targetRealPath: { value: '/Users/victim/.ssh/id_rsa' }
+        });
 
         assert.deepStrictEqual(failure, {
             type: 'symlink-target-outside-package',
@@ -448,22 +453,12 @@ suite('vendor-materializer', function () {
     });
 
     test('rejects a symlink whose target cannot be resolved (broken symlink) so packtory never blindly trusts it', async function () {
-        const failure = await runExpectingFailure(
-            {
-                readabilities: [{ value: { isReadable: true } }],
-                realPaths: [
-                    { value: '/repo/node_modules/pkg' },
-                    { error: new Error('ENOENT: no such file or directory') }
-                ],
-                listings: [
-                    {
-                        value: [{ name: 'broken.json', isDirectory: false, isSymbolicLink: true }]
-                    }
-                ],
-                fileReads: [{ value: '{}' }]
-            },
-            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
-        );
+        const failure = await runSinglePackageSymlinkScenario({
+            initialName: 'pkg',
+            packageRealPath: '/repo/node_modules/pkg',
+            listings: [{ value: [{ name: 'broken.json', isDirectory: false, isSymbolicLink: true }] }],
+            targetRealPath: { error: new Error('ENOENT: no such file or directory') }
+        });
 
         assert.deepStrictEqual(failure, {
             type: 'symlink-target-outside-package',

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -1,8 +1,16 @@
 import path from 'node:path';
 import { safeParse } from '@schema-hub/zod-error-formatter';
+import { Result } from 'true-myth';
 import { z } from 'zod/mini';
 import type { FileManager } from '../file-manager/file-manager.ts';
 import type { VendorEntry } from './vendor-entry.ts';
+
+export type SymlinkTargetOutsidePackageFailure = {
+    readonly type: 'symlink-target-outside-package';
+    readonly packageName: string;
+    readonly entryRelativePath: string;
+    readonly resolvedTargetPath: string;
+};
 
 type MaterializedExternals = {
     readonly entries: readonly VendorEntry[];
@@ -20,7 +28,9 @@ type MaterializeExternalsOptions = {
 };
 
 export type VendorMaterializer = {
-    materializeExternals: (options: MaterializeExternalsOptions) => Promise<MaterializedExternals>;
+    materializeExternals: (
+        options: MaterializeExternalsOptions
+    ) => Promise<Result<MaterializedExternals, SymlinkTargetOutsidePackageFailure>>;
 };
 
 const nodeModulesFolderName = 'node_modules';
@@ -85,6 +95,131 @@ function parseManifestSummary(content: string): ParsedManifestSummary {
     };
 }
 
+function isInside(rootDirectory: string, candidate: string): boolean {
+    const relative = path.relative(rootDirectory, candidate);
+    if (relative === '') {
+        return true;
+    }
+    if (relative.startsWith(`..${path.sep}`) || relative === '..') {
+        return false;
+    }
+    return !path.isAbsolute(relative);
+}
+
+type FileWalkerDependencies = Pick<FileManager, 'getRealPath' | 'listDirectoryEntries'>;
+
+type CollectRequest = {
+    readonly rootDirectory: string;
+    readonly packageName: string;
+    readonly collected: VendorEntry[];
+};
+
+async function checkSymlinkInsidePackage(
+    walker: FileWalkerDependencies,
+    rootDirectory: string,
+    packageName: string,
+    relativeEntryPath: string
+): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
+    const absoluteEntryPath = path.join(rootDirectory, relativeEntryPath);
+    const normalizedEntryRelativePath = relativeEntryPath.split(path.sep).join('/');
+    try {
+        const resolvedTargetPath = await walker.getRealPath(absoluteEntryPath);
+        if (!isInside(rootDirectory, resolvedTargetPath)) {
+            return Result.err({
+                type: 'symlink-target-outside-package',
+                packageName,
+                entryRelativePath: normalizedEntryRelativePath,
+                resolvedTargetPath
+            });
+        }
+        return Result.ok(undefined);
+    } catch {
+        return Result.err({
+            type: 'symlink-target-outside-package',
+            packageName,
+            entryRelativePath: normalizedEntryRelativePath,
+            resolvedTargetPath: absoluteEntryPath
+        });
+    }
+}
+
+async function evaluatePackageEntry(
+    walker: FileWalkerDependencies,
+    request: CollectRequest,
+    relativeEntryPath: string,
+    entry: { readonly isDirectory: boolean; readonly isSymbolicLink: boolean }
+): Promise<Result<{ readonly shouldRecurse: boolean }, SymlinkTargetOutsidePackageFailure>> {
+    if (entry.isSymbolicLink) {
+        const symlinkCheck = await checkSymlinkInsidePackage(
+            walker,
+            request.rootDirectory,
+            request.packageName,
+            relativeEntryPath
+        );
+        if (symlinkCheck.isErr) {
+            return Result.err(symlinkCheck.error);
+        }
+    }
+    if (entry.isDirectory) {
+        return Result.ok({ shouldRecurse: true });
+    }
+    request.collected.push(buildVendorEntry(request.rootDirectory, request.packageName, relativeEntryPath));
+    return Result.ok({ shouldRecurse: false });
+}
+
+type RecurseFn = (relativeDirectory: string) => Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>>;
+
+async function processSinglePackageEntry(
+    context: { readonly walker: FileWalkerDependencies; readonly request: CollectRequest; readonly recurse: RecurseFn },
+    relativeEntryPath: string,
+    entry: { readonly isDirectory: boolean; readonly isSymbolicLink: boolean }
+): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
+    const evaluated = await evaluatePackageEntry(context.walker, context.request, relativeEntryPath, entry);
+    if (evaluated.isErr) {
+        return Result.err(evaluated.error);
+    }
+    if (evaluated.value.shouldRecurse) {
+        return await context.recurse(relativeEntryPath);
+    }
+    return Result.ok(undefined);
+}
+
+async function walkPackageDirectory(
+    walker: FileWalkerDependencies,
+    request: CollectRequest,
+    relativeDirectory: string
+): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
+    const recurse: RecurseFn = async (childDirectory) => {
+        return await walkPackageDirectory(walker, request, childDirectory);
+    };
+    const absoluteDirectory = path.join(request.rootDirectory, relativeDirectory);
+    const entries = await walker.listDirectoryEntries(absoluteDirectory);
+    const includedEntries = entries.filter((entry) => {
+        return entry.name !== nodeModulesFolderName;
+    });
+    for (const entry of includedEntries) {
+        const relativeEntryPath = path.join(relativeDirectory, entry.name);
+        const processed = await processSinglePackageEntry({ walker, request, recurse }, relativeEntryPath, entry);
+        if (processed.isErr) {
+            return processed;
+        }
+    }
+    return Result.ok(undefined);
+}
+
+async function collectPackageFiles(
+    walker: FileWalkerDependencies,
+    rootDirectory: string,
+    packageName: string
+): Promise<Result<readonly VendorEntry[], SymlinkTargetOutsidePackageFailure>> {
+    const collected: VendorEntry[] = [];
+    const result = await walkPackageDirectory(walker, { rootDirectory, packageName, collected }, '');
+    if (result.isErr) {
+        return Result.err(result.error);
+    }
+    return Result.ok(collected);
+}
+
 export function createVendorMaterializer(dependencies: VendorMaterializerDependencies): VendorMaterializer {
     const { fileManager } = dependencies;
 
@@ -113,56 +248,47 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
         return parseManifestSummary(content);
     }
 
-    async function collectPackageFiles(rootDirectory: string, packageName: string): Promise<readonly VendorEntry[]> {
-        const collected: VendorEntry[] = [];
-
-        async function walk(relativeDirectory: string): Promise<void> {
-            const absoluteDirectory = path.join(rootDirectory, relativeDirectory);
-            const entries = await fileManager.listDirectoryEntries(absoluteDirectory);
-            const includedEntries = entries.filter((entry) => {
-                return entry.name !== nodeModulesFolderName;
-            });
-            for (const entry of includedEntries) {
-                const relativeEntryPath = path.join(relativeDirectory, entry.name);
-                if (entry.isDirectory) {
-                    await walk(relativeEntryPath);
-                } else {
-                    collected.push(buildVendorEntry(rootDirectory, packageName, relativeEntryPath));
-                }
-            }
-        }
-
-        await walk('');
-        return collected;
-    }
-
-    async function ingestResolvedPackage(closure: Closure, name: string, realPath: string): Promise<void> {
+    async function ingestResolvedPackage(
+        closure: Closure,
+        name: string,
+        realPath: string
+    ): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
         closure.visited.add(name);
         const summary = await readManifestSummary(realPath);
         enqueueDependencies(closure, realPath, summary.transitiveDependencyNames);
         closure.peerRequirements.set(name, summary.peerDependencyNames);
-        const packageEntries = await collectPackageFiles(realPath, name);
-        closure.entries.push(...packageEntries);
+        const packageEntries = await collectPackageFiles(fileManager, realPath, name);
+        if (packageEntries.isErr) {
+            return Result.err(packageEntries.error);
+        }
+        closure.entries.push(...packageEntries.value);
+        return Result.ok(undefined);
     }
 
-    async function processQueueItem(closure: Closure, item: QueueItem): Promise<void> {
+    async function processQueueItem(
+        closure: Closure,
+        item: QueueItem
+    ): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
         if (closure.visited.has(item.name)) {
-            return;
+            return Result.ok(undefined);
         }
         const realPath = await findPackageRealPath(item.name, item.fromFolder);
         if (realPath === undefined) {
-            return;
+            return Result.ok(undefined);
         }
-        await ingestResolvedPackage(closure, item.name, realPath);
+        return await ingestResolvedPackage(closure, item.name, realPath);
     }
 
-    async function drainQueue(closure: Closure): Promise<void> {
+    async function drainQueue(closure: Closure): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
         const item = closure.queue.shift();
         if (item === undefined) {
-            return;
+            return Result.ok(undefined);
         }
-        await processQueueItem(closure, item);
-        await drainQueue(closure);
+        const processed = await processQueueItem(closure, item);
+        if (processed.isErr) {
+            return processed;
+        }
+        return await drainQueue(closure);
     }
 
     return {
@@ -175,12 +301,15 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
                 }),
                 peerRequirements: new Map<string, readonly string[]>()
             };
-            await drainQueue(closure);
-            return {
+            const drained = await drainQueue(closure);
+            if (drained.isErr) {
+                return Result.err(drained.error);
+            }
+            return Result.ok({
                 entries: closure.entries,
                 packageNames: Array.from(closure.visited),
                 peerRequirements: closure.peerRequirements
-            };
+            });
         }
     };
 }

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -140,14 +140,32 @@ async function checkSymlinkInsidePackage(
     }
 }
 
-type EntryEvaluation = { readonly kind: 'leaf'; readonly vendorEntry: VendorEntry } | { readonly kind: 'recurse' };
+type RecurseFn = (relativeDirectory: string) => Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>>;
+
+type EntryAction = (
+    request: CollectRequest,
+    recurse: RecurseFn
+) => Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>>;
+
+function collectAction(vendorEntry: VendorEntry): EntryAction {
+    return async (request) => {
+        request.collected.push(vendorEntry);
+        return Result.ok(undefined);
+    };
+}
+
+function recurseAction(relativeEntryPath: string): EntryAction {
+    return async (_request, recurse) => {
+        return await recurse(relativeEntryPath);
+    };
+}
 
 async function evaluatePackageEntry(
     walker: FileWalkerDependencies,
     request: CollectRequest,
     relativeEntryPath: string,
     entry: { readonly isDirectory: boolean; readonly isSymbolicLink: boolean }
-): Promise<Result<EntryEvaluation, SymlinkTargetOutsidePackageFailure>> {
+): Promise<Result<EntryAction, SymlinkTargetOutsidePackageFailure>> {
     if (entry.isSymbolicLink) {
         const symlinkCheck = await checkSymlinkInsidePackage(
             walker,
@@ -160,13 +178,10 @@ async function evaluatePackageEntry(
         }
     }
     if (entry.isDirectory) {
-        return Result.ok({ kind: 'recurse' });
+        return Result.ok(recurseAction(relativeEntryPath));
     }
-    const vendorEntry = buildVendorEntry(request.rootDirectory, request.packageName, relativeEntryPath);
-    return Result.ok({ kind: 'leaf', vendorEntry });
+    return Result.ok(collectAction(buildVendorEntry(request.rootDirectory, request.packageName, relativeEntryPath)));
 }
-
-type RecurseFn = (relativeDirectory: string) => Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>>;
 
 async function processSinglePackageEntry(
     context: { readonly walker: FileWalkerDependencies; readonly request: CollectRequest; readonly recurse: RecurseFn },
@@ -177,11 +192,7 @@ async function processSinglePackageEntry(
     if (evaluated.isErr) {
         return Result.err(evaluated.error);
     }
-    if (evaluated.value.kind === 'recurse') {
-        return await context.recurse(relativeEntryPath);
-    }
-    context.request.collected.push(evaluated.value.vendorEntry);
-    return Result.ok(undefined);
+    return await evaluated.value(context.request, context.recurse);
 }
 
 async function walkPackageDirectory(

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -97,9 +97,6 @@ function parseManifestSummary(content: string): ParsedManifestSummary {
 
 function isInside(rootDirectory: string, candidate: string): boolean {
     const relative = path.relative(rootDirectory, candidate);
-    if (relative === '') {
-        return true;
-    }
     if (relative.startsWith(`..${path.sep}`) || relative === '..') {
         return false;
     }
@@ -143,12 +140,14 @@ async function checkSymlinkInsidePackage(
     }
 }
 
+type EntryEvaluation = { readonly kind: 'leaf'; readonly vendorEntry: VendorEntry } | { readonly kind: 'recurse' };
+
 async function evaluatePackageEntry(
     walker: FileWalkerDependencies,
     request: CollectRequest,
     relativeEntryPath: string,
     entry: { readonly isDirectory: boolean; readonly isSymbolicLink: boolean }
-): Promise<Result<{ readonly shouldRecurse: boolean }, SymlinkTargetOutsidePackageFailure>> {
+): Promise<Result<EntryEvaluation, SymlinkTargetOutsidePackageFailure>> {
     if (entry.isSymbolicLink) {
         const symlinkCheck = await checkSymlinkInsidePackage(
             walker,
@@ -161,10 +160,10 @@ async function evaluatePackageEntry(
         }
     }
     if (entry.isDirectory) {
-        return Result.ok({ shouldRecurse: true });
+        return Result.ok({ kind: 'recurse' });
     }
-    request.collected.push(buildVendorEntry(request.rootDirectory, request.packageName, relativeEntryPath));
-    return Result.ok({ shouldRecurse: false });
+    const vendorEntry = buildVendorEntry(request.rootDirectory, request.packageName, relativeEntryPath);
+    return Result.ok({ kind: 'leaf', vendorEntry });
 }
 
 type RecurseFn = (relativeDirectory: string) => Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>>;
@@ -178,9 +177,10 @@ async function processSinglePackageEntry(
     if (evaluated.isErr) {
         return Result.err(evaluated.error);
     }
-    if (evaluated.value.shouldRecurse) {
+    if (evaluated.value.kind === 'recurse') {
         return await context.recurse(relativeEntryPath);
     }
+    context.request.collected.push(evaluated.value.vendorEntry);
     return Result.ok(undefined);
 }
 


### PR DESCRIPTION
## Summary

Fixes a high-severity supply-chain vulnerability in `packtory pack --vendor-dependencies`.

The vendor materializer walked each external package's directory including symbolic links, then read each entry with `fs.readFile`/`fs.copyFile` — both of which dereference symlinks. A malicious npm dependency could plant a symlink at install time pointing at the developer's `~/.npmrc`, `~/.aws/credentials`, or `~/.ssh/id_rsa`; on `packtory pack --vendor-dependencies` the secret's contents were read and embedded into the artifact under `node_modules/<evil>/<symlink-name>`, leaking when the bundle was published or shared. This mirrors the credential-theft pattern of the 2025 Shai-Hulud / @ctrl/tinycolor / ultralytics npm worms, but here the conventional "we don't run lifecycle scripts" defense does not protect, since packtory reads files from `node_modules` without executing them — but it does follow symlinks.

## Fix

- The walk now resolves each symlinked entry through `fs.realpath` and requires the canonical target to stay inside the resolved package directory (`source/vendor-materializer/vendor-materializer.ts`).
- Out-of-package and unreadable symlinks short-circuit the materializer with a typed `symlink-target-outside-package` failure that propagates through `prepareVendoredArtifact` as a new `vendor-symlink-target-outside-package` `PackPackageFailure` variant.
- The CLI handler formats the new failure with the vendored package name, the escaping entry, and the resolved target so the user can identify and remove the offending dependency.
- Intra-package symlinks (e.g. a published `bin/` shim pointing to its own package's JS file) keep working — only escapes are rejected.
- `materializeExternals` now returns `Result<...>` so the failure path is explicit at every caller seam.

## Test plan

- [x] `just test-unit` — 2755 passing
- [x] `just test-types` — passing
- [x] `just lint` — passing
- [x] New unit tests cover: in-package symlink allowed, out-of-package symlink rejected, broken symlink rejected, end-to-end `PackPackageFailure` mapping, CLI handler formatting.

Docs for the `pack` command live on an unmerged branch (`feature/pack-documentation`); the new failure mode (`vendor-symlink-target-outside-package`) and its exit code should be added there in a follow-up so the CLI README error reference stays complete.
