### PR TITLE
Synthesize types condition for JS-only node_modules manifests

### DIFF
--- a/documentation/how-it-works.md
+++ b/documentation/how-it-works.md
@@ -150,6 +150,12 @@ A few details worth highlighting:
 
 If `includeSourceMapFiles: true`, the scanner also locates the paired `.map` for every code file (`source-map-file-locator.ts`) and adds it to the graph as a leaf. If a root declares a `.d.ts`, a _second_ scan is performed with `resolveDeclarationFiles: true` so the type graph is captured alongside the JavaScript graph.
 
+### Bridging TypeScript's exports strictness for JS-only dependencies
+
+Node.js's `exports` field is a runtime resolution map: only the `import`, `require`, and `default` conditions are part of the spec. The `types` condition is a TypeScript convention layered on top. Under `moduleResolution: node16`, TypeScript refuses to follow an `exports` entry that has no `types` condition (or sibling `.d.ts`), even when the target is a perfectly resolvable JavaScript file — so a spec-compliant JS-only dependency like `{ "exports": { ".": { "import": "./lib/index.js" } } }` becomes unresolvable to the scanner.
+
+Packtory bridges the gap with a virtual file-system layer wrapping the ts-morph host. When a `node_modules/<pkg>/package.json` is read, the layer walks the `exports` tree and, for every conditions object that has an `import` (or `default`) target but no `types` sibling, synthesizes a `types` condition pointing at the same JavaScript file. TypeScript then follows the synthetic condition, lands on the `.js`, and — because `allowJs` is enabled for the analysis project — loads it as a source file. Manifests with an explicit `types` condition, manifests without `exports`, and reads outside `node_modules` are left untouched. The patch lives at the analysis layer only; the user's own build configuration and the dependency's published manifest are never modified.
+
 ## 5. Stage: Linker — import path rewriting
 
 This is where packtory turns "monorepo with relative imports" into "npm package that references its siblings by name".

--- a/integration-tests/fixtures/with-exports-only-js-node-module-dependency/node_modules/exports-only-module/lib/index.js
+++ b/integration-tests/fixtures/with-exports-only-js-node-module-dependency/node_modules/exports-only-module/lib/index.js
@@ -1,0 +1,1 @@
+export const example = 'example';

--- a/integration-tests/fixtures/with-exports-only-js-node-module-dependency/node_modules/exports-only-module/package.json
+++ b/integration-tests/fixtures/with-exports-only-js-node-module-dependency/node_modules/exports-only-module/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "exports-only-module",
+    "version": "1.2.3",
+    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./lib/index.js"
+        }
+    }
+}

--- a/integration-tests/fixtures/with-exports-only-js-node-module-dependency/package.json
+++ b/integration-tests/fixtures/with-exports-only-js-node-module-dependency/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "test-fixture",
+    "version": "0.0.0-dev",
+    "type": "module",
+    "dependencies": {
+        "exports-only-module": "1.2.3"
+    }
+}

--- a/integration-tests/fixtures/with-exports-only-js-node-module-dependency/src/entry.js
+++ b/integration-tests/fixtures/with-exports-only-js-node-module-dependency/src/entry.js
@@ -1,0 +1,3 @@
+import { example } from 'exports-only-module';
+
+export const foo = example;

