### PR TITLE
Treat `sbom.cdx.json` as dependency-derived in release classification

### DIFF
--- a/source/packtory/release-analysis.test.ts
+++ b/source/packtory/release-analysis.test.ts
@@ -136,6 +136,35 @@ suite('release-analysis', function () {
         );
     });
 
+    test('classifyPackageRelease treats SBOM-only diffs alongside dependency-only package.json changes as dependency-only', function () {
+        const buildResult = buildResultWithPublishedFiles([
+            file('package.json', '{"name":"pkg-a","version":"1.0.0","dependencies":{"a":"1.0.0"}}'),
+            file('sbom.cdx.json', '{"components":[{"name":"a","version":"1.0.0"}]}')
+        ]);
+
+        const result = classifyPackageRelease(buildResult, [
+            file('package.json', '{"name":"pkg-a","version":"1.0.1","dependencies":{"a":"1.1.0"}}'),
+            file('sbom.cdx.json', '{"components":[{"name":"a","version":"1.1.0"}]}')
+        ]);
+
+        assert.strictEqual(result.classification, 'dependency-only');
+    });
+
+    test('classifyPackageRelease keeps substantive classification when source files differ even if SBOM also differs', function () {
+        assertSubstantiveClassification(
+            [
+                file('package.json', '{"name":"pkg-a","version":"1.0.0","dependencies":{"a":"1.0.0"}}'),
+                file('sbom.cdx.json', '{"components":[{"name":"a","version":"1.0.0"}]}'),
+                file('index.js', 'export const value = 1;\n')
+            ],
+            [
+                file('package.json', '{"name":"pkg-a","version":"1.0.1","dependencies":{"a":"1.1.0"}}'),
+                file('sbom.cdx.json', '{"components":[{"name":"a","version":"1.1.0"}]}'),
+                file('index.js', 'export const value = 2;\n')
+            ]
+        );
+    });
+
     test('classifyPackageRelease treats packages without package.json in the published artifacts as substantive', function () {
         assertSubstantiveClassification(
             [file('index.js', 'export const value = 1;\n')],

--- a/source/packtory/release-analysis.ts
+++ b/source/packtory/release-analysis.ts
@@ -1,12 +1,15 @@
 import { isDeepStrictEqual } from 'node:util';
 import { maxDate } from '../common/max-date.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
+import { sbomFilePath } from '../sbom/sbom-file.ts';
 import type { BuildAndPublishResult } from './package-processor.ts';
 import type {
     PackageReleaseAnalysis,
     PackageReleaseAnalysisClassification,
     ReleaseAnalysis
 } from './packtory-results.ts';
+
+const dependencyDerivedFilePaths = new Set(['package.json', sbomFilePath]);
 
 const dependencyOnlyPackageJsonFields = new Set([
     'bundleDependencies',
@@ -83,13 +86,16 @@ function indexFiles(files: readonly FileDescription[]): ReadonlyMap<string, File
     );
 }
 
-function nonPackageJsonFilesMatch(
+function nonDependencyDerivedFilesMatch(
     previousIndex: ReadonlyMap<string, FileDescription>,
     newIndex: ReadonlyMap<string, FileDescription>
 ): boolean {
     return Array.from(previousIndex.entries()).every(([filePath, previousFile]) => {
+        if (dependencyDerivedFilePaths.has(filePath)) {
+            return true;
+        }
         const currentFile = newIndex.get(filePath);
-        return filePath === 'package.json' || isDeepStrictEqual(previousFile, currentFile);
+        return isDeepStrictEqual(previousFile, currentFile);
     });
 }
 
@@ -133,7 +139,7 @@ function isDependencyOnlyPublishedChange(
 
     const { previousIndex, newIndex } = createComparisonIndexes(previousFiles, newFiles);
 
-    if (!nonPackageJsonFilesMatch(previousIndex, newIndex)) {
+    if (!nonDependencyDerivedFilesMatch(previousIndex, newIndex)) {
         return false;
     }
 

--- a/source/sbom/sbom-file.ts
+++ b/source/sbom/sbom-file.ts
@@ -6,7 +6,7 @@ import type { LicenseResolver } from './license-resolver.ts';
 import type { SbomSerializer } from './sbom-serializer.ts';
 import { buildSbom, type SbomDependency, type SbomDependencyKind } from './sbom-builder.ts';
 
-const sbomFilePath = 'sbom.cdx.json';
+export const sbomFilePath = 'sbom.cdx.json';
 
 type ToolVersionProvider = () => Promise<string>;
 


### PR DESCRIPTION
## Symptom

The publish workflow's release gate keeps publishing despite `DEPENDENCY_ONLY_MIN_AGE_DAYS=7`. Renovate-only merges trigger releases within minutes instead of the configured 7-day delay.

Example: run [`26487850873`](https://github.com/enormora/packtory/actions/runs/26487850873) published at `02:54` on 2026-05-27 with only `#648` (`remeda` → `2.37.0`) and `#649` (`@packtory/cli` → `0.0.19`) merged since the previous publish. The gate logged `release classification: substantive` and let it through.

## Root cause

`isDependencyOnlyPublishedChange` in `source/packtory/release-analysis.ts` requires every non-`package.json` file to be byte-equal between the previously published bundle and the new one. Bundles include a CycloneDX SBOM at `sbom.cdx.json` whose content enumerates every dependency and version. A `remeda` bump flips the SBOM content even when no source file changed, fails the equality check, and falls through to `substantive` — bypassing the 7-day policy.

## Fix

Exempt `sbom.cdx.json` alongside `package.json` from the equality check: both files are dependency-derived, so a diff that originates solely from a version bump must not disqualify a `dependency-only` classification.
