### PR TITLE
Run the dry-run via the installed packtory CLI

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,4 +60,4 @@ benchmark:
     node --experimental-strip-types --enable-source-maps ./benchmarks/run-benchmarks.ts
 
 publish-dry-run:
-    node --experimental-strip-types --enable-source-maps ./source/packages/command-line-interface/command-line-interface.entry-point.ts publish
+    npx packtory publish

--- a/source/packtory/release-analysis.ts
+++ b/source/packtory/release-analysis.ts
@@ -18,7 +18,6 @@ const dependencyOnlyPackageJsonFields = new Set([
     'version'
 ]);
 
-const invalidJson = Symbol('invalid-json');
 const unchangedPriority = 0;
 const dependencyOnlyPriority = 1;
 const substantivePriority = 2;
@@ -29,22 +28,24 @@ type ClassificationPriority =
     | typeof substantivePriority
     | typeof unchangedPriority;
 
-function parseJsonFile(file: FileDescription): unknown {
+type PackageJsonComparisonValue = { readonly invalid: false; readonly value: unknown } | { readonly invalid: true };
+
+function parseJsonFile(file: FileDescription): PackageJsonComparisonValue {
     const { content } = file;
 
     return (() => {
         try {
-            return JSON.parse(content) as unknown;
+            return { invalid: false, value: JSON.parse(content) as unknown };
         } catch {
-            return invalidJson;
+            return { invalid: true };
         }
     })();
 }
 
-function packageJsonValueForComparison(index: ReadonlyMap<string, FileDescription>): unknown {
+function packageJsonValueForComparison(index: ReadonlyMap<string, FileDescription>): PackageJsonComparisonValue {
     const file = index.get('package.json');
     if (file === undefined) {
-        return invalidJson;
+        return { invalid: true };
     }
 
     return parseJsonFile(file);
@@ -64,10 +65,6 @@ function hasLatestPublishedAt(
     analysis: PackageReleaseAnalysis
 ): analysis is PackageReleaseAnalysis & { readonly latestPublishedAt: Date } {
     return analysis.latestPublishedAt !== undefined;
-}
-
-function hasInvalidPackageJsonValues(previousValue: unknown, newValue: unknown): boolean {
-    return previousValue === invalidJson || newValue === invalidJson;
 }
 
 function normalizePackageJsonForDependencyComparison(value: unknown): unknown {
@@ -103,13 +100,13 @@ function packageJsonChangeIsDependencyOnly(
     const previousPackageJsonValue = packageJsonValueForComparison(previousIndex);
     const newPackageJsonValue = packageJsonValueForComparison(newIndex);
 
-    if (hasInvalidPackageJsonValues(previousPackageJsonValue, newPackageJsonValue)) {
+    if (previousPackageJsonValue.invalid || newPackageJsonValue.invalid) {
         return false;
     }
 
     return isDeepStrictEqual(
-        normalizePackageJsonForDependencyComparison(previousPackageJsonValue),
-        normalizePackageJsonForDependencyComparison(newPackageJsonValue)
+        normalizePackageJsonForDependencyComparison(previousPackageJsonValue.value),
+        normalizePackageJsonForDependencyComparison(newPackageJsonValue.value)
     );
 }
 


### PR DESCRIPTION
## Summary
CI's `Dry-run publish` was running the **local** CLI source while the scheduled `Publish` workflow runs `npx packtory publish` against the **installed** `@packtory/cli@0.0.15`. The recent dead-code refactor taught the local side-effect classifier to treat `Symbol(...)` as a pure builtin, but `@packtory/cli@0.0.15` doesn't know that yet — so CI saw the relaxed local rule, passed, and production hit the stricter old rule and crashed on `release-analysis.js`'s top-level `Symbol('invalid-json')`.

This PR fixes both halves of the gap:

1. **`justfile`** — `publish-dry-run` now invokes `npx packtory publish`, the same CLI that the scheduled job uses. Dry-run is a faithful preflight again.
2. **`source/packtory/release-analysis.ts`** — replace the `Symbol(...)` sentinel with a discriminated union (`{ invalid: false; value } | { invalid: true }`). No top-level side effect to flag, and the truthy-`invalid` discriminator makes downstream mutation tests killable (an empty-object mutant falls into the parsed branch and trips the JSON normalisation).

## Verification
- `npx just compile` — clean.
- `npx just test-unit` — 2919 tests pass.
- `npx just publish-dry-run` — both packages report success in dry-run.
- `stryker run --mutate source/packtory/release-analysis.ts` — 100/100.
- `eslint source/packtory/release-analysis.ts` — clean.

## Test plan
- [ ] CI green on this branch (`Node.js v24.x`, `Node.js v26.x`, `Mutation testing`, `Benchmarks`).
- [ ] After merge, next scheduled `Publish` run completes without the `noSideEffects` failure.
