### PR TITLE
Make `registrySettings` optional; require `auth` only for non-dry-run publish

### DIFF
--- a/integration-tests/packtory/publish-fixture-support.ts
+++ b/integration-tests/packtory/publish-fixture-support.ts
@@ -66,7 +66,7 @@ type PublishFixturePackagesParams = {
 function createRegistrySettings(
     registryDetails: RegistryDetails,
     authMode: PublishFixturePackagesParams['authMode'] = 'bearer'
-): PublishConfig['registrySettings'] {
+): NonNullable<PublishConfig['registrySettings']> {
     if (authMode === 'basic') {
         return {
             registryUrl: registryDetails.registryUrl,

--- a/readme.md
+++ b/readme.md
@@ -46,11 +46,12 @@ Your root `package.json` must declare `"type": "module"`. `packtory` only suppor
 import path from 'node:path';
 import fs from 'node:fs';
 
+const npmToken = process.env.NPM_TOKEN;
+
 export const config = {
-    // Customize your registry settings, if needed
-    registrySettings: {
-        auth: { type: 'bearer-token', token: process.env.NPM_TOKEN }
-    },
+    // `registrySettings` is only required to publish (non-dry-run). Pack, dry-run publish,
+    // release-diff and release analysis read registry metadata anonymously when omitted.
+    ...(npmToken === undefined ? {} : { registrySettings: { auth: { type: 'bearer-token', token: npmToken } } }),
 
     // Common settings shared among packages
     commonPackageSettings: {
@@ -140,9 +141,10 @@ For a deeper look at the pipeline, the package graph, parallel scheduling, the t
 
 The configuration for `packtory` is an object with the following properties:
 
-1. **`registrySettings`** (Required):
-    - An object with a required `auth` configuration.
-    - Optionally, you can provide a custom `registryUrl`.
+1. **`registrySettings`** (Optional):
+    - Only required to publish in non-dry-run mode. Pack, dry-run publish, release-diff and release analysis read registry metadata anonymously when `registrySettings` (or its `auth`) is omitted. Non-dry-run publish fails fast with one config error before any package is built when `auth` is missing.
+    - `auth` (Optional): the credentials used to read metadata and/or publish.
+    - `registryUrl` (Optional): a custom registry URL.
     - Supported publish auth strategies:
         - `type: 'bearer-token'` with a `token`
         - `type: 'basic'` with `username` and `password`
@@ -156,6 +158,14 @@ The configuration for `packtory` is an object with the following properties:
         - `'auto'`
         - explicit bearer/basic auth
     - `packtory` does not read `.npmrc`; provide auth explicitly in `packtory.config.js`.
+    - To keep environment-variable reads lazy, gate `registrySettings` on the env var inside `buildConfig`:
+        ```js
+        const npmToken = process.env.NPM_TOKEN;
+        return {
+            ...(npmToken === undefined ? {} : { registrySettings: { auth: { type: 'bearer-token', token: npmToken } } })
+            // …
+        };
+        ```
 
 2. **`commonPackageSettings`** (Optional):
     - Defines settings that can be shared for all packages.

--- a/source/bundle-emitter/registry/registry-auth-config.test.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.test.ts
@@ -144,6 +144,26 @@ suite('registry-auth-config', function () {
         });
     });
 
+    test('resolveMetadataAuthOptions returns anonymous options when auth is undefined', function () {
+        assert.deepStrictEqual(resolveMetadataAuthOptions({}), {
+            allowsAutomaticRetry: false,
+            registry: undefined,
+            options: { alwaysAuth: true, registry: undefined }
+        });
+    });
+
+    test('resolvePublishAuth throws when auth is undefined', function () {
+        try {
+            resolvePublishAuth({});
+            assert.fail('Expected resolvePublishAuth() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'registrySettings.auth must be configured to publish; this code path should be unreachable when auth is missing.'
+            );
+        }
+    });
+
     test('resolveMetadataAuthOptions keeps npm-oidc metadata inheritance anonymous when explicitly requested', function () {
         assert.deepStrictEqual(
             resolveMetadataAuthOptions({ auth: { publish: { type: 'npm-oidc' }, metadata: 'inherit-publish-auth' } }),

--- a/source/bundle-emitter/registry/registry-auth-config.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.ts
@@ -1,5 +1,10 @@
 import type _npmFetch from 'npm-registry-fetch';
-import type { MetadataAuthStrategy, PublishAuthStrategy, RegistrySettings } from '../../config/registry-settings.ts';
+import type {
+    MetadataAuthMode,
+    MetadataAuthStrategy,
+    PublishAuthStrategy,
+    RegistrySettings
+} from '../../config/registry-settings.ts';
 
 export const npmRegistryUrl = 'https://registry.npmjs.org/';
 
@@ -19,7 +24,13 @@ export function isNpmRegistry(registry: string | undefined): boolean {
     return new URL(registry ?? npmRegistryUrl).href === npmRegistryUrl;
 }
 
+const publishAuthRequiredErrorMessage =
+    'registrySettings.auth must be configured to publish; this code path should be unreachable when auth is missing.';
+
 export function resolvePublishAuth(registrySettings: Readonly<RegistrySettings>): PublishAuthStrategy {
+    if (registrySettings.auth === undefined) {
+        throw new Error(publishAuthRequiredErrorMessage);
+    }
     return 'type' in registrySettings.auth ? registrySettings.auth : registrySettings.auth.publish;
 }
 
@@ -87,23 +98,29 @@ function resolveInheritedMetadataAuth(
         : buildAuthOptions(publishAuth, registrySettings);
 }
 
-export function resolveMetadataAuthOptions(registrySettings: Readonly<RegistrySettings>): AuthResolution {
-    if ('type' in registrySettings.auth) {
-        return resolveInheritedMetadataAuth(registrySettings.auth, registrySettings);
-    }
-
-    const metadataMode = registrySettings.auth.metadata;
+function resolveMetadataAuthFromMode(
+    metadataMode: MetadataAuthMode | undefined,
+    publishAuth: PublishAuthStrategy,
+    registrySettings: Readonly<RegistrySettings>
+): AuthResolution {
     if (metadataMode === 'auto') {
         return createAutomaticRetryAuthResolution(registrySettings);
     }
-
     if (metadataMode === 'anonymous') {
         return createAnonymousAuthResolution(registrySettings);
     }
-
     if (typeof metadataMode === 'object') {
         return buildAuthOptions(metadataMode, registrySettings);
     }
+    return resolveInheritedMetadataAuth(publishAuth, registrySettings);
+}
 
-    return resolveInheritedMetadataAuth(registrySettings.auth.publish, registrySettings);
+export function resolveMetadataAuthOptions(registrySettings: Readonly<RegistrySettings>): AuthResolution {
+    if (registrySettings.auth === undefined) {
+        return createAnonymousAuthResolution(registrySettings);
+    }
+    if ('type' in registrySettings.auth) {
+        return resolveInheritedMetadataAuth(registrySettings.auth, registrySettings);
+    }
+    return resolveMetadataAuthFromMode(registrySettings.auth.metadata, registrySettings.auth.publish, registrySettings);
 }

--- a/source/config/config.test.ts
+++ b/source/config/config.test.ts
@@ -38,7 +38,7 @@ suite('config', function () {
         );
     });
 
-    test('config schema rejects configs without registrySettings', function () {
+    test('config schema accepts configs without registrySettings', function () {
         assert.strictEqual(
             safeParse(packtoryConfigSchema, {
                 packages: [
@@ -50,7 +50,7 @@ suite('config', function () {
                     }
                 ]
             }).success,
-            false
+            true
         );
     });
 
@@ -90,8 +90,8 @@ suite('config', function () {
     );
 
     test(
-        'validation fails when registrySettings is missing',
-        checkValidationFailure({
+        'validation succeeds when registrySettings is omitted',
+        checkValidationSuccess({
             schema: packtoryConfigSchema,
             data: {
                 packages: [
@@ -102,8 +102,25 @@ suite('config', function () {
                         roots: { main: { js: 'foo' } }
                     }
                 ]
-            },
-            expectedMessages: ['at registrySettings: missing property']
+            }
+        })
+    );
+
+    test(
+        'validation succeeds when registrySettings is provided without auth',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { registryUrl: 'https://registry.example' },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } }
+                    }
+                ]
+            }
         })
     );
 
@@ -602,7 +619,7 @@ suite('config', function () {
         checkValidationFailure({
             schema: packtoryConfigSchema,
             data: {},
-            expectedMessages: ['at registrySettings: missing property', 'invalid value doesn’t match expected union']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -21,7 +21,7 @@ export type PacktoryConfigWithoutRegistry = {
 };
 
 export type PacktoryConfig = PacktoryConfigWithoutRegistry & {
-    readonly registrySettings: RegistrySettings;
+    readonly registrySettings?: RegistrySettings | undefined;
 };
 
 const packageConfigOperations = { getBundledDependencies: getBundledDependenciesBase };

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
-import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
+import { checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
 
 const validConfig = {
@@ -22,7 +22,7 @@ suite('packtory-config-schema', function () {
         assert.strictEqual(safeParse(packtoryConfigSchema, validConfig).success, true);
     });
 
-    test('packtory config schema rejects configs without registrySettings', function () {
+    test('packtory config schema accepts configs without registrySettings', function () {
         assert.strictEqual(
             safeParse(packtoryConfigSchema, {
                 packages: [
@@ -35,7 +35,7 @@ suite('packtory-config-schema', function () {
                     }
                 ]
             }).success,
-            false
+            true
         );
     });
 
@@ -49,8 +49,8 @@ suite('packtory-config-schema', function () {
     );
 
     test(
-        'packtory config schema: validation fails when registrySettings is missing',
-        checkValidationFailure({
+        'packtory config schema: validation succeeds when registrySettings is omitted',
+        checkValidationSuccess({
             schema: packtoryConfigSchema,
             data: {
                 packages: [
@@ -62,8 +62,26 @@ suite('packtory-config-schema', function () {
                         publishSettings: { access: 'public' }
                     }
                 ]
-            },
-            expectedMessages: ['at registrySettings: missing property']
+            }
+        })
+    );
+
+    test(
+        'packtory config schema: validation succeeds when registrySettings is provided without auth',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { registryUrl: 'https://registry.example' },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        publishSettings: { access: 'public' }
+                    }
+                ]
+            }
         })
     );
 

--- a/source/config/packtory-config-schema.ts
+++ b/source/config/packtory-config-schema.ts
@@ -4,7 +4,7 @@ import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-r
 
 export const packtoryConfigSchema = z.intersection(
     z.object({
-        registrySettings: registrySettingsSchema
+        registrySettings: z.optional(registrySettingsSchema)
     }),
     packtoryConfigWithoutRegistrySchema
 );

--- a/source/config/registry-settings.report.test.ts
+++ b/source/config/registry-settings.report.test.ts
@@ -60,6 +60,23 @@ suite('registry-settings.report', function () {
         });
     });
 
+    test('omits auth when undefined', function () {
+        const settings = {
+            registryUrl: 'https://registry.example.com'
+        } as unknown as RegistrySettings;
+
+        const redacted = redactRegistrySettings(settings);
+
+        assert.deepStrictEqual(redacted, { registryUrl: 'https://registry.example.com' });
+        assert.strictEqual('auth' in redacted, false);
+    });
+
+    test('returns an empty object when both registryUrl and auth are undefined', function () {
+        const redacted = redactRegistrySettings({} as unknown as RegistrySettings);
+
+        assert.deepStrictEqual(redacted, {});
+    });
+
     test('omits registryUrl when undefined', function () {
         const settings = {
             auth: { type: 'bearer-token', token: 'real-secret' }

--- a/source/config/registry-settings.report.ts
+++ b/source/config/registry-settings.report.ts
@@ -47,10 +47,10 @@ function redactMetadata(metadata: MetadataAuthMode): RedactedMetadata {
 
 export type RedactedRegistrySettings = {
     readonly registryUrl?: string;
-    readonly auth: RedactedAuth | { readonly publish: RedactedAuth; readonly metadata?: RedactedMetadata };
+    readonly auth?: RedactedAuth | { readonly publish: RedactedAuth; readonly metadata?: RedactedMetadata };
 };
 
-function redactAuth(auth: RegistrySettings['auth']): RedactedRegistrySettings['auth'] {
+function redactAuth(auth: NonNullable<RegistrySettings['auth']>): NonNullable<RedactedRegistrySettings['auth']> {
     if ('publish' in auth) {
         return {
             publish: redactPublishAuth(auth.publish),
@@ -63,6 +63,6 @@ function redactAuth(auth: RegistrySettings['auth']): RedactedRegistrySettings['a
 export function redactRegistrySettings(settings: RegistrySettings): RedactedRegistrySettings {
     return {
         ...(settings.registryUrl === undefined ? {} : { registryUrl: settings.registryUrl }),
-        auth: redactAuth(settings.auth)
+        ...(settings.auth === undefined ? {} : { auth: redactAuth(settings.auth) })
     };
 }

--- a/source/config/registry-settings.test.ts
+++ b/source/config/registry-settings.test.ts
@@ -11,8 +11,12 @@ suite('registry-settings', function () {
         assert.strictEqual(safeParse(registrySettingsSchema, { auth: bearerTokenAuth }).success, true);
     });
 
-    test('schema rejects registry settings without auth', function () {
-        assert.strictEqual(safeParse(registrySettingsSchema, { registryUrl: 'bar' }).success, false);
+    test('schema accepts registry settings without auth', function () {
+        assert.strictEqual(safeParse(registrySettingsSchema, { registryUrl: 'bar' }).success, true);
+    });
+
+    test('schema accepts an empty registry settings object', function () {
+        assert.strictEqual(safeParse(registrySettingsSchema, {}).success, true);
     });
 
     test(
@@ -135,11 +139,11 @@ suite('registry-settings', function () {
     );
 
     test(
-        'validation fails when an empty object is given',
-        checkValidationFailure({
+        'validation succeeds when an empty object is given',
+        checkValidationSuccess({
             schema: registrySettingsSchema,
             data: {},
-            expectedMessages: ['at auth: missing property']
+            expectedData: {}
         })
     );
 

--- a/source/config/registry-settings.ts
+++ b/source/config/registry-settings.ts
@@ -53,7 +53,7 @@ const authConfigSchema = z.union([
 export const registrySettingsSchema = z.readonly(
     z.strictObject({
         registryUrl: z.optional(nonEmptyStringSchema),
-        auth: authConfigSchema
+        auth: z.optional(authConfigSchema)
     })
 );
 

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -290,9 +290,9 @@ suite('schema-contracts', function () {
             missingRootJsSuccess: false,
             extraRootPropertySuccess: false,
             validRegistrySuccess: true,
-            missingRegistryTokenSuccess: false,
+            missingRegistryTokenSuccess: true,
             validConfigSuccess: true,
-            missingConfigRegistrySuccess: false,
+            missingConfigRegistrySuccess: true,
             emptyConfigPackagesSuccess: false
         });
     }).timeout(probeTestTimeoutMs);

--- a/source/config/validation.test.ts
+++ b/source/config/validation.test.ts
@@ -36,10 +36,7 @@ function fooPackage(name = 'foo'): ConfigInput {
 suite('validation', function () {
     test('returns the issues when the given config doesn’t match the schema', function () {
         const result = validateConfig({ not: 'valid' });
-        assert.deepStrictEqual(
-            result,
-            Result.err(['at registrySettings: missing property', 'invalid value doesn’t match expected union'])
-        );
+        assert.deepStrictEqual(result, Result.err(['invalid value doesn’t match expected union']));
     });
 
     test('returns an issue when a package with the same name exists twice', function () {

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -25,7 +25,7 @@ packtory <command> [options]
 
 **Options:**
 
-- **--no-dry-run:** Disables dry-run mode (enabled by default), allowing actual publishing.
+- **--no-dry-run:** Disables dry-run mode (enabled by default), allowing actual publishing. The CLI fails fast with a single config error when `registrySettings.auth` is missing in this mode; dry-run, `preview`, `release-diff` and `pack` work without `auth` against any registry that allows anonymous metadata reads.
 - **preview --open:** Generates the same fresh preview report as `packtory preview`, writes a temporary HTML file, and opens it with the platform opener.
 - **publish --report-json:** Writes `packtory-report.json`, the machine-readable `BuildReport`.
 - **publish --report-html:** Writes `packtory-report.html`, the rich HTML report used by `packtory preview --open`.

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -130,10 +130,10 @@ describe('PacktoryConfig — accepted shapes', () => {
 });
 
 describe('PacktoryConfig — rejected shapes', () => {
-    test('rejects a configuration without registrySettings', () => {
-        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
-            readonly packages: readonly [];
-        }>();
+    test('accepts a configuration without registrySettings (read-only ops do not require auth)', () => {
+        expect<{
+            readonly packages: readonly [{ readonly name: 'pkg'; readonly roots: Record<string, never> }];
+        }>().type.toBeAssignableTo<PacktoryConfig>();
     });
 
     test('rejects a configuration without packages', () => {
@@ -144,11 +144,11 @@ describe('PacktoryConfig — rejected shapes', () => {
         }>();
     });
 
-    test('rejects a registrySettings without auth', () => {
-        expect<PacktoryConfig>().type.not.toBeAssignableFrom<{
+    test('accepts a registrySettings without auth (publish fails fast at runtime instead)', () => {
+        expect<{
             readonly registrySettings: { readonly registryUrl: 'https://registry.example' };
-            readonly packages: readonly [];
-        }>();
+            readonly packages: readonly [{ readonly name: 'pkg'; readonly roots: Record<string, never> }];
+        }>().type.toBeAssignableTo<PacktoryConfig>();
     });
 
     test('rejects a package without name or roots', () => {
@@ -179,10 +179,17 @@ describe('PacktoryConfig — exposed structure', () => {
     });
 
     test('registrySettings exposes the documented auth fields', () => {
-        expect<PacktoryConfig['registrySettings']['registryUrl']>().type.toBe<string | undefined>();
-        type ExpandedAuth = Extract<PacktoryConfig['registrySettings']['auth'], { publish: unknown }>;
+        type RequiredRegistrySettings = NonNullable<PacktoryConfig['registrySettings']>;
+        expect<RequiredRegistrySettings['registryUrl']>().type.toBe<string | undefined>();
+        type ExpandedAuth = Extract<RequiredRegistrySettings['auth'], { publish: unknown }>;
         expect<ExpandedAuth['publish']>().type.toBe<PublishAuthStrategy>();
         expect<ExpandedAuth['metadata']>().type.toBe<MetadataAuthMode | undefined>();
+    });
+
+    test('registrySettings is optional on PacktoryConfig', () => {
+        expect<PacktoryConfig['registrySettings']>().type.toBe<
+            NonNullable<PacktoryConfig['registrySettings']> | undefined
+        >();
     });
 
     test('PackageConfig requires name and roots', () => {

--- a/source/packages/packtory/readme.md
+++ b/source/packages/packtory/readme.md
@@ -44,7 +44,7 @@ const config = {
 
 **Parameters:**
 
-- **config:** The packtory configuration object.
+- **config:** The packtory configuration object. `registrySettings` is optional; it is only required to publish in non-dry-run mode. Pack, dry-run publish, release-diff and release analysis read registry metadata anonymously when `registrySettings` (or its `auth`) is omitted. Calling `buildAndPublishAll(config, { dryRun: false })` without `auth` fails fast with one `ConfigError` before any package is processed.
 - **options:** Per-function options object:
     - `buildAndPublishAll`: `{ dryRun: boolean; collectReport?: boolean }`.
     - `resolveAndLinkAll`: optional `{ collectReport?: boolean }`.

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -503,6 +503,34 @@ suite('map-config', function () {
         assert.deepStrictEqual(result.allowMutableSpecifiers, ['only-this']);
     });
 
+    test('preserves the configured registrySettings on the produced options', function () {
+        const result = runMapConfig(fooPackageConfigFactory.build(), {
+            extraConfig: {
+                registrySettings: {
+                    registryUrl: 'https://registry.example',
+                    auth: { type: 'bearer-token', token: 'tok' }
+                }
+            }
+        });
+
+        assert.deepStrictEqual(result.registrySettings, {
+            registryUrl: 'https://registry.example',
+            auth: { type: 'bearer-token', token: 'tok' }
+        });
+    });
+
+    test('defaults registrySettings to an empty object when the config omits them', function () {
+        const packageConfig = {
+            ...fooPackageConfigFactory.build(),
+            publishSettings: { access: 'public' }
+        } as unknown as PackageConfigInput;
+        const config = { packages: [packageConfig] } as unknown as PacktoryConfigInput;
+
+        const result = configToBuildAndPublishOptions('foo', { foo: packageConfig }, config, []);
+
+        assert.deepStrictEqual(result.registrySettings, {});
+    });
+
     test('throws a "missing publish settings" error when neither commonPackageSettings nor the package supplies one', function () {
         const packageWithoutPublishSettings = fooPackageConfigFactory.build();
         const config = {

--- a/source/packtory/map-config.ts
+++ b/source/packtory/map-config.ts
@@ -13,7 +13,7 @@ export type BuildOptions = SharedPackageOptions<PublishedPackageWithManifest> & 
 };
 
 export type BuildAndPublishOptions = SharedPackageOptions<PublishedPackageWithManifest> & {
-    readonly registrySettings: PacktoryConfig['registrySettings'];
+    readonly registrySettings: NonNullable<PacktoryConfig['registrySettings']>;
     readonly publishSettings: PublishSettings;
     readonly versioning: VersioningSettings;
 };
@@ -37,7 +37,7 @@ export function configToBuildAndPublishOptions(
     return {
         ...sharedOptions,
         versioning,
-        registrySettings: packtoryConfig.registrySettings,
+        registrySettings: packtoryConfig.registrySettings ?? {},
         publishSettings
     };
 }

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -334,9 +334,46 @@ suite('packtory', function () {
             result,
             Result.err({
                 type: 'config',
-                issues: ['at registrySettings: missing property', 'invalid value doesn’t match expected union']
+                issues: ['invalid value doesn’t match expected union']
             })
         );
+    });
+
+    test('buildAndPublishAll() fails fast with a single config issue when non-dry-run lacks auth', async function () {
+        const buildAndPublish = fake();
+        const tryBuildAndPublish = fake();
+        const resolveAndLink = fake();
+        const { packtory, scheduler } = createPacktoryUnderTest({
+            resolveAndLink,
+            buildAndPublish,
+            tryBuildAndPublish
+        });
+
+        const { result } = await packtory.buildAndPublishAll(createConfigWithoutRegistry(), { dryRun: false });
+
+        assert.deepStrictEqual(
+            result,
+            Result.err({
+                type: 'config',
+                issues: [
+                    'registrySettings.auth must be configured to publish; run with dryRun=true to skip the registry write.'
+                ]
+            })
+        );
+        assert.strictEqual(resolveAndLink.callCount, 0);
+        assert.strictEqual(tryBuildAndPublish.callCount, 0);
+        assert.strictEqual(buildAndPublish.callCount, 0);
+        assert.strictEqual(scheduler.runForEachScheduledPackage.callCount, 0);
+    });
+
+    test('buildAndPublishAll() allows dry-run when auth is omitted (anonymous read)', async function () {
+        const { packtory, tryBuildAndPublish, buildAndPublish } = createPacktoryUnderTest();
+
+        const { result } = await packtory.buildAndPublishAll(createConfigWithoutRegistry(), { dryRun: true });
+
+        assert.strictEqual(result.isOk, true);
+        assert.strictEqual(tryBuildAndPublish.callCount, 1);
+        assert.strictEqual(buildAndPublish.callCount, 0);
     });
 
     test('buildAndPublishAll() returns check failures without entering publish mode', async function () {

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -100,6 +100,19 @@ type Reporting<TReport> = {
     readonly getReport: () => TReport;
 };
 
+const missingPublishAuthIssue =
+    'registrySettings.auth must be configured to publish; run with dryRun=true to skip the registry write.';
+
+function ensureAuthConfiguredForRealPublish(
+    validated: ValidConfigResult,
+    options: BuildAndPublishAllOptions
+): Result<ValidConfigResult, PublishAllResult> {
+    if (options.dryRun || validated.packtoryConfig.registrySettings?.auth !== undefined) {
+        return Result.ok(validated);
+    }
+    return Result.err(Result.err(configError([missingPublishAuthIssue])));
+}
+
 export function createPacktory(dependencies: PacktoryDependencies): Packtory {
     const { progressBroadcaster } = dependencies;
     const {
@@ -168,7 +181,11 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
             },
             validate: validateConfig,
             async runValidated(validated) {
-                return runBuildAndPublish(validated, options);
+                const guarded = ensureAuthConfiguredForRealPublish(validated, options);
+                if (guarded.isErr) {
+                    return guarded.error;
+                }
+                return runBuildAndPublish(guarded.value, options);
             },
             createValidationErrorResult(issues) {
                 return Result.err(configError(issues));

--- a/source/report/config-redactor.test.ts
+++ b/source/report/config-redactor.test.ts
@@ -148,6 +148,15 @@ suite('config-redactor', function () {
         assert.strictEqual(redacted.name, 'pkg-missing');
     });
 
+    test('redactConfigForPackage() omits registrySettings when the config does not define them', function () {
+        const redacted = redactConfigForPackage(
+            { packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a/index.js' } } }] } as unknown as PacktoryConfig,
+            'pkg-a'
+        );
+
+        assert.strictEqual('registrySettings' in redacted, false);
+    });
+
     test('redactConfigForPackage() falls back to common settings when the package name does not match but common settings exist', function () {
         const redacted = redactConfigForPackage(
             baseConfig({

--- a/source/report/config-redactor.ts
+++ b/source/report/config-redactor.ts
@@ -5,7 +5,7 @@ import { redactRegistrySettings, type RedactedRegistrySettings } from '../config
 
 export type RedactedPackageConfig = {
     readonly name: string;
-    readonly registrySettings: RedactedRegistrySettings;
+    readonly registrySettings?: RedactedRegistrySettings;
     readonly publishSettings?: RedactedPublishSettings;
     readonly sourcesFolder?: string;
 };
@@ -33,7 +33,8 @@ export function redactConfigForPackage(config: PacktoryConfig, packageName: stri
     return pickBy(
         {
             name: packageName,
-            registrySettings: redactRegistrySettings(config.registrySettings),
+            registrySettings:
+                config.registrySettings === undefined ? undefined : redactRegistrySettings(config.registrySettings),
             publishSettings,
             sourcesFolder
         },


### PR DESCRIPTION
## Summary
- `registrySettings` and its `auth` field become optional in the config schema. Pack, dry-run publish, release-diff and release analysis fall back to anonymous metadata reads.
- `buildAndPublishAll` with `dryRun: false` fails fast with a single `ConfigError` before any package is processed when `auth` is missing, instead of letting every package attempt and fail individually.
- Documentation and type tests updated; the root readme now shows a lazy env-read pattern so users following the example don't trip the missing-token error in commands that never publish.
