### PR TITLE
Match dependency-derived files under the npm tarball `package/` prefix

### DIFF
--- a/source/common/package-layout.ts
+++ b/source/common/package-layout.ts
@@ -3,6 +3,12 @@ import path from 'node:path';
 export const packageManifestFilePath = 'package.json';
 export const installedDependenciesFolderName = 'node_modules';
 
+const tarballPackageRootPrefix = 'package/';
+
+export function bundleRelativePath(filePath: string): string {
+    return filePath.startsWith(tarballPackageRootPrefix) ? filePath.slice(tarballPackageRootPrefix.length) : filePath;
+}
+
 function currentAndAncestorFolders(startFolder: string): readonly string[] {
     const folders: string[] = [];
     let currentFolder = path.resolve(startFolder);

--- a/source/packtory/release-analysis.test.ts
+++ b/source/packtory/release-analysis.test.ts
@@ -158,6 +158,35 @@ suite('release-analysis', function () {
         assert.strictEqual(result.classification, 'dependency-only');
     });
 
+    test('classifyPackageRelease classifies dependency-only diffs as such when paths carry the npm tarball package prefix', function () {
+        const buildResult = buildResultWithPublishedFiles([
+            file('package/package.json', '{"name":"pkg-a","version":"1.0.0","dependencies":{"a":"1.0.0"}}'),
+            file('package/sbom.cdx.json', '{"components":[{"name":"a","version":"1.0.0"}]}'),
+            file('package/index.js', 'export const value = 1;\n')
+        ]);
+
+        const result = classifyPackageRelease(buildResult, [
+            file('package/package.json', '{"name":"pkg-a","version":"1.0.1","dependencies":{"a":"1.1.0"}}'),
+            file('package/sbom.cdx.json', '{"components":[{"name":"a","version":"1.1.0"}]}'),
+            file('package/index.js', 'export const value = 1;\n')
+        ]);
+
+        assert.strictEqual(result.classification, 'dependency-only');
+    });
+
+    test('classifyPackageRelease keeps substantive classification with the npm tarball package prefix when bundled sources differ', function () {
+        assertSubstantiveClassification(
+            [
+                file('package/package.json', '{"name":"pkg-a","version":"1.0.0","dependencies":{"a":"1.0.0"}}'),
+                file('package/index.js', 'export const value = 1;\n')
+            ],
+            [
+                file('package/package.json', '{"name":"pkg-a","version":"1.0.1","dependencies":{"a":"1.1.0"}}'),
+                file('package/index.js', 'export const value = 2;\n')
+            ]
+        );
+    });
+
     test('classifyPackageRelease keeps substantive classification when source files differ even if SBOM also differs', function () {
         assertSubstantiveClassification(
             [

--- a/source/packtory/release-analysis.ts
+++ b/source/packtory/release-analysis.ts
@@ -1,7 +1,6 @@
 import { isDeepStrictEqual } from 'node:util';
 import { maxDate } from '../common/max-date.ts';
-import { packageManifestFilePath } from '../common/package-layout.ts';
-import { fileDescriptionByPath } from '../file-manager/file-description-by-path.ts';
+import { bundleRelativePath, packageManifestFilePath } from '../common/package-layout.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import { sbomFilePath } from '../sbom/sbom-file.ts';
 import type { BuildAndPublishResult } from './package-processor.ts';
@@ -118,6 +117,14 @@ function packageJsonChangeIsDependencyOnly(
     );
 }
 
+function fileDescriptionByBundleRelativePath(files: readonly FileDescription[]): ReadonlyMap<string, FileDescription> {
+    const index = new Map<string, FileDescription>();
+    for (const file of files) {
+        index.set(bundleRelativePath(file.filePath), file);
+    }
+    return index;
+}
+
 function createComparisonIndexes(
     previousFiles: readonly FileDescription[],
     newFiles: readonly FileDescription[]
@@ -126,8 +133,8 @@ function createComparisonIndexes(
     readonly newIndex: ReadonlyMap<string, FileDescription>;
 } {
     return {
-        previousIndex: fileDescriptionByPath(previousFiles),
-        newIndex: fileDescriptionByPath(newFiles)
+        previousIndex: fileDescriptionByBundleRelativePath(previousFiles),
+        newIndex: fileDescriptionByBundleRelativePath(newFiles)
     };
 }
 


### PR DESCRIPTION
The release classifier compared bundle file paths against the bare `packageManifestFilePath` and `sbomFilePath()` constants, but both sides of the comparison arrive with the npm tarball `package/` prefix: `extractPackageTarball` preserves the tar header name for the previous release, and the freshly built side comes from `collectContents(bundle, "package", extraFiles)`. `isDependencyDerivedFilePath` therefore never matched, every dependency bump fell through to `substantive`, and the `DEPENDENCY_ONLY_MIN_AGE_DAYS` gate was unreachable in production — visible as the recent Renovate self-publish loop on `main`. The existing unit tests passed because they used bare paths.

The fix adds a `bundleRelativePath` helper in `package-layout.ts` and rebuilds the comparison indexes through it, so lookups against the bare constants work for both prefixed and unprefixed inputs. Regression tests cover prefixed inputs for both the `dependency-only` and `substantive` outcomes.