--- a/integration-tests/package-processor/exports-only-js-dependency.test.ts
+++ b/integration-tests/package-processor/exports-only-js-dependency.test.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { packageProcessor } from '../../source/packages/package-processor/package-processor.entry-point.ts';
+import { bindingAnalysis } from '../analyzed-bundle-fixtures.ts';
+import { loadPackageJson } from '../load-package-json.ts';
+import { asImplicitExportsBundle } from '../modern-bundle.ts';
+
+suite('exports-only-js-dependency', function () {
+    test('records the dependency when a node_modules package declares only an "import" condition under exports', async function () {
+        const fixture = path.join(
+            process.cwd(),
+            'integration-tests/fixtures/with-exports-only-js-node-module-dependency'
+        );
+        const result = await packageProcessor.build({
+            name: 'the-package-name',
+            version: '42.0.0',
+            sourcesFolder: path.join(fixture, 'src'),
+            roots: { main: { js: path.join(fixture, 'src/entry.js') } },
+            mainPackageJson: await loadPackageJson(fixture),
+            includeSourceMapFiles: false,
+            additionalFiles: [],
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            deadCodeElimination: { enabled: false }
+        });
+
+        assert.deepStrictEqual(
+            result,
+            asImplicitExportsBundle({
+                additionalAttributes: {},
+                packageJson: {
+                    dependencies: { 'exports-only-module': '1.2.3' },
+                    name: 'the-package-name',
+                    sideEffects: false,
+                    type: 'module',
+                    version: '42.0.0'
+                },
+                manifestFile: {
+                    isExecutable: false,
+                    content: '',
+                    filePath: 'package.json'
+                },
+                contents: [
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "import { example } from 'exports-only-module';\n\nexport const foo = example;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/entry.js'),
+                            targetFilePath: 'entry.js'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('example', 'foo')
+                    }
+                ],
+                dependencies: {
+                    'exports-only-module': '1.2.3'
+                },
+                mainFile: {
+                    content: "import { example } from 'exports-only-module';\n\nexport const foo = example;\n",
+                    isExecutable: false,
+                    sourceFilePath: path.join(fixture, 'src/entry.js'),
+                    targetFilePath: 'entry.js'
+                },
+                name: 'the-package-name',
+                packageType: 'module',
+                peerDependencies: {},
+                sideEffectsField: false,
+                typesMainFile: undefined,
+                version: '42.0.0'
+            })
+        );
+    });
+});

