### PR TITLE
Relax OIDC exchange schema and surface validation issues

### DIFF
--- a/source/bundle-emitter/registry/oidc-token-exchange.test.ts
+++ b/source/bundle-emitter/registry/oidc-token-exchange.test.ts
@@ -117,8 +117,20 @@ suite('oidc-token-exchange', function () {
                     fakeFetchResponse({ json: { token_type: 'oidc' } })
                 ) as unknown as typeof globalThis.fetch
             }),
-            'OIDC token exchange returned an invalid response'
+            'OIDC token exchange returned an invalid response: at token: missing property; at expires: missing property'
         );
+    });
+
+    test('exchangeToken accepts an OIDC response that omits token_type and created', async function () {
+        const exchanger = exchangerFactory({
+            fetch: fake.resolves(
+                fakeFetchResponse({
+                    json: { token: 'exchanged-token', expires: '2026-05-06T11:00:00.000Z' }
+                })
+            ) as unknown as typeof globalThis.fetch
+        });
+
+        assert.strictEqual(await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth), 'exchanged-token');
     });
 
     test('exchangeToken throws when the OIDC response expiry is not parseable', async function () {

--- a/source/bundle-emitter/registry/oidc-token-exchange.ts
+++ b/source/bundle-emitter/registry/oidc-token-exchange.ts
@@ -77,14 +77,14 @@ export function createOidcTokenExchanger(dependencies: OidcExchangerDependencies
 
     function parseExchangedToken(body: unknown): { readonly token: string; readonly expiresAt: number } {
         const parsed = parseOidcExchangeResponse(body);
-        if (parsed === undefined) {
-            throw new TypeError('OIDC token exchange returned an invalid response');
+        if (!parsed.success) {
+            throw new TypeError(`OIDC token exchange returned an invalid response: ${parsed.issues.join('; ')}`);
         }
-        const expiresAt = Date.parse(parsed.expires);
+        const expiresAt = Date.parse(parsed.data.expires);
         if (!Number.isFinite(expiresAt)) {
             throw new TypeError('OIDC token exchange returned an invalid expiry timestamp');
         }
-        return { token: parsed.token, expiresAt };
+        return { token: parsed.data.token, expiresAt };
     }
 
     async function requestExchange(

--- a/source/bundle-emitter/registry/registry-client.test.ts
+++ b/source/bundle-emitter/registry/registry-client.test.ts
@@ -1022,7 +1022,7 @@ suite('registry-client', function () {
                 },
                 { access: 'public' }
             );
-        }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+        }, /^TypeError: OIDC token exchange returned an invalid response: /u);
     });
 
     test('publishPackage() rejects a non-object OIDC exchange response body', async function () {
@@ -1048,7 +1048,7 @@ suite('registry-client', function () {
                 },
                 { access: 'public' }
             );
-        }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+        }, /^TypeError: OIDC token exchange returned an invalid response: /u);
     });
 
     test('publishPackage() rejects a null OIDC exchange response body', async function () {
@@ -1074,7 +1074,7 @@ suite('registry-client', function () {
                 },
                 { access: 'public' }
             );
-        }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+        }, /^TypeError: OIDC token exchange returned an invalid response: /u);
     });
 
     test('publishPackage() rejects a failing OIDC exchange request', async function () {
@@ -1186,7 +1186,7 @@ suite('registry-client', function () {
                         },
                         { access: 'public' }
                     );
-                }, /^TypeError: OIDC token exchange returned an invalid response$/u);
+                }, /^TypeError: OIDC token exchange returned an invalid response: /u);
             });
         }
     });

--- a/source/bundle-emitter/registry/registry-response-schemas.test.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.test.ts
@@ -82,15 +82,28 @@ suite('registry-response-schemas', function () {
                 expires: '2026-01-01T01:00:00Z'
             }),
             {
-                token_type: 'Bearer',
-                token: 'abc',
-                created: '2026-01-01T00:00:00Z',
-                expires: '2026-01-01T01:00:00Z'
+                success: true,
+                data: {
+                    token_type: 'Bearer',
+                    token: 'abc',
+                    created: '2026-01-01T00:00:00Z',
+                    expires: '2026-01-01T01:00:00Z'
+                }
             }
         );
     });
 
