### PR TITLE
Compile TypeScript before evaluating the release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
                   node-version: 26.x
             - name: Install dependencies for release gate
               run: npm clean-install
+            - name: Compile TypeScript for release gate
+              run: npx just compile
             - name: Evaluate GitHub release gate
               id: release-gate
               run: node --experimental-strip-types --enable-source-maps ./source/packages/github-release-gate/github-release-gate.entry-point.ts
@@ -48,6 +50,9 @@ jobs:
             - name: Install dependencies
               if: steps.release-gate.outputs.should_publish == 'true'
               run: npm clean-install
+            - name: Compile TypeScript
+              if: steps.release-gate.outputs.should_publish == 'true'
+              run: npx just compile
             - name: Publish packages
               if: steps.release-gate.outputs.should_publish == 'true'
               run: npx packtory publish --no-dry-run


### PR DESCRIPTION
## Summary
- Latest publish failures: `ENOENT: no such file or directory, open '/home/runner/work/packtory/packtory/target/build/source/packages/packtory/packtory.entry-point.js'`.
- Root cause: the gate runner calls `analyzeReleaseAgainstLatestPublished` once the time portion of the gate opens. That call goes through `packtory.config.js`, which references compiled JS files under `target/build/`. CI starts with a clean checkout — no build — so the gate crashes the moment the quiet/max-latency window elapses.
- Fix: run `npx just compile` after `npm clean-install`. Repeated after the post-gate re-checkout so `npx packtory publish` sees the same artifacts (the second `actions/checkout` defaults to `clean: true` and wipes `target/build/` from the first compile).

## Trade-off
Every 10-minute tick now pays the compile cost (~30s on top of install), even when the gate is closed. The clean architectural alternative — split `runGitHubReleaseGate` into a time-only phase and a separate policy phase, then only build when the time phase opens — is deferred to keep this PR focused on unblocking the cron.

## Test plan
- [ ] After merge, trigger `workflow_dispatch` on the Publish workflow and confirm the gate step now completes without ENOENT.
- [ ] Confirm the next scheduled cron tick either publishes cleanly or reports the gate as closed.
