### PR TITLE
Use open for preview file launching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "libnpmpublish": "11.2.0",
                 "npm-package-arg": "14.0.0",
                 "npm-registry-fetch": "20.0.0",
+                "open": "11.0.0",
                 "remeda": "2.34.1",
                 "semver": "7.8.1",
                 "spdx-expression-parse": "4.0.0",
@@ -6212,6 +6213,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -7190,6 +7206,34 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/defer-to-connect": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -7198,6 +7242,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/delayed-stream": {
@@ -9593,6 +9649,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-error-instance": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-error-instance/-/is-error-instance-3.0.1.tgz",
@@ -9694,6 +9765,36 @@
             },
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-in-ssh": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+            "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -9851,6 +9952,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -11772,6 +11888,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/open": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+            "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.4.0",
+                "define-lazy-prop": "^3.0.0",
+                "is-in-ssh": "^1.0.0",
+                "is-inside-container": "^1.0.0",
+                "powershell-utils": "^0.1.0",
+                "wsl-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12424,6 +12560,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/powershell-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+            "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/prelude-ls": {
@@ -13214,6 +13362,18 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -15486,6 +15646,22 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/xdg-basedir": {
             "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "libnpmpublish": "11.2.0",
         "npm-package-arg": "14.0.0",
         "npm-registry-fetch": "20.0.0",
+        "open": "11.0.0",
         "remeda": "2.34.1",
         "semver": "7.8.1",
         "spdx-expression-parse": "4.0.0",