--- a/source/dependency-scanner/node-modules-manifest-synthesizer.test.ts
+++ b/source/dependency-scanner/node-modules-manifest-synthesizer.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable node/no-sync -- exercises the ts-morph synchronous file-system interface */
+import assert from 'node:assert';
+import path from 'node:path';
+import { suite, test } from 'mocha';
+import { createDelegatingFileSystemHost } from '../test-libraries/delegating-file-system-host.ts';
+import { createNodeModulesManifestSynthesizingHost } from './node-modules-manifest-synthesizer.ts';
+
+function nodeModulesManifestPath(packageName: string): string {
+    return path.join('/project', 'node_modules', packageName, 'package.json');
+}
+
+async function readBothWays(filePath: string, content: string): Promise<readonly [string, string]> {
+    const host = createNodeModulesManifestSynthesizingHost(
+        createDelegatingFileSystemHost(new Map([[filePath, content]]))
+    );
+    return [host.readFileSync(filePath), await host.readFile(filePath)];
+}
+
+type RewriteCase = {
+    readonly title: string;
+    readonly inputExports: unknown;
+    readonly expectedExports: unknown;
+    readonly expectedConditionKeyOrder?: readonly string[];
+};
+
+const rewriteCases: readonly RewriteCase[] = [
+    {
+        title: 'injects a types condition mirroring import when the conditions object lacks one',
+        inputExports: { '.': { import: './lib/index.js' } },
+        expectedExports: { '.': { types: './lib/index.js', import: './lib/index.js' } },
+        expectedConditionKeyOrder: ['types', 'import']
+    },
+    {
+        title: 'falls back to the default condition when no import condition exists',
+        inputExports: { '.': { default: './lib/index.js' } },
+        expectedExports: { '.': { types: './lib/index.js', default: './lib/index.js' } }
+    },
+    {
+        title: 'prefers the import condition when both import and default are present',
+        inputExports: { '.': { import: './lib/import.js', default: './lib/default.js' } },
+        expectedExports: {
+            '.': { types: './lib/import.js', import: './lib/import.js', default: './lib/default.js' }
+        }
+    },
+    {
+        title: 'leaves the manifest untouched when an explicit types condition is already present',
+        inputExports: { '.': { types: './lib/index.d.ts', import: './lib/index.js' } },
+        expectedExports: { '.': { types: './lib/index.d.ts', import: './lib/index.js' } }
+    },
+    {
+        title: 'walks nested subpath exports and synthesizes types per condition object',
+        inputExports: {
+            '.': { import: './lib/index.js' },
+            './sub': { import: './lib/sub.js' }
+        },
+        expectedExports: {
+            '.': { types: './lib/index.js', import: './lib/index.js' },
+            './sub': { types: './lib/sub.js', import: './lib/sub.js' }
+        }
+    },
+    {
+        title: 'does not inject types at a level whose import points at a nested conditions object',
+        inputExports: { '.': { import: { node: './lib/node.js' } } },
+        expectedExports: { '.': { import: { node: './lib/node.js' } } }
+    },
+    {
+        title: 'leaves a conditions object with only non-import non-default keys untouched',
+        inputExports: { '.': { require: './lib/cjs.js' } },
+        expectedExports: { '.': { require: './lib/cjs.js' } }
+    },
+    {
+        title: 'preserves null condition values used to deny subpaths',
+        inputExports: { '.': { import: './lib/index.js' }, './deny': null },
+        expectedExports: { '.': { types: './lib/index.js', import: './lib/index.js' }, './deny': null }
+    }
+];
+
+type PassthroughCase = {
+    readonly title: string;
+    readonly filePath: string;
+    readonly content: string;
+};
+
+const passthroughCases: readonly PassthroughCase[] = [
+    {
+        title: 'does not modify manifests without an exports field',
+        filePath: nodeModulesManifestPath('main-only-module'),
+        content: JSON.stringify({ name: 'main-only-module', main: './lib/index.js' })
+    },
+    {
+        title: 'passes through reads for package.json paths outside node_modules unchanged',
+        filePath: '/project/src/package.json',
+        content: JSON.stringify({ exports: { '.': { import: './lib/index.js' } } })
+    },
+    {
+        title: 'passes through reads for non-manifest files inside node_modules',
+        filePath: path.join('/project', 'node_modules', 'something', 'index.js'),
+        content: 'export const example = "example";\n'
+    },
+    {
+        title: 'returns non-object JSON manifests unchanged',
+        filePath: nodeModulesManifestPath('array-module'),
+        content: '[1, 2, 3]'
+    },
+    {
+        title: 'returns string-content JSON manifests unchanged',
+        filePath: nodeModulesManifestPath('string-content-module'),
+        content: '"just a string"'
+    }
+];
+
+suite('node-modules-manifest-synthesizer', function () {
+    suite('rewrites', function () {
+        for (const testCase of rewriteCases) {
+            test(testCase.title, async function () {
+                const filePath = nodeModulesManifestPath('test-module');
+                const content = JSON.stringify({ exports: testCase.inputExports });
+                const [synchronous, asynchronous] = await readBothWays(filePath, content);
+
+                const parsedSync = JSON.parse(synchronous) as Record<string, unknown>;
+                const parsedAsync = JSON.parse(asynchronous) as Record<string, unknown>;
+
+                assert.deepStrictEqual(parsedSync.exports, testCase.expectedExports);
+                assert.deepStrictEqual(parsedAsync.exports, testCase.expectedExports);
+                if (testCase.expectedConditionKeyOrder !== undefined) {
+                    const subpath = (parsedSync.exports as Record<string, Record<string, unknown>>)['.']!;
+                    assert.deepStrictEqual(Object.keys(subpath), testCase.expectedConditionKeyOrder);
+                }
+            });
+        }
+    });
+
+    suite('passthroughs', function () {
+        for (const testCase of passthroughCases) {
+            test(testCase.title, async function () {
+                const [synchronous, asynchronous] = await readBothWays(testCase.filePath, testCase.content);
+                assert.strictEqual(synchronous, testCase.content);
+                assert.strictEqual(asynchronous, testCase.content);
+            });
+        }
+    });
+});

