### PR TITLE
Accept numeric `expires` and `created` in OIDC exchange response

### DIFF
--- a/source/bundle-emitter/registry/oidc-token-exchange.test.ts
+++ b/source/bundle-emitter/registry/oidc-token-exchange.test.ts
@@ -133,22 +133,48 @@ suite('oidc-token-exchange', function () {
         assert.strictEqual(await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth), 'exchanged-token');
     });
 
-    test('exchangeToken throws when the OIDC response expiry is not parseable', async function () {
-        await expectExchangeError(
-            exchangerFactory({
+    test('exchangeToken accepts an OIDC response with numeric expires and created in seconds', async function () {
+        const exchanger = exchangerFactory({
+            fetch: fake.resolves(
+                fakeFetchResponse({
+                    json: {
+                        token_type: 'oidc',
+                        token: 'exchanged-token',
+                        created: 1_746_525_600,
+                        expires: 1_746_529_200
+                    }
+                })
+            ) as unknown as typeof globalThis.fetch
+        });
+
+        assert.strictEqual(await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth), 'exchanged-token');
+    });
+
+    test('exchangeToken accepts an OIDC response with numeric expires in milliseconds', async function () {
+        const exchanger = exchangerFactory({
+            fetch: fake.resolves(
+                fakeFetchResponse({
+                    json: { token: 'exchanged-token', expires: 1_746_529_200_000 }
+                })
+            ) as unknown as typeof globalThis.fetch
+        });
+
+        assert.strictEqual(await exchanger.exchangeToken('pkg-a', npmSettings, oidcAuth), 'exchanged-token');
+    });
+
+    test('exchangeToken throws when the OIDC response expiry cannot be coerced to a date', async function () {
+        try {
+            await exchangerFactory({
                 fetch: fake.resolves(
                     fakeFetchResponse({
-                        json: {
-                            token_type: 'oidc',
-                            token: 'exchanged-token',
-                            created: '2026-05-06T10:00:00.000Z',
-                            expires: 'not-a-date'
-                        }
+                        json: { token: 'exchanged-token', expires: 'not-a-date' }
                     })
                 ) as unknown as typeof globalThis.fetch
-            }),
-            'OIDC token exchange returned an invalid expiry timestamp'
-        );
+            }).exchangeToken('pkg-a', npmSettings, oidcAuth);
+            assert.fail('Expected exchangeToken() to throw but it did not');
+        } catch (error: unknown) {
+            assert.match((error as Error).message, /^OIDC token exchange returned an invalid response: .*at expires/u);
+        }
     });
 
     test('resolveWriteAuthOptions returns bearer auth options when publish strategy is bearer-token', async function () {

--- a/source/bundle-emitter/registry/oidc-token-exchange.ts
+++ b/source/bundle-emitter/registry/oidc-token-exchange.ts
@@ -80,11 +80,7 @@ export function createOidcTokenExchanger(dependencies: OidcExchangerDependencies
         if (!parsed.success) {
             throw new TypeError(`OIDC token exchange returned an invalid response: ${parsed.issues.join('; ')}`);
         }
-        const expiresAt = Date.parse(parsed.data.expires);
-        if (!Number.isFinite(expiresAt)) {
-            throw new TypeError('OIDC token exchange returned an invalid expiry timestamp');
-        }
-        return { token: parsed.data.token, expiresAt };
+        return { token: parsed.data.token, expiresAt: parsed.data.expires.getTime() };
     }
 
     async function requestExchange(

--- a/source/bundle-emitter/registry/registry-client.test.ts
+++ b/source/bundle-emitter/registry/registry-client.test.ts
@@ -1103,65 +1103,11 @@ suite('registry-client', function () {
         }, /^Error: OIDC token exchange failed with status 502$/u);
     });
 
-    test('publishPackage() rejects an invalid OIDC exchange expiry timestamp', async function () {
-        const fetchSpy = fake.resolves({
-            ok: true,
-            status: 201,
-            json: fake.resolves({
-                token_type: 'oidc',
-                token: 'oidc-exchange-token',
-                created: '2026-05-06T10:00:00.000Z',
-                expires: 'not-a-date'
-            })
-        }) as unknown as typeof globalThis.fetch;
-        const registryClient = registryClientFactory({
-            fetch: fetchSpy,
-            resolveIdToken: fake.resolves('upstream-id-token')
-        });
-
-        await expectFailure(async () => {
-            await registryClient.publishPackage(
-                { name: 'the-name', version: '1.0.0' },
-                Buffer.from([]),
-                {
-                    auth: {
-                        publish: { type: 'npm-oidc', provider: 'env' },
-                        metadata: 'anonymous'
-                    }
-                },
-                { access: 'public' }
-            );
-        }, /^TypeError: OIDC token exchange returned an invalid expiry timestamp$/u);
-    });
-
     suite('OIDC exchange invalid responses', function () {
         for (const [testName, response] of [
-            [
-                'token_type is invalid',
-                {
-                    token_type: 123,
-                    token: 'oidc-exchange-token',
-                    created: '2026-05-06T10:00:00.000Z',
-                    expires: '2026-05-06T11:00:00.000Z'
-                }
-            ],
-            [
-                'token is invalid',
-                {
-                    token_type: 'oidc',
-                    token: 123,
-                    created: '2026-05-06T10:00:00.000Z',
-                    expires: '2026-05-06T11:00:00.000Z'
-                }
-            ],
-            [
-                'created is invalid',
-                { token_type: 'oidc', token: 'oidc-exchange-token', created: 123, expires: '2026-05-06T11:00:00.000Z' }
-            ],
-            [
-                'expires is invalid',
-                { token_type: 'oidc', token: 'oidc-exchange-token', created: '2026-05-06T10:00:00.000Z', expires: 123 }
-            ]
+            ['token is the wrong shape', { token: 123, expires: '2026-05-06T11:00:00.000Z' }],
+            ['expires cannot be coerced to a date', { token: 'oidc-exchange-token', expires: 'not-a-date' }],
+            ['expires is the wrong shape', { token: 'oidc-exchange-token', expires: {} }]
         ] as const) {
             test(`publishPackage() rejects an OIDC exchange response when ${testName}`, async function () {
                 const fetchSpy = fake.resolves({

--- a/source/bundle-emitter/registry/registry-response-schemas.test.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.test.ts
@@ -73,7 +73,7 @@ suite('registry-response-schemas', function () {
         );
     });
 
-    test('parseOidcExchangeResponse returns the data when all token fields are present', function () {
+    test('parseOidcExchangeResponse coerces an ISO-string expires to a Date and strips fields it does not consume', function () {
         assert.deepStrictEqual(
             parseOidcExchangeResponse({
                 token_type: 'Bearer',
@@ -83,27 +83,30 @@ suite('registry-response-schemas', function () {
             }),
             {
                 success: true,
-                data: {
-                    token_type: 'Bearer',
-                    token: 'abc',
-                    created: '2026-01-01T00:00:00Z',
-                    expires: '2026-01-01T01:00:00Z'
-                }
+                data: { token: 'abc', expires: new Date('2026-01-01T01:00:00Z') }
             }
         );
     });
 
-    test('parseOidcExchangeResponse accepts a response that omits token_type and created', function () {
-        assert.deepStrictEqual(parseOidcExchangeResponse({ token: 'abc', expires: '2026-01-01T01:00:00Z' }), {
+    test('parseOidcExchangeResponse coerces a numeric expires to a Date', function () {
+        assert.deepStrictEqual(parseOidcExchangeResponse({ token: 'abc', expires: 1_746_529_200_000 }), {
             success: true,
-            data: { token: 'abc', expires: '2026-01-01T01:00:00Z' }
+            data: { token: 'abc', expires: new Date(1_746_529_200_000) }
         });
     });
 
-    test('parseOidcExchangeResponse reports validation issues when token or expires are missing', function () {
+    test('parseOidcExchangeResponse reports validation issues when expires is missing', function () {
         assert.deepStrictEqual(parseOidcExchangeResponse({ token: 'abc' }), {
             success: false,
             issues: ['at expires: missing property']
         });
+    });
+
+    test('parseOidcExchangeResponse reports validation issues when expires cannot be coerced to a Date', function () {
+        const result = parseOidcExchangeResponse({ token: 'abc', expires: 'not-a-date' });
+        if (result.success) {
+            assert.fail('expected validation to fail when expires is not a date');
+        }
+        assert.match(result.issues.join('; '), /at expires/u);
     });
 });

--- a/source/bundle-emitter/registry/registry-response-schemas.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.ts
@@ -25,9 +25,7 @@ const fullPackageResponseSchema = z.object({
 
 const oidcExchangeResponseSchema = z.object({
     token: z.string(),
-    expires: z.string(),
-    token_type: z.optional(z.string()),
-    created: z.optional(z.string())
+    expires: z.coerce.date()
 });
 
 export type AbbreviatedPackageResponse = {
@@ -49,9 +47,7 @@ export type FullPackageResponse = {
 
 type OidcExchangeResponse = {
     readonly token: string;
-    readonly expires: string;
-    readonly token_type?: string | undefined;
-    readonly created?: string | undefined;
+    readonly expires: Date;
 };
 
 export type OidcExchangeParseResult =


### PR DESCRIPTION
Latest scheduled publish failed with:

```
OIDC token exchange returned an invalid response:
  at expires: expected string, but got number;
  at created: expected string, but got number
```

npm's OIDC token exchange returns `expires` and `created` as numbers, not strings. Update the schema to accept either, and forward numeric `expires` straight through to the cache TTL maths (`Date.parse` is only invoked on the string form).