--- a/source/command-line-interface/preview-io/preview-io-shared.test.ts
+++ b/source/command-line-interface/preview-io/preview-io-shared.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-restricted-syntax, functional/no-this-expressions, destructuring/in-params, sonarjs/publicly-writable-directories, no-undef -- fake child-process scaffolding is intentionally imperative in these tests */
+/* eslint-disable no-restricted-syntax, functional/no-this-expressions, destructuring/in-params, sonarjs/publicly-writable-directories -- fake child-process scaffolding is intentionally imperative in these tests */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { withPromiseDeadline } from '../../test-libraries/promise-with-deadline.ts';
@@ -13,8 +13,8 @@ type FakeSpawnResult = {
 };
 
 type PreviewIoFactoryOverrides = {
+    readonly openFile?: ((filePath: string) => Promise<void>) | undefined;
     readonly pager?: string | undefined;
-    readonly platform?: NodeJS.Platform;
     readonly shell?: string | undefined;
     readonly stdoutIsTTY?: boolean;
     readonly spawnHook?: ((result: FakeSpawnResult) => void) | undefined;
@@ -68,7 +68,18 @@ class FakeSpawnedProcess implements SpawnedProcess {
 
 function previewIoFactory(overrides: PreviewIoFactoryOverrides = {}) {
     const calls: FakeSpawnResult[] = [];
+    const openedFiles: string[] = [];
+    const openFile =
+        overrides.openFile ??
+        (async (_: string) => {
+            await Promise.resolve();
+        });
+
     const previewIo = createPreviewIo({
+        async openFile(filePath) {
+            openedFiles.push(filePath);
+            await openFile(filePath);
+        },
         spawnProcess: (command, args, options) => {
             const child = new FakeSpawnedProcess(overrides.stdinMode);
             const result = { command, args, options, child };
@@ -78,12 +89,11 @@ function previewIoFactory(overrides: PreviewIoFactoryOverrides = {}) {
         },
         randomUuid: () => 'uuid-123',
         tmpdir: () => '/tmp',
-        platform: overrides.platform ?? 'linux',
         shell: overrides.shell,
         pager: overrides.pager,
         stdoutIsTTY: overrides.stdoutIsTTY ?? true
     });
-    return { previewIo, calls };
+    return { previewIo, calls, openedFiles };
 }
 
 function requireFirstCall(calls: readonly FakeSpawnResult[]): FakeSpawnResult {
@@ -207,67 +217,26 @@ suite('preview-io-shared', function () {
         assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'preview null stdin'), false);
     });
 
-    test('openPreviewFile uses open on macOS', async function () {
-        const { previewIo: io, calls } = previewIoFactory({ platform: 'darwin' });
+    test('openPreviewFile delegates to the injected file opener', async function () {
+        const { previewIo: io, openedFiles } = previewIoFactory();
 
         assert.strictEqual(
-            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview on macOS'),
+            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview file'),
             true
         );
-        assert.deepStrictEqual(
-            calls.map((call) => [call.command, call.args]),
-            [['open', ['/tmp/report.html']]]
-        );
-        const firstCall = requireFirstCall(calls);
-        assert.deepStrictEqual(firstCall.options, { detached: true, stdio: 'ignore' });
-        assert.ok(firstCall.child.listeners.error !== undefined);
-        assert.strictEqual(firstCall.child.wasUnrefCalled, true);
-    });
-
-    test('openPreviewFile uses start on Windows', async function () {
-        const { previewIo: io, calls } = previewIoFactory({ platform: 'win32' });
-
-        assert.strictEqual(
-            await withPromiseDeadline(io.openPreviewFile('C:\\report.html'), 'open preview on Windows'),
-            true
-        );
-        assert.deepStrictEqual(
-            calls.map((call) => [call.command, call.args]),
-            [['cmd', ['/c', 'start', '', 'C:\\report.html']]]
-        );
-    });
-
-    test('openPreviewFile uses xdg-open on other platforms', async function () {
-        const { previewIo: io, calls } = previewIoFactory({ platform: 'linux' });
-
-        assert.strictEqual(
-            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview on Linux'),
-            true
-        );
-        assert.deepStrictEqual(
-            calls.map((call) => [call.command, call.args]),
-            [['xdg-open', ['/tmp/report.html']]]
-        );
+        assert.deepStrictEqual(openedFiles, ['/tmp/report.html']);
     });
 
     test('openPreviewFile returns false when opening emits an error', async function () {
-        const { previewIo: io } = previewIoFactory({ spawnHook: emitProcessError('error') });
+        const { previewIo: io } = previewIoFactory({
+            openFile: async () => {
+                throw new Error('boom');
+            }
+        });
 
         assert.strictEqual(
             await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview error'),
             false
         );
-    });
-
-    test('openPreviewFile ignores an error emitted after the success path has already settled', async function () {
-        const { previewIo: io, calls } = previewIoFactory();
-
-        assert.strictEqual(
-            await withPromiseDeadline(io.openPreviewFile('/tmp/report.html'), 'open preview late error ignore'),
-            true
-        );
-        const firstCall = requireFirstCall(calls);
-        firstCall.child.listeners.error?.();
-        assert.strictEqual(firstCall.child.wasUnrefCalled, true);
     });
 });

--- a/source/command-line-interface/preview-io/preview-io-shared.ts
+++ b/source/command-line-interface/preview-io/preview-io-shared.ts
@@ -1,15 +1,14 @@
-/* eslint-disable no-undef -- the NodeJS namespace type is used for portable platform detection */
 import path from 'node:path';
-import { spawnDetached, spawnForCompletion, type SpawnFunction } from './preview-spawn.ts';
+import { spawnForCompletion, type SpawnFunction } from './preview-spawn.ts';
 
 export type PreviewIoDependencies = {
+    readonly openFile: (filePath: string) => Promise<void>;
     readonly spawnProcess: SpawnFunction;
     readonly randomUuid: () => string;
-    readonly tmpdir: () => string;
-    readonly platform: NodeJS.Platform;
-    readonly shell: string | undefined;
     readonly pager: string | undefined;
+    readonly shell: string | undefined;
     readonly stdoutIsTTY: boolean;
+    readonly tmpdir: () => string;
 };
 
 export type PreviewIo = {
@@ -43,13 +42,12 @@ export function createPreviewIo(dependencies: PreviewIoDependencies): PreviewIo 
             return spawnForCompletion(dependencies.spawnProcess, shell, ['-lc', 'less -R'], content);
         },
         async openPreviewFile(filePath) {
-            if (dependencies.platform === 'darwin') {
-                return spawnDetached(dependencies.spawnProcess, 'open', [filePath]);
+            try {
+                await dependencies.openFile(filePath);
+                return true;
+            } catch {
+                return false;
             }
-            if (dependencies.platform === 'win32') {
-                return spawnDetached(dependencies.spawnProcess, 'cmd', ['/c', 'start', '', filePath]);
-            }
-            return spawnDetached(dependencies.spawnProcess, 'xdg-open', [filePath]);
         }
     };
 }

--- a/source/command-line-interface/preview-io/preview-io.test.ts
+++ b/source/command-line-interface/preview-io/preview-io.test.ts
@@ -3,10 +3,14 @@ import { suite, test } from 'mocha';
 import { withPromiseDeadline } from '../../test-libraries/promise-with-deadline.ts';
 import { createDefaultPreviewIo } from './preview-io.ts';
 
+async function ignoreOpenFile(_: string): Promise<void> {
+    await Promise.resolve();
+}
+
 suite('preview-io', function () {
     test('createDefaultPreviewIo exposes the default preview helpers', function () {
         const previewIo = createDefaultPreviewIo({
-            platform: 'linux',
+            openFile: ignoreOpenFile,
             shell: 'sh',
             pager: undefined,
             stdoutIsTTY: true
@@ -20,17 +24,35 @@ suite('preview-io', function () {
 
     test('createDefaultPreviewIo falls back to the default spawn process when no custom spawner is injected', async function () {
         const previewIo = createDefaultPreviewIo({
-            platform: 'linux',
+            openFile: ignoreOpenFile,
             shell: 'sh',
             pager: 'cat >/dev/null',
             stdoutIsTTY: true,
             randomUuid: () => 'uuid-123',
-            tmpdir: () => '/tmp'
+            tmpdir: () => '/var/folders'
         });
 
         assert.strictEqual(
-            await withPromiseDeadline(previewIo.pagePreviewOutput('hello'), 'default preview io fallback spawner'),
+            await withPromiseDeadline(previewIo.pagePreviewOutput('hello'), 'default preview io fallback spawner', 500),
             true
         );
+    });
+
+    test('createDefaultPreviewIo uses an injected file opener', async function () {
+        const openedFiles: string[] = [];
+        const previewIo = createDefaultPreviewIo({
+            async openFile(filePath) {
+                openedFiles.push(filePath);
+            },
+            shell: 'sh',
+            pager: undefined,
+            stdoutIsTTY: true
+        });
+
+        assert.strictEqual(
+            await withPromiseDeadline(previewIo.openPreviewFile('/var/folders/report.html'), 'default preview open'),
+            true
+        );
+        assert.deepStrictEqual(openedFiles, ['/var/folders/report.html']);
     });
 });

--- a/source/command-line-interface/preview-io/preview-io.ts
+++ b/source/command-line-interface/preview-io/preview-io.ts
@@ -4,14 +4,14 @@ import { createPreviewIo, type PreviewIo, type PreviewIoDependencies } from './p
 import { defaultSpawnProcess } from './preview-spawn.ts';
 
 type DefaultPreviewIoDependencies = Partial<Pick<PreviewIoDependencies, 'randomUuid' | 'spawnProcess' | 'tmpdir'>> &
-    Pick<PreviewIoDependencies, 'pager' | 'platform' | 'shell' | 'stdoutIsTTY'>;
+    Pick<PreviewIoDependencies, 'openFile' | 'pager' | 'shell' | 'stdoutIsTTY'>;
 
 export function createDefaultPreviewIo(dependencies: DefaultPreviewIoDependencies): PreviewIo {
     return createPreviewIo({
+        openFile: dependencies.openFile,
         spawnProcess: dependencies.spawnProcess ?? defaultSpawnProcess,
         randomUuid: dependencies.randomUuid ?? randomUUID,
         tmpdir: dependencies.tmpdir ?? os.tmpdir,
-        platform: dependencies.platform,
         shell: dependencies.shell,
         pager: dependencies.pager,
         stdoutIsTTY: dependencies.stdoutIsTTY

--- a/source/command-line-interface/preview-io/preview-spawn.ts
+++ b/source/command-line-interface/preview-io/preview-spawn.ts
@@ -47,20 +47,3 @@ export async function spawnForCompletion(
         child.stdin.end(content);
     });
 }
-
-export async function spawnDetached(
-    spawnProcess: SpawnFunction,
-    command: string,
-    args: readonly string[]
-): Promise<boolean> {
-    return new Promise<boolean>((resolve) => {
-        const child = spawnProcess(command, args, { detached: true, stdio: 'ignore' });
-        child.on('error', () => {
-            resolve(false);
-        });
-        child.unref();
-        queueMicrotask(() => {
-            resolve(true);
-        });
-    });
-}

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -39,7 +39,10 @@ const spinnerRenderer = createSpinnerRenderer();
 const clock = createClock();
 const fileManager = createFileManager({ hostFileSystem: fs.promises });
 const previewIo = createDefaultPreviewIo({
-    platform: process.platform,
+    async openFile(filePath) {
+        const { default: open } = await import('open');
+        await open(filePath, { wait: false });
+    },
     shell: process.env.SHELL,
     pager: process.env.PAGER,
     stdoutIsTTY: process.stdout.isTTY


### PR DESCRIPTION
- replace platform-specific preview launch commands with the open package
- keep pager spawning in the shared preview helper
- lazy-load the opener in the CLI entry point so unrelated commands do not pay for it