--- a/source/dependency-scanner/node-modules-manifest-synthesizer.test.ts
+++ b/source/dependency-scanner/node-modules-manifest-synthesizer.test.ts
@@ -98,6 +98,16 @@ const passthroughCases: readonly PassthroughCase[] = [
         content: 'export const example = "example";\n'
     },
     {
+        title: 'passes through reads for non-package.json JSON files inside node_modules even when they contain an exports field',
+        filePath: path.join('/project', 'node_modules', 'something', 'data.json'),
+        content: JSON.stringify({ exports: { '.': { import: './lib/index.js' } } })
+    },
+    {
+        title: 'returns trailing-comma manifests unchanged so ts-morph can surface its own resolution error',
+        filePath: nodeModulesManifestPath('trailing-comma-module'),
+        content: '{\n    "types": "index.d.ts",\n}\n'
+    },
+    {
         title: 'returns non-object JSON manifests unchanged',
         filePath: nodeModulesManifestPath('array-module'),
         content: '[1, 2, 3]'

--- a/source/dependency-scanner/node-modules-manifest-synthesizer.ts
+++ b/source/dependency-scanner/node-modules-manifest-synthesizer.ts
@@ -1,0 +1,61 @@
+import path from 'node:path';
+import { isString } from 'remeda';
+import type { FileSystemHost } from 'ts-morph';
+import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
+
+const packageJsonIndentationSpaces = 2;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function injectTypesCondition(_key: string, value: unknown): unknown {
+    if (!isPlainObject(value)) {
+        return value;
+    }
+    const target = value.import ?? value.default;
+    if (!isString(target)) {
+        return value;
+    }
+    return { types: target, ...value };
+}
+
+function rewriteManifestContent(content: string): string {
+    const parsed: unknown = JSON.parse(content);
+    if (!isPlainObject(parsed) || !('exports' in parsed)) {
+        return content;
+    }
+    const rewrittenExports: unknown = JSON.parse(JSON.stringify(parsed.exports, injectTypesCondition));
+    return JSON.stringify({ ...parsed, exports: rewrittenExports }, null, packageJsonIndentationSpaces);
+}
+
+function isNodeModulesManifestPath(filePath: string): boolean {
+    return (
+        path.basename(filePath) === 'package.json' && path.normalize(filePath).split(path.sep).includes('node_modules')
+    );
+}
+
+export function createNodeModulesManifestSynthesizingHost(fileSystemHost: FileSystemHost): FileSystemHost {
+    const readFileSync = bindRequiredMethod(fileSystemHost, syncMethodNames.readFile, 'a string', isString);
+
+    const synthesizingHost: FileSystemHost = {
+        ...fileSystemHost,
+        readFile: async (filePath: string, encoding?: string): Promise<string> => {
+            const content = await fileSystemHost.readFile(filePath, encoding);
+            if (!isNodeModulesManifestPath(filePath)) {
+                return content;
+            }
+            return rewriteManifestContent(content);
+        },
+        [syncMethodNames.readFile]: (filePath: string): string => {
+            // eslint-disable-next-line node/no-sync -- the ts-morph host interface requires this synchronous method
+            const content = readFileSync(filePath);
+            if (!isNodeModulesManifestPath(filePath)) {
+                return content;
+            }
+            return rewriteManifestContent(content);
+        }
+    };
+    Object.setPrototypeOf(synthesizingHost, fileSystemHost);
+    return synthesizingHost;
+}

--- a/source/dependency-scanner/node-modules-manifest-synthesizer.ts
+++ b/source/dependency-scanner/node-modules-manifest-synthesizer.ts
@@ -6,7 +6,7 @@ import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
 const packageJsonIndentationSpaces = 2;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
+    return value !== null && !Array.isArray(value);
 }
 
 function injectTypesCondition(_key: string, value: unknown): unknown {
@@ -21,12 +21,14 @@ function injectTypesCondition(_key: string, value: unknown): unknown {
 }
 
 function rewriteManifestContent(content: string): string {
-    const parsed: unknown = JSON.parse(content);
-    if (!isPlainObject(parsed) || !('exports' in parsed)) {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse returns any; the catch handles structural mismatch at runtime
+        const parsed: Record<string, unknown> = JSON.parse(content);
+        const rewrittenExports: unknown = JSON.parse(JSON.stringify(parsed.exports, injectTypesCondition));
+        return JSON.stringify({ ...parsed, exports: rewrittenExports }, null, packageJsonIndentationSpaces);
+    } catch {
         return content;
     }
-    const rewrittenExports: unknown = JSON.parse(JSON.stringify(parsed.exports, injectTypesCondition));
-    return JSON.stringify({ ...parsed, exports: rewrittenExports }, null, packageJsonIndentationSpaces);
 }
 
 function isNodeModulesManifestPath(filePath: string): boolean {

--- a/source/dependency-scanner/typescript-file-host.test.ts
+++ b/source/dependency-scanner/typescript-file-host.test.ts
@@ -257,7 +257,9 @@ suite('typescript-file-host', function () {
                     fileExists: fake(),
                     fileExistsSync: true,
                     directoryExists: fake(),
-                    directoryExistsSync: fake()
+                    directoryExistsSync: fake(),
+                    readFile: fake(),
+                    readFileSync: fake()
                 } as unknown as FileSystemAdaptersDependencies['fileSystemHost']
             });
             assert.fail('Expected createFileSystemAdapters() to throw but it did not');

--- a/source/dependency-scanner/typescript-file-host.ts
+++ b/source/dependency-scanner/typescript-file-host.ts
@@ -3,6 +3,7 @@ import { isBoolean } from 'remeda';
 import type { MainPackageJson } from '../config/package-json.ts';
 import { isDeclarationFile, isTypesRootFolder } from './file-host-predicates.ts';
 import { bindRequiredMethod, syncMethodNames } from './host-method-binding.ts';
+import { createNodeModulesManifestSynthesizingHost } from './node-modules-manifest-synthesizer.ts';
 import { createVirtualPackageJsonHost } from './virtual-package-json-host.ts';
 
 export type FileSystemAdaptersDependencies = {
@@ -67,9 +68,10 @@ function createDeclarationFilteringHost(fileSystemHost: FileSystemHost): FileSys
 
 export function createFileSystemAdapters(dependencies: FileSystemAdaptersDependencies): FileSystemAdapters {
     const { fileSystemHost } = dependencies;
+    const synthesizingHost = createNodeModulesManifestSynthesizingHost(fileSystemHost);
     return {
-        fileSystemHostWithoutFilter: fileSystemHost,
-        fileSystemHostFilteringDeclarationFiles: createDeclarationFilteringHost(fileSystemHost),
+        fileSystemHostWithoutFilter: synthesizingHost,
+        fileSystemHostFilteringDeclarationFiles: createDeclarationFilteringHost(synthesizingHost),
         withVirtualPackageJson: createVirtualPackageJsonHost
     };
 }

--- a/source/dependency-scanner/virtual-package-json-host.test.ts
+++ b/source/dependency-scanner/virtual-package-json-host.test.ts
@@ -1,24 +1,16 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions, node/no-sync -- test stubs cast partial mocks of complex orchestrator types and exercise the ts-morph synchronous file-system interface */
+/* eslint-disable node/no-sync -- exercises the ts-morph synchronous file-system interface */
 import assert from 'node:assert';
 import path from 'node:path';
 import { suite, test } from 'mocha';
-import type { FileSystemHost } from 'ts-morph';
+import { createDelegatingFileSystemHost } from '../test-libraries/delegating-file-system-host.ts';
 import { createVirtualPackageJsonHost } from './virtual-package-json-host.ts';
 
-function delegatingHost(records: Map<string, string>): FileSystemHost {
-    return {
-        fileExists: async (filePath: string) => records.has(filePath),
-        fileExistsSync: (filePath: string) => records.has(filePath),
-        readFile: async (filePath: string) => records.get(filePath) ?? '',
-        readFileSync: (filePath: string) => records.get(filePath) ?? ''
-    } as unknown as FileSystemHost;
-}
-
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- MainPackageJson is a complex branded type; tests only need a structurally-compatible literal
 const stubMainPackageJson = { name: 'pkg', version: '1.0.0', type: 'module' } as never;
 
 suite('virtual-package-json-host', function () {
     test('createVirtualPackageJsonHost reports the virtual package.json as existing', async function () {
-        const host = createVirtualPackageJsonHost(delegatingHost(new Map()), '/p', stubMainPackageJson);
+        const host = createVirtualPackageJsonHost(createDelegatingFileSystemHost(new Map()), '/p', stubMainPackageJson);
         const packageJsonPath = path.resolve('/p', 'package.json');
 
         assert.strictEqual(host.fileExistsSync(packageJsonPath), true);
@@ -26,7 +18,7 @@ suite('virtual-package-json-host', function () {
     });
 
     test('createVirtualPackageJsonHost serves the serialized main package.json content', async function () {
-        const host = createVirtualPackageJsonHost(delegatingHost(new Map()), '/p', stubMainPackageJson);
+        const host = createVirtualPackageJsonHost(createDelegatingFileSystemHost(new Map()), '/p', stubMainPackageJson);
         const packageJsonPath = path.resolve('/p', 'package.json');
 
         assert.deepStrictEqual(JSON.parse(host.readFileSync(packageJsonPath)), stubMainPackageJson);
@@ -35,7 +27,7 @@ suite('virtual-package-json-host', function () {
 
     test('createVirtualPackageJsonHost delegates unrelated file reads to the wrapped host', async function () {
         const records = new Map([['/other.txt', 'hello']]);
-        const host = createVirtualPackageJsonHost(delegatingHost(records), '/p', stubMainPackageJson);
+        const host = createVirtualPackageJsonHost(createDelegatingFileSystemHost(records), '/p', stubMainPackageJson);
 
         assert.strictEqual(host.readFileSync('/other.txt'), 'hello');
         assert.strictEqual(await host.readFile('/other.txt'), 'hello');
@@ -43,10 +35,27 @@ suite('virtual-package-json-host', function () {
 
     test('createVirtualPackageJsonHost delegates fileExists calls for unrelated paths to the wrapped host', async function () {
         const records = new Map([['/other.txt', 'hello']]);
-        const host = createVirtualPackageJsonHost(delegatingHost(records), '/p', stubMainPackageJson);
+        const host = createVirtualPackageJsonHost(createDelegatingFileSystemHost(records), '/p', stubMainPackageJson);
 
         assert.strictEqual(host.fileExistsSync('/other.txt'), true);
         assert.strictEqual(await host.fileExists('/other.txt'), true);
         assert.strictEqual(host.fileExistsSync('/missing.txt'), false);
+    });
+
+    test('createVirtualPackageJsonHost throws when the wrapped readFileSync returns a non-string for delegated reads', function () {
+        const misbehavingHost = {
+            fileExists: async () => true,
+            fileExistsSync: () => true,
+            readFile: async () => '',
+            readFileSync: () => true
+        } as unknown as Parameters<typeof createVirtualPackageJsonHost>[0];
+        const host = createVirtualPackageJsonHost(misbehavingHost, '/p', stubMainPackageJson);
+
+        try {
+            host.readFileSync('/other.txt');
+            assert.fail('Expected readFileSync() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Expected readFileSync to return a string');
+        }
     });
 });

--- a/source/test-libraries/delegating-file-system-host.ts
+++ b/source/test-libraries/delegating-file-system-host.ts
@@ -1,0 +1,11 @@
+import type { FileSystemHost } from 'ts-morph';
+
+export function createDelegatingFileSystemHost(records: Map<string, string>): FileSystemHost {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the host interface from ts-morph has many methods; tests only need the read/exists subset
+    return {
+        fileExists: async (filePath: string) => records.has(filePath),
+        fileExistsSync: (filePath: string) => records.has(filePath),
+        readFile: async (filePath: string) => records.get(filePath) ?? '',
+        readFileSync: (filePath: string) => records.get(filePath) ?? ''
+    } as unknown as FileSystemHost;
+}


### PR DESCRIPTION
## Summary

- ts-morph under Node16 resolution refuses to follow `exports` entries that lack a `types` condition (or sibling `.d.ts`), so a spec-compliant JS-only dependency like `{ "exports": { ".": { "import": "./lib/index.js" } } }` is rejected during scanning.
- A new virtual file-system layer wraps node_modules `package.json` reads and synthesizes a `types` condition mirroring the `import` (or `default`) target. With `allowJs` already enabled on the analysis project, ts-morph follows the synthetic condition into the JS file as a source.
- Manifests with an explicit `types`, manifests without `exports`, and reads outside `node_modules` are passed through unchanged.
