### PR TITLE
Stabilise publish cadence with off-peak cron and self-rechain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,14 @@ name: Publish
 
 on:
     schedule:
-        - cron: '*/10 * * * *'
+        # GitHub Actions throttles scheduled workflows hard at the top of the hour.
+        # Spreading entries across off-peak minutes gives the cron a better shot at
+        # firing at least a couple of times per hour as a fallback for the
+        # self-rechain below.
+        - cron: '7 * * * *'
+        - cron: '23 * * * *'
+        - cron: '37 * * * *'
+        - cron: '53 * * * *'
     workflow_dispatch:
 
 concurrency:
@@ -13,7 +20,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         permissions:
-            actions: read
+            actions: write
             contents: read
             id-token: write
             issues: read
@@ -56,3 +63,10 @@ jobs:
             - name: Publish packages
               if: steps.release-gate.outputs.should_publish == 'true'
               run: npx packtory publish --no-dry-run
+            - name: Schedule next tick
+              if: always()
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  sleep 600
+                  gh workflow run publish.yml --ref main


### PR DESCRIPTION
## Summary
The publish workflow's `*/10 * * * *` cron was firing at gaps of 1–4h instead of every 10 minutes — GitHub Actions' scheduled-workflow scheduler throttles hard at the top of every hour and has no SLA at sub-hour cadences. The recent 15-run window averaged ~80 min/run (1h04m to 4h25m gaps).

Two changes:

1. **Spread the cron entries across off-peak minutes.** `7, 23, 37, 53` instead of `*/10`. Stays well clear of the high-load top-of-hour slot. This still relies on GitHub's scheduler, so it's only a fallback.
2. **Self-rechain via `workflow_dispatch`.** After the job finishes, sleep 10 minutes and dispatch the workflow again via `gh workflow run`. `workflow_dispatch` events are processed promptly regardless of cron throttling, so as long as the chain is healthy we get near-deterministic 10-minute cadence. The cron above kicks the chain back to life when a run dies before reaching the final step. The repo is public, so the sleep doesn't consume billed minutes.

Bumped `permissions.actions` from `read` to `write` so the in-job `GITHUB_TOKEN` can dispatch the workflow.

## Test plan
- [ ] After merge, watch the next ~30 minutes of runs; expect roughly one run per 10 minutes once the chain warms up.
- [ ] If a run fails before the `Schedule next tick` step, confirm one of the cron entries restarts the chain within ~15 minutes.
