### PR TITLE
Drop spinner-worker `unref()` to let it exit cleanly before main

### DIFF
--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -118,6 +118,7 @@ async function main(): Promise<void> {
 }
 
 function crash(error: unknown): void {
+    spinnerRenderer.stopAll();
     console.error(error);
     process.exitCode = 1;
 }

--- a/source/packages/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/packages/command-line-interface/spinner-boot.entry-point.ts
@@ -20,7 +20,9 @@ function spawnWorker(request: WorkerSpawnRequest): void {
         },
         execArgv: workerExecArgv
     });
-    worker.unref();
+    worker.on('error', (error: Error) => {
+        process.stderr.write(`spinner worker error: ${error.message}\n`);
+    });
 }
 
 export function createBootedSpinnerRuntime(): SpinnerRuntime {


### PR DESCRIPTION
The CLI publish was emitting hundreds of `Warning: File descriptor N opened in unmanaged mode` lines and the process was being terminated with `SIGKILL` after the publishes had already succeeded.

Root cause: the spinner worker thread is `unref()`d, so once the main thread finishes the `publish` flow and reaches its natural exit, Node yanks the worker mid-shutdown. The internal `MessagePort` pipes used to bridge the worker to the parent get torn down without going through Node's managed close path. libuv emits the unmanaged-FD warnings and the OS signals `SIGKILL`.

Fix:

- Keep the worker referenced. `spinner-worker-backend.shutdown` already requests a clean shutdown via the shared-state flag, the worker clears its `setInterval`, drains, and exits on its own — main waits for it instead of pulling the rug out.
- Call `spinnerRenderer.stopAll()` from the top-level `crash` handler so an unhandled error path still triggers the same clean shutdown, otherwise the now-referenced worker would keep the process alive forever.
- Attach an `error` listener on the worker so a worker-level error is surfaced as a one-line message on stderr instead of crashing the parent.
