### PR TITLE
Bump packtory CLI and switch publish to 30-minute cadence

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,9 @@ on:
     schedule:
         # GitHub Actions throttles scheduled workflows hard at the top of the hour.
         # Spreading entries across off-peak minutes gives the cron a better shot at
-        # firing at least a couple of times per hour as a fallback for the
-        # self-rechain below.
-        - cron: '7 * * * *'
-        - cron: '23 * * * *'
-        - cron: '37 * * * *'
-        - cron: '53 * * * *'
+        # firing as a fallback for the self-rechain below.
+        - cron: '17 * * * *'
+        - cron: '47 * * * *'
     workflow_dispatch:
 
 concurrency:
@@ -68,5 +65,5 @@ jobs:
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
-                  sleep 600
+                  sleep 1800
                   gh workflow run publish.yml --ref main

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "@enormora/eslint-config-typescript": "0.0.36",
                 "@enormora/objectory": "0.0.7",
                 "@ls-lint/ls-lint": "2.3.1",
-                "@packtory/cli": "0.0.15",
+                "@packtory/cli": "0.0.16",
                 "@stryker-mutator/core": "9.6.1",
                 "@stryker-mutator/mocha-runner": "9.6.1",
                 "@types/mocha": "10.0.10",
@@ -3168,9 +3168,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3188,9 +3185,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3208,9 +3202,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3228,9 +3219,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3248,9 +3236,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3268,9 +3253,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3288,9 +3270,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3308,9 +3287,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3523,9 +3499,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3540,9 +3513,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3557,9 +3527,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3574,9 +3541,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3591,9 +3555,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3608,9 +3569,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3625,9 +3583,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3642,9 +3597,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3732,15 +3684,15 @@
             "license": "MIT"
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.15",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.15.tgz",
-            "integrity": "sha512-4+GEH9TgD/LO+Mk7ilQ1wg7aWX+GHs5Auu22PfPLs7cq+/kD7Cq9vFMwE85ypR3Hc2DxC/ms3bWtkiJWqFXdKw==",
+            "version": "0.0.16",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.16.tgz",
+            "integrity": "sha512-57WUtuoUqzyD9JajrOjz4FQgpY84CfkoGuBIFk9OkIUu03ajHcX1K2y34zSVY36hpUUYqh5DGYH37tbSoMBb6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cmd-ts": "0.15.0",
-                "diff": "9.0.0",
-                "packtory": "0.0.15",
+                "open": "11.0.0",
+                "packtory": "0.0.16",
                 "remeda": "2.34.1",
                 "yoctocolors": "2.1.2"
             },
@@ -4948,9 +4900,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4965,9 +4914,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4982,9 +4928,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4999,9 +4942,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5016,9 +4956,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5033,9 +4970,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5050,9 +4984,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5067,9 +4998,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5084,9 +5012,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5101,9 +5026,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -12452,9 +12374,9 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/packtory": {
-            "version": "0.0.15",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.15.tgz",
-            "integrity": "sha512-J5McQn/0zJiCOqzuVzhT2Ewbj2JhQVyNVfma2LqVttzMQ3pE4bOtffVS2NIk6PNWChP35Mfdlyda8dvNImy1og==",
+            "version": "0.0.16",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.16.tgz",
+            "integrity": "sha512-U26FM/DzxUz/dJJlCw8X8n90tlKUY9R/di1lL2O9nsWZ0rkqeaVcpnLGwRau2Q8l+rjoaSardsjzxbMbPAx8/g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12466,12 +12388,14 @@
                 "@types/libnpmpublish": "9.0.1",
                 "@types/npm-registry-fetch": "8.0.9",
                 "common-tags": "1.8.2",
-                "hosted-git-info": "10.1.0",
-                "libnpmpublish": "11.1.3",
+                "diff": "9.0.0",
+                "fflate": "0.8.3",
+                "hosted-git-info": "10.1.1",
+                "libnpmpublish": "11.2.0",
                 "npm-package-arg": "14.0.0",
-                "npm-registry-fetch": "19.1.1",
+                "npm-registry-fetch": "20.0.0",
                 "remeda": "2.34.1",
-                "semver": "7.8.0",
+                "semver": "7.8.1",
                 "spdx-expression-parse": "4.0.0",
                 "tar-stream": "3.1.8",
                 "true-myth": "9.3.1",
@@ -12484,269 +12408,6 @@
                 "node": "^24 || ^26"
             }
         },