-    test('parseOidcExchangeResponse returns undefined when a required field is missing', function () {
-        assert.strictEqual(parseOidcExchangeResponse({ token: 'abc' }), undefined);
+    test('parseOidcExchangeResponse accepts a response that omits token_type and created', function () {
+        assert.deepStrictEqual(parseOidcExchangeResponse({ token: 'abc', expires: '2026-01-01T01:00:00Z' }), {
+            success: true,
+            data: { token: 'abc', expires: '2026-01-01T01:00:00Z' }
+        });
+    });
+
+    test('parseOidcExchangeResponse reports validation issues when token or expires are missing', function () {
+        assert.deepStrictEqual(parseOidcExchangeResponse({ token: 'abc' }), {
+            success: false,
+            issues: ['at expires: missing property']
+        });
     });
 });

--- a/source/bundle-emitter/registry/registry-response-schemas.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.ts
@@ -1,3 +1,4 @@
+import { safeParse } from '@schema-hub/zod-error-formatter';
 import { z } from 'zod/mini';
 
 const packageVersionDetailsSchema = z.object({
@@ -23,10 +24,10 @@ const fullPackageResponseSchema = z.object({
 });
 
 const oidcExchangeResponseSchema = z.object({
-    token_type: z.string(),
     token: z.string(),
-    created: z.string(),
-    expires: z.string()
+    expires: z.string(),
+    token_type: z.optional(z.string()),
+    created: z.optional(z.string())
 });
 
 export type AbbreviatedPackageResponse = {
@@ -46,12 +47,16 @@ export type FullPackageResponse = {
     readonly versions: Readonly<Record<string, { readonly dist: { readonly tarball: string } }>>;
 };
 
-export type OidcExchangeResponse = {
-    readonly token_type: string;
+type OidcExchangeResponse = {
     readonly token: string;
-    readonly created: string;
     readonly expires: string;
+    readonly token_type?: string | undefined;
+    readonly created?: string | undefined;
 };
+
+export type OidcExchangeParseResult =
+    | { readonly success: false; readonly issues: readonly string[] }
+    | { readonly success: true; readonly data: OidcExchangeResponse };
 
 export function parseAbbreviatedPackageResponse(response: unknown): AbbreviatedPackageResponse | undefined {
     const result = abbreviatedPackageResponseSchema.safeParse(response);
@@ -63,7 +68,10 @@ export function parseFullPackageResponse(response: unknown): FullPackageResponse
     return result.success ? result.data : undefined;
 }
 
-export function parseOidcExchangeResponse(response: unknown): OidcExchangeResponse | undefined {
-    const result = oidcExchangeResponseSchema.safeParse(response);
-    return result.success ? result.data : undefined;
+export function parseOidcExchangeResponse(response: unknown): OidcExchangeParseResult {
+    const result = safeParse(oidcExchangeResponseSchema, response);
+    if (result.success) {
+        return { success: true, data: result.data as OidcExchangeResponse };
+    }
+    return { success: false, issues: result.error.issues };
 }


### PR DESCRIPTION
## Summary
The 06:18 scheduled `Publish` run crashed with the opaque error `OIDC token exchange returned an invalid response`. Trusted publishers on the npm side are set up correctly — the failure is on packtory's parser:

- The schema in `registry-response-schemas.ts` required all four fields (`token_type`, `token`, `created`, `expires`) as strings, but only `token` and `expires` are actually consumed by the exchanger.
- `parseOidcExchangeResponse` threw the zod issues away and returned `undefined`, so the log line gave us no clue which field was wrong.

Two changes:

1. **Relax the schema** — keep `token` and `expires` required, make `token_type` and `created` optional. A leaner npm response no longer trips validation, and the consumed shape is unchanged.
2. **Surface validation issues** — `parseOidcExchangeResponse` now returns `{ success: true, data } | { success: false, issues }` and the `TypeError` thrown by the exchanger embeds the issues. Next time this fails we'll see e.g. `at expires: missing property` instead of guessing.

Migrated the parse helper to `safeParse` from `@schema-hub/zod-error-formatter` so the surfaced issues come out as the project's standard formatted strings.

## Caveat
The currently-installed `@packtory/cli@0.0.15` still has the old strict schema, so this PR doesn't fix the *immediate* failing publish — that needs a new release of `@packtory/cli`. Once published, the next scheduled run picks up the relaxed schema and the better diagnostics.

## Test plan
- [x] `tsc --build` clean.
- [x] Full unit suite passes (`mocha --config mocha.config.unit-tests.cjs` — 2921 tests).
- [x] `eslint source/bundle-emitter/registry` clean.
- [x] `stryker run --mutate source/bundle-emitter/registry/oidc-token-exchange.ts,source/bundle-emitter/registry/registry-response-schemas.ts` — 100/100.
- [x] `npx just publish-dry-run` reports both packages as published.
- [ ] After this lands and a fresh `@packtory/cli` ships, the next scheduled publish run no longer trips the OIDC schema.
