### PR TITLE
Validate dependency-key names declared in vendored manifests

### DIFF
--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -175,6 +175,32 @@ suite('pack-handler', function () {
         );
     });
 
+    test('returns 1 and identifies the source manifest and offending key when a vendored package.json carries an invalid dependency name', async function () {
+        await expectFailure(
+            {
+                type: 'vendor-invalid-dependency-name',
+                packageName: 'pkg-a',
+                sourcePackageName: 'legit-utils',
+                invalidDependencyName: '../../legit-utils'
+            },
+            [
+                /invalid dependency name\n- "legit-utils" declares dependency "\.\.\/\.\.\/legit-utils" which is not a valid npm package name/u
+            ]
+        );
+    });
+
+    test('returns 1 and labels the source as the configured external set when an invalid dependency name is supplied directly to the materializer', async function () {
+        await expectFailure(
+            {
+                type: 'vendor-invalid-dependency-name',
+                packageName: 'pkg-a',
+                sourcePackageName: undefined,
+                invalidDependencyName: '../escape'
+            },
+            [/invalid dependency name\n- the configured external set declares dependency "\.\.\/escape"/u]
+        );
+    });
+
     test('returns 1 and summarises partial resolve failures with one line per failure', async function () {
         await expectFailure(
             { type: 'partial', error: { succeeded: [], failures: [new Error('resolve A'), new Error('resolve B')] } },

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -62,12 +62,25 @@ function formatVendorSymlinkOutsidePackageFailure(
     return [header, details].join('\n');
 }
 
+function formatVendorInvalidDependencyNameFailure(
+    error: PackFailure & { readonly type: 'vendor-invalid-dependency-name' }
+): string {
+    const reason = 'rejected a vendored package.json with an invalid dependency name';
+    const header = `${getErrorSymbol()} Pack of "${error.packageName}" ${reason}`;
+    const sourceLabel =
+        error.sourcePackageName === undefined ? 'the configured external set' : `"${error.sourcePackageName}"`;
+    const tail = 'which is not a valid npm package name';
+    const details = `- ${sourceLabel} declares dependency "${error.invalidDependencyName}" ${tail}`;
+    return [header, details].join('\n');
+}
+
 type ConfigOrCheckError = PackFailure & { readonly type: 'checks' | 'config' };
 type PackPackageError = PackFailure & {
     readonly type:
         | 'bundle-dependencies-unsupported'
         | 'package-not-found'
         | 'peer-dependencies-unsatisfied'
+        | 'vendor-invalid-dependency-name'
         | 'vendor-symlink-target-outside-package';
 };
 
@@ -88,6 +101,9 @@ function formatPackPackageFailure(error: PackPackageError): string {
     if (error.type === 'vendor-symlink-target-outside-package') {
         return formatVendorSymlinkOutsidePackageFailure(error);
     }
+    if (error.type === 'vendor-invalid-dependency-name') {
+        return formatVendorInvalidDependencyNameFailure(error);
+    }
     return formatPeerFailure(error);
 }
 
@@ -100,7 +116,8 @@ function isPackPackageError(error: PackFailure): error is PackPackageError {
         error.type === 'package-not-found' ||
         error.type === 'bundle-dependencies-unsupported' ||
         error.type === 'peer-dependencies-unsatisfied' ||
-        error.type === 'vendor-symlink-target-outside-package'
+        error.type === 'vendor-symlink-target-outside-package' ||
+        error.type === 'vendor-invalid-dependency-name'
     );
 }
 

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -367,37 +367,67 @@ suite('packtory-pack', function () {
         assert.strictEqual(fakes.packEmitterPack.callCount, 0);
     });
 
-    test('maps a vendor symlink-target-outside-package failure to the corresponding pack failure and never emits an artifact', async function () {
-        const materializerSpy = fake.resolves(
-            Result.err({
-                type: 'symlink-target-outside-package',
-                packageName: 'evil',
-                entryRelativePath: 'leak.json',
-                resolvedTargetPath: '/Users/victim/.npmrc'
-            })
-        );
+    async function runPackExpectingMaterializerFailure(
+        materializerError: unknown,
+        externalDependencyName: string
+    ): Promise<{ readonly failure: InternalPackFailure; readonly emitCallCount: number }> {
+        const materializerSpy = fake.resolves(Result.err(materializerError));
         const { dependencies, fakes } = createDependencies({
             materializerSpy,
             resolveResult: Result.ok([
-                makeResolvedPackage({ externalDependencyNames: ['evil'], sourcesFolder: '/repo/source' })
+                makeResolvedPackage({
+                    externalDependencyNames: [externalDependencyName],
+                    sourcesFolder: '/repo/source'
+                })
             ])
         });
         const runPack = createRunPackValidated(dependencies);
-
         const result = await runPack(
             validatedConfig,
             { ...baseOptions, vendorDependencies: true },
             fakes.resolveAndLinkAll
         );
+        return { failure: expectErr(result), emitCallCount: fakes.packEmitterPack.callCount };
+    }
 
-        assert.deepStrictEqual(expectErr(result), {
+    test('maps a vendor symlink-target-outside-package failure to the corresponding pack failure and never emits an artifact', async function () {
+        const outcome = await runPackExpectingMaterializerFailure(
+            {
+                type: 'symlink-target-outside-package',
+                packageName: 'evil',
+                entryRelativePath: 'leak.json',
+                resolvedTargetPath: '/Users/victim/.npmrc'
+            },
+            'evil'
+        );
+
+        assert.deepStrictEqual(outcome.failure, {
             type: 'vendor-symlink-target-outside-package',
             packageName: 'pkg-a',
             vendoredPackageName: 'evil',
             entryRelativePath: 'leak.json',
             resolvedTargetPath: '/Users/victim/.npmrc'
         });
-        assert.strictEqual(fakes.packEmitterPack.callCount, 0);
+        assert.strictEqual(outcome.emitCallCount, 0);
+    });
+
+    test('maps a vendor invalid-dependency-name failure to the corresponding pack failure and never emits an artifact', async function () {
+        const outcome = await runPackExpectingMaterializerFailure(
+            {
+                type: 'invalid-dependency-name',
+                sourcePackageName: 'legit-utils',
+                invalidDependencyName: '../../legit-utils'
+            },
+            'legit-utils'
+        );
+
+        assert.deepStrictEqual(outcome.failure, {
+            type: 'vendor-invalid-dependency-name',
+            packageName: 'pkg-a',
+            sourcePackageName: 'legit-utils',
+            invalidDependencyName: '../../legit-utils'
+        });
+        assert.strictEqual(outcome.emitCallCount, 0);
     });
 
     test('aggregates peer requirements from both the bundle-dep closure and the external vendor closure', async function () {

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -10,8 +10,10 @@ import type { VersionManager } from '../version-manager/manager.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
 import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
 import type {
+    InvalidDependencyNameFailure,
     SymlinkTargetOutsidePackageFailure,
-    VendorMaterializer
+    VendorMaterializer,
+    VendorMaterializerFailure
 } from '../vendor-materializer/vendor-materializer.ts';
 import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 import type { ResolvedPackage } from './resolved-package.ts';
@@ -232,7 +234,7 @@ type MaterializedExternalsResult = Awaited<
     ReturnType<PackRunDependencies['vendorMaterializer']['materializeExternals']>
 >;
 
-function mapMaterializerFailure(
+function mapSymlinkFailure(
     packageName: string,
     materializerFailure: SymlinkTargetOutsidePackageFailure
 ): PackPackageFailure {
@@ -243,6 +245,28 @@ function mapMaterializerFailure(
         entryRelativePath: materializerFailure.entryRelativePath,
         resolvedTargetPath: materializerFailure.resolvedTargetPath
     };
+}
+
+function mapInvalidDependencyNameFailure(
+    packageName: string,
+    materializerFailure: InvalidDependencyNameFailure
+): PackPackageFailure {
+    return {
+        type: 'vendor-invalid-dependency-name',
+        packageName,
+        sourcePackageName: materializerFailure.sourcePackageName,
+        invalidDependencyName: materializerFailure.invalidDependencyName
+    };
+}
+
+function mapMaterializerFailure(
+    packageName: string,
+    materializerFailure: VendorMaterializerFailure
+): PackPackageFailure {
+    if (materializerFailure.type === 'symlink-target-outside-package') {
+        return mapSymlinkFailure(packageName, materializerFailure);
+    }
+    return mapInvalidDependencyNameFailure(packageName, materializerFailure);
 }
 
 function checkClosurePeers(

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -26,8 +26,16 @@ type VendorSymlinkOutsidePackageFailure = {
     readonly resolvedTargetPath: string;
 };
 
+type VendorInvalidDependencyNameFailure = {
+    readonly type: 'vendor-invalid-dependency-name';
+    readonly packageName: string;
+    readonly sourcePackageName: string | undefined;
+    readonly invalidDependencyName: string;
+};
+
 export type PackPackageFailure =
     | PeerDependenciesUnsatisfiedFailure
+    | VendorInvalidDependencyNameFailure
     | VendorSymlinkOutsidePackageFailure
     | { readonly type: 'bundle-dependencies-unsupported'; readonly packageName: string }
     | { readonly type: 'package-not-found'; readonly packageName: string };

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -3,11 +3,9 @@ import { suite, test } from 'mocha';
 import { createFakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
     createVendorMaterializer,
-    type SymlinkTargetOutsidePackageFailure,
-    type VendorMaterializer
+    type VendorMaterializer,
+    type VendorMaterializerFailure
 } from './vendor-materializer.ts';
-
-type VendorMaterializerFailure = SymlinkTargetOutsidePackageFailure;
 
 type ReadabilityResponse = { readonly value: { readonly isReadable: boolean } };
 type StringResponse = { readonly error: Error } | { readonly value: string };
@@ -52,9 +50,7 @@ function expectOk(result: Awaited<ReturnType<VendorMaterializer['materializeExte
     return result.value;
 }
 
-function expectErr(
-    result: Awaited<ReturnType<VendorMaterializer['materializeExternals']>>
-): SymlinkTargetOutsidePackageFailure {
+function expectErr(result: Awaited<ReturnType<VendorMaterializer['materializeExternals']>>): VendorMaterializerFailure {
     if (result.isOk) {
         assert.fail('expected materializeExternals to fail but it returned Ok');
     }
@@ -73,7 +69,7 @@ async function runWith(
 async function runExpectingFailure(
     setup: FakeSetup,
     request: { readonly initialDependencyNames: readonly string[]; readonly projectFolder: string }
-): Promise<SymlinkTargetOutsidePackageFailure> {
+): Promise<VendorMaterializerFailure> {
     const fileManager = setupFileManager(setup);
     const materializer = createVendorMaterializer({ fileManager });
     return expectErr(await materializer.materializeExternals(request));
@@ -466,5 +462,97 @@ suite('vendor-materializer', function () {
             entryRelativePath: 'broken.json',
             resolvedTargetPath: '/repo/node_modules/pkg/broken.json'
         });
+    });
+
+    test('rejects a vendored manifest whose dependencies key uses path traversal syntax so the materializer never probes outside node_modules', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/legit-utils' }],
+                listings: [{ value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }],
+                fileReads: [{ value: JSON.stringify({ dependencies: { '../../legit-utils': '*' } }) }]
+            },
+            { initialDependencyNames: ['legit-utils'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'invalid-dependency-name',
+            sourcePackageName: 'legit-utils',
+            invalidDependencyName: '../../legit-utils'
+        });
+    });
+
+    test('rejects an absolute-path dependency name in a vendored manifest', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }],
+                listings: [{ value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }],
+                fileReads: [{ value: JSON.stringify({ dependencies: { '/etc/passwd': '*' } }) }]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'invalid-dependency-name',
+            sourcePackageName: 'pkg',
+            invalidDependencyName: '/etc/passwd'
+        });
+    });
+
+    test('rejects an initial dependency name that is not a valid npm package name without touching the filesystem', async function () {
+        const fileManager = setupFileManager({ readabilities: [], realPaths: [], listings: [], fileReads: [] });
+        const materializer = createVendorMaterializer({ fileManager });
+
+        const failure = expectErr(
+            await materializer.materializeExternals({
+                initialDependencyNames: ['../escape'],
+                projectFolder: '/repo'
+            })
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'invalid-dependency-name',
+            sourcePackageName: undefined,
+            invalidDependencyName: '../escape'
+        });
+        assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 0);
+    });
+
+    test('only flags the offending key when an earlier dependency key is valid and a later one is not parseable', async function () {
+        const failure = await runExpectingFailure(
+            {
+                readabilities: [{ value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/pkg' }],
+                listings: [{ value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }],
+                fileReads: [
+                    { value: JSON.stringify({ dependencies: { 'valid-one': '1.0.0', 'has space': '*' } }) }
+                ]
+            },
+            { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(failure, {
+            type: 'invalid-dependency-name',
+            sourcePackageName: 'pkg',
+            invalidDependencyName: 'has space'
+        });
+    });
+
+    test('accepts a scoped package name in dependency keys', async function () {
+        const result = await runWith(
+            {
+                readabilities: [{ value: { isReadable: true } }, { value: { isReadable: true } }],
+                realPaths: [{ value: '/repo/node_modules/host' }, { value: '/repo/node_modules/@scope/sub' }],
+                listings: [
+                    { value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] },
+                    { value: [{ name: 'lib.js', isDirectory: false, isSymbolicLink: false }] }
+                ],
+                fileReads: [{ value: JSON.stringify({ dependencies: { '@scope/sub': '*' } }) }, { value: '{}' }]
+            },
+            { initialDependencyNames: ['host'], projectFolder: '/repo' }
+        );
+
+        assert.deepStrictEqual(result.packageNames, ['host', '@scope/sub']);
     });
 });

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -525,9 +525,7 @@ suite('vendor-materializer', function () {
                 readabilities: [{ value: { isReadable: true } }],
                 realPaths: [{ value: '/repo/node_modules/pkg' }],
                 listings: [{ value: [{ name: 'index.js', isDirectory: false, isSymbolicLink: false }] }],
-                fileReads: [
-                    { value: JSON.stringify({ dependencies: { 'valid-one': '1.0.0', 'has space': '*' } }) }
-                ]
+                fileReads: [{ value: JSON.stringify({ dependencies: { 'valid-one': '1.0.0', 'has space': '*' } }) }]
             },
             { initialDependencyNames: ['pkg'], projectFolder: '/repo' }
         );

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { safeParse } from '@schema-hub/zod-error-formatter';
+import npa from 'npm-package-arg';
 import { Result } from 'true-myth';
 import { z } from 'zod/mini';
 import type { FileManager } from '../file-manager/file-manager.ts';
@@ -11,6 +12,14 @@ export type SymlinkTargetOutsidePackageFailure = {
     readonly entryRelativePath: string;
     readonly resolvedTargetPath: string;
 };
+
+export type InvalidDependencyNameFailure = {
+    readonly type: 'invalid-dependency-name';
+    readonly sourcePackageName: string | undefined;
+    readonly invalidDependencyName: string;
+};
+
+export type VendorMaterializerFailure = InvalidDependencyNameFailure | SymlinkTargetOutsidePackageFailure;
 
 type MaterializedExternals = {
     readonly entries: readonly VendorEntry[];
@@ -30,7 +39,7 @@ type MaterializeExternalsOptions = {
 export type VendorMaterializer = {
     materializeExternals: (
         options: MaterializeExternalsOptions
-    ) => Promise<Result<MaterializedExternals, SymlinkTargetOutsidePackageFailure>>;
+    ) => Promise<Result<MaterializedExternals, VendorMaterializerFailure>>;
 };
 
 const nodeModulesFolderName = 'node_modules';
@@ -82,17 +91,45 @@ type ParsedManifestSummary = {
     readonly peerDependencyNames: readonly string[];
 };
 
-function parseManifestSummary(content: string): ParsedManifestSummary {
+function rejectDependencyNameIfInvalid(name: string): string | undefined {
+    try {
+        if (npa(name).name === name) {
+            return undefined;
+        }
+        return name;
+    } catch {
+        return name;
+    }
+}
+
+function findFirstInvalidDependencyName(names: readonly string[]): string | undefined {
+    for (const name of names) {
+        const offending = rejectDependencyNameIfInvalid(name);
+        if (offending !== undefined) {
+            return offending;
+        }
+    }
+    return undefined;
+}
+
+function parseManifestSummary(
+    sourcePackageName: string,
+    content: string
+): Result<ParsedManifestSummary, InvalidDependencyNameFailure> {
     const parsed = safeParse(packageManifestSchema, JSON.parse(content));
     if (!parsed.success) {
-        return { transitiveDependencyNames: [], peerDependencyNames: [] };
+        return Result.ok({ transitiveDependencyNames: [], peerDependencyNames: [] });
     }
     const dependencyNames = Object.keys(parsed.data.dependencies ?? {});
     const peerDependencyNames = Object.keys(parsed.data.peerDependencies ?? {});
-    return {
+    const invalidDependencyName = findFirstInvalidDependencyName([...dependencyNames, ...peerDependencyNames]);
+    if (invalidDependencyName !== undefined) {
+        return Result.err({ type: 'invalid-dependency-name', sourcePackageName, invalidDependencyName });
+    }
+    return Result.ok({
         transitiveDependencyNames: [...dependencyNames, ...peerDependencyNames],
         peerDependencyNames
-    };
+    });
 }
 
 function isInside(rootDirectory: string, candidate: string): boolean {
@@ -253,21 +290,36 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
         return undefined;
     }
 
-    async function readManifestSummary(packageDirectory: string): Promise<ParsedManifestSummary> {
+    async function readManifestSummary(
+        sourcePackageName: string,
+        packageDirectory: string
+    ): Promise<Result<ParsedManifestSummary, InvalidDependencyNameFailure>> {
         const manifestPath = path.join(packageDirectory, 'package.json');
         const content = await fileManager.readFile(manifestPath);
-        return parseManifestSummary(content);
+        return parseManifestSummary(sourcePackageName, content);
+    }
+
+    function recordResolvedSummary(
+        closure: Closure,
+        name: string,
+        realPath: string,
+        summary: ParsedManifestSummary
+    ): void {
+        enqueueDependencies(closure, realPath, summary.transitiveDependencyNames);
+        closure.peerRequirements.set(name, summary.peerDependencyNames);
     }
 
     async function ingestResolvedPackage(
         closure: Closure,
         name: string,
         realPath: string
-    ): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
+    ): Promise<Result<undefined, VendorMaterializerFailure>> {
         closure.visited.add(name);
-        const summary = await readManifestSummary(realPath);
-        enqueueDependencies(closure, realPath, summary.transitiveDependencyNames);
-        closure.peerRequirements.set(name, summary.peerDependencyNames);
+        const summaryResult = await readManifestSummary(name, realPath);
+        if (summaryResult.isErr) {
+            return Result.err(summaryResult.error);
+        }
+        recordResolvedSummary(closure, name, realPath, summaryResult.value);
         const packageEntries = await collectPackageFiles(fileManager, realPath, name);
         if (packageEntries.isErr) {
             return Result.err(packageEntries.error);
@@ -279,7 +331,7 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
     async function processQueueItem(
         closure: Closure,
         item: QueueItem
-    ): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
+    ): Promise<Result<undefined, VendorMaterializerFailure>> {
         if (closure.visited.has(item.name)) {
             return Result.ok(undefined);
         }
@@ -290,7 +342,7 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
         return await ingestResolvedPackage(closure, item.name, realPath);
     }
 
-    async function drainQueue(closure: Closure): Promise<Result<undefined, SymlinkTargetOutsidePackageFailure>> {
+    async function drainQueue(closure: Closure): Promise<Result<undefined, VendorMaterializerFailure>> {
         const item = closure.queue.shift();
         if (item === undefined) {
             return Result.ok(undefined);
@@ -304,6 +356,14 @@ export function createVendorMaterializer(dependencies: VendorMaterializerDepende
 
     return {
         async materializeExternals(options) {
+            const invalidInitialName = findFirstInvalidDependencyName(options.initialDependencyNames);
+            if (invalidInitialName !== undefined) {
+                return Result.err({
+                    type: 'invalid-dependency-name',
+                    sourcePackageName: undefined,
+                    invalidDependencyName: invalidInitialName
+                });
+            }
             const closure: Closure = {
                 visited: new Set<string>(),
                 entries: [],


### PR DESCRIPTION
## Summary

Fixes a high-severity path-traversal vulnerability in `packtory pack --vendor-dependencies`.

The vendor materializer accepted every key of `dependencies` and `peerDependencies` from a vendored `package.json` as a dependency name, then fed those raw strings into both `findPackageRealPath` (which probes `<folder>/node_modules/<key>`) and `buildVendorEntry` (which interpolates the string into `node_modules/<key>/...` for the archive entry path). A malicious transitive package could declare a key like `"../../legit-utils"` in its own manifest, causing the materializer to walk outside `node_modules`, ingest a foreign directory, and emit archive entries whose normalized target path escapes the artifact root on extraction:

- **Folder output:** `path.join(targetFolder, "node_modules/../../legit-utils/payload.js")` resolves outside `--out`, writing attacker-controlled content to an attacker-named directory next to the build output.
- **Tar/zip output:** the entry name `node_modules/../../legit-utils/payload.js` ships verbatim to downstream consumers — any non-sanitizing extractor is then vulnerable to tar-slip / zip-slip.

## Fix

- `parseManifestSummary` now runs every dependency and peer-dependency key through `npm-package-arg` (already a direct dep) and rejects entries that aren't a parseable registry-style name. A key is valid when `npa(key).name === key` and `npa(key).type` is one of `alias`, `range`, `tag`, or `version`. The same check runs against the initial dependency names passed to `materializeExternals` so a poisoned import-path extraction can't smuggle a traversal through the entry point either.
- Rejection short-circuits with a typed `invalid-dependency-name` failure that propagates through `prepareVendoredArtifact` as a new `vendor-invalid-dependency-name` `PackPackageFailure` variant.
- The CLI handler formats the new failure with the offending source manifest and the dependency key so the user can identify and patch the upstream package.
- Scoped names (`@scope/name`), aliases, and ranges keep working — only path-traversal-style and otherwise-unparseable keys are rejected.

## Stacking

This PR is stacked on top of #622 (`feature/pack-vendor-symlink-boundary`). It introduces the second variant of the materializer's typed failure union introduced there. Merge #622 first, then rebase.

## Test plan

- [x] `just test-unit` — 2762 passing
- [x] `just test-types` — passing
- [x] `just lint` — passing
- [x] New unit tests cover: traversal key (`../../legit-utils`) rejected, absolute-path key (`/etc/passwd`) rejected, invalid initial dep name rejected before any filesystem access, scoped names (`@scope/sub`) accepted, end-to-end `PackPackageFailure` mapping, CLI handler formatting (both with and without a source manifest).

Docs for the `pack` command live on an unmerged branch (`feature/pack-documentation`); the new failure mode (`vendor-invalid-dependency-name`) and its exit code should be added there in a follow-up so the CLI README error reference stays complete.
