### PR TITLE
Handle committed timeline events in the release gate

### DIFF
--- a/source/github-release-gate/cli-runner.test.ts
+++ b/source/github-release-gate/cli-runner.test.ts
@@ -133,7 +133,8 @@ suite('github-release-gate-cli-runner', function () {
         routes[timelinePath] = {
             body: [
                 {
-                    created_at: '2026-05-20T11:58:00.000Z',
+                    committer: { date: '2026-05-20T11:58:00.000Z' },
+                    created_at: null,
                     event: 'committed'
                 }
             ]
@@ -199,7 +200,8 @@ suite('github-release-gate-cli-runner', function () {
         routes[timelinePath] = {
             body: [
                 {
-                    created_at: new Date(now - 5 * 60 * 1000).toISOString(),
+                    committer: { date: new Date(now - 5 * 60 * 1000).toISOString() },
+                    created_at: null,
                     event: 'committed'
                 }
             ]

--- a/source/github-release-gate/github-api.test.ts
+++ b/source/github-release-gate/github-api.test.ts
@@ -155,7 +155,8 @@ suite('github-release-gate-github-api', function () {
         routes['/repos/enormora/packtory/issues/2/timeline?per_page=100'] = {
             body: [
                 {
-                    created_at: '2026-05-19T10:25:00.000Z',
+                    committer: { date: '2026-05-19T10:25:00.000Z' },
+                    created_at: null,
                     event: 'committed'
                 }
             ]
@@ -225,7 +226,8 @@ suite('github-release-gate-github-api', function () {
         routes[timelinePath] = {
             body: [
                 {
-                    created_at: 'not-a-timestamp',
+                    committer: { date: 'not-a-timestamp' },
+                    created_at: null,
                     event: 'committed'
                 }
             ]
@@ -235,5 +237,28 @@ suite('github-release-gate-github-api', function () {
         await assert.rejects(async () => {
             await api.getOpenPullRequestActivities();
         }, /Invalid timestamp/u);
+    });
+
+    test('getOpenPullRequestActivities skips timeline events without a timestamp', async function () {
+        const routes = createBaseRoutes() as Record<string, MockRoute>;
+        routes[timelinePath] = {
+            body: [
+                { event: 'reviewed', submitted_at: '2026-05-19T10:40:00.000Z' },
+                {
+                    committer: { date: '2026-05-19T10:45:00.000Z' },
+                    created_at: null,
+                    event: 'committed'
+                }
+            ]
+        };
+        const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
+
+        assert.deepStrictEqual(await api.getOpenPullRequestActivities(), [
+            {
+                activityAt: new Date('2026-05-19T10:45:00.000Z'),
+                htmlUrl: 'https://github.com/enormora/packtory/pull/1',
+                number: 1
+            }
+        ]);
     });
 });

--- a/source/github-release-gate/github-api.test.ts
+++ b/source/github-release-gate/github-api.test.ts
@@ -239,6 +239,48 @@ suite('github-release-gate-github-api', function () {
         }, /Invalid timestamp/u);
     });
 
+    test('getOpenPullRequestActivities uses created_at for non-committed branch-activity events', async function () {
+        const routes = createBaseRoutes() as Record<string, MockRoute>;
+        routes[timelinePath] = {
+            body: [
+                {
+                    created_at: '2026-05-19T11:00:00.000Z',
+                    event: 'head_ref_force_pushed'
+                }
+            ]
+        };
+        const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
+
+        assert.deepStrictEqual(await api.getOpenPullRequestActivities(), [
+            {
+                activityAt: new Date('2026-05-19T11:00:00.000Z'),
+                htmlUrl: 'https://github.com/enormora/packtory/pull/1',
+                number: 1
+            }
+        ]);
+    });
+
+    test('getOpenPullRequestActivities skips committed events without a committer date', async function () {
+        const routes = createBaseRoutes() as Record<string, MockRoute>;
+        routes[timelinePath] = {
+            body: [
+                {
+                    created_at: null,
+                    event: 'committed'
+                }
+            ]
+        };
+        const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
+
+        assert.deepStrictEqual(await api.getOpenPullRequestActivities(), [
+            {
+                activityAt: new Date('2026-05-19T10:15:00.000Z'),
+                htmlUrl: 'https://github.com/enormora/packtory/pull/1',
+                number: 1
+            }
+        ]);
+    });
+
     test('getOpenPullRequestActivities skips timeline events without a timestamp', async function () {
         const routes = createBaseRoutes() as Record<string, MockRoute>;
         routes[timelinePath] = {

--- a/source/github-release-gate/github-api.ts
+++ b/source/github-release-gate/github-api.ts
@@ -32,7 +32,8 @@ type BranchResponse = {
 };
 
 type RawTimelineEvent = {
-    readonly created_at: string;
+    readonly created_at?: string | null | undefined;
+    readonly committer?: { readonly date: string } | undefined;
     readonly event: string;
 };
 
@@ -68,9 +69,17 @@ const pullRequestSchema = z.object({
     number: z.number()
 });
 const timelineEventSchema = z.object({
-    created_at: z.string(),
+    created_at: z.optional(z.union([z.null(), z.string()])),
+    committer: z.optional(z.object({ date: z.string() })),
     event: z.string()
 });
+
+function selectTimelineEventTimestamp(event: RawTimelineEvent): string | undefined {
+    if (event.event === 'committed') {
+        return event.committer?.date;
+    }
+    return event.created_at ?? undefined;
+}
 
 function parseTimestamp(timestamp: string): Date {
     const date = new Date(timestamp);
@@ -186,11 +195,12 @@ async function getPullRequestActivity(
             return z.array(timelineEventSchema).parse(value);
         }
     );
-    const timelineEvents: PullRequestTimelineEvent[] = timeline.map((event) => {
-        return {
-            createdAt: parseTimestamp(event.created_at),
-            event: event.event
-        };
+    const timelineEvents: PullRequestTimelineEvent[] = timeline.flatMap((event) => {
+        const timestamp = selectTimelineEventTimestamp(event);
+        if (timestamp === undefined) {
+            return [];
+        }
+        return [{ createdAt: parseTimestamp(timestamp), event: event.event }];
     });
 
     return {

--- a/source/github-release-gate/github-api.ts
+++ b/source/github-release-gate/github-api.ts
@@ -1,3 +1,4 @@
+import { isDefined } from 'remeda';
 import { z } from 'zod/mini';
 import {
     selectPullRequestActivityAt,
@@ -74,13 +75,6 @@ const timelineEventSchema = z.object({
     event: z.string()
 });
 
-function selectTimelineEventTimestamp(event: RawTimelineEvent): string | undefined {
-    if (event.event === 'committed') {
-        return event.committer?.date;
-    }
-    return event.created_at ?? undefined;
-}
-
 function parseTimestamp(timestamp: string): Date {
     const date = new Date(timestamp);
 
@@ -89,6 +83,21 @@ function parseTimestamp(timestamp: string): Date {
     }
 
     return date;
+}
+
+function selectTimelineEventTimestamp(event: RawTimelineEvent): string | undefined {
+    if (event.event === 'committed') {
+        return event.committer?.date;
+    }
+    return event.created_at ?? undefined;
+}
+
+function toPullRequestTimelineEvent(event: RawTimelineEvent): PullRequestTimelineEvent | undefined {
+    const timestamp = selectTimelineEventTimestamp(event);
+    if (timestamp === undefined) {
+        return undefined;
+    }
+    return { createdAt: parseTimestamp(timestamp), event: event.event };
 }
 
 function getHeaders(token: string): Readonly<Record<string, string>> {
@@ -195,13 +204,7 @@ async function getPullRequestActivity(
             return z.array(timelineEventSchema).parse(value);
         }
     );
-    const timelineEvents: PullRequestTimelineEvent[] = timeline.flatMap((event) => {
-        const timestamp = selectTimelineEventTimestamp(event);
-        if (timestamp === undefined) {
-            return [];
-        }
-        return [{ createdAt: parseTimestamp(timestamp), event: event.event }];
-    });
+    const timelineEvents = timeline.map(toPullRequestTimelineEvent).filter(isDefined);
 
     return {
         number: pullRequest.number,

--- a/source/github-release-gate/test-support.ts
+++ b/source/github-release-gate/test-support.ts
@@ -104,7 +104,8 @@ export function createBaseRoutes(): RouteMap {
         [timelinePath]: {
             body: [
                 {
-                    created_at: '2026-05-19T10:30:00.000Z',
+                    committer: { date: '2026-05-19T10:30:00.000Z' },
+                    created_at: null,
                     event: 'committed'
                 }
             ]


### PR DESCRIPTION
## Summary
- Follow-up to #626. With the gate now running, the next failure was a Zod schema error: `created_at` was expected to be a string but the GitHub timeline API returns `null` for `committed` events and puts the commit timestamp under `committer.date`. The schema rejected every PR with a commit in its timeline.
- Make `created_at` optional/nullable and add `committer.date` to the timeline schema. Select the appropriate timestamp per event type; skip events that carry neither.
- The gate's `branchActivityEvents` set is unchanged — `committed` is still consumed, the timestamp now just comes from the correct field.

## Verification
Ran the gate locally against the real `enormora/packtory` repo with `gh auth token`. It now resolves all four open PRs' timelines and reports `should_publish=true` with reason `quiet_period_elapsed` — exactly what the previous (crashing) production runs were supposed to produce.

## Test plan
- [ ] All `github-release-gate-*` unit tests pass locally.
- [ ] `tsc --build` and `eslint source/github-release-gate` clean.
- [ ] After merge, trigger `workflow_dispatch` on the Publish workflow and confirm the gate step succeeds.
