### PR TITLE
Support npm `publish --stage` releases

### DIFF
--- a/benchmarks/build-artifacts.benchmark.ts
+++ b/benchmarks/build-artifacts.benchmark.ts
@@ -16,7 +16,7 @@ export async function runBuildArtifactsBenchmark(
         const workload = await generateWorkload({ rootDirectory, size, workloads });
         const config = workload.createConfig(registry.settings);
         const result = await measureAsyncTask(`build-artifacts:${size}`, async () => {
-            const { result: runResult } = await buildAndPublishAll(config, { dryRun: true });
+            const { result: runResult } = await buildAndPublishAll(config, { dryRun: true, stage: false });
 
             if (runResult.isErr) {
                 throw new Error(`buildAndPublishAll failed for "${size}" with error type "${runResult.error.type}"`);

--- a/integration-tests/packtory/publish-fixture-support.ts
+++ b/integration-tests/packtory/publish-fixture-support.ts
@@ -157,7 +157,7 @@ export async function publishFixturePackages(params: PublishFixturePackagesParam
     const config = await createPublishConfig(configParams);
     const registrySettings = createRegistrySettings(params.registryDetails, params.authMode);
 
-    const outcome = await buildAndPublishAll({ ...config, registrySettings }, { dryRun: false });
+    const outcome = await buildAndPublishAll({ ...config, registrySettings }, { dryRun: false, stage: false });
     return outcome.result;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,14 @@ Execute the following command from the root of your project, no worries it runs 
 npx packtory publish
 ```
 
+To send the next release to npm's staging area instead of publishing it live:
+
+```bash
+npx packtory publish --no-dry-run --stage
+```
+
+Staged publishing is npm-only. The package must already exist on npm, and automatic versioning in stage mode must be able to list pending staged versions before it picks the next version.
+
 For more details about the CLI application have a look at the [full documentation](./source/packages/command-line-interface/readme.md).
 
 ## Concept

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -10,21 +10,30 @@ import { emptyTarball, tarballWithOneFile } from '../test-libraries/tarball-fixt
 import { createBundleEmitter, type BundleEmitterDependencies, type BundleEmitter } from './emitter.ts';
 
 const registrySettings = { auth: { type: 'bearer-token', token: 'the-token' } } as const;
+const publishedOutcome = { type: 'published' } as const;
 const publishedAt = new Date('2026-05-20T00:00:00.000Z');
 const latestReleaseMetadata = {
     version: '1.2.3',
     tarballUrl: 'https://registry.example.test/package.tgz',
     publishedAt
 } as const;
+type CurrentVersionRequest = Parameters<BundleEmitter['determineCurrentVersion']>[0];
+type PublishRequest = Parameters<BundleEmitter['publish']>[0];
 
 function namedBundle(): ReturnType<typeof versionedBundleWithManifest> {
     return versionedBundleWithManifest({ name: 'the-name' });
+}
+
+function bundleWithRepository(repository: string | undefined): ReturnType<typeof versionedBundleWithManifest> {
+    const packageJson = repository === undefined ? { name: 'the-name' } : { name: 'the-name', repository };
+    return versionedBundleWithManifest({ packageJson });
 }
 
 type Overrides = {
     readonly buildTarball?: SinonSpy;
     readonly publishPackage?: SinonSpy;
     readonly fetchLatestVersion?: SinonSpy;
+    readonly fetchStagedVersions?: SinonSpy;
     readonly fetchLatestReleaseMetadata?: SinonSpy;
     readonly collectContents?: SinonSpy;
     readonly fetchTarball?: SinonSpy;
@@ -51,6 +60,7 @@ function emitterFactory(overrides: Overrides = {}): BundleEmitter {
             publishPackage: createSpy(overrides.publishPackage, fake),
             fetchLatestReleaseMetadata: createSpy(overrides.fetchLatestReleaseMetadata, fake),
             fetchLatestVersion: createSpy(overrides.fetchLatestVersion, fake),
+            fetchStagedVersions: createSpy(overrides.fetchStagedVersions, fake),
             fetchTarball: createSpy(overrides.fetchTarball, () => {
                 return fake.resolves(emptyTarball);
             })
@@ -59,6 +69,96 @@ function emitterFactory(overrides: Overrides = {}): BundleEmitter {
     };
 
     return createBundleEmitter(dependencies);
+}
+
+function currentVersionRequest(params: {
+    readonly stage: boolean;
+    readonly versioning: CurrentVersionRequest['versioning'];
+    readonly registrySettings?: CurrentVersionRequest['registrySettings'];
+}): CurrentVersionRequest {
+    return {
+        name: 'the-name',
+        registrySettings: params.registrySettings ?? registrySettings,
+        stage: params.stage,
+        versioning: params.versioning
+    };
+}
+
+async function determineCurrentVersion(
+    emitter: BundleEmitter,
+    params: {
+        readonly stage: boolean;
+        readonly versioning: CurrentVersionRequest['versioning'];
+        readonly registrySettings?: CurrentVersionRequest['registrySettings'];
+    }
+): Promise<Maybe<string>> {
+    return emitter.determineCurrentVersion(currentVersionRequest(params));
+}
+
+async function expectCurrentVersionFailure(
+    emitter: BundleEmitter,
+    params: {
+        readonly stage: boolean;
+        readonly versioning: CurrentVersionRequest['versioning'];
+        readonly registrySettings?: CurrentVersionRequest['registrySettings'];
+    },
+    matcher: RegExp
+): Promise<void> {
+    await assert.rejects(async () => {
+        await determineCurrentVersion(emitter, params);
+    }, matcher);
+}
+
+function publishRequest(params: {
+    readonly bundle?: PublishRequest['bundle'];
+    readonly publishSettings: PublishRequest['publishSettings'];
+    readonly stage?: boolean;
+    readonly extraFiles?: PublishRequest['extraFiles'];
+}): PublishRequest {
+    return {
+        registrySettings,
+        bundle: params.bundle ?? namedBundle(),
+        publishSettings: params.publishSettings,
+        stage: params.stage ?? false,
+        ...(params.extraFiles === undefined ? {} : { extraFiles: params.extraFiles })
+    };
+}
+
+async function publishBundle(
+    emitter: BundleEmitter,
+    params: {
+        readonly bundle?: PublishRequest['bundle'];
+        readonly publishSettings: PublishRequest['publishSettings'];
+        readonly stage?: boolean;
+        readonly extraFiles?: PublishRequest['extraFiles'];
+    }
+): Promise<void> {
+    await emitter.publish(publishRequest(params));
+}
+
+function createPublishScenario(ciRepositoryUrl: string | undefined): {
+    readonly buildTarball: SinonSpy;
+    readonly publishPackage: SinonSpy;
+    readonly emitter: BundleEmitter;
+} {
+    const buildTarball = fake.resolves({ tarData: emptyTarball });
+    const publishPackage = fake.resolves(publishedOutcome);
+    return {
+        buildTarball,
+        publishPackage,
+        emitter: emitterFactory({ buildTarball, publishPackage, ciRepositoryUrl })
+    };
+}
+
+function buildSbomWithDependency(params: {
+    readonly packtoryVersion: string;
+    readonly dependencyName: string;
+    readonly dependencyVersion: string;
+}): string {
+    return buildSbomFixtureContent({
+        packtoryVersion: params.packtoryVersion,
+        dependencyComponents: [{ name: params.dependencyName, version: params.dependencyVersion }]
+    });
 }
 
 function createPublishedBundleScenario(): {
@@ -115,11 +215,7 @@ suite('emitter', function () {
         const fetchLatestVersion = fake.resolves(Maybe.nothing());
         const emitter = emitterFactory({ fetchLatestVersion });
 
-        await emitter.determineCurrentVersion({
-            name: 'the-name',
-            registrySettings,
-            versioning: { automatic: true }
-        });
+        await determineCurrentVersion(emitter, { stage: false, versioning: { automatic: true } });
 
         assert.strictEqual(fetchLatestVersion.callCount, 1);
         assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
@@ -129,9 +225,8 @@ suite('emitter', function () {
         const fetchLatestVersion = fake.resolves(Maybe.just({ version: 'the-version' }));
         const emitter = emitterFactory({ fetchLatestVersion });
 
-        const result = await emitter.determineCurrentVersion({
-            name: 'the-name',
-            registrySettings,
+        const result = await determineCurrentVersion(emitter, {
+            stage: false,
             versioning: { automatic: true }
         });
 
@@ -142,9 +237,8 @@ suite('emitter', function () {
         const fetchLatestVersion = fake.resolves(Maybe.nothing());
         const emitter = emitterFactory({ fetchLatestVersion });
 
-        await emitter.determineCurrentVersion({
-            name: 'the-name',
-            registrySettings,
+        await determineCurrentVersion(emitter, {
+            stage: false,
             versioning: { automatic: false, version: '' }
         });
 
@@ -154,13 +248,99 @@ suite('emitter', function () {
     test('determineCurrentVersion() returns the given version when manual versioning is enabled', async function () {
         const emitter = emitterFactory({});
 
-        const result = await emitter.determineCurrentVersion({
-            name: 'the-name',
-            registrySettings,
+        const result = await determineCurrentVersion(emitter, {
+            stage: false,
             versioning: { automatic: false, version: 'manual-version' }
         });
 
         assert.deepStrictEqual(result, Maybe.just('manual-version'));
+    });
+
+    test('determineCurrentVersion() selects the highest staged version in stage mode', async function () {
+        for (const stagedVersions of [
+            ['1.2.4', '1.2.5'],
+            ['1.2.5', '1.2.4']
+        ] as const) {
+            const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3' }));
+            const fetchStagedVersions = fake.resolves(stagedVersions);
+            const emitter = emitterFactory({ fetchLatestVersion, fetchStagedVersions });
+
+            const result = await determineCurrentVersion(emitter, {
+                stage: true,
+                versioning: { automatic: true }
+            });
+
+            assert.deepStrictEqual(result, Maybe.just('1.2.5'));
+            assert.deepStrictEqual(fetchStagedVersions.firstCall.args, ['the-name', registrySettings]);
+        }
+    });
+
+    test('determineCurrentVersion() returns the configured manual version in stage mode after validating package existence', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3' }));
+        const fetchStagedVersions = fake.resolves(['1.2.4']);
+        const emitter = emitterFactory({ fetchLatestVersion, fetchStagedVersions });
+
+        const result = await determineCurrentVersion(emitter, {
+            stage: true,
+            versioning: { automatic: false, version: '9.9.9' }
+        });
+
+        assert.deepStrictEqual(result, Maybe.just('9.9.9'));
+        assert.strictEqual(fetchStagedVersions.callCount, 0);
+    });
+
+    test('determineCurrentVersion() rejects an invalid staged version returned by the registry', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3' }));
+        const fetchStagedVersions = fake.resolves(['not-semver']);
+        const emitter = emitterFactory({ fetchLatestVersion, fetchStagedVersions });
+
+        await expectCurrentVersionFailure(
+            emitter,
+            { stage: true, versioning: { automatic: true } },
+            /invalid version "not-semver"/u
+        );
+    });
+
+    test('determineCurrentVersion() rejects an invalid latest version returned by the registry in stage mode', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: undefined } as never));
+        const fetchStagedVersions = fake.resolves([]);
+        const emitter = emitterFactory({ fetchLatestVersion, fetchStagedVersions });
+
+        await expectCurrentVersionFailure(
+            emitter,
+            { stage: true, versioning: { automatic: true } },
+            /invalid version "undefined"/u
+        );
+    });
+
+    test('determineCurrentVersion() rejects staged publishing for a first publish', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.nothing());
+        const emitter = emitterFactory({ fetchLatestVersion });
+
+        await expectCurrentVersionFailure(
+            emitter,
+            { stage: true, versioning: { automatic: false, version: '1.0.0' } },
+            /already exist on the npm registry/u
+        );
+    });
+
+    test('determineCurrentVersion() rejects staged publishing for non-npm registries', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3' }));
+        const emitter = emitterFactory({ fetchLatestVersion });
+
+        await expectCurrentVersionFailure(
+            emitter,
+            {
+                registrySettings: {
+                    registryUrl: 'https://registry.example.test',
+                    auth: { type: 'bearer-token', token: 'the-token' }
+                },
+                stage: true,
+                versioning: { automatic: true }
+            },
+            /only supported with the npmjs.org registry/u
+        );
+        assert.strictEqual(fetchLatestVersion.callCount, 0);
     });
 
     test('checkBundleAlreadyPublished() fetches the latest release metadata', async function () {
@@ -252,35 +432,34 @@ suite('emitter', function () {
     });
 
     test('checkBundleAlreadyPublished() still detects SBOM changes beyond the packtory tool version', async function () {
-        const previousSbom = buildSbomFixtureContent({
+        const previousSbom = buildSbomWithDependency({
             packtoryVersion: '1.2.3',
-            dependencyComponents: [{ name: 'old-dependency', version: '1.0.0' }]
+            dependencyName: 'old-dependency',
+            dependencyVersion: '1.0.0'
         });
-        const currentSbom = buildSbomFixtureContent({
+        const currentSbom = buildSbomWithDependency({
             packtoryVersion: '9.9.9',
-            dependencyComponents: [{ name: 'new-dependency', version: '2.0.0' }]
+            dependencyName: 'new-dependency',
+            dependencyVersion: '2.0.0'
         });
         assert.strictEqual(await runSbomComparison(previousSbom, currentSbom), false);
     });
 
     test('publish() publishes the given bundle', async function () {
         const buildTarball = fake.resolves({ tarData: emptyTarball });
-        const publishPackage = fake.resolves(undefined);
+        const publishPackage = fake.resolves(publishedOutcome);
         const emitter = emitterFactory({ buildTarball, publishPackage });
         const publishSettings = { access: 'public' } as const;
 
-        await emitter.publish({
-            registrySettings,
-            bundle: namedBundle(),
-            publishSettings
-        });
+        await publishBundle(emitter, { publishSettings });
 
         assert.strictEqual(publishPackage.callCount, 1);
         assert.deepStrictEqual(publishPackage.firstCall.args, [
             { name: '', version: '' },
             emptyTarball,
             registrySettings,
-            publishSettings
+            publishSettings,
+            false
         ]);
     });
 
@@ -290,8 +469,7 @@ suite('emitter', function () {
         const bundle = namedBundle();
         const extraFile = { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false };
 
-        await emitter.publish({
-            registrySettings,
+        await publishBundle(emitter, {
             bundle,
             publishSettings: { access: 'public' },
             extraFiles: [extraFile]
@@ -300,90 +478,57 @@ suite('emitter', function () {
         assert.deepStrictEqual(buildTarball.firstCall.args, [bundle, [extraFile]]);
     });
 
-    function bundleWithRepository(repository: string | undefined): ReturnType<typeof versionedBundleWithManifest> {
-        const packageJson = repository === undefined ? { name: 'the-name' } : { name: 'the-name', repository };
-        return versionedBundleWithManifest({ packageJson });
-    }
-
     test('publish() rejects under provenance auto mode when the manifest repository differs from the CI repository', async function () {
-        const buildTarball = fake.resolves({ tarData: emptyTarball });
-        const publishPackage = fake.resolves(undefined);
-        const emitter = emitterFactory({
-            buildTarball,
-            publishPackage,
-            ciRepositoryUrl: 'https://github.com/upstream/package'
-        });
+        const scenario = createPublishScenario('https://github.com/upstream/package');
 
         try {
-            await emitter.publish({
-                registrySettings,
+            await publishBundle(scenario.emitter, {
                 bundle: bundleWithRepository('https://github.com/foo/forked-package'),
                 publishSettings: { access: 'public', provenance: { type: 'auto' } }
             });
         } catch (error) {
             assert.ok(error instanceof Error);
             assert.match(error.message, /repository URL does not match/u);
-            assert.strictEqual(buildTarball.callCount, 0);
-            assert.strictEqual(publishPackage.callCount, 0);
+            assert.strictEqual(scenario.buildTarball.callCount, 0);
+            assert.strictEqual(scenario.publishPackage.callCount, 0);
             return;
         }
         assert.fail('Expected publish() to throw');
     });
 
     test('publish() does not run the coherence check under provenance file mode', async function () {
-        const buildTarball = fake.resolves({ tarData: emptyTarball });
-        const publishPackage = fake.resolves(undefined);
-        const emitter = emitterFactory({
-            buildTarball,
-            publishPackage,
-            ciRepositoryUrl: 'https://github.com/upstream/package'
-        });
+        const scenario = createPublishScenario('https://github.com/upstream/package');
 
-        await emitter.publish({
-            registrySettings,
+        await publishBundle(scenario.emitter, {
             bundle: bundleWithRepository('https://github.com/foo/forked-package'),
             publishSettings: { access: 'public', provenance: { type: 'file', path: '/build/bundle.sigstore' } }
         });
 
-        assert.strictEqual(buildTarball.callCount, 1);
-        assert.strictEqual(publishPackage.callCount, 1);
+        assert.strictEqual(scenario.buildTarball.callCount, 1);
+        assert.strictEqual(scenario.publishPackage.callCount, 1);
     });
 
     test('publish() does not run the coherence check when provenance is unset', async function () {
-        const buildTarball = fake.resolves({ tarData: emptyTarball });
-        const publishPackage = fake.resolves(undefined);
-        const emitter = emitterFactory({
-            buildTarball,
-            publishPackage,
-            ciRepositoryUrl: undefined
-        });
+        const scenario = createPublishScenario(undefined);
 
-        await emitter.publish({
-            registrySettings,
+        await publishBundle(scenario.emitter, {
             bundle: bundleWithRepository(undefined),
             publishSettings: { access: 'public' }
         });
 
-        assert.strictEqual(buildTarball.callCount, 1);
-        assert.strictEqual(publishPackage.callCount, 1);
+        assert.strictEqual(scenario.buildTarball.callCount, 1);
+        assert.strictEqual(scenario.publishPackage.callCount, 1);
     });
 
     test('publish() does not run the coherence check when access is restricted even if provenance is set to auto', async function () {
-        const buildTarball = fake.resolves({ tarData: emptyTarball });
-        const publishPackage = fake.resolves(undefined);
-        const emitter = emitterFactory({
-            buildTarball,
-            publishPackage,
-            ciRepositoryUrl: 'https://github.com/upstream/package'
-        });
+        const scenario = createPublishScenario('https://github.com/upstream/package');
 
-        await emitter.publish({
-            registrySettings,
+        await publishBundle(scenario.emitter, {
             bundle: bundleWithRepository('https://github.com/foo/forked-package'),
             publishSettings: { access: 'restricted', provenance: { type: 'auto' } } as unknown as PublishSettings
         });
 
-        assert.strictEqual(buildTarball.callCount, 1);
-        assert.strictEqual(publishPackage.callCount, 1);
+        assert.strictEqual(scenario.buildTarball.callCount, 1);
+        assert.strictEqual(scenario.publishPackage.callCount, 1);
     });
 });

--- a/source/bundle-emitter/emitter.ts
+++ b/source/bundle-emitter/emitter.ts
@@ -1,16 +1,37 @@
-/* eslint-disable import/max-dependencies -- the publish/check flow legitimately depends on registry, artifacts, file-manager, and provenance helpers */
+import semver from 'semver';
 import { Maybe } from 'true-myth';
 import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
-import type { PublishSettings } from '../config/publish-settings.ts';
-import type { RegistrySettings } from '../config/registry-settings.ts';
-import type { VersioningSettings } from '../config/versioning-settings.ts';
 import { compareFileDescriptions, fileDescriptionComparisonStatus } from '../file-manager/compare.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import type { ArtifactPublishPackage } from '../published-package/published-package.ts';
 import { canonicalizeSbomInFileSet } from '../sbom/sbom-canonicalizer.ts';
-import { fetchPublishedArtifacts, type PublishedReleaseArtifacts } from './fetch-published-artifacts.ts';
+import { fetchPublishedArtifacts } from './fetch-published-artifacts.ts';
 import type { RegistryClient } from './registry/registry-client.ts';
 import { assertRepositoryCoherence } from './repository-coherence.ts';
+
+type Second<TValues extends readonly unknown[]> = TValues extends readonly [
+    unknown,
+    infer TValue,
+    ...(readonly unknown[])
+]
+    ? TValue
+    : never;
+type Fourth<TValues extends readonly unknown[]> = TValues extends readonly [
+    unknown,
+    unknown,
+    unknown,
+    infer TValue,
+    ...(readonly unknown[])
+]
+    ? TValue
+    : never;
+type RegistryClientPublishArguments = Parameters<RegistryClient['publishPackage']>;
+type ExtraFiles = readonly FileDescription[];
+type PublicationOutcome = Awaited<ReturnType<RegistryClient['publishPackage']>>;
+type PublishSettings = Fourth<RegistryClientPublishArguments>;
+type RegistrySettings = Second<Parameters<RegistryClient['fetchLatestVersion']>>;
+type VersioningSettings = { readonly automatic: false; readonly version: string } | { readonly automatic: true };
+type PreviousReleaseArtifacts = Awaited<ReturnType<typeof fetchPublishedArtifacts>>;
 
 export type BundleEmitterDependencies = {
     readonly artifactsBuilder: ArtifactsBuilder;
@@ -22,38 +43,96 @@ type PublishOptions = {
     readonly bundle: ArtifactPublishPackage;
     readonly registrySettings: RegistrySettings;
     readonly publishSettings: PublishSettings;
-    readonly extraFiles?: readonly FileDescription[];
+    readonly stage: boolean;
+    readonly extraFiles?: ExtraFiles;
 };
 
 type AlreadyPublishedCheckOptions = {
     readonly bundle: ArtifactPublishPackage;
     readonly registrySettings: RegistrySettings;
-    readonly extraFiles?: readonly FileDescription[];
+    readonly extraFiles?: ExtraFiles;
 };
 
 type CurrentVersionLookupOptions = {
     readonly name: string;
     readonly registrySettings: RegistrySettings;
+    readonly stage: boolean;
     readonly versioning: VersioningSettings;
 };
 
 type BundlePublishedCheckResult = {
     readonly alreadyPublishedAsLatest: boolean;
-    readonly previousReleaseArtifacts: Maybe<PublishedReleaseArtifacts>;
+    readonly previousReleaseArtifacts: PreviousReleaseArtifacts;
 };
 
 export type BundleEmitter = {
-    publish: (options: PublishOptions) => Promise<void>;
+    publish: (options: PublishOptions) => Promise<PublicationOutcome>;
     determineCurrentVersion: (options: CurrentVersionLookupOptions) => Promise<Maybe<string>>;
     checkBundleAlreadyPublished: (options: AlreadyPublishedCheckOptions) => Promise<BundlePublishedCheckResult>;
 };
 
+const stageRegistryUnsupportedMessage = 'npm staged publishing is only supported with the npmjs.org registry';
+const stageFirstPublishUnsupportedMessage =
+    'npm staged publishing requires the package to already exist on the npm registry';
+const npmRegistryUrl = 'https://registry.npmjs.org/';
+
+function isNpmRegistry(registryUrl: string | undefined): boolean {
+    return new URL(registryUrl ?? npmRegistryUrl).href === npmRegistryUrl;
+}
+
+function validateVersion(version: string): string {
+    const normalized = semver.valid(version);
+    if (normalized === null) {
+        throw new Error(`Registry returned an invalid version "${version}" for staged publishing`);
+    }
+    return normalized;
+}
+
+function highestVersion(firstVersion: string, laterVersions: readonly string[]): string {
+    let highest = validateVersion(firstVersion);
+
+    for (const version of laterVersions) {
+        const candidate = validateVersion(version);
+        if (semver.gt(candidate, highest)) {
+            highest = candidate;
+        }
+    }
+
+    return highest;
+}
+
 export function createBundleEmitter(dependencies: BundleEmitterDependencies): BundleEmitter {
     const { artifactsBuilder, registryClient, ciRepositoryUrl } = dependencies;
 
+    async function determineCurrentVersionForStageMode(
+        name: string,
+        registrySettings: RegistrySettings,
+        versioning: VersioningSettings
+    ): Promise<Maybe<string>> {
+        if (!isNpmRegistry(registrySettings.registryUrl)) {
+            throw new Error(stageRegistryUnsupportedMessage);
+        }
+
+        const latestVersion = await registryClient.fetchLatestVersion(name, registrySettings);
+        if (latestVersion.isNothing) {
+            throw new Error(stageFirstPublishUnsupportedMessage);
+        }
+
+        if (!versioning.automatic) {
+            return Maybe.just(versioning.version);
+        }
+
+        const stagedVersions = await registryClient.fetchStagedVersions(name, registrySettings);
+        return Maybe.just(highestVersion(latestVersion.value.version, stagedVersions));
+    }
+
     return {
         async determineCurrentVersion(options) {
-            const { versioning, registrySettings, name } = options;
+            const { versioning, registrySettings, name, stage } = options;
+
+            if (stage) {
+                return determineCurrentVersionForStageMode(name, registrySettings, versioning);
+            }
 
             if (versioning.automatic) {
                 const latestVersion = await registryClient.fetchLatestVersion(name, registrySettings);
@@ -90,11 +169,12 @@ export function createBundleEmitter(dependencies: BundleEmitterDependencies): Bu
 
             const tarball = await artifactsBuilder.buildTarball(options.bundle, options.extraFiles);
 
-            await registryClient.publishPackage(
+            return registryClient.publishPackage(
                 options.bundle.packageJson,
                 tarball.tarData,
                 options.registrySettings,
-                options.publishSettings
+                options.publishSettings,
+                options.stage
             );
         }
     };

--- a/source/bundle-emitter/fetch-published-artifacts.test.ts
+++ b/source/bundle-emitter/fetch-published-artifacts.test.ts
@@ -15,6 +15,7 @@ function registryClientWith(overrides: {
     return {
         fetchLatestReleaseMetadata: overrides.fetchLatestReleaseMetadata ?? fake(),
         fetchLatestVersion: fake(),
+        fetchStagedVersions: fake(),
         fetchTarball: overrides.fetchTarball ?? fake(),
         publishPackage: fake()
     };

--- a/source/bundle-emitter/publication-outcome.test.ts
+++ b/source/bundle-emitter/publication-outcome.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { noPublication, publishedToRegistry, stagedForApproval } from './publication-outcome.ts';
+
+suite('publication-outcome', function () {
+    test('exposes the none outcome constant', function () {
+        assert.deepStrictEqual(noPublication, { type: 'none' });
+    });
+
+    test('exposes the published outcome constant', function () {
+        assert.deepStrictEqual(publishedToRegistry, { type: 'published' });
+    });
+
+    test('creates staged outcomes with the stage id', function () {
+        assert.deepStrictEqual(stagedForApproval('stage-123'), {
+            type: 'staged',
+            stageId: 'stage-123'
+        });
+    });
+});

--- a/source/bundle-emitter/publication-outcome.ts
+++ b/source/bundle-emitter/publication-outcome.ts
@@ -1,0 +1,11 @@
+export type PublicationOutcome =
+    | { readonly type: 'none' }
+    | { readonly type: 'published' }
+    | { readonly type: 'staged'; readonly stageId: string };
+
+export const noPublication: PublicationOutcome = { type: 'none' };
+export const publishedToRegistry: PublicationOutcome = { type: 'published' };
+
+export function stagedForApproval(stageId: string): PublicationOutcome {
+    return { type: 'staged', stageId };
+}

--- a/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
@@ -6,7 +6,8 @@ import type { RegistrySettings } from '../../config/registry-settings.ts';
 import {
     fetchLatestPackageReleaseMetadata,
     fetchLatestPackageVersion,
-    fetchPackageTarball
+    fetchPackageTarball,
+    fetchStagedPackageVersions
 } from './package-metadata-fetcher.ts';
 
 type FakeNpmFetch = SinonSpy & { json: SinonSpy };
@@ -28,6 +29,22 @@ function latestPackageResponse(time?: string): Record<string, unknown> {
         ...(time === undefined ? {} : { time: { [latestVersion]: time } }),
         versions: { [latestVersion]: { dist: { tarball: tarballUrl } } }
     };
+}
+
+function fakeJsonSequence(...responses: readonly (Error | Record<string, unknown>)[]): SinonSpy {
+    let callIndex = 0;
+
+    return fake(async () => {
+        const response = responses[callIndex];
+        callIndex += 1;
+        if (response === undefined) {
+            throw new Error('Unexpected extra stage lookup');
+        }
+        if (response instanceof Error) {
+            throw response;
+        }
+        return response;
+    });
 }
 
 async function expectError(npmFetch: typeof _npmFetch, expectedMessage: string): Promise<void> {
@@ -164,6 +181,41 @@ suite('package-metadata-fetcher', function () {
         } catch (error: unknown) {
             assert.strictEqual((error as Error).message, 'Version publish time "not-a-date" is not a valid timestamp');
         }
+    });
+
+    test('fetchStagedPackageVersions returns staged versions across pages and stops when it reaches the total', async function () {
+        const json = fakeJsonSequence(
+            { items: [{ version: '1.2.4' }], total: 2 },
+            { items: [{ version: '1.2.5' }], total: 2 },
+            new Error('Unexpected extra stage lookup')
+        );
+
+        const result = await fetchStagedPackageVersions(fakeNpmFetch(json), 'pkg-a', settings);
+
+        assert.deepStrictEqual(result, ['1.2.4', '1.2.5']);
+        assert.strictEqual(json.callCount, 2);
+    });
+
+    test('fetchStagedPackageVersions stops when a later page is empty even if the total is larger', async function () {
+        const json = fakeJsonSequence(
+            { items: [{ version: '1.2.4' }], total: 3 },
+            { items: [], total: 3 },
+            new Error('Unexpected extra stage lookup')
+        );
+
+        const result = await fetchStagedPackageVersions(fakeNpmFetch(json), 'pkg-a', settings);
+
+        assert.deepStrictEqual(result, ['1.2.4']);
+        assert.strictEqual(json.callCount, 2);
+    });
+
+    test('fetchStagedPackageVersions returns an empty list when the first page is empty', async function () {
+        const json = fakeJsonSequence({ items: [], total: 0 }, new Error('Unexpected extra stage lookup'));
+
+        const result = await fetchStagedPackageVersions(fakeNpmFetch(json), 'pkg-a', settings);
+
+        assert.deepStrictEqual(result, []);
+        assert.strictEqual(json.callCount, 1);
     });
 
     test('fetchPackageTarball returns the buffered tarball contents', async function () {

--- a/source/bundle-emitter/registry/package-metadata-fetcher.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.ts
@@ -3,7 +3,7 @@ import { Maybe } from 'true-myth';
 import type { RegistrySettings } from '../../config/registry-settings.ts';
 import { retryWithFallbackAuth } from './metadata-auth-retry.ts';
 import { toRegistryPackagePath } from './registry-package-path.ts';
-import { resolveMetadataAuthOptions } from './registry-auth-config.ts';
+import { resolveMetadataAuthOptions, resolveStageListingAuthOptions } from './registry-auth-config.ts';
 import {
     parseAbbreviatedPackageResponse,
     parseFullPackageResponse,
@@ -45,6 +45,35 @@ function parseTimestamp(timestamp: string): Date {
     return parsed;
 }
 
+function isNonNegativeInteger(value: unknown): value is number {
+    if (!Number.isSafeInteger(value)) {
+        return false;
+    }
+
+    return Number(value) >= 0;
+}
+
+function parseStagedPackageListResponse(response: unknown): StagedPackageListResponse {
+    if (!isRecord(response)) {
+        throw new Error('Got an invalid response from registry stage API');
+    }
+
+    const { items, total } = response;
+    if (!Array.isArray(items) || !isNonNegativeInteger(total)) {
+        throw new Error('Got an invalid response from registry stage API');
+    }
+
+    return {
+        items: items.map((item) => {
+            if (!isRecord(item) || typeof item.version !== 'string') {
+                throw new Error('Got an invalid response from registry stage API');
+            }
+            return { version: item.version };
+        }),
+        total
+    };
+}
+
 type PackageMetadataRequest<TPackageResponse extends Record<string, unknown>> = {
     readonly headers: Readonly<Record<string, string>> | undefined;
     readonly parsePackageResponse: (response: unknown) => TPackageResponse | undefined;
@@ -59,6 +88,17 @@ const fullPackageMetadataRequest: PackageMetadataRequest<FullPackageResponse> = 
     parsePackageResponse: parseFullPackageResponse,
     headers: undefined
 };
+
+type StagedPackageListItem = {
+    readonly version: string;
+};
+
+type StagedPackageListResponse = {
+    readonly items: readonly StagedPackageListItem[];
+    readonly total: number;
+};
+
+const stageListPageSize = 100;
 
 async function fetchAndParsePackageMetadata<TPackageResponse extends Record<string, unknown>>(
     npmFetch: typeof _npmFetch,
@@ -151,6 +191,38 @@ export async function fetchLatestPackageReleaseMetadata(
         tarballUrl: latestVersion.value.tarballUrl,
         publishedAt: publishedAtTimestamp === undefined ? undefined : parseTimestamp(publishedAtTimestamp)
     });
+}
+
+export async function fetchStagedPackageVersions(
+    npmFetch: typeof _npmFetch,
+    packageName: string,
+    registrySettings: RegistrySettings
+): Promise<readonly string[]> {
+    const auth = resolveStageListingAuthOptions(registrySettings);
+
+    async function fetchPage(page: number, versions: readonly string[]): Promise<readonly string[]> {
+        const searchParams = new URLSearchParams({
+            package: packageName,
+            page: String(page),
+            perPage: String(stageListPageSize)
+        });
+        const response = parseStagedPackageListResponse(
+            await npmFetch.json(`/-/stage?${searchParams.toString()}`, auth.options)
+        );
+        const nextVersions = versions.concat(
+            response.items.map((item) => {
+                return item.version;
+            })
+        );
+
+        if (nextVersions.length >= response.total || response.items.length === 0) {
+            return nextVersions;
+        }
+
+        return fetchPage(page + 1, nextVersions);
+    }
+
+    return fetchPage(0, []);
 }
 
 export async function fetchPackageTarball(

--- a/source/bundle-emitter/registry/registry-auth-config.test.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.test.ts
@@ -7,7 +7,8 @@ import {
     isNpmRegistry,
     resolveMetadataAuthOptions,
     resolvePublishAuth,
-    resolveRegistryUrl
+    resolveRegistryUrl,
+    resolveStageListingAuthOptions
 } from './registry-auth-config.ts';
 
 const tokenAuth = { type: 'bearer-token', token: 'abc' } as const;
@@ -23,6 +24,22 @@ function settings(overrides: Partial<RegistrySettings> = {}): RegistrySettings {
 }
 
 const basicEncoded = Buffer.from('user:pass').toString('base64');
+const stagedVersionLookupRequiresTokenAuthMessage =
+    'npm staged publishing with automatic versioning requires token-based metadata auth ' +
+    'when publish auth uses npm-oidc';
+
+function expectedBasicAuthOptionsResult() {
+    return {
+        allowsAutomaticRetry: false,
+        registry: undefined,
+        options: {
+            alwaysAuth: true,
+            registry: undefined,
+            forceAuth: { _auth: basicEncoded },
+            email: 'user@example.com'
+        }
+    };
+}
 
 suite('registry-auth-config', function () {
     test('resolveRegistryUrl returns the configured registry URL', function () {
@@ -132,16 +149,10 @@ suite('registry-auth-config', function () {
     });
 
     test('resolveMetadataAuthOptions uses a custom metadata auth strategy when one is provided', function () {
-        assert.deepStrictEqual(resolveMetadataAuthOptions({ auth: { publish: tokenAuth, metadata: basicAuth } }), {
-            allowsAutomaticRetry: false,
-            registry: undefined,
-            options: {
-                alwaysAuth: true,
-                registry: undefined,
-                forceAuth: { _auth: basicEncoded },
-                email: 'user@example.com'
-            }
-        });
+        assert.deepStrictEqual(
+            resolveMetadataAuthOptions({ auth: { publish: tokenAuth, metadata: basicAuth } }),
+            expectedBasicAuthOptionsResult()
+        );
     });
 
     test('resolveMetadataAuthOptions keeps npm-oidc metadata inheritance anonymous when explicitly requested', function () {
@@ -152,6 +163,54 @@ suite('registry-auth-config', function () {
                 registry: undefined,
                 options: { alwaysAuth: true, registry: undefined }
             }
+        );
+    });
+
+    test('resolveStageListingAuthOptions throws for shorthand npm-oidc auth', function () {
+        assert.throws(() => {
+            resolveStageListingAuthOptions({ auth: { type: 'npm-oidc' } });
+        }, /requires token-based metadata auth/u);
+    });
+
+    test('resolveStageListingAuthOptions uses shorthand publish auth when it is token-based', function () {
+        assert.deepStrictEqual(resolveStageListingAuthOptions({ auth: tokenAuth }), {
+            allowsAutomaticRetry: false,
+            registry: undefined,
+            options: { alwaysAuth: true, registry: undefined, forceAuth: { token: 'abc' } }
+        });
+    });
+
+    test('resolveStageListingAuthOptions throws the documented message for expanded npm-oidc publish auth', function () {
+        assert.throws(
+            () => {
+                resolveStageListingAuthOptions({
+                    auth: {
+                        publish: { type: 'npm-oidc', provider: 'env' },
+                        metadata: 'anonymous'
+                    }
+                });
+            },
+            new RegExp(`^Error: ${stagedVersionLookupRequiresTokenAuthMessage}$`, 'u')
+        );
+    });
+
+    test('resolveStageListingAuthOptions uses explicit metadata auth when it is configured', function () {
+        assert.deepStrictEqual(
+            resolveStageListingAuthOptions({ auth: { publish: tokenAuth, metadata: basicAuth } }),
+            expectedBasicAuthOptionsResult()
+        );
+    });
+
+    test('resolveStageListingAuthOptions still prefers explicit metadata auth when auth includes unrelated keys', function () {
+        assert.deepStrictEqual(
+            resolveStageListingAuthOptions({
+                auth: {
+                    '': { type: 'npm-oidc', provider: 'env' },
+                    metadata: basicAuth,
+                    publish: tokenAuth
+                }
+            } as unknown as RegistrySettings),
+            expectedBasicAuthOptionsResult()
         );
     });
 });

--- a/source/bundle-emitter/registry/registry-auth-config.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.ts
@@ -107,3 +107,21 @@ export function resolveMetadataAuthOptions(registrySettings: Readonly<RegistrySe
 
     return resolveInheritedMetadataAuth(registrySettings.auth.publish, registrySettings);
 }
+
+const stagedVersionLookupRequiresTokenAuthMessage =
+    'npm staged publishing with automatic versioning requires token-based metadata auth ' +
+    'when publish auth uses npm-oidc';
+
+export function resolveStageListingAuthOptions(registrySettings: Readonly<RegistrySettings>): AuthResolution {
+    const publishAuth = resolvePublishAuth(registrySettings);
+
+    if (!('type' in registrySettings.auth) && typeof registrySettings.auth.metadata === 'object') {
+        return buildAuthOptions(registrySettings.auth.metadata, registrySettings);
+    }
+
+    if (publishAuth.type === 'npm-oidc') {
+        throw new Error(stagedVersionLookupRequiresTokenAuthMessage);
+    }
+
+    return buildAuthOptions(publishAuth, registrySettings);
+}

--- a/source/bundle-emitter/registry/registry-client.test.ts
+++ b/source/bundle-emitter/registry/registry-client.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
+import { stagedForApproval } from '../publication-outcome.ts';
 import type { PublishAuthStrategy } from '../../config/registry-settings.ts';
 import { createFakeClock, type FakeClock } from '../../test-libraries/fake-clock.ts';
 import { createRegistryClient, type RegistryClientDependencies, type RegistryClient } from './registry-client.ts';
@@ -80,6 +81,17 @@ function buildLatestVersionFetchJson(): SinonSpy {
     });
 }
 
+function buildStagedVersionsFetchJson(
+    pages: readonly { readonly items: readonly { readonly version: string }[]; readonly total: number }[]
+): SinonSpy {
+    let callIndex = 0;
+    return fake(async () => {
+        const page = pages[callIndex] ?? pages.at(-1) ?? { items: [], total: 0 };
+        callIndex += 1;
+        return page;
+    });
+}
+
 suite('registry-client', function () {
     test('publishPackage() uses shorthand bearer auth and one-time-password prompt when provided', async function () {
         const publish = fake.resolves(undefined);
@@ -93,7 +105,8 @@ suite('registry-client', function () {
             {
                 auth: { type: 'bearer-token', token: 'the-token' }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.deepStrictEqual(publish.firstCall.args, [
@@ -125,7 +138,8 @@ suite('registry-client', function () {
                     password: 'secret'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.deepStrictEqual(publish.firstCall.args.at(-1), {
@@ -319,6 +333,148 @@ suite('registry-client', function () {
                 headers: { accept: 'application/vnd.npm.install-v1+json' }
             }
         ]);
+    });
+
+    test('fetchStagedVersions() uses authenticated publish auth even when metadata is anonymous', async function () {
+        const npmFetchJson = buildStagedVersionsFetchJson([{ items: [{ version: '1.2.4' }], total: 1 }]);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchStagedVersions('the-name', {
+            auth: {
+                publish: { type: 'bearer-token', token: 'writer-token' },
+                metadata: 'anonymous'
+            }
+        });
+
+        assert.deepStrictEqual(result, ['1.2.4']);
+        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
+            '/-/stage?package=the-name&page=0&perPage=100',
+            {
+                alwaysAuth: true,
+                registry: undefined,
+                forceAuth: { token: 'writer-token' }
+            }
+        ]);
+    });
+
+    test('fetchStagedVersions() collects staged versions across pages', async function () {
+        const npmFetchJson = buildStagedVersionsFetchJson([
+            { items: [{ version: '1.2.4' }], total: 2 },
+            { items: [{ version: '1.2.5' }], total: 2 }
+        ]);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchStagedVersions('the-name', {
+            auth: { type: 'bearer-token', token: 'writer-token' }
+        });
+
+        assert.deepStrictEqual(result, ['1.2.4', '1.2.5']);
+        assert.strictEqual(npmFetchJson.callCount, 2);
+        assert.strictEqual(npmFetchJson.firstCall.firstArg, '/-/stage?package=the-name&page=0&perPage=100');
+        assert.strictEqual(npmFetchJson.secondCall.firstArg, '/-/stage?package=the-name&page=1&perPage=100');
+    });
+
+    test('fetchStagedVersions() accepts an empty stage list with total zero', async function () {
+        const npmFetchJson = buildStagedVersionsFetchJson([{ items: [], total: 0 }]);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchStagedVersions('the-name', {
+            auth: { type: 'bearer-token', token: 'writer-token' }
+        });
+
+        assert.deepStrictEqual(result, []);
+        assert.strictEqual(npmFetchJson.callCount, 1);
+    });
+
+    test('fetchStagedVersions() stops fetching when a later page is empty even if the total is larger', async function () {
+        const npmFetchJson = buildStagedVersionsFetchJson([
+            { items: [{ version: '1.2.4' }], total: 3 },
+            { items: [], total: 3 }
+        ]);
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        const result = await registryClient.fetchStagedVersions('the-name', {
+            auth: { type: 'bearer-token', token: 'writer-token' }
+        });
+
+        assert.deepStrictEqual(result, ['1.2.4']);
+        assert.strictEqual(npmFetchJson.callCount, 2);
+    });
+
+    test('fetchStagedVersions() requires token-based metadata auth when publish auth uses npm oidc', async function () {
+        const npmFetchJson = fake();
+        const registryClient = registryClientFactory({ npmFetchJson });
+
+        await expectFailure(async () => {
+            await registryClient.fetchStagedVersions('the-name', {
+                auth: {
+                    publish: { type: 'npm-oidc', provider: 'env' },
+                    metadata: 'auto'
+                }
+            });
+        }, /requires token-based metadata auth/u);
+
+        assert.strictEqual(npmFetchJson.callCount, 0);
+    });
+
+    test('fetchStagedVersions() rejects a non-object stage-list response', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves('invalid-response')
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchStagedVersions('the-name', {
+                auth: { type: 'bearer-token', token: 'writer-token' }
+            });
+        }, /invalid response from registry stage API/u);
+    });
+
+    test('fetchStagedVersions() rejects a null stage-list response', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves(null)
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchStagedVersions('the-name', {
+                auth: { type: 'bearer-token', token: 'writer-token' }
+            });
+        }, /invalid response from registry stage API/u);
+    });
+
+    test('fetchStagedVersions() rejects a stage-list response with invalid pagination fields', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({ items: [], total: '1' })
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchStagedVersions('the-name', {
+                auth: { type: 'bearer-token', token: 'writer-token' }
+            });
+        }, /invalid response from registry stage API/u);
+    });
+
+    test('fetchStagedVersions() rejects a stage-list response with a negative total', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({ items: [], total: -1 })
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchStagedVersions('the-name', {
+                auth: { type: 'bearer-token', token: 'writer-token' }
+            });
+        }, /invalid response from registry stage API/u);
+    });
+
+    test('fetchStagedVersions() rejects a stage-list response with an invalid item version', async function () {
+        const registryClient = registryClientFactory({
+            npmFetchJson: fake.resolves({ items: [{}], total: 1 })
+        });
+
+        await expectFailure(async () => {
+            await registryClient.fetchStagedVersions('the-name', {
+                auth: { type: 'bearer-token', token: 'writer-token' }
+            });
+        }, /invalid response from registry stage API/u);
     });
 
     test('fetchLatestVersion() inherits publish auth for metadata when explicit metadata mode requests it', async function () {
@@ -678,7 +834,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc', provider: 'github-actions' }]);
@@ -721,7 +878,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
         await registryClient.publishPackage(
             { name: '@scope/the-name', version: '1.0.1' },
@@ -732,7 +890,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
@@ -772,7 +931,8 @@ suite('registry-client', function () {
             {
                 auth: { type: 'npm-oidc' }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.deepStrictEqual(resolveIdToken.firstCall.args, [{ type: 'npm-oidc' }]);
@@ -808,7 +968,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         clock.tick(61_000);
@@ -822,7 +983,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
@@ -857,7 +1019,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         await registryClient.publishPackage(
@@ -869,7 +1032,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
@@ -902,7 +1066,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
         await registryClient.publishPackage(
             { name: '@scope/second-package', version: '1.0.0' },
@@ -913,7 +1078,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 2);
@@ -960,7 +1126,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
         await registryClient.publishPackage(
             { name: '@scope/the-name', version: '1.0.1' },
@@ -972,7 +1139,8 @@ suite('registry-client', function () {
                     metadata: 'anonymous'
                 }
             },
-            { access: 'public' }
+            { access: 'public' },
+            false
         );
 
         assert.strictEqual((fetchSpy as unknown as SinonSpy).callCount, 1);
@@ -994,7 +1162,8 @@ suite('registry-client', function () {
                         metadata: 'anonymous'
                     }
                 },
-                { access: 'public' }
+                { access: 'public' },
+                false
             );
         }, /^Error: npm-oidc auth is only supported with the npmjs.org registry$/u);
     });
@@ -1020,7 +1189,8 @@ suite('registry-client', function () {
                         metadata: 'anonymous'
                     }
                 },
-                { access: 'public' }
+                { access: 'public' },
+                false
             );
         }, /^TypeError: OIDC token exchange returned an invalid response: /u);
     });
@@ -1046,7 +1216,8 @@ suite('registry-client', function () {
                         metadata: 'anonymous'
                     }
                 },
-                { access: 'public' }
+                { access: 'public' },
+                false
             );
         }, /^TypeError: OIDC token exchange returned an invalid response: /u);
     });
@@ -1072,7 +1243,8 @@ suite('registry-client', function () {
                         metadata: 'anonymous'
                     }
                 },
-                { access: 'public' }
+                { access: 'public' },
+                false
             );
         }, /^TypeError: OIDC token exchange returned an invalid response: /u);
     });
@@ -1098,7 +1270,8 @@ suite('registry-client', function () {
                         metadata: 'anonymous'
                     }
                 },
-                { access: 'public' }
+                { access: 'public' },
+                false
             );
         }, /^Error: OIDC token exchange failed with status 502$/u);
     });
@@ -1130,7 +1303,8 @@ suite('registry-client', function () {
                                 metadata: 'anonymous'
                             }
                         },
-                        { access: 'public' }
+                        { access: 'public' },
+                        false
                     );
                 }, /^TypeError: OIDC token exchange returned an invalid response: /u);
             });
@@ -1292,7 +1466,8 @@ suite('registry-client', function () {
             { name: 'the-name', version: '1.0.0' },
             Buffer.from([]),
             { auth: { type: 'bearer-token', token: 'the-token' } },
-            { access: 'public', provenance: { type: 'auto' } }
+            { access: 'public', provenance: { type: 'auto' } },
+            false
         );
 
         const publishOptions = publish.firstCall.args.at(-1) as Record<string, unknown>;
@@ -1315,13 +1490,72 @@ suite('registry-client', function () {
                 { name: 'the-name', version: '1.0.0' },
                 Buffer.from([]),
                 { auth: { type: 'bearer-token', token: 'the-token' } },
-                { access: 'public', provenance: { type: 'auto' } }
+                { access: 'public', provenance: { type: 'auto' } },
+                false
             );
             assert.fail('Expected publishPackage() to throw');
         } catch (error: unknown) {
             assert.ok(error instanceof Error, 'Expected the thrown value to be an Error');
             assert.match(error.message, /^Provenance auto mode requires GitHub Actions or GitLab CI/u);
             assert.strictEqual(error.cause, original);
+        }
+    });
+
+    test('publishPackage() stages the package and returns the stage id when stage mode is enabled', async function () {
+        const publish = fake.resolves({ stageId: 'stage-123' });
+        const registryClient = registryClientFactory({ publish });
+
+        const result = await registryClient.publishPackage(
+            { name: 'the-name', version: 'the-version' },
+            Buffer.from([]),
+            {
+                auth: { type: 'bearer-token', token: 'the-token' }
+            },
+            { access: 'public' },
+            true
+        );
+
+        assert.deepStrictEqual(result, stagedForApproval('stage-123'));
+        assert.strictEqual((publish.firstCall.lastArg as { stage?: boolean }).stage, true);
+    });
+
+    test('publishPackage() rejects a staged publish response without a stage id', async function () {
+        const publish = fake.resolves({});
+        const registryClient = registryClientFactory({ publish });
+
+        await expectFailure(async () => {
+            await registryClient.publishPackage(
+                { name: 'the-name', version: '1.0.0' },
+                Buffer.from([]),
+                { auth: { type: 'bearer-token', token: 'the-token' } },
+                { access: 'public' },
+                true
+            );
+        }, /without returning a stage ID/u);
+    });
+
+    suite('publishPackage() rejects invalid staged publish responses', function () {
+        for (const [testName, response] of [
+            ['when the response is null', null],
+            ['when the response is a string', 'not-a-stage-response'],
+            ['when the stage id is numeric', { stageId: 123 }],
+            ['when the stage id is object-shaped but not a string', { stageId: { length: 1 } }],
+            ['when the stage id is empty', { stageId: '' }]
+        ] as const) {
+            test(testName, async function () {
+                const publish = fake.resolves(response);
+                const registryClient = registryClientFactory({ publish });
+
+                await expectFailure(async () => {
+                    await registryClient.publishPackage(
+                        { name: 'the-name', version: '1.0.0' },
+                        Buffer.from([]),
+                        { auth: { type: 'bearer-token', token: 'the-token' } },
+                        { access: 'public' },
+                        true
+                    );
+                }, /without returning a stage ID/u);
+            });
         }
     });
 });

--- a/source/bundle-emitter/registry/registry-client.ts
+++ b/source/bundle-emitter/registry/registry-client.ts
@@ -1,25 +1,42 @@
 import type _npmFetch from 'npm-registry-fetch';
-import type { publish as _publish } from 'libnpmpublish';
 import type { Maybe } from 'true-myth';
 import type { Clock } from '../../common/clock.ts';
 import type { PublishSettings } from '../../config/publish-settings.ts';
 import type { NpmOidcPublishAuth, RegistrySettings } from '../../config/registry-settings.ts';
-import type { PublishedPackageJson } from '../../published-package/published-package.ts';
+import { publishedToRegistry, stagedForApproval, type PublicationOutcome } from '../publication-outcome.ts';
 import { createOidcTokenExchanger } from './oidc-token-exchange.ts';
 import {
     fetchLatestPackageReleaseMetadata,
-    fetchLatestPackageVersion,
     fetchPackageTarball,
+    fetchLatestPackageVersion,
+    fetchStagedPackageVersions,
     type PackageReleaseMetadata,
     type PackageVersionDetails
 } from './package-metadata-fetcher.ts';
 import { buildPublishOptionsForPublishSettings, remapPublishError } from './publish-settings-bridge.ts';
 
-type PublishFunction = typeof _publish;
+type PublishManifest = {
+    readonly name: string;
+    readonly version: string;
+};
+type PublishLibraryOptions = Readonly<Record<string, unknown>>;
+type PublishOptionsForLibrary = PublishLibraryOptions & {
+    readonly stage?: boolean;
+};
+type PublishOptionsWithOneTimePassword = PublishOptionsForLibrary & {
+    readonly otpPrompt: (() => Promise<string | undefined>) | undefined;
+};
+type PublishPackageArguments = readonly [
+    manifest: PublishManifest,
+    tarData: Buffer,
+    config: RegistrySettings,
+    publishSettings: PublishSettings,
+    stage: boolean
+];
 
 export type RegistryClientDependencies = {
     readonly npmFetch: typeof _npmFetch;
-    readonly publish: PublishFunction;
+    readonly publish: (manifest: PublishManifest, tarData: Buffer, options?: PublishLibraryOptions) => Promise<unknown>;
     readonly fetch: typeof globalThis.fetch;
     readonly clock: Clock;
     readonly resolveIdToken: (auth: NpmOidcPublishAuth) => Promise<string>;
@@ -32,19 +49,27 @@ export type RegistryClient = {
         config: RegistrySettings
     ) => Promise<Maybe<PackageReleaseMetadata>>;
     fetchLatestVersion: (packageName: string, config: RegistrySettings) => Promise<Maybe<PackageVersionDetails>>;
-    publishPackage: (
-        manifest: Readonly<PublishedPackageJson>,
-        tarData: Buffer,
-        config: RegistrySettings,
-        publishSettings: PublishSettings
-    ) => Promise<void>;
+    fetchStagedVersions: (packageName: string, config: RegistrySettings) => Promise<readonly string[]>;
+    publishPackage: (...args: PublishPackageArguments) => Promise<PublicationOutcome>;
     fetchTarball: (tarballUrl: string, config: RegistrySettings) => Promise<Buffer>;
 };
 
-type PublishManifest = Readonly<Parameters<PublishFunction>[0]>;
-function toPublishManifest(manifest: Readonly<PublishedPackageJson>): PublishManifest {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- libnpmpublish expects @npm/types PackageJson, which is structurally compatible with our validated manifest
-    return manifest as unknown as PublishManifest;
+function hasStageId(response: unknown): response is { readonly stageId: string } {
+    return (
+        typeof response === 'object' &&
+        response !== null &&
+        'stageId' in response &&
+        typeof response.stageId === 'string' &&
+        response.stageId.length > 0
+    );
+}
+
+function readStageId(response: unknown): string {
+    if (!hasStageId(response)) {
+        throw new Error('npm staged publish succeeded without returning a stage ID');
+    }
+
+    return response.stageId;
 }
 
 export function createRegistryClient(dependencies: Readonly<RegistryClientDependencies>): RegistryClient {
@@ -63,25 +88,27 @@ export function createRegistryClient(dependencies: Readonly<RegistryClientDepend
             return fetchPackageTarball(npmFetch, tarballUrl, registrySettings);
         },
 
-        async publishPackage(manifest, tarData, registrySettings, publishSettings) {
+        async publishPackage(...[manifest, tarData, registrySettings, publishSettings, stage]) {
             const authOptions = await oidcExchanger.resolveWriteAuthOptions(manifest.name, registrySettings);
             const publishOptionsFromSettings = buildPublishOptionsForPublishSettings(publishSettings);
-            const publishOptions = {
+            const publishOptions: PublishOptionsForLibrary = {
                 defaultTag: 'latest',
                 ...authOptions,
-                ...publishOptionsFromSettings
+                ...publishOptionsFromSettings,
+                ...(stage ? { stage: true } : {})
             };
-            const publishOptionsWithOneTimePassword = {
+            const publishOptionsWithOneTimePassword: PublishOptionsWithOneTimePassword = {
                 ...publishOptions,
                 otpPrompt: promptForOneTimePassword
             };
             const publishPromise =
                 promptForOneTimePassword === undefined
-                    ? publish(toPublishManifest(manifest), tarData, publishOptions)
-                    : publish(toPublishManifest(manifest), tarData, publishOptionsWithOneTimePassword);
+                    ? publish(manifest, tarData, publishOptions)
+                    : publish(manifest, tarData, publishOptionsWithOneTimePassword);
 
             try {
-                await publishPromise;
+                const response = await publishPromise;
+                return stage ? stagedForApproval(readStageId(response)) : publishedToRegistry;
             } catch (error: unknown) {
                 throw remapPublishError(error, publishSettings);
             }
@@ -89,6 +116,10 @@ export function createRegistryClient(dependencies: Readonly<RegistryClientDepend
 
         async fetchLatestVersion(packageName, registrySettings) {
             return fetchLatestPackageVersion(npmFetch, packageName, registrySettings);
+        },
+
+        async fetchStagedVersions(packageName, registrySettings) {
+            return fetchStagedPackageVersions(npmFetch, packageName, registrySettings);
         },
 
         async fetchLatestReleaseMetadata(packageName, registrySettings) {

--- a/source/command-line-interface/runner/failure-printing.test.ts
+++ b/source/command-line-interface/runner/failure-printing.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { dim } from 'yoctocolors';
 import { noPublication, stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import type { PublishFailure } from '../../packtory/packtory-results.ts';
 import { printDryRunNote, printPublishFailure, printSuccessSummary } from './failure-printing.ts';
@@ -116,7 +117,7 @@ suite('failure-printing', function () {
 
         assert.strictEqual(
             sink.messages[0],
-            `${getSuccessSymbol()} Success: staged 1 package(s); 1 already up-to-date`
+            `${getSuccessSymbol()} Success: staged 1 package(s); ${dim('1')} already up-to-date`
         );
         assert.strictEqual(sink.messages[1], 'Staged packages:\n- a@1.0.0: stage-a');
     });

--- a/source/command-line-interface/runner/failure-printing.test.ts
+++ b/source/command-line-interface/runner/failure-printing.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { noPublication, stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import type { PublishFailure } from '../../packtory/packtory-results.ts';
 import { printDryRunNote, printPublishFailure, printSuccessSummary } from './failure-printing.ts';
 
@@ -33,7 +34,7 @@ suite('failure-printing', function () {
         const sink = captureLogger();
         const failure: PublishFailure = { type: 'config', issues: ['issue A', 'issue B'] };
 
-        printPublishFailure(sink.log, failure);
+        printPublishFailure(sink.log, failure, { stage: false });
 
         assert.strictEqual(sink.messages.length, 1);
         const message = sink.messages[0] ?? '';
@@ -45,7 +46,7 @@ suite('failure-printing', function () {
         const sink = captureLogger();
         const failure: PublishFailure = { type: 'checks', issues: ['check X'] };
 
-        printPublishFailure(sink.log, failure);
+        printPublishFailure(sink.log, failure, { stage: false });
 
         const message = sink.messages[0] ?? '';
         assert.match(message, /Checks failed, there are 1 issue\(s\)/u);
@@ -56,22 +57,100 @@ suite('failure-printing', function () {
         const sink = captureLogger();
         const failure: PublishFailure = {
             type: 'partial',
-            succeeded: [{ name: 'pkg-a' }, { name: 'pkg-b' }] as never,
+            succeeded: [
+                { bundle: { name: 'pkg-a', version: '1.0.0' }, publication: stagedForApproval('stage-a') },
+                { bundle: { name: 'pkg-b', version: '1.0.0' }, publication: noPublication }
+            ] as never,
             failures: [{ message: 'pkg-c failed' }] as never
         };
 
-        printPublishFailure(sink.log, failure);
+        printPublishFailure(sink.log, failure, { stage: true });
 
-        const message = sink.messages[0] ?? '';
-        assert.ok(message.includes('package(s) failed'));
-        assert.ok(message.includes('- pkg-c failed'));
+        assert.ok((sink.messages[0] ?? '').includes('package(s) failed'));
+        assert.ok((sink.messages[0] ?? '').includes('- pkg-c failed'));
+        assert.deepStrictEqual(sink.messages[1], 'Staged packages:\n- pkg-a@1.0.0: stage-a');
+    });
+
+    test('printPublishFailure omits the staged package list when no partial successes were staged', function () {
+        const sink = captureLogger();
+        const failure: PublishFailure = {
+            type: 'partial',
+            succeeded: [{ bundle: { name: 'pkg-a', version: '1.0.0' }, publication: noPublication }] as never,
+            failures: [{ message: 'pkg-b failed' }] as never
+        };
+
+        printPublishFailure(sink.log, failure, { stage: true });
+
+        assert.strictEqual(sink.messages.length, 1);
+        assert.ok((sink.messages[0] ?? '').includes('- pkg-b failed'));
     });
 
     test('printSuccessSummary logs the count of published packages', function () {
         const sink = captureLogger();
 
-        printSuccessSummary(sink.log, [{ name: 'a' }, { name: 'b' }] as never);
+        printSuccessSummary(sink.log, [{ name: 'a' }, { name: 'b' }] as never, { stage: false });
 
         assert.match(sink.messages[0] ?? '', /all 2 package\(s\) have been published/u);
+    });
+
+    test('printSuccessSummary logs stage ids for staged packages', function () {
+        const sink = captureLogger();
+
+        printSuccessSummary(
+            sink.log,
+            [
+                {
+                    bundle: { name: 'a', version: '1.0.0' },
+                    publication: stagedForApproval('stage-a'),
+                    status: 'new-version'
+                },
+                {
+                    bundle: { name: 'b', version: '1.0.0' },
+                    publication: noPublication,
+                    status: 'already-published'
+                }
+            ] as never,
+            { stage: true }
+        );
+
+        assert.strictEqual(sink.messages[0], '✔ Success: staged 1 package(s); 1 already up-to-date');
+        assert.strictEqual(sink.messages[1], 'Staged packages:\n- a@1.0.0: stage-a');
+    });
+
+    test('printSuccessSummary omits the unchanged suffix when every successful package was staged', function () {
+        const sink = captureLogger();
+
+        printSuccessSummary(
+            sink.log,
+            [
+                {
+                    bundle: { name: 'a', version: '1.0.0' },
+                    publication: stagedForApproval('stage-a'),
+                    status: 'new-version'
+                }
+            ] as never,
+            { stage: true }
+        );
+
+        assert.strictEqual(sink.messages[0], '✔ Success: staged 1 package(s)');
+        assert.strictEqual(sink.messages[1], 'Staged packages:\n- a@1.0.0: stage-a');
+    });
+
+    test('printSuccessSummary reports when stage mode found nothing to stage', function () {
+        const sink = captureLogger();
+
+        printSuccessSummary(
+            sink.log,
+            [
+                { bundle: { name: 'a', version: '1.0.0' }, publication: noPublication, status: 'already-published' }
+            ] as never,
+            { stage: true }
+        );
+
+        assert.strictEqual(
+            sink.messages[0],
+            '✔ Success: no packages were staged; all 1 package(s) were already up-to-date'
+        );
+        assert.strictEqual(sink.messages.length, 1);
     });
 });

--- a/source/command-line-interface/runner/failure-printing.test.ts
+++ b/source/command-line-interface/runner/failure-printing.test.ts
@@ -3,6 +3,7 @@ import { suite, test } from 'mocha';
 import { noPublication, stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import type { PublishFailure } from '../../packtory/packtory-results.ts';
 import { printDryRunNote, printPublishFailure, printSuccessSummary } from './failure-printing.ts';
+import { getSuccessSymbol } from './runner-symbols.ts';
 
 function captureLogger(): { readonly log: (message: string) => void; readonly messages: string[] } {
     const messages: string[] = [];
@@ -90,7 +91,7 @@ suite('failure-printing', function () {
 
         printSuccessSummary(sink.log, [{ name: 'a' }, { name: 'b' }] as never, { stage: false });
 
-        assert.match(sink.messages[0] ?? '', /all 2 package\(s\) have been published/u);
+        assert.strictEqual(sink.messages[0], `${getSuccessSymbol()} Success: all 2 package(s) have been published`);
     });
 
     test('printSuccessSummary logs stage ids for staged packages', function () {
@@ -113,7 +114,10 @@ suite('failure-printing', function () {
             { stage: true }
         );
 
-        assert.strictEqual(sink.messages[0], '✔ Success: staged 1 package(s); 1 already up-to-date');
+        assert.strictEqual(
+            sink.messages[0],
+            `${getSuccessSymbol()} Success: staged 1 package(s); 1 already up-to-date`
+        );
         assert.strictEqual(sink.messages[1], 'Staged packages:\n- a@1.0.0: stage-a');
     });
 
@@ -132,7 +136,7 @@ suite('failure-printing', function () {
             { stage: true }
         );
 
-        assert.strictEqual(sink.messages[0], '✔ Success: staged 1 package(s)');
+        assert.strictEqual(sink.messages[0], `${getSuccessSymbol()} Success: staged 1 package(s)`);
         assert.strictEqual(sink.messages[1], 'Staged packages:\n- a@1.0.0: stage-a');
     });
 
@@ -149,7 +153,7 @@ suite('failure-printing', function () {
 
         assert.strictEqual(
             sink.messages[0],
-            '✔ Success: no packages were staged; all 1 package(s) were already up-to-date'
+            `${getSuccessSymbol()} Success: no packages were staged; all 1 package(s) were already up-to-date`
         );
         assert.strictEqual(sink.messages.length, 1);
     });

--- a/source/command-line-interface/runner/failure-printing.ts
+++ b/source/command-line-interface/runner/failure-printing.ts
@@ -1,5 +1,6 @@
 import { match } from 'ts-pattern';
 import { bold, dim, green, red } from 'yoctocolors';
+import type { PublicationOutcome } from '../../bundle-emitter/publication-outcome.ts';
 import {
     checksErrorType,
     configErrorType,
@@ -12,6 +13,9 @@ import type { PartialError } from '../../packtory/scheduler.ts';
 import { getErrorSymbol, getSuccessSymbol, getWarningSymbol } from './runner-symbols.ts';
 
 type PublishPartialError = PartialError<BuildAndPublishResult>;
+type StagedResult = BuildAndPublishResult & {
+    readonly publication: Extract<PublicationOutcome, { type: 'staged' }>;
+};
 type Logger = (message: string) => void;
 const issueTitleByType = {
     [configErrorType]: 'The provided config is invalid',
@@ -31,12 +35,46 @@ export function printDryRunNote(log: Logger, flags: { readonly noDryRun: boolean
     );
 }
 
+function formatStageReceipt(result: StagedResult): string {
+    return `- ${result.bundle.name}@${result.bundle.version}: ${result.publication.stageId}`;
+}
+
+function isStagedResult(result: BuildAndPublishResult): result is StagedResult {
+    return result.publication.type === 'staged';
+}
+
+function stagedResultsFrom(results: readonly BuildAndPublishResult[]): readonly StagedResult[] {
+    return results.filter(isStagedResult);
+}
+
+function printStagedPackageList(log: Logger, results: readonly BuildAndPublishResult[]): void {
+    const stagedResults = stagedResultsFrom(results);
+    if (stagedResults.length === 0) {
+        return;
+    }
+    log(['Staged packages:', ...stagedResults.map(formatStageReceipt)].join('\n'));
+}
+
 function printIssueSummary(log: Logger, title: string, issues: readonly string[]): void {
     const header = `${getErrorSymbol()} ${title}, there are ${issues.length} issue(s)`;
     log(`${header}\n\n- ${issues.join('\n- ')}`);
 }
 
-function printPartialErrorSummary(log: Logger, error: PublishPartialError): void {
+function stageSuccessSummary(results: readonly BuildAndPublishResult[]): string {
+    const stagedResults = stagedResultsFrom(results);
+    if (stagedResults.length === 0) {
+        return (
+            `${getSuccessSymbol()} Success: no packages were staged; ` +
+            `all ${results.length} package(s) were already up-to-date`
+        );
+    }
+
+    const unchangedCount = results.length - stagedResults.length;
+    const unchangedSuffix = unchangedCount === 0 ? '' : `; ${dim(String(unchangedCount))} already up-to-date`;
+    return `${getSuccessSymbol()} Success: staged ${stagedResults.length} package(s)${unchangedSuffix}`;
+}
+
+function printPartialErrorSummary(log: Logger, error: PublishPartialError, flags: { readonly stage: boolean }): void {
     const total = error.succeeded.length + error.failures.length;
     const failureCount = red(String(error.failures.length));
     const successCount = green(String(error.succeeded.length));
@@ -47,18 +85,31 @@ function printPartialErrorSummary(log: Logger, error: PublishPartialError): void
         return `- ${message}`;
     });
     log([summary, ...details].join('\n'));
+    if (flags.stage) {
+        printStagedPackageList(log, error.succeeded);
+    }
 }
 
-export function printPublishFailure(log: Logger, error: PublishFailure): void {
+export function printPublishFailure(log: Logger, error: PublishFailure, flags: { readonly stage: boolean }): void {
     match(error)
         .with({ type: partialFailureType }, (partialError) => {
-            printPartialErrorSummary(log, partialError);
+            printPartialErrorSummary(log, partialError, flags);
         })
         .otherwise((issueError) => {
             printIssueSummary(log, issueTitleByType[issueError.type], issueError.issues);
         });
 }
 
-export function printSuccessSummary(log: Logger, results: readonly BuildAndPublishResult[]): void {
-    log(`${getSuccessSymbol()} Success: all ${results.length} package(s) have been published`);
+export function printSuccessSummary(
+    log: Logger,
+    results: readonly BuildAndPublishResult[],
+    flags: { readonly stage: boolean }
+): void {
+    if (!flags.stage) {
+        log(`${getSuccessSymbol()} Success: all ${results.length} package(s) have been published`);
+        return;
+    }
+
+    log(stageSuccessSummary(results));
+    printStagedPackageList(log, results);
 }

--- a/source/command-line-interface/runner/preview-handler.ts
+++ b/source/command-line-interface/runner/preview-handler.ts
@@ -55,7 +55,7 @@ export async function runPreviewHandler(deps: PreviewHandlerDeps): Promise<numbe
     const { packtory, spinnerRenderer, configLoader, fileManager } = deps;
     try {
         const config = await configLoader.load();
-        const outcome = await packtory.buildAndPublishAll(config, { dryRun: true, collectReport: true });
+        const outcome = await packtory.buildAndPublishAll(config, { dryRun: true, stage: false, collectReport: true });
         spinnerRenderer.stopAll();
         const report = outcome.getReport() ?? createEmptyReport();
         const document = await buildPreviewDocument({

--- a/source/command-line-interface/runner/progress-wiring.test.ts
+++ b/source/command-line-interface/runner/progress-wiring.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { noPublication, stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import { registerProgressListeners } from './progress-wiring.ts';
@@ -58,7 +59,12 @@ suite('progress-wiring', function () {
         const sink = captureSpinner();
         registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-        broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'already-published', version: '1.0.0' });
+        broadcaster.provider.emit('done', {
+            packageName: 'pkg-a',
+            status: 'already-published',
+            version: '1.0.0',
+            publication: noPublication
+        });
 
         assert.deepStrictEqual(sink.calls, [
             {
@@ -75,7 +81,12 @@ suite('progress-wiring', function () {
         const sink = captureSpinner();
         registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-        broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'initial-version', version: '1.0.0' });
+        broadcaster.provider.emit('done', {
+            packageName: 'pkg-a',
+            status: 'initial-version',
+            version: '1.0.0',
+            publication: noPublication
+        });
 
         assert.deepStrictEqual(sink.calls, [
             { kind: 'stop', id: 'pkg-a', status: 'success', message: 'First version 1.0.0 has been published' }
@@ -87,10 +98,49 @@ suite('progress-wiring', function () {
         const sink = captureSpinner();
         registerProgressListeners(broadcaster.consumer, sink.renderer);
 
-        broadcaster.provider.emit('done', { packageName: 'pkg-a', status: 'new-version', version: '2.0.0' });
+        broadcaster.provider.emit('done', {
+            packageName: 'pkg-a',
+            status: 'new-version',
+            version: '2.0.0',
+            publication: noPublication
+        });
 
         assert.deepStrictEqual(sink.calls, [
             { kind: 'stop', id: 'pkg-a', status: 'success', message: 'New version 2.0.0 published' }
+        ]);
+    });
+
+    test('registerProgressListeners reports staged publications on a done event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
+
+        broadcaster.provider.emit('done', {
+            packageName: 'pkg-a',
+            status: 'new-version',
+            version: '2.0.0',
+            publication: stagedForApproval('stage-123')
+        });
+
+        assert.deepStrictEqual(sink.calls, [
+            { kind: 'stop', id: 'pkg-a', status: 'success', message: 'New version 2.0.0 staged (stage-123)' }
+        ]);
+    });
+
+    test('registerProgressListeners reports staged first publications on a done event', function () {
+        const broadcaster = createProgressBroadcaster();
+        const sink = captureSpinner();
+        registerProgressListeners(broadcaster.consumer, sink.renderer);
+
+        broadcaster.provider.emit('done', {
+            packageName: 'pkg-a',
+            status: 'initial-version',
+            version: '1.0.0',
+            publication: stagedForApproval('stage-123')
+        });
+
+        assert.deepStrictEqual(sink.calls, [
+            { kind: 'stop', id: 'pkg-a', status: 'success', message: 'First version 1.0.0 staged (stage-123)' }
         ]);
     });
 

--- a/source/command-line-interface/runner/progress-wiring.ts
+++ b/source/command-line-interface/runner/progress-wiring.ts
@@ -1,9 +1,16 @@
+import type { PublicationOutcome } from '../../bundle-emitter/publication-outcome.ts';
 import type { ProgressBroadcastConsumer } from '../../progress/progress-broadcaster.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 
-function describeDoneStatus(status: string, version: string): string {
+function describeDoneStatus(status: string, version: string, publication: PublicationOutcome): string {
     if (status === 'already-published') {
         return `Nothing has changed, published version ${version} is already up-to-date`;
+    }
+    if (publication.type === 'staged') {
+        if (status === 'initial-version') {
+            return `First version ${version} staged (${publication.stageId})`;
+        }
+        return `New version ${version} staged (${publication.stageId})`;
     }
     if (status === 'initial-version') {
         return `First version ${version} has been published`;
@@ -24,7 +31,11 @@ export function registerProgressListeners(
     });
 
     progressBroadcaster.on('done', (payload) => {
-        spinnerRenderer.stop(payload.packageName, 'success', describeDoneStatus(payload.status, payload.version));
+        spinnerRenderer.stop(
+            payload.packageName,
+            'success',
+            describeDoneStatus(payload.status, payload.version, payload.publication)
+        );
     });
 
     progressBroadcaster.on('building', (payload) => {

--- a/source/command-line-interface/runner/publish-handler.test.ts
+++ b/source/command-line-interface/runner/publish-handler.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
@@ -15,7 +16,12 @@ import { runPublishHandler } from './publish-handler.ts';
 type BuildOutcome = Awaited<ReturnType<Packtory['buildAndPublishAll']>>;
 
 async function captureMessages(
-    flags: { readonly noDryRun: boolean; readonly reportJson: boolean; readonly reportHtml: boolean },
+    flags: {
+        readonly noDryRun: boolean;
+        readonly stage: boolean;
+        readonly reportJson: boolean;
+        readonly reportHtml: boolean;
+    },
     outcome: BuildOutcome
 ): Promise<{ readonly code: number; readonly messages: readonly string[] }> {
     const messages: string[] = [];
@@ -35,7 +41,7 @@ async function captureMessages(
 suite('publish-handler', function () {
     test('runPublishHandler returns 0 and logs a success summary when the build succeeds', async function () {
         const { code, messages } = await captureMessages(
-            { noDryRun: true, reportJson: false, reportHtml: false },
+            { noDryRun: true, stage: false, reportJson: false, reportHtml: false },
             buildOutcome({
                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/value matter to the handler
                 result: { isOk: true, isErr: false, value: [{ name: 'pkg-a' }] } as never
@@ -46,9 +52,33 @@ suite('publish-handler', function () {
         assert.ok(messages.some((message) => message.includes('all 1 package(s) have been published')));
     });
 
+    test('runPublishHandler passes stage mode through to the success summary', async function () {
+        const { code, messages } = await captureMessages(
+            { noDryRun: true, stage: true, reportJson: false, reportHtml: false },
+            buildOutcome({
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only handler-visible fields matter here
+                result: {
+                    isOk: true,
+                    isErr: false,
+                    value: [
+                        {
+                            bundle: { name: 'pkg-a', version: '1.0.0' },
+                            publication: stagedForApproval('stage-123'),
+                            status: 'new-version'
+                        }
+                    ]
+                } as never
+            })
+        );
+
+        assert.strictEqual(code, 0);
+        assert.ok(messages.some((message) => message.includes('staged 1 package(s)')));
+        assert.ok(messages.some((message) => message.includes('stage-123')));
+    });
+
     test('runPublishHandler returns 1 and logs the publish failure when the build fails', async function () {
         const { code, messages } = await captureMessages(
-            { noDryRun: true, reportJson: false, reportHtml: false },
+            { noDryRun: true, stage: false, reportJson: false, reportHtml: false },
             buildOutcome({
                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/error.type matter to the handler
                 result: { isOk: false, isErr: true, error: { type: 'config', issues: ['missing field'] } } as never
@@ -59,9 +89,36 @@ suite('publish-handler', function () {
         assert.ok(messages.some((message) => message.includes('The provided config is invalid')));
     });
 
+    test('runPublishHandler passes stage mode through to the publish failure summary', async function () {
+        const { code, messages } = await captureMessages(
+            { noDryRun: true, stage: true, reportJson: false, reportHtml: false },
+            buildOutcome({
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only handler-visible fields matter here
+                result: {
+                    isOk: false,
+                    isErr: true,
+                    error: {
+                        type: 'partial',
+                        succeeded: [
+                            {
+                                bundle: { name: 'pkg-a', version: '1.0.0' },
+                                publication: stagedForApproval('stage-123')
+                            }
+                        ],
+                        failures: [new Error('boom')]
+                    }
+                } as never
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.ok(messages.some((message) => message.includes('Staged packages')));
+        assert.ok(messages.some((message) => message.includes('stage-123')));
+    });
+
     test('runPublishHandler appends the dry-run reminder when noDryRun is false', async function () {
         const { messages } = await captureMessages(
-            { noDryRun: false, reportJson: false, reportHtml: false },
+            { noDryRun: false, stage: false, reportJson: false, reportHtml: false },
             buildOutcome()
         );
 
@@ -80,7 +137,7 @@ suite('publish-handler', function () {
                 spinnerRenderer: spinner,
                 configLoader: configLoaderStub(),
                 fileManager: createFakeFileManager(),
-                flags: { noDryRun: true, reportJson: false, reportHtml: false }
+                flags: { noDryRun: true, stage: false, reportJson: false, reportHtml: false }
             });
             assert.fail('Expected runPublishHandler to throw');
         } catch (error: unknown) {

--- a/source/command-line-interface/runner/publish-handler.ts
+++ b/source/command-line-interface/runner/publish-handler.ts
@@ -14,7 +14,7 @@ export type PublishHandlerDeps = {
     readonly spinnerRenderer: TerminalSpinnerRenderer;
     readonly configLoader: ConfigLoader;
     readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
-    readonly flags: ReportFlags & { readonly noDryRun: boolean };
+    readonly flags: ReportFlags & { readonly noDryRun: boolean; readonly stage: boolean };
 };
 
 async function reportOutcome(
@@ -26,9 +26,9 @@ async function reportOutcome(
     let exitCode = 0;
     if (outcome.result.isErr) {
         exitCode = 1;
-        printPublishFailure(log, outcome.result.error);
+        printPublishFailure(log, outcome.result.error, { stage: flags.stage });
     } else {
-        printSuccessSummary(log, outcome.result.value);
+        printSuccessSummary(log, outcome.result.value, { stage: flags.stage });
     }
     await writeReports(fileManager, outcome.getReport(), outcome.result, flags, !flags.noDryRun);
     return exitCode;
@@ -40,6 +40,7 @@ export async function runPublishHandler(deps: PublishHandlerDeps): Promise<numbe
     try {
         const outcome = await packtory.buildAndPublishAll(await configLoader.load(), {
             dryRun: !flags.noDryRun,
+            stage: flags.stage,
             collectReport: flags.reportJson || flags.reportHtml
         });
         shouldStopSpinners = false;

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -19,6 +19,8 @@ import {
     type CommandLineInterfaceRunnerDependencies
 } from './runner.ts';
 
+const noPublicationOutcome = { type: 'none' } as const;
+
 type Overrides = {
     readonly buildAndPublishAll?: SinonSpy;
     readonly diffAgainstLatestPublished?: SinonSpy;
@@ -149,7 +151,7 @@ async function expectCollectReportFlag(flag: '--report-html' | '--report-json'):
 
     await runner.run(['foo', 'bar', 'publish', flag]);
 
-    assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: true });
+    assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, stage: false, collectReport: true });
 }
 
 async function runPreview(
@@ -177,7 +179,11 @@ suite('runner', function () {
         await runner.run(['foo', 'bar', 'publish']);
 
         assert.strictEqual(buildAndPublishAll.callCount, 1);
-        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: false });
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], {
+            dryRun: true,
+            stage: false,
+            collectReport: false
+        });
     });
 
     test('publish command runs not in dry-run mode when no-dry-run flag is set', async function () {
@@ -187,7 +193,25 @@ suite('runner', function () {
         await runner.run(['foo', 'bar', 'publish', '--no-dry-run']);
 
         assert.strictEqual(buildAndPublishAll.callCount, 1);
-        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: false, collectReport: false });
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], {
+            dryRun: false,
+            stage: false,
+            collectReport: false
+        });
+    });
+
+    test('publish command enables staged publishing when --stage is set', async function () {
+        const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
+        const runner = runnerFactory({ buildAndPublishAll });
+
+        await runner.run(['foo', 'bar', 'publish', '--stage']);
+
+        assert.strictEqual(buildAndPublishAll.callCount, 1);
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], {
+            dryRun: true,
+            stage: true,
+            collectReport: false
+        });
     });
 
     test('preview command loads the config file and passes it to buildAndPublishAll()', async function () {
@@ -200,7 +224,11 @@ suite('runner', function () {
 
         await runner.run(['foo', 'bar', 'preview']);
 
-        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], { dryRun: true, collectReport: true });
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], {
+            dryRun: true,
+            stage: false,
+            collectReport: true
+        });
     });
 
     test('returns exit code 0 when publish command had no errors', async function () {
@@ -423,7 +451,12 @@ suite('runner', function () {
 
     test('stops a running spinner with success status when progressBroadcaster receives an "done" event and already-published status', async function () {
         const stop = fake();
-        await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'already-published' });
+        await runWithProgressEvent({ stop }, 'done', {
+            packageName: 'foo',
+            version: '1',
+            status: 'already-published',
+            publication: noPublicationOutcome
+        });
 
         assert.strictEqual(stop.callCount, 1);
         assert.deepStrictEqual(stop.firstCall.args, [
@@ -435,7 +468,12 @@ suite('runner', function () {
 
     test('stops a running spinner with success status when progressBroadcaster receives an "done" event and initial-version status', async function () {
         const stop = fake();
-        await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'initial-version' });
+        await runWithProgressEvent({ stop }, 'done', {
+            packageName: 'foo',
+            version: '1',
+            status: 'initial-version',
+            publication: noPublicationOutcome
+        });
 
         assert.strictEqual(stop.callCount, 1);
         assert.deepStrictEqual(stop.firstCall.args, ['foo', 'success', 'First version 1 has been published']);
@@ -443,7 +481,12 @@ suite('runner', function () {
 
     test('stops a running spinner with success status when progressBroadcaster receives an "done" event and new-version status', async function () {
         const stop = fake();
-        await runWithProgressEvent({ stop }, 'done', { packageName: 'foo', version: '1', status: 'new-version' });
+        await runWithProgressEvent({ stop }, 'done', {
+            packageName: 'foo',
+            version: '1',
+            status: 'new-version',
+            publication: noPublicationOutcome
+        });
 
         assert.strictEqual(stop.callCount, 1);
         assert.deepStrictEqual(stop.firstCall.args, ['foo', 'success', 'New version 1 published']);

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -56,17 +56,18 @@ export function createCommandLineInterfaceRunner(
                 description: 'Builds and publishes all packages (dry-run enabled by default).',
                 args: {
                     noDryRun: flag({ long: 'no-dry-run' }),
+                    stage: flag({ long: 'stage' }),
                     reportJson: flag({ long: 'report-json' }),
                     reportHtml: flag({ long: 'report-html' })
                 },
-                async handler({ noDryRun, reportJson, reportHtml }) {
+                async handler({ noDryRun, stage, reportJson, reportHtml }) {
                     exitCode = await runPublishHandler({
                         log,
                         packtory,
                         spinnerRenderer,
                         configLoader,
                         fileManager,
-                        flags: { noDryRun, reportJson, reportHtml }
+                        flags: { noDryRun, stage, reportJson, reportHtml }
                     });
                 }
             }),

--- a/source/dead-code-eliminator/pure-expression.ts
+++ b/source/dead-code-eliminator/pure-expression.ts
@@ -132,19 +132,38 @@ function newExpressionIsPure(
     return isPureNewExpression(expression.asKindOrThrow(SyntaxKind.NewExpression), recurse, settings);
 }
 
-function createExpressionPurityRules(): ReadonlyMap<SyntaxKind, PurityRule> {
-    return new Map<SyntaxKind, PurityRule>([
-        [SyntaxKind.TemplateExpression, templateExpressionIsPure],
-        [SyntaxKind.ArrayLiteralExpression, arrayLiteralExpressionIsPure],
-        [SyntaxKind.ObjectLiteralExpression, objectLiteralExpressionIsPure],
-        [SyntaxKind.PrefixUnaryExpression, prefixUnaryExpressionIsPure],
-        [SyntaxKind.BinaryExpression, binaryExpressionIsPure],
-        [SyntaxKind.CallExpression, callExpressionIsPure],
-        [SyntaxKind.NewExpression, newExpressionIsPure]
-    ]);
+function literalStructurePurityRuleFor(kind: SyntaxKind): PurityRule | undefined {
+    if (kind === SyntaxKind.TemplateExpression) {
+        return templateExpressionIsPure;
+    }
+    if (kind === SyntaxKind.ArrayLiteralExpression) {
+        return arrayLiteralExpressionIsPure;
+    }
+    if (kind === SyntaxKind.ObjectLiteralExpression) {
+        return objectLiteralExpressionIsPure;
+    }
+    return undefined;
 }
 
-const expressionPurityRules = createExpressionPurityRules();
+function operationPurityRuleFor(kind: SyntaxKind): PurityRule | undefined {
+    if (kind === SyntaxKind.PrefixUnaryExpression) {
+        return prefixUnaryExpressionIsPure;
+    }
+    if (kind === SyntaxKind.BinaryExpression) {
+        return binaryExpressionIsPure;
+    }
+    if (kind === SyntaxKind.CallExpression) {
+        return callExpressionIsPure;
+    }
+    if (kind === SyntaxKind.NewExpression) {
+        return newExpressionIsPure;
+    }
+    return undefined;
+}
+
+function expressionPurityRuleFor(kind: SyntaxKind): PurityRule | undefined {
+    return literalStructurePurityRuleFor(kind) ?? operationPurityRuleFor(kind);
+}
 
 export function isPureExpression(expression: Expression, settings: DeadCodeEliminationSettings | undefined): boolean {
     const unwrapped = unwrapExpression(expression);
@@ -155,5 +174,5 @@ export function isPureExpression(expression: Expression, settings: DeadCodeElimi
     if (pureLeafKinds.has(kind)) {
         return true;
     }
-    return expressionPurityRules.get(kind)?.(unwrapped, recurse, settings) ?? false;
+    return expressionPurityRuleFor(kind)?.(unwrapped, recurse, settings) ?? false;
 }

--- a/source/dead-code-eliminator/side-effect-classifier.ts
+++ b/source/dead-code-eliminator/side-effect-classifier.ts
@@ -1,7 +1,7 @@
 import type { SourceFile, Statement } from 'ts-morph';
 import type { DeadCodeEliminationSettings } from '../config/dead-code-elimination-settings.ts';
 import type { SideEffectStatement } from './analyzed-bundle.ts';
-import { statementClassifiers } from './statement-classifiers.ts';
+import { statementClassifierFor } from './statement-classifiers.ts';
 import { describeControlFlowStatementKind, pureDeclarationKinds } from './syntax-kind-sets.ts';
 
 function classifyTopLevelStatement(
@@ -16,7 +16,7 @@ function classifyTopLevelStatement(
     if (controlFlowKind !== undefined) {
         return controlFlowKind;
     }
-    const classifier = statementClassifiers.get(kind);
+    const classifier = statementClassifierFor(kind);
     if (classifier !== undefined) {
         return classifier(statement, settings);
     }

--- a/source/dead-code-eliminator/statement-classifiers.test.ts
+++ b/source/dead-code-eliminator/statement-classifiers.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { SyntaxKind, type SourceFile, type Statement } from 'ts-morph';
 import { createProject } from '../test-libraries/typescript-project.ts';
-import { statementClassifiers } from './statement-classifiers.ts';
+import { statementClassifierFor } from './statement-classifiers.ts';
 
 function firstStatementOfKind(content: string, kind: SyntaxKind): Statement {
     const project = createProject({ withFiles: [{ filePath: 'index.ts', content }] });
@@ -13,42 +13,42 @@ function firstStatementOfKind(content: string, kind: SyntaxKind): Statement {
 
 suite('statement-classifiers', function () {
     test('statementClassifiers maps ImportDeclaration to a classifier that flags .css imports', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ImportDeclaration);
+        const classifier = statementClassifierFor(SyntaxKind.ImportDeclaration);
         const statement = firstStatementOfKind('import "./style.css";', SyntaxKind.ImportDeclaration);
 
         assert.strictEqual(classifier?.(statement, undefined), 'css import');
     });
 
     test('statementClassifiers maps ImportDeclaration to a classifier that returns undefined for non-css imports', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ImportDeclaration);
+        const classifier = statementClassifierFor(SyntaxKind.ImportDeclaration);
         const statement = firstStatementOfKind('import "./other.js";', SyntaxKind.ImportDeclaration);
 
         assert.strictEqual(classifier?.(statement, undefined), undefined);
     });
 
     test('statementClassifiers maps ExpressionStatement to a classifier that always reports it as a side effect', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ExpressionStatement);
+        const classifier = statementClassifierFor(SyntaxKind.ExpressionStatement);
         const statement = firstStatementOfKind('foo();', SyntaxKind.ExpressionStatement);
 
         assert.strictEqual(classifier?.(statement, undefined), 'expression statement');
     });
 
     test('statementClassifiers maps VariableStatement to a classifier that flags impure initializers', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.VariableStatement);
+        const classifier = statementClassifierFor(SyntaxKind.VariableStatement);
         const statement = firstStatementOfKind('const x = Math.random();', SyntaxKind.VariableStatement);
 
         assert.strictEqual(classifier?.(statement, undefined), 'variable initializer');
     });
 
     test('statementClassifiers maps VariableStatement to a classifier that returns undefined for pure initializers', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.VariableStatement);
+        const classifier = statementClassifierFor(SyntaxKind.VariableStatement);
         const statement = firstStatementOfKind('const x = 1;', SyntaxKind.VariableStatement);
 
         assert.strictEqual(classifier?.(statement, undefined), undefined);
     });
 
     test('statementClassifiers maps ClassDeclaration to a classifier that flags decorated classes', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ClassDeclaration);
+        const classifier = statementClassifierFor(SyntaxKind.ClassDeclaration);
         const statement = firstStatementOfKind(
             'function dec(_: unknown): void {}\n@dec\nclass Foo { method() { return 1; } }',
             SyntaxKind.ClassDeclaration
@@ -58,21 +58,21 @@ suite('statement-classifiers', function () {
     });
 
     test('statementClassifiers maps ClassDeclaration to a classifier that returns undefined for plain classes', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ClassDeclaration);
+        const classifier = statementClassifierFor(SyntaxKind.ClassDeclaration);
         const statement = firstStatementOfKind('class Foo { method() { return 1; } }', SyntaxKind.ClassDeclaration);
 
         assert.strictEqual(classifier?.(statement, undefined), undefined);
     });
 
     test('statementClassifiers maps ExportAssignment to a classifier that flags impure default exports', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ExportAssignment);
+        const classifier = statementClassifierFor(SyntaxKind.ExportAssignment);
         const statement = firstStatementOfKind('export default Math.random();', SyntaxKind.ExportAssignment);
 
         assert.strictEqual(classifier?.(statement, undefined), 'export assignment');
     });
 
     test('statementClassifiers maps ExportAssignment to a classifier that returns undefined for pure default exports', function () {
-        const classifier = statementClassifiers.get(SyntaxKind.ExportAssignment);
+        const classifier = statementClassifierFor(SyntaxKind.ExportAssignment);
         const statement = firstStatementOfKind('export default 1;', SyntaxKind.ExportAssignment);
 
         assert.strictEqual(classifier?.(statement, undefined), undefined);

--- a/source/dead-code-eliminator/statement-classifiers.ts
+++ b/source/dead-code-eliminator/statement-classifiers.ts
@@ -10,7 +10,7 @@ import type { DeadCodeEliminationSettings } from '../config/dead-code-eliminatio
 import { hasClassImpurity } from './class-purity.ts';
 import { isPureExpression } from './pure-expression.ts';
 
-export type StatementClassifier = (
+type StatementClassifier = (
     statement: Statement,
     settings: DeadCodeEliminationSettings | undefined
 ) => string | undefined;
@@ -60,38 +60,58 @@ function classifyVariableStatement(
     return undefined;
 }
 
-export const statementClassifiers: ReadonlyMap<SyntaxKind, StatementClassifier> = new Map<
-    SyntaxKind,
-    StatementClassifier
->([
-    [
-        SyntaxKind.ImportDeclaration,
-        (statement) => {
-            return classifyImportDeclaration(statement.asKindOrThrow(SyntaxKind.ImportDeclaration));
-        }
-    ],
-    [
-        SyntaxKind.ExportAssignment,
-        (statement, settings) => {
-            return classifyExportAssignment(statement.asKindOrThrow(SyntaxKind.ExportAssignment), settings);
-        }
-    ],
-    [
-        SyntaxKind.ClassDeclaration,
-        (statement, settings) => {
-            return classifyClassDeclaration(statement.asKindOrThrow(SyntaxKind.ClassDeclaration), settings);
-        }
-    ],
-    [
-        SyntaxKind.VariableStatement,
-        (statement, settings) => {
-            return classifyVariableStatement(statement.asKindOrThrow(SyntaxKind.VariableStatement), settings);
-        }
-    ],
-    [
-        SyntaxKind.ExpressionStatement,
-        () => {
-            return 'expression statement';
-        }
-    ]
-]);
+function importDeclarationClassifier(statement: Statement): string | undefined {
+    return classifyImportDeclaration(statement.asKindOrThrow(SyntaxKind.ImportDeclaration));
+}
+
+function exportAssignmentClassifier(
+    statement: Statement,
+    settings: DeadCodeEliminationSettings | undefined
+): string | undefined {
+    return classifyExportAssignment(statement.asKindOrThrow(SyntaxKind.ExportAssignment), settings);
+}
+
+function classDeclarationClassifier(
+    statement: Statement,
+    settings: DeadCodeEliminationSettings | undefined
+): string | undefined {
+    return classifyClassDeclaration(statement.asKindOrThrow(SyntaxKind.ClassDeclaration), settings);
+}
+
+function variableStatementClassifier(
+    statement: Statement,
+    settings: DeadCodeEliminationSettings | undefined
+): string | undefined {
+    return classifyVariableStatement(statement.asKindOrThrow(SyntaxKind.VariableStatement), settings);
+}
+
+function expressionStatementClassifier(): string {
+    return 'expression statement';
+}
+
+function declarationStatementClassifierFor(kind: SyntaxKind): StatementClassifier | undefined {
+    if (kind === SyntaxKind.ImportDeclaration) {
+        return importDeclarationClassifier;
+    }
+    if (kind === SyntaxKind.ExportAssignment) {
+        return exportAssignmentClassifier;
+    }
+    return undefined;
+}
+
+function executableStatementClassifierFor(kind: SyntaxKind): StatementClassifier | undefined {
+    if (kind === SyntaxKind.ClassDeclaration) {
+        return classDeclarationClassifier;
+    }
+    if (kind === SyntaxKind.VariableStatement) {
+        return variableStatementClassifier;
+    }
+    if (kind === SyntaxKind.ExpressionStatement) {
+        return expressionStatementClassifier;
+    }
+    return undefined;
+}
+
+export function statementClassifierFor(kind: SyntaxKind): StatementClassifier | undefined {
+    return declarationStatementClassifierFor(kind) ?? executableStatementClassifierFor(kind);
+}

--- a/source/dependency-scanner/source-file-references.ts
+++ b/source/dependency-scanner/source-file-references.ts
@@ -36,9 +36,6 @@ export type ModuleReference =
     | LocalAssetReference
     | LocalCodeReference;
 
-const localAssetExtensions = new Set(['.json', '.wasm']);
-const wasmExtension = '.wasm';
-
 function hashImportPrefix(): string {
     return '#';
 }
@@ -93,12 +90,17 @@ function externalPackageNameForResolvedImport(
     return packageNameFromSpecifier(importValue);
 }
 
+function isLocalAssetReference(filePath: string): boolean {
+    const extension = path.extname(filePath);
+    return extension === '.json' || extension === '.wasm';
+}
+
 function classifyLocalReference(resolvedFilePath: string, packageJsonPath: string): ModuleReference {
     if (path.resolve(resolvedFilePath) === path.resolve(packageJsonPath)) {
         return { kind: moduleReferenceKind.generatedManifest, filePath: resolvedFilePath };
     }
 
-    if (localAssetExtensions.has(path.extname(resolvedFilePath))) {
+    if (isLocalAssetReference(resolvedFilePath)) {
         return { kind: moduleReferenceKind.localAsset, filePath: resolvedFilePath };
     }
 
@@ -186,7 +188,7 @@ function resolveModuleReferenceForImport(
         return classifyLocalReference(resolvedModule.resolvedFileName, packageJsonPath);
     }
 
-    return importValue.endsWith(wasmExtension)
+    return importValue.endsWith('.wasm')
         ? resolveWasmReference(importValue, containingSourceFile, packageJsonPath)
         : undefined;
 }

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -29,6 +29,7 @@ packtory <command> [options]
 - **preview --open:** Generates the same fresh preview report as `packtory preview`, writes a temporary HTML file, and opens it with the platform opener.
 - **publish --report-json:** Writes `packtory-report.json`, the machine-readable `BuildReport`.
 - **publish --report-html:** Writes `packtory-report.html`, the rich HTML report used by `packtory preview --open`.
+- **publish --stage:** Uses npm staged publishing instead of a direct publish. Successful runs print the npm `stageId` per package. Approval still happens later via `npm stage approve <stage-id>` or npmjs.com. Stage mode is npm-only, and the package must already exist on npm.
 - **pack &lt;package&gt; --format &lt;zip|tar|folder&gt; --out &lt;path&gt;:** Selects which package from the configuration to build and where to write it. `--format` and `--out` are required.
 - **pack --version &lt;version&gt;:** Stamps the produced manifest with the given version. Defaults to `0.0.0` when omitted, since `pack` is decoupled from the registry-driven automatic versioning used by `publish`.
 - **pack --vendor-dependencies:** Resolves every external (and bundle) dependency from the local `node_modules` and materializes them next to the package files inside the artifact. Use this for self-contained deployments where the runtime cannot run `npm install` (e.g. AWS Lambda zips). Without the flag, dependencies are recorded in the generated `package.json` only.
@@ -87,6 +88,8 @@ Your root `package.json` must declare `"type": "module"`.
 - If the registry challenges a publish with a one-time password, the CLI prompts for it when running in an interactive TTY.
 - The prompt times out after 90 seconds.
 - Non-interactive runs cannot answer a one-time-password challenge. For CI, prefer an auth method that does not require live one-time-password entry, such as npm trusted publishing / OIDC or a suitable registry token setup.
+- npm staged publishing (`publish --stage`) can use the same write auth as a normal publish, including npm OIDC/trusted publishing. Approving or rejecting a staged package still happens outside packtory.
+- Automatic versioning in npm stage mode also inspects pending staged versions. If publish auth uses npm OIDC/trusted publishing, configure token-based metadata auth too so packtory can perform that lookup.
 
 **Publish settings:**
 

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'tstyche';
 import type { Result } from 'true-myth';
+import type { PublicationOutcome } from '../../bundle-emitter/publication-outcome.ts';
 import type { MetadataAuthMode, PublishAuthStrategy } from '../../config/registry-settings.ts';
 import type {
     buildAndPublishAll,
@@ -38,7 +39,7 @@ describe('public functions', () => {
         expect<typeof buildAndPublishAll>().type.toBe<
             (
                 config: unknown,
-                options: { readonly dryRun: boolean; readonly collectReport?: boolean }
+                options: { readonly dryRun: boolean; readonly stage: boolean; readonly collectReport?: boolean }
             ) => Promise<PublishAllOutcome>
         >();
     });
@@ -220,10 +221,15 @@ describe('PublishAllResult', () => {
     test('each result element exposes status and bundle', () => {
         expect<BuildAndPublishResult>().type.toHaveProperty('status');
         expect<BuildAndPublishResult>().type.toHaveProperty('bundle');
+        expect<BuildAndPublishResult>().type.toHaveProperty('publication');
     });
 
     test('the status field is a fixed string union', () => {
         expect<BuildAndPublishResult['status']>().type.toBe<'already-published' | 'initial-version' | 'new-version'>();
+    });
+
+    test('the publication field captures whether the package was published, staged, or skipped', () => {
+        expect<BuildAndPublishResult['publication']>().type.toBe<PublicationOutcome>();
     });
 
     test('the failure variant is a discriminated union keyed by `type`', () => {

--- a/source/packages/packtory/readme.md
+++ b/source/packages/packtory/readme.md
@@ -25,7 +25,7 @@ const config = {
 };
 
 (async () => {
-    const publishOutcome = await buildAndPublishAll(config, { dryRun: true });
+    const publishOutcome = await buildAndPublishAll(config, { dryRun: true, stage: false });
     console.log(publishOutcome.result);
 
     const resolvedOutcome = await resolveAndLinkAll(config);
@@ -46,13 +46,15 @@ const config = {
 
 - **config:** The packtory configuration object.
 - **options:** Per-function options object:
-    - `buildAndPublishAll`: `{ dryRun: boolean; collectReport?: boolean }`.
+    - `buildAndPublishAll`: `{ dryRun: boolean; stage: boolean; collectReport?: boolean }`.
     - `resolveAndLinkAll`: optional `{ collectReport?: boolean }`.
     - `packPackage`: `{ packageName, format, outputPath, version, vendorDependencies }`. `format` is `'zip' | 'tar' | 'folder'`. `version` stamps the generated manifest (no automatic versioning is performed). `vendorDependencies` toggles materializing the resolved `node_modules` tree (including any `bundleDependencies`) into the artifact for self-contained deployments.
 
 **Return Values:**
 
 - `buildAndPublishAll` returns a `PublishAllOutcome` whose `result` is either a list of successful publish results or a partial error if some packages failed.
+  Each successful item includes `publication`, which is `{ type: 'none' }` for dry-runs / already-up-to-date packages, `{ type: 'published' }` for direct publishes, or `{ type: 'staged', stageId }` for npm staged publishing.
+- Stage mode is npm-only. The package must already exist on npm, and automatic versioning in stage mode must be able to list pending staged versions before choosing the next version. If publish auth uses npm OIDC/trusted publishing, provide token-based metadata auth for that lookup.
 - `resolveAndLinkAll` returns a `ResolveAndLinkAllOutcome` whose `result` carries the resolved package information or details about the failure (validation errors, check failures, or partial execution issues).
 - `diffAgainstLatestPublished` returns a `ReleaseDiffAllOutcome` whose `result` carries the per-package release diff list or a failure variant.
 - `packPackage` returns a `PackOutcome` whose `result` is `Ok(undefined)` on success or a `PackFailure`. `PackFailure` is a discriminated union covering configuration errors, check failures, partial resolve failures, and the pack-specific variants `package-not-found`, `bundle-dependencies-unsupported` (rejected when `vendorDependencies` is `false` and the target declares `bundleDependencies`), and `peer-dependencies-unsatisfied` (raised when a vendored dependency declares a peer that no other vendored package satisfies).

--- a/source/packtory/package-processor-publish.test.ts
+++ b/source/packtory/package-processor-publish.test.ts
@@ -30,7 +30,8 @@ suite('package-processor-publish', function () {
         try {
             await operations.tryBuildAndPublish({
                 analyzedBundle: { name: 'pkg-a' } as never,
-                buildOptions: { mainPackageJson: { type: 'commonjs' } } as never
+                buildOptions: { mainPackageJson: { type: 'commonjs' } } as never,
+                stage: false
             });
             assert.fail('expected tryBuildAndPublish to reject the non-ESM main package json');
         } catch (error) {

--- a/source/packtory/package-processor-publish.ts
+++ b/source/packtory/package-processor-publish.ts
@@ -1,13 +1,8 @@
-/* eslint-disable import/max-dependencies -- the publish operation legitimately bridges bundle-emitter, version-manager, sbom, progress, and option-mapping helpers */
 import { isDefined, pickBy } from 'remeda';
-import type { Maybe } from 'true-myth';
+import { noPublication } from '../bundle-emitter/publication-outcome.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
-import { bundledDependenciesFrom } from '../common/bundled-dependency-groups.ts';
 import type { BundleEmitter } from '../bundle-emitter/emitter.ts';
-import type { PublishedReleaseArtifacts } from '../bundle-emitter/fetch-published-artifacts.ts';
-import type { FileDescription } from '../file-manager/file-description.ts';
 import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
-import type { SbomSiblingPackage } from '../published-package/published-package.ts';
 import type { SbomFileBuilder } from '../sbom/sbom-file.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
 import type { BuildAndPublishOptions } from './map-config.ts';
@@ -15,6 +10,14 @@ import { determineBuildVersion, inferVersionTrigger, shouldIncreaseVersion } fro
 import { publishedReleaseStatus, type PublishedReleaseStatus, wasAlreadyPublished } from './published-release-state.ts';
 
 type VersionedBundleWithManifest = Awaited<ReturnType<VersionManager['addVersion']>>;
+type CurrentVersion = Awaited<ReturnType<BundleEmitter['determineCurrentVersion']>>;
+type PublicationOutcome = Awaited<ReturnType<BundleEmitter['publish']>>;
+type PreviousReleaseArtifacts = Awaited<
+    ReturnType<BundleEmitter['checkBundleAlreadyPublished']>
+>['previousReleaseArtifacts'];
+type ExtraFiles = Exclude<Awaited<ReturnType<SbomFileBuilder['generate']>>, undefined>;
+type SiblingPackage = Parameters<SbomFileBuilder['generate']>[1][number];
+
 type PublishDependencies = {
     readonly bundleEmitter: BundleEmitter;
     readonly progressBroadcaster: ProgressBroadcastProvider;
@@ -25,13 +28,15 @@ type PublishDependencies = {
 export type BuildAndPublishResult = {
     readonly status: PublishedReleaseStatus;
     readonly bundle: VersionedBundleWithManifest;
-    readonly extraFiles: readonly FileDescription[];
-    readonly previousReleaseArtifacts: Maybe<PublishedReleaseArtifacts>;
+    readonly publication: PublicationOutcome;
+    readonly extraFiles: ExtraFiles;
+    readonly previousReleaseArtifacts: PreviousReleaseArtifacts;
 };
 
 export type DetermineVersionAndPublishOptions = {
     readonly analyzedBundle: AnalyzedBundle;
     readonly buildOptions: BuildAndPublishOptions;
+    readonly stage: boolean;
     readonly substitutionPublicModuleSourcePaths?: ReadonlySet<string> | undefined;
 };
 
@@ -41,7 +46,9 @@ function assertEsmMainPackageJson(mainPackageJson: { readonly type?: string | un
     }
 }
 
-const siblingsFromOptions = bundledDependenciesFrom<SbomSiblingPackage>;
+function siblingsFromOptions(buildOptions: BuildAndPublishOptions): readonly SiblingPackage[] {
+    return [...buildOptions.bundleDependencies, ...buildOptions.bundlePeerDependencies];
+}
 
 export type PublishOperations = {
     readonly buildAndPublish: (options: DetermineVersionAndPublishOptions) => Promise<BuildAndPublishResult>;
@@ -52,16 +59,18 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
     async function buildVersionedBundle(
         analyzedBundle: AnalyzedBundle,
         options: BuildAndPublishOptions,
+        stage: boolean,
         substitutionPublicModuleSourcePaths: ReadonlySet<string> | undefined
     ): Promise<{
         versionedBundle: VersionedBundleWithManifest;
-        currentVersion: Maybe<string>;
+        currentVersion: CurrentVersion;
         version: string;
     }> {
         assertEsmMainPackageJson(options.mainPackageJson);
         const currentVersion = await dependencies.bundleEmitter.determineCurrentVersion({
             name: analyzedBundle.name,
             registrySettings: options.registrySettings,
+            stage,
             versioning: options.versioning
         });
         const version = determineBuildVersion(currentVersion, options);
@@ -77,7 +86,7 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
 
     function emitVersionDetermined(args: {
         readonly options: BuildAndPublishOptions;
-        readonly currentVersion: Maybe<string>;
+        readonly currentVersion: CurrentVersion;
         readonly chosenVersion: string;
         readonly didBump: boolean;
     }): void {
@@ -93,12 +102,12 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
     }
 
     function finalizeWithoutBump(
-        buildContext: { versionedBundle: VersionedBundleWithManifest; currentVersion: Maybe<string> },
+        buildContext: { versionedBundle: VersionedBundleWithManifest; currentVersion: CurrentVersion },
         options: BuildAndPublishOptions,
         status: BuildAndPublishResult['status'],
         extras: {
-            extraFiles: readonly FileDescription[];
-            previousReleaseArtifacts: Maybe<PublishedReleaseArtifacts>;
+            extraFiles: ExtraFiles;
+            previousReleaseArtifacts: PreviousReleaseArtifacts;
         }
     ): BuildAndPublishResult {
         emitVersionDetermined({
@@ -110,13 +119,18 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
         return {
             bundle: buildContext.versionedBundle,
             status,
+            publication: noPublication,
             extraFiles: extras.extraFiles,
             previousReleaseArtifacts: extras.previousReleaseArtifacts
         };
     }
 
     async function bumpVersion(
-        buildContext: { versionedBundle: VersionedBundleWithManifest; version: string; currentVersion: Maybe<string> },
+        buildContext: {
+            readonly versionedBundle: VersionedBundleWithManifest;
+            readonly version: string;
+            readonly currentVersion: CurrentVersion;
+        },
         options: BuildAndPublishOptions
     ): Promise<VersionedBundleWithManifest> {
         dependencies.progressBroadcaster.emit('rebuilding', {
@@ -136,7 +150,7 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
     async function generateExtraFiles(
         versionedBundle: VersionedBundleWithManifest,
         buildOptions: BuildAndPublishOptions
-    ): Promise<readonly FileDescription[]> {
+    ): Promise<ExtraFiles> {
         const result = await dependencies.sbomFileBuilder.generate(
             versionedBundle,
             siblingsFromOptions(buildOptions),
@@ -149,6 +163,7 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
         const buildContext = await buildVersionedBundle(
             options.analyzedBundle,
             options.buildOptions,
+            options.stage,
             options.substitutionPublicModuleSourcePaths
         );
         const preBumpExtraFiles = await generateExtraFiles(buildContext.versionedBundle, options.buildOptions);
@@ -189,6 +204,7 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
             status: buildContext.currentVersion.isJust
                 ? publishedReleaseStatus.newVersion
                 : publishedReleaseStatus.initialVersion,
+            publication: noPublication,
             extraFiles,
             previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts
         };
@@ -204,19 +220,20 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
             packageName: options.buildOptions.name,
             version: result.bundle.version
         });
-        await dependencies.bundleEmitter.publish(
+        const publication = await dependencies.bundleEmitter.publish(
             pickBy(
                 {
                     bundle: result.bundle,
                     registrySettings: options.buildOptions.registrySettings,
                     publishSettings: options.buildOptions.publishSettings,
+                    stage: options.stage,
                     extraFiles: result.extraFiles.length === 0 ? undefined : result.extraFiles
                 },
                 isDefined
             )
         );
 
-        return result;
+        return { ...result, publication };
     }
 
     return { buildAndPublish, tryBuildAndPublish };

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
+import { noPublication, publishedToRegistry, stagedForApproval } from '../bundle-emitter/publication-outcome.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { LinkedBundle } from '../linker/linked-bundle.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
@@ -191,13 +192,18 @@ function createBuildAndPublishOptions(): BuildAndPublishOptions {
     };
 }
 
+function createDetermineVersionAndPublishOptions(): DetermineVersionAndPublishOptions {
+    return {
+        analyzedBundle: createAnalyzedBundle(),
+        buildOptions: createBuildAndPublishOptions(),
+        stage: false
+    };
+}
+
 async function tryBuildAndPublishDefault(
     processor: ReturnType<typeof createPackageProcessor>
 ): ReturnType<ReturnType<typeof createPackageProcessor>['tryBuildAndPublish']> {
-    return processor.tryBuildAndPublish({
-        analyzedBundle: createAnalyzedBundle(),
-        buildOptions: createBuildAndPublishOptions()
-    });
+    return processor.tryBuildAndPublish(createDetermineVersionAndPublishOptions());
 }
 
 function getCallArgs(spy: SinonSpy): unknown[][] {
@@ -343,12 +349,14 @@ suite('package-processor', function () {
 
         const result = await processor.tryBuildAndPublish({
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions: createBuildAndPublishOptions()
+            buildOptions: createBuildAndPublishOptions(),
+            stage: false
         });
 
         assert.deepStrictEqual(result, {
             bundle: versionedBundle,
             status: 'already-published',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -377,6 +385,7 @@ suite('package-processor', function () {
         assert.deepStrictEqual(result, {
             bundle: rebuiltBundle,
             status: 'initial-version',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -384,6 +393,7 @@ suite('package-processor', function () {
             {
                 name: 'package-a',
                 registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                stage: false,
                 versioning: { automatic: true }
             }
         ]);
@@ -407,6 +417,7 @@ suite('package-processor', function () {
         assert.deepStrictEqual(result, {
             bundle: rebuiltBundle,
             status: 'new-version',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -425,12 +436,14 @@ suite('package-processor', function () {
         };
         const result = await processor.tryBuildAndPublish({
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions
+            buildOptions,
+            stage: false
         });
 
         assert.deepStrictEqual(result, {
             bundle: manualBundle,
             status: 'initial-version',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -451,12 +464,14 @@ suite('package-processor', function () {
         };
         const result = await processor.tryBuildAndPublish({
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions
+            buildOptions,
+            stage: false
         });
 
         assert.deepStrictEqual(result, {
             bundle: currentBundle,
             status: 'new-version',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -477,12 +492,14 @@ suite('package-processor', function () {
         };
         const result = await processor.tryBuildAndPublish({
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions
+            buildOptions,
+            stage: false
         });
 
         assert.deepStrictEqual(result, {
             bundle: minimumVersionBundle,
             status: 'initial-version',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -504,7 +521,7 @@ suite('package-processor', function () {
 
         const analyzedBundle = createAnalyzedBundle();
         const buildOptions = createBuildAndPublishOptions();
-        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions });
+        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions, stage: false });
 
         assert.deepStrictEqual(addVersion.firstCall.args, [
             {
@@ -528,12 +545,14 @@ suite('package-processor', function () {
             buildOptions: {
                 ...createBuildAndPublishOptions(),
                 versioning: { automatic: false, version: '3.2.1' }
-            }
+            },
+            stage: false
         });
 
         assert.deepStrictEqual(result, {
             bundle: manualBundle,
             status: 'new-version',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -546,6 +565,7 @@ suite('package-processor', function () {
         const alreadyPublishedResult: BuildAndPublishResult = {
             bundle: createVersionedBundle(),
             status: 'already-published',
+            publication: noPublication,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         };
@@ -561,7 +581,8 @@ suite('package-processor', function () {
 
         const result = await processor.buildAndPublish({
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions: createBuildAndPublishOptions()
+            buildOptions: createBuildAndPublishOptions(),
+            stage: false
         });
 
         assert.deepStrictEqual(result, alreadyPublishedResult);
@@ -571,7 +592,7 @@ suite('package-processor', function () {
 
     test('buildAndPublish() publishes the rebuilt bundle and emits publishing progress', async function () {
         const rebuiltBundle = createVersionedBundle('package-a', '1.2.4');
-        const publish = fake.resolves(undefined);
+        const publish = fake.resolves(publishedToRegistry);
         const { processor, emit } = createProcessor({
             determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
             addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
@@ -581,13 +602,15 @@ suite('package-processor', function () {
 
         const options: DetermineVersionAndPublishOptions = {
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions: createBuildAndPublishOptions()
+            buildOptions: createBuildAndPublishOptions(),
+            stage: false
         };
         const result = await processor.buildAndPublish(options);
 
         assert.deepStrictEqual(result, {
             bundle: rebuiltBundle,
             status: 'new-version',
+            publication: publishedToRegistry,
             extraFiles: [],
             previousReleaseArtifacts: Maybe.nothing()
         });
@@ -595,7 +618,8 @@ suite('package-processor', function () {
             {
                 bundle: rebuiltBundle,
                 registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-                publishSettings: { access: 'public', sbom: { enabled: false } }
+                publishSettings: { access: 'public', sbom: { enabled: false } },
+                stage: false
             }
         ]);
         assert.deepStrictEqual(getCallArgs(emit), [
@@ -603,6 +627,26 @@ suite('package-processor', function () {
             ['rebuilding', { packageName: 'package-a', version: '1.2.3' }],
             ['publishing', { packageName: 'package-a', version: '1.2.4' }]
         ]);
+    });
+
+    test('buildAndPublish() returns a staged publication outcome when stage mode is enabled', async function () {
+        const rebuiltBundle = createVersionedBundle('package-a', '1.2.4');
+        const publish = fake.resolves(stagedForApproval('stage-123'));
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion: fake.returns(createVersionedBundle('package-a', '1.2.3')),
+            increaseVersion: fake.returns(rebuiltBundle),
+            publish
+        });
+
+        const result = await processor.buildAndPublish({
+            analyzedBundle: createAnalyzedBundle(),
+            buildOptions: createBuildAndPublishOptions(),
+            stage: true
+        });
+
+        assert.deepStrictEqual(result.publication, stagedForApproval('stage-123'));
+        assert.strictEqual((publish.firstCall.args[0] as { stage: boolean }).stage, true);
     });
 
     function setupSbomScenario(
@@ -640,7 +684,7 @@ suite('package-processor', function () {
             ...createBuildAndPublishOptions(),
             publishSettings: { access: 'public', sbom: { enabled: true } }
         };
-        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions });
+        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions, stage: false });
 
         assert.strictEqual(generateSbom.callCount, 2);
         const expectedSiblings = [...buildOptions.bundleDependencies, ...buildOptions.bundlePeerDependencies];
@@ -658,7 +702,11 @@ suite('package-processor', function () {
     test('tryBuildAndPublish() omits extraFiles when sbomFileBuilder returns undefined', async function () {
         const { analyzedBundle, checkBundleAlreadyPublished, processor } = setupSbomScenario(undefined);
 
-        await processor.tryBuildAndPublish({ analyzedBundle, buildOptions: createBuildAndPublishOptions() });
+        await processor.tryBuildAndPublish({
+            analyzedBundle,
+            buildOptions: createBuildAndPublishOptions(),
+            stage: false
+        });
 
         const checkArgs = checkBundleAlreadyPublished.firstCall.args[0] as Record<string, unknown>;
         assert.strictEqual('extraFiles' in checkArgs, false);
@@ -785,7 +833,8 @@ suite('package-processor', function () {
 
         await processor.tryBuildAndPublish({
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions: { ...createBuildAndPublishOptions(), versioning: { automatic: false, version: '4.5.6' } }
+            buildOptions: { ...createBuildAndPublishOptions(), versioning: { automatic: false, version: '4.5.6' } },
+            stage: false
         });
 
         expectSingleVersionDetermined(emit, {
@@ -829,7 +878,8 @@ suite('package-processor', function () {
             buildOptions: {
                 ...createBuildAndPublishOptions(),
                 versioning: { automatic: true, minimumVersion: '1.2.3' }
-            }
+            },
+            stage: false
         });
 
         expectSingleVersionDetermined(emit, {
@@ -935,7 +985,8 @@ suite('package-processor', function () {
 
         const options: DetermineVersionAndPublishOptions = {
             analyzedBundle: createAnalyzedBundle(),
-            buildOptions: { ...createBuildAndPublishOptions(), publishSettings: { access: 'public' } }
+            buildOptions: { ...createBuildAndPublishOptions(), publishSettings: { access: 'public' } },
+            stage: false
         };
         await processor.buildAndPublish(options);
 

--- a/source/packtory/packtory-publish.test.ts
+++ b/source/packtory/packtory-publish.test.ts
@@ -23,7 +23,7 @@ suite('packtory-publish', function () {
 
         const result = await run(
             { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-            { dryRun: false },
+            { dryRun: false, stage: false },
             async () => Result.ok([])
         );
 
@@ -35,7 +35,7 @@ suite('packtory-publish', function () {
 
         const result = await run(
             { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-            { dryRun: false },
+            { dryRun: false, stage: false },
             async () => Result.err({ type: 'config', issues: ['bad'] })
         );
 
@@ -55,7 +55,7 @@ suite('packtory-publish', function () {
 
         const result = await run(
             { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
-            { dryRun: false },
+            { dryRun: false, stage: false },
             async () => Result.ok([])
         );
 

--- a/source/packtory/packtory-release-analysis.test.ts
+++ b/source/packtory/packtory-release-analysis.test.ts
@@ -17,6 +17,7 @@ type BuildAndPublishResult = Awaited<
 >;
 type PackageProcessor = ReleaseAnalysisOrchestratorDependencies['packageProcessor'];
 type FileCollection = ReleaseAnalysisOrchestratorDependencies['artifactsBuilder']['collectContents'];
+const noPublicationOutcome = { type: 'none' } as const;
 
 function validatedConfigFor(packageNames: readonly string[]): ValidConfigResult {
     const result = validateConfig({
@@ -86,6 +87,7 @@ function buildResultFor(
 
     return {
         status: 'new-version',
+        publication: noPublicationOutcome,
         bundle: versionedBundleWithManifest({
             name: packageName,
             version: '1.0.1',
@@ -226,6 +228,34 @@ function dependencyOnlyFiles(version: string): readonly {
 }
 
 suite('packtory-release-analysis', function () {
+    test('runs dry-run publish analysis with staged publishing disabled', async function () {
+        const validated = validatedConfigFor(['pkg-a']);
+        const analyze = createAnalyzer({
+            packageNames: ['pkg-a'],
+            packageProcessor: {
+                async build() {
+                    throw new Error('build() should not be called in release-analysis tests');
+                },
+                async buildAndPublish() {
+                    throw new Error('buildAndPublish() should not be called in release-analysis dry runs');
+                },
+                async resolveAndLink() {
+                    throw new Error('resolveAndLink() should not be called in release-analysis tests');
+                },
+                async tryBuildAndPublish(options) {
+                    assert.strictEqual(options.stage, false);
+                    return buildResultFor();
+                }
+            }
+        });
+
+        const result = await analyze(validated, async () => {
+            return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
+        });
+
+        assert.strictEqual(result.isOk, true);
+    });
+
     test('passes non-partial resolve failures through unchanged', async function () {
         const analyze = createAnalyzer({ packageNames: [] });
         const validated = validatedConfigFor(['pkg-a']);

--- a/source/packtory/packtory-release-analysis.ts
+++ b/source/packtory/packtory-release-analysis.ts
@@ -105,7 +105,8 @@ export function createAnalyzeReleaseAgainstLatestPublishedValidated(
         }
 
         const publishResult = await determineVersionAndPublishAll(dependencies, validated, resolved.value, {
-            dryRun: true
+            dryRun: true,
+            stage: false
         });
         const analysisResult = await analyzeSucceededPublishes(
             dependencies.artifactsBuilder,

--- a/source/packtory/packtory-release-diff.test.ts
+++ b/source/packtory/packtory-release-diff.test.ts
@@ -6,6 +6,7 @@ import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
 import type { ValidConfigResult } from '../config/validation.ts';
 import { createIteratingScheduler } from '../test-libraries/iterating-scheduler.ts';
 import { stubPackageProcessor, stubProgressBroadcaster } from '../test-libraries/orchestrator-stub-fixtures.ts';
+import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import type { BuildAndPublishResult } from './package-processor.ts';
 import {
     createDiffAgainstLatestPublishedValidated,
@@ -19,6 +20,21 @@ const artifactsBuilder = { collectContents: () => [] } as unknown as Pick<Artifa
 
 function configFor(packageNames: readonly string[]): ValidConfigResult {
     return {
+        packageConfigs: Object.fromEntries(
+            packageNames.map((name) => {
+                return [
+                    name,
+                    {
+                        name,
+                        roots: { main: { js: `${name}.js` } },
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        publishSettings: { access: 'public' },
+                        registrySettings: { auth: { type: 'bearer-token', token: 'token' } }
+                    }
+                ];
+            })
+        ),
         packtoryConfig: {
             packages: packageNames.map((name) => {
                 return { name };
@@ -31,10 +47,13 @@ const okResolve = async () => {
     return Result.ok([] as readonly ResolvedPackage[]);
 };
 
-function createDiff(scheduler: PackageScheduler): ReturnType<typeof createDiffAgainstLatestPublishedValidated> {
+function createDiff(
+    scheduler: PackageScheduler,
+    packageProcessor: ReleaseDiffOrchestratorDependencies['packageProcessor'] = stubPackageProcessor
+): ReturnType<typeof createDiffAgainstLatestPublishedValidated> {
     const dependencies: ReleaseDiffOrchestratorDependencies = {
         artifactsBuilder,
-        packageProcessor: stubPackageProcessor,
+        packageProcessor,
         progressBroadcaster: stubProgressBroadcaster,
         scheduler
     };
@@ -121,6 +140,45 @@ function expectPartialErr(result: ReleaseDiffAllResult): PartialError<unknown> &
 }
 
 suite('packtory-release-diff', function () {
+    test('runs dry-run publish preparation with staged publishing disabled', async function () {
+        let sawDryRunStageFlag = false;
+        const diff = createDiff(createIteratingScheduler(['pkg-a']), {
+            ...stubPackageProcessor,
+            async tryBuildAndPublish(options) {
+                sawDryRunStageFlag = true;
+                assert.strictEqual(options.stage, false);
+                return {
+                    status: 'already-published',
+                    bundle: versionedBundleWithManifest({
+                        name: 'pkg-a',
+                        version: '1.0.0',
+                        packageJson: { name: 'pkg-a', version: '1.0.0' }
+                    }),
+                    extraFiles: [],
+                    previousReleaseArtifacts: Maybe.nothing()
+                } as unknown as BuildAndPublishResult;
+            }
+        });
+
+        const result = await diff(configFor(['pkg-a']), async () => {
+            return Result.ok([
+                {
+                    name: 'pkg-a',
+                    analyzedBundle: {
+                        name: 'pkg-a',
+                        contents: [],
+                        roots: {},
+                        surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+                    },
+                    resolveOptions: {}
+                }
+            ] as unknown as readonly ResolvedPackage[]);
+        });
+
+        assert.strictEqual(result.isOk, true);
+        assert.strictEqual(sawDryRunStageFlag, true);
+    });
+
     test('returns a config Err when resolve-and-link returns a non-partial failure (unchanged passthrough)', async function () {
         const diff = createDiff(createIteratingScheduler([]));
 

--- a/source/packtory/packtory-release-diff.ts
+++ b/source/packtory/packtory-release-diff.ts
@@ -77,7 +77,8 @@ export function createDiffAgainstLatestPublishedValidated(
             return Result.err(mapResolveFailureToReleaseDiffFailure(resolved.error));
         }
         const publishResult = await determineVersionAndPublishAll(dependencies, validated, resolved.value, {
-            dryRun: true
+            dryRun: true,
+            stage: false
         });
         const succeededPublish = succeededFromPublish(publishResult);
         const stageResult = await runReleaseDiffStage(dependencies, validated, succeededPublish);

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -50,6 +50,7 @@ export type PackPackageFailure =
 
 export type BuildAndPublishAllOptions = {
     readonly dryRun: boolean;
+    readonly stage: boolean;
     readonly collectReport?: boolean;
 };
 

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -9,6 +9,11 @@ import { createTestProgressBroadcaster, getErrResult, getOkResult } from '../tes
 import type { PackageProcessor } from './package-processor.ts';
 import { createPacktory } from './packtory.ts';
 
+type PublicationOutcome = { readonly type: 'none' } | { readonly type: 'published' };
+
+const noPublicationOutcome: Extract<PublicationOutcome, { type: 'none' }> = { type: 'none' };
+const publishedOutcome: Extract<PublicationOutcome, { type: 'published' }> = { type: 'published' };
+
 function createLinkedBundle(name: string, sourceFilePath = `/${name}/index.js`): ReturnType<typeof linkedBundle> {
     return linkedBundle({
         name,
@@ -53,6 +58,7 @@ type CreateProgressEvent = (params: {
 }) => {
     version: string;
     status: 'already-published' | 'initial-version' | 'new-version';
+    publication: PublicationOutcome;
 };
 
 type StageParams = {
@@ -161,6 +167,7 @@ function createPacktoryUnderTest(
             return {
                 bundle: createVersionedBundle(options.buildOptions.name),
                 status: 'initial-version' as const,
+                publication: noPublicationOutcome,
                 extraFiles: [],
                 previousReleaseArtifacts: Maybe.nothing()
             };
@@ -171,6 +178,7 @@ function createPacktoryUnderTest(
             return {
                 bundle: createVersionedBundle(options.buildOptions.name),
                 status: 'new-version' as const,
+                publication: publishedOutcome,
                 extraFiles: [],
                 previousReleaseArtifacts: Maybe.nothing()
             };
@@ -328,7 +336,7 @@ suite('packtory', function () {
     test('buildAndPublishAll() returns config issues when the config with registry is invalid', async function () {
         const { packtory } = createPacktoryUnderTest();
 
-        const { result } = await packtory.buildAndPublishAll({ invalid: true }, { dryRun: true });
+        const { result } = await packtory.buildAndPublishAll({ invalid: true }, { dryRun: true, stage: false });
 
         assert.deepStrictEqual(
             result,
@@ -355,7 +363,7 @@ suite('packtory', function () {
                 checks: { noDuplicatedFiles: { enabled: true } },
                 packages: twoPackageEntries
             }),
-            { dryRun: false }
+            { dryRun: false, stage: false }
         );
 
         assert.deepStrictEqual(
@@ -372,7 +380,7 @@ suite('packtory', function () {
     test('buildAndPublishAll() uses tryBuildAndPublish() in dry-run mode and returns successful publish results', async function () {
         const { packtory, tryBuildAndPublish, buildAndPublish, scheduler } = createPacktoryUnderTest();
 
-        const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
+        const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: true, stage: false });
 
         assert.deepStrictEqual(
             result,
@@ -380,6 +388,7 @@ suite('packtory', function () {
                 {
                     bundle: createVersionedBundle('package-a'),
                     status: 'initial-version',
+                    publication: noPublicationOutcome,
                     extraFiles: [],
                     previousReleaseArtifacts: Maybe.nothing()
                 }
@@ -393,7 +402,7 @@ suite('packtory', function () {
     test('buildAndPublishAll() uses buildAndPublish() outside dry-run mode', async function () {
         const { packtory, tryBuildAndPublish, buildAndPublish } = createPacktoryUnderTest();
 
-        const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: false });
+        const { result } = await packtory.buildAndPublishAll(createConfig(), { dryRun: false, stage: false });
 
         assert.deepStrictEqual(
             result,
@@ -401,6 +410,7 @@ suite('packtory', function () {
                 {
                     bundle: createVersionedBundle('package-a'),
                     status: 'new-version',
+                    publication: publishedOutcome,
                     extraFiles: [],
                     previousReleaseArtifacts: Maybe.nothing()
                 }
@@ -451,7 +461,7 @@ suite('packtory', function () {
         });
         const received = subscribeToPackageFailed(progressBroadcaster);
 
-        await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
+        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, stage: false });
 
         const publishFailures = received.filter((entry) => {
             return entry.stage === 'publish';
@@ -486,7 +496,7 @@ suite('packtory', function () {
     test('buildAndPublishAll() disposes the report aggregator after the call completes', async function () {
         const { packtory, progressBroadcaster } = createPacktoryUnderTest();
 
-        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, stage: false, collectReport: true });
 
         assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
     });
@@ -504,7 +514,7 @@ suite('packtory', function () {
             publishStage: runPublishStageUntilFailure
         });
 
-        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+        await packtory.buildAndPublishAll(createConfig(), { dryRun: true, stage: false, collectReport: true });
 
         assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
     });
@@ -528,7 +538,11 @@ suite('packtory', function () {
     test('buildAndPublishAll() with collectReport=true returns a non-undefined getReport', async function () {
         const { packtory } = createPacktoryUnderTest();
 
-        const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true, collectReport: true });
+        const outcome = await packtory.buildAndPublishAll(createConfig(), {
+            dryRun: true,
+            stage: false,
+            collectReport: true
+        });
 
         assert.notStrictEqual(outcome.getReport(), undefined);
     });
@@ -536,7 +550,7 @@ suite('packtory', function () {
     test('buildAndPublishAll() without collectReport returns a getReport that yields undefined', async function () {
         const { packtory } = createPacktoryUnderTest();
 
-        const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true });
+        const outcome = await packtory.buildAndPublishAll(createConfig(), { dryRun: true, stage: false });
 
         assert.strictEqual(outcome.getReport(), undefined);
     });
@@ -641,6 +655,7 @@ suite('packtory', function () {
                 return {
                     bundle: createVersionedBundle(options.buildOptions.name, '1.0.1'),
                     status: 'new-version' as const,
+                    publication: noPublicationOutcome,
                     extraFiles: [],
                     previousReleaseArtifacts: Maybe.just({
                         version: '1.0.0',

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
+import { noPublication } from '../bundle-emitter/publication-outcome.ts';
 import { validateConfigWithoutRegistry, type ValidConfigWithoutRegistryResult } from '../config/validation.ts';
 import { getErrResult } from '../test-libraries/result-helpers.ts';
 import { createScheduler, type Scheduler as SchedulerType } from './scheduler.ts';
@@ -120,14 +121,18 @@ suite('scheduler', function () {
             createProgressEvent: (params) => {
                 return {
                     version: '1.0.0',
-                    status: params.result.packageName === 'package-a' ? 'initial-version' : 'new-version'
+                    status: params.result.packageName === 'package-a' ? 'initial-version' : 'new-version',
+                    publication: noPublication
                 };
             }
         });
 
         assert.deepStrictEqual(result, Result.ok([{ packageName: 'package-a' }]));
         assert.deepStrictEqual(getEmitCallArguments(emit), [
-            ['done', { packageName: 'package-a', version: '1.0.0', status: 'initial-version' }]
+            [
+                'done',
+                { packageName: 'package-a', version: '1.0.0', status: 'initial-version', publication: noPublication }
+            ]
         ]);
     });
 
@@ -157,7 +162,8 @@ suite('scheduler', function () {
             createProgressEvent: (params) => {
                 return {
                     version: params.result,
-                    status: 'new-version'
+                    status: 'new-version',
+                    publication: noPublication
                 };
             }
         });
@@ -170,8 +176,19 @@ suite('scheduler', function () {
             ['scheduled', { packageName: 'root' }],
             ['scheduled', { packageName: 'package-a' }],
             ['scheduled', { packageName: 'package-b' }],
-            ['done', { packageName: 'root', version: 'root-result', status: 'new-version' }],
-            ['done', { packageName: 'package-a', version: 'package-a-result', status: 'new-version' }],
+            [
+                'done',
+                { packageName: 'root', version: 'root-result', status: 'new-version', publication: noPublication }
+            ],
+            [
+                'done',
+                {
+                    packageName: 'package-a',
+                    version: 'package-a-result',
+                    status: 'new-version',
+                    publication: noPublication
+                }
+            ],
             ['error', { packageName: 'package-b', error: new Error('package-b failed') }]
         ]);
     });

--- a/source/packtory/scheduler.ts
+++ b/source/packtory/scheduler.ts
@@ -1,4 +1,5 @@
 import { Result } from 'true-myth';
+import type { PublicationOutcome } from '../bundle-emitter/publication-outcome.ts';
 import type { ConfigWithGraph } from '../config/validation.ts';
 import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
 import type { PackageConfig } from '../config/config.ts';
@@ -94,6 +95,7 @@ type PackageSuccess<TResult, TOptions> = {
 type ProgressEventReturnValue = {
     version: string;
     status: PublishedReleaseStatus;
+    publication: PublicationOutcome;
 };
 
 type SchedulerState<TResult, TNext> = {

--- a/source/packtory/stages/publish-stage.test.ts
+++ b/source/packtory/stages/publish-stage.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { noPublication } from '../../bundle-emitter/publication-outcome.ts';
 import { createIteratingScheduler as iteratingScheduler } from '../../test-libraries/iterating-scheduler.ts';
 import {
     emptyScheduler,
@@ -20,7 +21,7 @@ suite('publish-stage', function () {
             },
             { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
             [],
-            { dryRun: false }
+            { dryRun: false, stage: false }
         );
 
         assert.strictEqual(result.isOk, true);
@@ -31,7 +32,7 @@ suite('publish-stage', function () {
             failingDependencies('boom'),
             { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
             [],
-            { dryRun: false }
+            { dryRun: false, stage: false }
         );
 
         assert.strictEqual(result.isErr, true);
@@ -63,7 +64,7 @@ suite('publish-stage', function () {
             },
             config as never,
             [],
-            { dryRun: false }
+            { dryRun: false, stage: false }
         );
 
         if (!result.isErr) {
@@ -82,7 +83,7 @@ suite('publish-stage', function () {
             version: '2.0.0',
             packageJson: { name: 'pkg-a', version: '2.0.0' }
         };
-        const buildResult = { bundle, status: 'new-version' as const };
+        const buildResult = { bundle, status: 'new-version' as const, publication: noPublication };
         const processor = {
             ...stubPackageProcessor,
             async buildAndPublish() {
@@ -114,10 +115,12 @@ suite('publish-stage', function () {
                     resolveOptions: {}
                 } as never
             ],
-            { dryRun: false }
+            { dryRun: false, stage: false }
         );
 
         assert.deepStrictEqual(capture.selected, [bundle]);
-        assert.deepStrictEqual(capture.events, [{ version: '2.0.0', status: 'new-version' }]);
+        assert.deepStrictEqual(capture.events, [
+            { version: '2.0.0', status: 'new-version', publication: noPublication }
+        ]);
     });
 });

--- a/source/packtory/stages/publish-stage.ts
+++ b/source/packtory/stages/publish-stage.ts
@@ -74,6 +74,7 @@ export async function determineVersionAndPublishAll(
             const processorOptions: DetermineVersionAndPublishOptions = {
                 analyzedBundle,
                 buildOptions,
+                stage: options.stage,
                 substitutionPublicModuleSourcePaths: publicModuleUsageByName.get(buildOptions.name)
             };
 
@@ -89,7 +90,8 @@ export async function determineVersionAndPublishAll(
         createProgressEvent: (params) => {
             return {
                 version: params.result.bundle.packageJson.version,
-                status: params.result.status
+                status: params.result.status,
+                publication: params.result.publication
             };
         }
     });

--- a/source/packtory/stages/release-diff-stage.test.ts
+++ b/source/packtory/stages/release-diff-stage.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe, Result } from 'true-myth';
+import { noPublication } from '../../bundle-emitter/publication-outcome.ts';
 import type { ArtifactsBuilder } from '../../artifacts/artifacts-builder.ts';
 import type { ValidConfigResult } from '../../config/validation.ts';
 import type { FileDescription } from '../../file-manager/file-description.ts';
@@ -26,6 +27,7 @@ function configFor(packageNames: readonly string[]): ValidConfigResult {
 function buildResultFor(name: string, overrides: Partial<BuildAndPublishResult> = {}): BuildAndPublishResult {
     return {
         status: 'new-version',
+        publication: noPublication,
         bundle: {
             name,
             version: '1.0.0',
@@ -185,6 +187,7 @@ suite('release-diff-stage', function () {
             [
                 {
                     status: 'new-version',
+                    publication: noPublication,
                     bundle,
                     extraFiles: [extraFile],
                     previousReleaseArtifacts: Maybe.nothing()

--- a/source/progress/progress-broadcaster.ts
+++ b/source/progress/progress-broadcaster.ts
@@ -1,3 +1,5 @@
+import type { PublicationOutcome } from '../bundle-emitter/publication-outcome.ts';
+
 export type StageName = 'build' | 'eliminate' | 'publish' | 'resolveAndLink' | 'tryPublish';
 
 export type IncludedFile = {
@@ -101,6 +103,7 @@ type DonePayload = {
     readonly packageName: string;
     readonly version: string;
     readonly status: 'already-published' | 'initial-version' | 'new-version';
+    readonly publication: PublicationOutcome;
 };
 
 type InputsResolvedPayload = {

--- a/source/report/aggregator/package-report-materialization.test.ts
+++ b/source/report/aggregator/package-report-materialization.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import type { MutablePackageReport } from './report-types.ts';
 import { toPackageReport } from './package-report-materialization.ts';
 
@@ -78,6 +79,12 @@ suite('package-report-materialization', function () {
         const result = toPackageReport(mutable({ failure: { stage: 'publish', message: 'boom' } }));
 
         assert.deepStrictEqual(result.failure, { stage: 'publish', message: 'boom' });
+    });
+
+    test('toPackageReport surfaces publication when present on the mutable report', function () {
+        const result = toPackageReport(mutable({ publication: stagedForApproval('stage-123') }));
+
+        assert.deepStrictEqual(result.publication, stagedForApproval('stage-123'));
     });
 
     test('toPackageReport applies the import-path-rewrite badge to tarball entries whose source path appears in decisions.linker.rewrites', function () {

--- a/source/report/aggregator/package-report-materialization.ts
+++ b/source/report/aggregator/package-report-materialization.ts
@@ -97,6 +97,7 @@ export function toPackageReport(entry: MutablePackageReport): PackageReport {
             timings: entry.timings,
             inputs,
             outputs,
+            publication: entry.publication,
             eliminatedSourceFiles: entry.eliminatedSourceFiles,
             failure: entry.failure
         },

--- a/source/report/aggregator/report-event-handlers.test.ts
+++ b/source/report/aggregator/report-event-handlers.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import { registerSubscribers, type AggregatorState } from './report-event-handlers.ts';
 
@@ -114,6 +115,21 @@ suite('report-event-handlers', function () {
         broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'build', durationMs: 42 });
 
         assert.strictEqual(state.packages.get('pkg-a')?.timings.build, 42);
+    });
+
+    test('registerSubscribers records publication outcomes from done events', function () {
+        const state = freshState();
+        const broadcaster = createProgressBroadcaster();
+        registerSubscribers(state, broadcaster.consumer);
+
+        broadcaster.provider.emit('done', {
+            packageName: 'pkg-a',
+            version: '1.2.3',
+            status: 'new-version',
+            publication: stagedForApproval('stage-123')
+        });
+
+        assert.deepStrictEqual(state.packages.get('pkg-a')?.publication, stagedForApproval('stage-123'));
     });
 
     test('registerSubscribers records package failures', function () {

--- a/source/report/aggregator/report-event-handlers.ts
+++ b/source/report/aggregator/report-event-handlers.ts
@@ -80,6 +80,9 @@ function registerDecisionHandlers(state: AggregatorState, subscribe: Subscribe):
 }
 
 function registerOutcomeHandlers(state: AggregatorState, subscribe: Subscribe): void {
+    subscribe('done', (payload) => {
+        getOrCreate(state, payload.packageName).publication = payload.publication;
+    });
     subscribe('stageTimed', (payload) => {
         getOrCreate(state, payload.packageName).timings[payload.stage] = payload.durationMs;
     });

--- a/source/report/aggregator/report-types.ts
+++ b/source/report/aggregator/report-types.ts
@@ -1,3 +1,4 @@
+import type { PublicationOutcome } from '../../bundle-emitter/publication-outcome.ts';
 import type {
     ArtifactEntry,
     CrossBundleSeed,
@@ -48,6 +49,7 @@ export type PackageReport = {
     readonly outputs?: {
         readonly tarball: { readonly entries: readonly ArtifactEntry[]; readonly totalBytes: number };
     };
+    readonly publication?: PublicationOutcome;
     readonly eliminatedSourceFiles?: readonly EliminatedSourceFile[];
     readonly timings: Readonly<Record<string, number>>;
     readonly failure?: { readonly stage: StageName; readonly message: string };
@@ -78,6 +80,7 @@ export type MutablePackageReport = {
         packageJson?: Required<PackageReport['decisions']['packageJson']>;
     };
     outputs?: Required<PackageReport['outputs']>;
+    publication?: Required<PackageReport['publication']>;
     eliminatedSourceFiles?: PackageReport['eliminatedSourceFiles'];
     timings: Record<string, number>;
     failure?: Required<PackageReport['failure']>;

--- a/source/report/html-renderer/diagnostics-renderer.test.ts
+++ b/source/report/html-renderer/diagnostics-renderer.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { renderDiagnostics, renderFailureBanner } from './diagnostics-renderer.ts';
 
@@ -49,6 +50,17 @@ suite('diagnostics-renderer', function () {
         );
 
         assert.ok(html.includes('<summary>Outputs</summary>'));
+    });
+
+    test('renderDiagnostics renders the Publication section when publication is present', function () {
+        const html = renderDiagnostics(
+            packageWithDiagnostics({
+                ...emptyDiagnostics,
+                publication: stagedForApproval('stage-123')
+            }) as PreviewPackage
+        );
+
+        assert.ok(html.includes('<summary>Publication</summary>'));
     });
 
     test('renderDiagnostics renders the Timings section when timings are populated', function () {

--- a/source/report/html-renderer/diagnostics-renderer.ts
+++ b/source/report/html-renderer/diagnostics-renderer.ts
@@ -10,6 +10,9 @@ export function renderDiagnostics(pkg: PreviewPackage): string {
             ? ''
             : renderCollapsibleSection('Decisions', pkg.diagnostics.decisions),
         pkg.diagnostics.outputs === undefined ? '' : renderCollapsibleSection('Outputs', pkg.diagnostics.outputs),
+        pkg.diagnostics.publication === undefined
+            ? ''
+            : renderCollapsibleSection('Publication', pkg.diagnostics.publication),
         Object.keys(pkg.diagnostics.timings).length === 0
             ? ''
             : renderCollapsibleSection('Timings (ms)', pkg.diagnostics.timings),

--- a/source/report/terminal-renderer/terminal-artifact-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-artifact-renderer.test.ts
@@ -4,13 +4,15 @@ import type { PreviewArtifactNode } from '../preview/artifact-tree-builder.ts';
 import { renderArtifactNode } from './terminal-artifact-renderer.ts';
 import { createColors } from './terminal-preview-renderer-shared.ts';
 
-const colors = createColors(false);
+function colors() {
+    return createColors(false);
+}
 
 suite('terminal-artifact-renderer', function () {
     test('renderArtifactNode renders a directory with a triangle marker indented by depth', function () {
         const node: PreviewArtifactNode = { type: 'directory', name: 'src', path: 'src/', depth: 1 };
 
-        assert.strictEqual(renderArtifactNode(node, colors), '    ▸ src/');
+        assert.strictEqual(renderArtifactNode(node, colors()), '    ▸ src/');
     });
 
     test('renderArtifactNode renders a file node with kind, byte size, status and badge labels', function () {
@@ -28,7 +30,7 @@ suite('terminal-artifact-renderer', function () {
             }
         };
 
-        assert.strictEqual(renderArtifactNode(node, colors), '  • src/index.js (source, 42 B) [changed, rewrite]');
+        assert.strictEqual(renderArtifactNode(node, colors()), '  • src/index.js (source, 42 B) [changed, rewrite]');
     });
 
     test('renderArtifactNode omits trailing whitespace when there are no badges and the status label is empty', function () {
@@ -40,6 +42,6 @@ suite('terminal-artifact-renderer', function () {
             artifact: { path: 'file.txt', sizeBytes: 0, kind: 'additional', status: 'unchanged', badges: [] }
         };
 
-        assert.strictEqual(renderArtifactNode(node, colors).endsWith(' '), false);
+        assert.strictEqual(renderArtifactNode(node, colors()).endsWith(' '), false);
     });
 });

--- a/source/report/terminal-renderer/terminal-package-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-package-renderer.test.ts
@@ -7,11 +7,13 @@ import {
 import { renderPackage } from './terminal-package-renderer.ts';
 import { createColors } from './terminal-preview-renderer-shared.ts';
 
-const colors = createColors(false);
+function colors() {
+    return createColors(false);
+}
 
 suite('terminal-package-renderer', function () {
     test('renderPackage renders the name, version transition, tree, eliminated files, and diffs', function () {
-        const output = renderPackage(createPreviewPackageFixture(), colors);
+        const output = renderPackage(createPreviewPackageFixture(), colors());
 
         assert.strictEqual(
             output,
@@ -32,7 +34,7 @@ suite('terminal-package-renderer', function () {
     });
 
     test('renderPackage omits the version transition when it is undefined', function () {
-        const output = renderPackage(createPreviewPackageFixture({ versionTransition: undefined }), colors);
+        const output = renderPackage(createPreviewPackageFixture({ versionTransition: undefined }), colors());
 
         assert.ok(output.startsWith('pkg-a\n'));
         assert.ok(!output.includes('undefined'));
@@ -41,14 +43,14 @@ suite('terminal-package-renderer', function () {
     test('renderPackage prepends a failure line when the package has a failure', function () {
         const output = renderPackage(
             createPreviewPackageFixture({ failure: { stage: 'publish', message: 'boom' } }),
-            colors
+            colors()
         );
 
         assert.ok(output.includes('failure publish: boom'));
     });
 
     test('renderPackage omits the diffs and eliminated-files sections when both are absent', function () {
-        const output = renderPackage(createManifestOnlyPreviewPackageFixture(), colors);
+        const output = renderPackage(createManifestOnlyPreviewPackageFixture(), colors());
 
         assert.ok(!output.includes('Diffs'));
         assert.ok(!output.includes('Eliminated source files'));

--- a/source/report/terminal-renderer/terminal-preview-renderer-shared.ts
+++ b/source/report/terminal-renderer/terminal-preview-renderer-shared.ts
@@ -28,7 +28,9 @@ function withAnsi(openCode: number, closeCode: number): (value: string) => strin
     };
 }
 
-const disabledColors: Colors = { bold: identity, dim: identity, green: identity, red: identity, yellow: identity };
+function createDisabledColors(): Colors {
+    return { bold: identity, dim: identity, green: identity, red: identity, yellow: identity };
+}
 
 export function createColors(enabled: boolean | undefined): Colors {
     if (enabled === true) {
@@ -43,7 +45,7 @@ export function createColors(enabled: boolean | undefined): Colors {
     if (enabled === undefined) {
         return { bold, dim, green, red, yellow };
     }
-    return disabledColors;
+    return createDisabledColors();
 }
 
 export function renderDiffLine(line: PreviewDiffLine, colors: Colors): string {

--- a/source/report/terminal-renderer/terminal-release-diff-package-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-release-diff-package-renderer.test.ts
@@ -4,11 +4,13 @@ import { createPackageReleaseDiff as basePkg } from '../../test-libraries/releas
 import { createColors } from './terminal-preview-renderer-shared.ts';
 import { renderReleaseDiffPackage } from './terminal-release-diff-package-renderer.ts';
 
-const colors = createColors(false);
+function colors() {
+    return createColors(false);
+}
 
 suite('terminal-release-diff-package-renderer', function () {
     test('renders the unchanged state as exactly one dim no-changes line including the previous version', function () {
-        const output = renderReleaseDiffPackage(basePkg({ state: 'unchanged' }), colors);
+        const output = renderReleaseDiffPackage(basePkg({ state: 'unchanged' }), colors());
         assert.strictEqual(output, 'pkg-a  1.0.0  ·  no changes');
     });
 
@@ -28,7 +30,7 @@ suite('terminal-release-diff-package-renderer', function () {
                     unchanged: []
                 }
             }),
-            colors
+            colors()
         );
 
         assert.strictEqual(
@@ -74,7 +76,7 @@ suite('terminal-release-diff-package-renderer', function () {
                     unchanged: [{ path: 'readme.md', sizeBytes: 10, isExecutable: false }]
                 }
             }),
-            colors
+            colors()
         );
 
         assert.strictEqual(
@@ -115,7 +117,7 @@ suite('terminal-release-diff-package-renderer', function () {
                     unchanged: []
                 }
             }),
-            colors
+            colors()
         );
         assert.strictEqual(
             output,
@@ -147,7 +149,7 @@ suite('terminal-release-diff-package-renderer', function () {
                     unchanged: []
                 }
             }),
-            colors
+            colors()
         );
         assert.strictEqual(
             output,
@@ -179,7 +181,7 @@ suite('terminal-release-diff-package-renderer', function () {
                     unchanged: []
                 }
             }),
-            colors
+            colors()
         );
         assert.match(output, /mode 755 -> 644/u);
     });
@@ -194,7 +196,7 @@ suite('terminal-release-diff-package-renderer', function () {
                     unchanged: []
                 }
             }),
-            colors
+            colors()
         );
         assert.strictEqual(
             output,

--- a/source/sbom/sbom-builder.test.ts
+++ b/source/sbom/sbom-builder.test.ts
@@ -6,10 +6,8 @@ import { createSbomSerializer } from './sbom-serializer.ts';
 
 type SbomBuilderOptions = Parameters<typeof buildSbom>[0];
 
-const serializer = createSbomSerializer();
-
 function serialize(bom: ReturnType<typeof buildSbom>): Record<string, unknown> {
-    return JSON.parse(serializer.serialize(bom)) as Record<string, unknown>;
+    return JSON.parse(createSbomSerializer().serialize(bom)) as Record<string, unknown>;
 }
 
 function buildAndSerialize(options: Partial<SbomBuilderOptions>): Record<string, unknown> {

--- a/source/test-libraries/preview-fixtures.ts
+++ b/source/test-libraries/preview-fixtures.ts
@@ -1,4 +1,5 @@
 import { Maybe } from 'true-myth';
+import { noPublication } from '../bundle-emitter/publication-outcome.ts';
 import type { BuildAndPublishResult } from '../packtory/package-processor.ts';
 import type { ArtifactEntry } from '../progress/progress-broadcaster.ts';
 import type { PreviewDocument, PreviewPackage } from '../report/preview/preview-document.ts';
@@ -38,6 +39,7 @@ export function createBuildResultFixture(
     const version = overrides.version ?? '1.0.1';
     return {
         status: 'new-version',
+        publication: noPublication,
         bundle: versionedBundleWithManifest({
             name: packageName,
             version,

--- a/source/version-manager/specifier-classifier.ts
+++ b/source/version-manager/specifier-classifier.ts
@@ -1,15 +1,6 @@
 import npa from 'npm-package-arg';
 import { match } from 'ts-pattern';
 
-const workspaceProtocolPrefix = 'workspace:';
-const portalProtocolPrefix = 'portal:';
-
-const workspaceMalformedReason =
-    'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace,' +
-    ' not valid in a published manifest';
-const portalMalformedReason =
-    'portal protocol is yarn-specific; resolved as a local symlink, not valid in a published manifest';
-
 export type MutableNpaType = 'directory' | 'file' | 'git' | 'remote';
 
 export type Classification =
@@ -18,6 +9,17 @@ export type Classification =
     | { readonly kind: 'registry' };
 
 type NpaResultType = npa.Result['type'];
+
+function workspaceMalformedReason(): string {
+    return (
+        'workspace protocol is yarn/pnpm/bun-specific; resolved at install time by the workspace,' +
+        ' not valid in a published manifest'
+    );
+}
+
+function portalMalformedReason(): string {
+    return 'portal protocol is yarn-specific; resolved as a local symlink, not valid in a published manifest';
+}
 
 function classifyNpaResult(result: npa.Result): Classification {
     return match<NpaResultType, Classification>(result.type)
@@ -39,11 +41,11 @@ function classifyNpaResult(result: npa.Result): Classification {
 }
 
 export function classifySpecifier(name: string, specifier: string): Classification {
-    if (specifier.startsWith(workspaceProtocolPrefix)) {
-        return { kind: 'malformed', reason: workspaceMalformedReason };
+    if (specifier.startsWith('workspace:')) {
+        return { kind: 'malformed', reason: workspaceMalformedReason() };
     }
-    if (specifier.startsWith(portalProtocolPrefix)) {
-        return { kind: 'malformed', reason: portalMalformedReason };
+    if (specifier.startsWith('portal:')) {
+        return { kind: 'malformed', reason: portalMalformedReason() };
     }
 
     try {


### PR DESCRIPTION
## Summary
- add opt-in npm staged publishing through `packtory publish --stage`
- carry staged publication outcomes through versioning, progress output, and report rendering
- harden mutation-sensitive publish and dead-code paths so the mutation gate, including timeout-mutant checks, stays green
