### PR TITLE
Install dependencies before evaluating release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: 26.x
+            - name: Install dependencies for release gate
+              run: npm clean-install
             - name: Evaluate GitHub release gate
               id: release-gate
               run: node --experimental-strip-types --enable-source-maps ./source/packages/github-release-gate/github-release-gate.entry-point.ts


### PR DESCRIPTION
## Summary
- The publish cron job has been failing on every tick with `ERR_MODULE_NOT_FOUND: Cannot find package 'remeda'`. The gate entry point imports `config-loader.ts`, which imports `remeda`, but the existing `npm clean-install` step was gated behind the gate's own output — so the gate ran with no `node_modules` available and could never succeed.
- Run `npm clean-install` after `actions/setup-node` so the gate can resolve its imports. The second install (after the post-gate checkout to `main_head_sha`) is preserved.