-        "node_modules/packtory/node_modules/@npmcli/agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
-            "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.1",
-                "lru-cache": "^11.2.1",
-                "socks-proxy-agent": "^8.0.3"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/@npmcli/fs": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
-            "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/@npmcli/redact": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
-            "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/agent-base": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/packtory/node_modules/cacache": {
-            "version": "20.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
-            "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/fs": "^5.0.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^13.0.0",
-                "lru-cache": "^11.1.0",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^2.0.1",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^7.0.2",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/hosted-git-info": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.0.tgz",
-            "integrity": "sha512-GquyT8u4Y0JkvqQNuKanSa2z5tYEjPLqHeYW8yjJ3v7DTNvofVBctIVBh6TToHELghuaQAVh8LkVF0AqqZS01w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^11.1.0"
-            },
-            "engines": {
-                "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
-            }
-        },
-        "node_modules/packtory/node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/packtory/node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/packtory/node_modules/libnpmpublish": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-11.1.3.tgz",
-            "integrity": "sha512-NVPTth/71cfbdYHqypcO9Lt5WFGTzFEcx81lWd7GDJIgZ95ERdYHGUfCtFejHCyqodKsQkNEx2JCkMpreDty/A==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/package-json": "^7.0.0",
-                "ci-info": "^4.0.0",
-                "npm-package-arg": "^13.0.0",
-                "npm-registry-fetch": "^19.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.7",
-                "sigstore": "^4.0.0",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/libnpmpublish/node_modules/hosted-git-info": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^11.1.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/libnpmpublish/node_modules/npm-package-arg": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/lru-cache": {
-            "version": "11.5.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/packtory/node_modules/make-fetch-happen": {
-            "version": "15.0.5",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
-            "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@gar/promise-retry": "^1.0.0",
-                "@npmcli/agent": "^4.0.0",
-                "@npmcli/redact": "^4.0.0",
-                "cacache": "^20.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^1.0.0",
-                "proc-log": "^6.0.0",
-                "ssri": "^13.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/minipass-fetch": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
-            "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.0.3",
-                "minipass-sized": "^2.0.0",
-                "minizlib": "^3.0.1"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            },
-            "optionalDependencies": {
-                "iconv-lite": "^0.7.2"
-            }
-        },
-        "node_modules/packtory/node_modules/npm-registry-fetch": {
-            "version": "19.1.1",
-            "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
-            "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "@npmcli/redact": "^4.0.0",
-                "jsonparse": "^1.3.1",
-                "make-fetch-happen": "^15.0.0",
-                "minipass": "^7.0.2",
-                "minipass-fetch": "^5.0.0",
-                "minizlib": "^3.0.1",
-                "npm-package-arg": "^13.0.0",
-                "proc-log": "^6.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^11.1.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/packtory/node_modules/npm-registry-fetch/node_modules/npm-package-arg": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
-            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "hosted-git-info": "^9.0.0",
-                "proc-log": "^6.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^7.0.0"
-            },
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
-            }
-        },
         "node_modules/packtory/node_modules/remeda": {
             "version": "2.34.1",
             "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.34.1.tgz",
@@ -12757,34 +12418,6 @@
                 "url": "https://github.com/sponsors/remeda"
             }
         },
-        "node_modules/packtory/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/packtory/node_modules/socks-proxy-agent": {
-            "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "^4.3.4",
-                "socks": "^2.8.3"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/packtory/node_modules/true-myth": {
             "version": "9.3.1",
             "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-9.3.1.tgz",
@@ -12793,16 +12426,6 @@
             "license": "MIT",
             "engines": {
                 "node": "18.* || >= 20.*"
-            }
-        },
-        "node_modules/packtory/node_modules/validate-npm-package-name": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-            "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/pako": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "@enormora/eslint-config-typescript": "0.0.36",
         "@enormora/objectory": "0.0.7",
         "@ls-lint/ls-lint": "2.3.1",
-        "@packtory/cli": "0.0.15",
+        "@packtory/cli": "0.0.16",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/mocha-runner": "9.6.1",
         "@types/mocha": "10.0.10",


### PR DESCRIPTION
## Summary
Two scheduled-publish housekeeping tweaks now that the OIDC fix is live on npm:

1. **`@packtory/cli` 0.0.15 → 0.0.16.** The freshly-published `0.0.16` carries the relaxed OIDC exchange schema and the better diagnostics from #637, so the scheduled `Publish` workflow can resume trusted-publisher publishing without the `OIDC token exchange returned an invalid response` failure.
2. **Cron cadence 15-ish → 30 minutes.** Drop the four off-peak cron entries (`7,23,37,53`) to two (`17,47`) and extend the self-rechain `sleep` from `600s` to `1800s`. The gate's `quietPeriodMinutes: 45` and `maxLatencyHours: 24` windows are orders of magnitude bigger than 30 minutes, so this cadence catches everything the old one did with half the CI churn.

The temp local bearer-token workaround in `packtory.config.js` is *not* in this diff — it was kept out of git, as planned.

## Test plan
- [x] `npm install` updates the lockfile cleanly; installed `@packtory/cli` is `0.0.16`.
- [x] `tsc --build` clean.
- [x] `npx just publish-dry-run` (using the installed `0.0.16` CLI) reports both packages as published.
- [ ] After merge, the next scheduled run should publish via OIDC successfully (or report the gate as closed).
- [ ] Confirm the self-rechain fires the next run ~30 min after each completion.
