### PR TITLE
Add `checks.areTheTypesWrong` for generated package output

### DIFF
--- a/documentation/how-it-works.md
+++ b/documentation/how-it-works.md
@@ -333,7 +333,7 @@ Malformed source maps are passed through unchanged rather than dropped. Files wi
 
 ## 7. Stage: Checks
 
-After dead-code elimination, the full set of `AnalyzedBundle`s is fed through the configured check rules. Each rule is a pure function `(bundles, settings) → issues[]`. Every check is opt-in. They are documented end-to-end in the [readme](../readme.md#checks); the interesting architectural points are:
+After dead-code elimination, the full set of `AnalyzedBundle`s is fed through the configured check rules. Most rules inspect the analyzed bundles directly; `areTheTypesWrong` additionally materializes the generated `package.json` in memory and audits the emitted package surface. Every check is opt-in. They are documented end-to-end in the [readme](../readme.md#checks); the interesting architectural points are:
 
 - Checks see the bundles **after dead-code elimination**, so e.g. `noUnusedBundleDependencies` correctly reports a `bundleDependencies` entry whose imports have been tree-shaken away.
 - Rules are independent and run in arbitrary order; failures are aggregated into a single error.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0-dev",
             "license": "MIT",
             "dependencies": {
+                "@arethetypeswrong/core": "0.18.2",
                 "@cyclonedx/cyclonedx-library": "10.0.0",
                 "@jridgewell/gen-mapping": "0.3.13",
                 "@jridgewell/trace-mapping": "0.3.31",
@@ -79,6 +80,61 @@
             },
             "engines": {
                 "node": "^24 || ^26"
+            }
+        },
+        "node_modules/@andrewbranch/untar.js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@andrewbranch/untar.js/-/untar.js-1.0.3.tgz",
+            "integrity": "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="
+        },
+        "node_modules/@arethetypeswrong/core": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/@arethetypeswrong/core/-/core-0.18.2.tgz",
+            "integrity": "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==",
+            "license": "MIT",
+            "dependencies": {
+                "@andrewbranch/untar.js": "^1.0.3",
+                "@loaderkit/resolve": "^1.0.2",
+                "cjs-module-lexer": "^1.2.3",
+                "fflate": "^0.8.2",
+                "lru-cache": "^11.0.1",
+                "semver": "^7.5.4",
+                "typescript": "5.6.1-rc",
+                "validate-npm-package-name": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/typescript": {
+            "version": "5.6.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.1-rc.tgz",
+            "integrity": "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/@arethetypeswrong/core/node_modules/validate-npm-package-name": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
+            "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -619,6 +675,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@braidai/lang": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@braidai/lang/-/lang-1.1.2.tgz",
+            "integrity": "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==",
+            "license": "ISC"
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
@@ -2654,6 +2716,15 @@
             "dependencies": {
                 "@jscpd/core": "4.2.4",
                 "spark-md5": "^3.0.2"
+            }
+        },
+        "node_modules/@loaderkit/resolve": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@loaderkit/resolve/-/resolve-1.0.6.tgz",
+            "integrity": "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==",
+            "license": "ISC",
+            "dependencies": {
+                "@braidai/lang": "^1.0.0"
             }
         },
         "node_modules/@ls-lint/ls-lint": {
@@ -6758,6 +6829,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+            "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+            "license": "MIT"
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "url": "git+ssh://git@github.com/enormora/packtory.git"
     },
     "dependencies": {
+        "@arethetypeswrong/core": "0.18.2",
         "@cyclonedx/cyclonedx-library": "10.0.0",
         "@jridgewell/gen-mapping": "0.3.13",
         "@jridgewell/trace-mapping": "0.3.31",

--- a/readme.md
+++ b/readme.md
@@ -263,6 +263,7 @@ If `checks` is omitted, every rule is off.
 
 ```javascript
 checks: {
+    areTheTypesWrong: { enabled: true },
     noDuplicatedFiles: { enabled: true },
     requiredFiles: { enabled: true, files: ['LICENSE'] },
     maxBundleSize: { enabled: true, bytes: 500_000 },
@@ -272,6 +273,14 @@ checks: {
     noSideEffects: { enabled: true }
 }
 ```
+
+### `areTheTypesWrong`
+
+Runs [Are the Types Wrong?](https://arethetypeswrong.github.io/) against the emitted package contents and the generated `package.json`, before publish. This checks the exact public package surface packtory would ship, not the source tree.
+
+- **Top-level:** `enabled: boolean`, `profile?: 'strict' | 'node16' | 'esm-only'`.
+- **Per-package:** `profile?: 'strict' | 'node16' | 'esm-only'` — overrides the top-level profile for that package.
+- If no profile is set, packtory defaults to `esm-only`. Packtory only emits `type: "module"` packages, so this default ignores ATTW's expected CommonJS-only resolution failures and focuses on the ESM surface that packtory actually supports.
 
 ### `noDuplicatedFiles`
 

--- a/source/bundle-emitter/registry/registry-auth-config.test.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.test.ts
@@ -192,6 +192,12 @@ suite('registry-auth-config', function () {
         }, /requires token-based metadata auth/u);
     });
 
+    test('resolveStageListingAuthOptions throws when publish auth is missing entirely', function () {
+        assert.throws(() => {
+            resolveStageListingAuthOptions({});
+        }, /registrySettings\.auth must be configured to publish/u);
+    });
+
     test('resolveStageListingAuthOptions uses shorthand publish auth when it is token-based', function () {
         assert.deepStrictEqual(resolveStageListingAuthOptions({ auth: tokenAuth }), {
             allowsAutomaticRetry: false,

--- a/source/bundle-emitter/registry/registry-auth-config.ts
+++ b/source/bundle-emitter/registry/registry-auth-config.ts
@@ -130,10 +130,15 @@ const stagedVersionLookupRequiresTokenAuthMessage =
     'when publish auth uses npm-oidc';
 
 export function resolveStageListingAuthOptions(registrySettings: Readonly<RegistrySettings>): AuthResolution {
-    const publishAuth = resolvePublishAuth(registrySettings);
+    const { auth } = registrySettings;
+    if (auth === undefined) {
+        throw new Error(publishAuthRequiredErrorMessage);
+    }
 
-    if (!('type' in registrySettings.auth) && typeof registrySettings.auth.metadata === 'object') {
-        return buildAuthOptions(registrySettings.auth.metadata, registrySettings);
+    const publishAuth = 'type' in auth ? auth : auth.publish;
+
+    if (!('type' in auth) && typeof auth.metadata === 'object') {
+        return buildAuthOptions(auth.metadata, registrySettings);
     }
 
     if (publishAuth.type === 'npm-oidc') {

--- a/source/checks/check-runner.test.ts
+++ b/source/checks/check-runner.test.ts
@@ -4,9 +4,10 @@ import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
 import { runChecks } from './check-runner.ts';
 
 suite('check-runner', function () {
-    test('does not invoke any rule when settings are empty', function () {
-        const issues = runChecks({
+    test('does not invoke any rule when settings are empty', async function () {
+        const issues = await runChecks({
             settings: {},
+            publishedPackages: undefined,
             perPackageSettings: new Map(),
             packageConfigs: {},
             bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
@@ -15,9 +16,10 @@ suite('check-runner', function () {
         assert.deepStrictEqual(issues, []);
     });
 
-    test('dispatches an enabled rule with the provided bundles and aggregates its issues', function () {
-        const issues = runChecks({
+    test('dispatches an enabled rule with the provided bundles and aggregates its issues', async function () {
+        const issues = await runChecks({
             settings: { noDuplicatedFiles: { enabled: true } },
+            publishedPackages: undefined,
             perPackageSettings: new Map(),
             packageConfigs: {},
             bundles: [checkBundle('a', ['shared.ts']), checkBundle('b', ['shared.ts'])]
@@ -26,10 +28,11 @@ suite('check-runner', function () {
         assert.deepStrictEqual(issues, ['File "shared.ts" is included in multiple packages: a, b']);
     });
 
-    test('threads per-package settings through to the rule for cross-package consent decisions', function () {
+    test('threads per-package settings through to the rule for cross-package consent decisions', async function () {
         const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
-        const issues = runChecks({
+        const issues = await runChecks({
             settings: { noDuplicatedFiles: { enabled: true } },
+            publishedPackages: undefined,
             perPackageSettings: new Map([
                 ['a', consent],
                 ['b', consent]

--- a/source/checks/check-runner.ts
+++ b/source/checks/check-runner.ts
@@ -1,16 +1,21 @@
 import type { ChecksSettings, PackageChecksSettings, PackageConfigsByName } from '../config/config.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import type { PublishedPackageWithManifest } from '../published-package/published-package.ts';
 import { allRules } from './rules/registry.ts';
 
 export type CheckRunnerParams = {
     readonly bundles: readonly AnalyzedBundle[];
+    readonly publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest> | undefined;
     readonly settings: ChecksSettings | undefined;
     readonly perPackageSettings: ReadonlyMap<string, PackageChecksSettings | undefined>;
     readonly packageConfigs: PackageConfigsByName;
 };
 
-export function runChecks(params: CheckRunnerParams): readonly string[] {
-    return allRules.flatMap((rule) => {
-        return rule.run(params);
-    });
+export async function runChecks(params: CheckRunnerParams): Promise<readonly string[]> {
+    const issues = await Promise.all(
+        allRules.map(async (rule) => {
+            return await rule.run(params);
+        })
+    );
+    return issues.flat();
 }

--- a/source/checks/rule.ts
+++ b/source/checks/rule.ts
@@ -1,6 +1,7 @@
 import { z, type ZodMiniType } from 'zod/mini';
 import { nonEmptyStringSchema } from '../config/base-validations.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import type { PublishedPackageWithManifest } from '../published-package/published-package.ts';
 
 export const enabledOnlyGlobalSchema = z.strictObject({ enabled: z.boolean() });
 export const emptyPerPackageSchema = z.strictObject({});
@@ -34,6 +35,7 @@ export type RulePackageConfig = {
 
 export type RuleRunParams<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {
     readonly bundles: readonly AnalyzedBundle[];
+    readonly publishedPackages?: ReadonlyMap<string, PublishedPackageWithManifest> | undefined;
     readonly settings: Readonly<Partial<Record<TName, TGlobal | undefined>>> | undefined;
     readonly perPackageSettings: ReadonlyMap<
         string,
@@ -46,5 +48,5 @@ export type CheckRuleDefinition<TName extends string, TGlobal extends RuleGlobal
     readonly name: TName;
     readonly globalSchema: ZodMiniType<TGlobal>;
     readonly perPackageSchema: ZodMiniType<TPerPackage>;
-    readonly run: (params: RuleRunParams<TName, TGlobal, TPerPackage>) => readonly string[];
+    readonly run: (params: RuleRunParams<TName, TGlobal, TPerPackage>) => Promise<readonly string[]>;
 };

--- a/source/checks/rules/are-the-types-wrong.test.ts
+++ b/source/checks/rules/are-the-types-wrong.test.ts
@@ -1,0 +1,333 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { PublishedPackageWithManifest } from '../../published-package/published-package.ts';
+import { checkBundle } from '../../test-libraries/check-bundle-fixture.ts';
+import { areTheTypesWrongRule } from './are-the-types-wrong.ts';
+
+function createPublishedPackage(
+    packageName: string,
+    files: Readonly<Record<string, string>>
+): PublishedPackageWithManifest {
+    const manifestContent = files['package.json'];
+    if (manifestContent === undefined) {
+        throw new Error(`package.json missing for ${packageName}`);
+    }
+
+    return {
+        name: packageName,
+        version: '0.0.0',
+        manifestFile: {
+            filePath: 'package.json',
+            content: manifestContent,
+            isExecutable: false
+        },
+        contents: Object.entries(files)
+            .filter(([filePath]) => {
+                return filePath !== 'package.json';
+            })
+            .map(([filePath, content]) => {
+                return {
+                    directDependencies: new Set<string>(),
+                    fileDescription: {
+                        sourceFilePath: filePath,
+                        targetFilePath: filePath,
+                        content,
+                        isExecutable: false
+                    },
+                    isExplicitlyIncluded: false,
+                    isSubstituted: false
+                };
+            })
+    } as unknown as PublishedPackageWithManifest;
+}
+
+function createManifest(packageName: string): string {
+    return JSON.stringify({
+        name: packageName,
+        version: '0.0.0',
+        type: 'module',
+        exports: {
+            '.': {
+                import: './index.js',
+                types: './index.d.ts'
+            }
+        }
+    });
+}
+
+function createTypedPackage(
+    packageName: string,
+    javascriptSource: string,
+    declarationSource: string
+): PublishedPackageWithManifest {
+    return createPublishedPackage(packageName, {
+        'package.json': createManifest(packageName),
+        'index.js': javascriptSource,
+        'index.d.ts': declarationSource
+    });
+}
+
+function createEsmOnlyPackage(packageName: string): PublishedPackageWithManifest {
+    return createTypedPackage(packageName, 'export const value = 1;\n', 'export declare const value: number;\n');
+}
+
+function createTwoEntrypointEsmPackage(packageName: string): PublishedPackageWithManifest {
+    return createPublishedPackage(packageName, {
+        'package.json': JSON.stringify({
+            name: packageName,
+            version: '0.0.0',
+            type: 'module',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                },
+                './feature': {
+                    import: './feature.js',
+                    types: './feature.d.ts'
+                }
+            }
+        }),
+        'index.js': 'export const value = 1;\n',
+        'index.d.ts': 'export declare const value: number;\n',
+        'feature.js': 'export const feature = 1;\n',
+        'feature.d.ts': 'export declare const feature: number;\n'
+    });
+}
+
+function createBrokenPackage(packageName: string): PublishedPackageWithManifest {
+    return createTypedPackage(
+        packageName,
+        'module.exports = function value() {};\nmodule.exports.default = module.exports;\n',
+        'declare function value(): void;\nexport default value;\n'
+    );
+}
+
+function createMixedEntrypointPackage(packageName: string): PublishedPackageWithManifest {
+    return createPublishedPackage(packageName, {
+        'package.json': JSON.stringify({
+            name: packageName,
+            version: '0.0.0',
+            type: 'module',
+            exports: {
+                '.': {
+                    import: './index.js',
+                    types: './index.d.ts'
+                },
+                './feature': {
+                    require: './feature.cjs',
+                    types: './feature.d.ts'
+                }
+            }
+        }),
+        'index.js': 'module.exports = function value() {};\nmodule.exports.default = module.exports;\n',
+        'index.d.ts': 'declare function value(): void;\nexport default value;\n',
+        'feature.cjs': 'module.exports = function feature() {};\nmodule.exports.default = module.exports;\n',
+        'feature.d.ts': 'declare function feature(): void;\nexport default feature;\n'
+    });
+}
+
+function createUntypedPackage(packageName: string): PublishedPackageWithManifest {
+    return createPublishedPackage(packageName, {
+        'package.json': JSON.stringify({
+            name: packageName,
+            version: '0.0.0',
+            type: 'module',
+            exports: {
+                '.': './index.js'
+            }
+        }),
+        'index.js': 'export const value = 1;\n'
+    });
+}
+
+async function runRule(
+    packageName: string,
+    publishedPackage: PublishedPackageWithManifest,
+    settings: {
+        readonly areTheTypesWrong: { readonly enabled: true; readonly profile?: 'esm-only' | 'node16' | 'strict' };
+    },
+    perPackageSettings: ReadonlyMap<
+        string,
+        { readonly areTheTypesWrong?: { readonly profile?: 'esm-only' | 'node16' | 'strict' } }
+    > = new Map()
+): Promise<readonly string[]> {
+    return await areTheTypesWrongRule.run({
+        bundles: [checkBundle(packageName, ['index.js', 'index.d.ts'])],
+        publishedPackages: new Map([[packageName, publishedPackage]]),
+        settings,
+        perPackageSettings,
+        packageConfigs: {}
+    });
+}
+
+suite('are-the-types-wrong', function () {
+    test('returns no issues when the rule is not configured', async function () {
+        const packageName = 'not-configured-package';
+        const issues = await areTheTypesWrongRule.run({
+            bundles: [checkBundle(packageName, ['index.js', 'index.d.ts'])],
+            settings: undefined,
+            perPackageSettings: new Map(),
+            packageConfigs: {}
+        });
+
+        assert.deepStrictEqual(issues, []);
+    });
+
+    test('returns no issues when the rule is disabled', async function () {
+        const packageName = 'disabled-package';
+        const issues = await areTheTypesWrongRule.run({
+            bundles: [checkBundle(packageName, ['index.js', 'index.d.ts'])],
+            settings: { areTheTypesWrong: { enabled: false } },
+            perPackageSettings: new Map(),
+            packageConfigs: {}
+        });
+
+        assert.deepStrictEqual(issues, []);
+    });
+
+    test('default esm-only profile ignores the expected CJS-only failure mode for a valid ESM package', async function () {
+        const packageName = 'esm-only-package';
+        const issues = await runRule(packageName, createEsmOnlyPackage(packageName), {
+            areTheTypesWrong: { enabled: true }
+        });
+
+        assert.deepStrictEqual(issues, []);
+    });
+
+    test('strict profile reports the ESM-only CommonJS resolution problem', async function () {
+        const packageName = 'strict-package';
+        const issues = await runRule(packageName, createEsmOnlyPackage(packageName), {
+            areTheTypesWrong: { enabled: true, profile: 'strict' }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "strict-package" failed the Are the Types Wrong check: ESM (dynamic import only) affecting entrypoints "." in resolutions "node16-cjs"'
+        ]);
+    });
+
+    test('node16 profile reports the CommonJS resolution problem for an ESM-only package', async function () {
+        const packageName = 'node16-package';
+        const issues = await runRule(packageName, createEsmOnlyPackage(packageName), {
+            areTheTypesWrong: { enabled: true, profile: 'node16' }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "node16-package" failed the Are the Types Wrong check: ESM (dynamic import only) affecting entrypoints "." in resolutions "node16-cjs"'
+        ]);
+    });
+
+    test('groups repeated ATTW problem kinds into one finding summary', async function () {
+        const packageName = 'strict-multi-entrypoint-package';
+        const issues = await runRule(packageName, createTwoEntrypointEsmPackage(packageName), {
+            areTheTypesWrong: { enabled: true, profile: 'strict' }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "strict-multi-entrypoint-package" failed the Are the Types Wrong check: ESM (dynamic import only) (2 findings) affecting entrypoints ".", "./feature" in resolutions "node16-cjs"'
+        ]);
+    });
+
+    test('per-package profile overrides the top-level profile', async function () {
+        const packageName = 'override-package';
+        const issues = await runRule(
+            packageName,
+            createEsmOnlyPackage(packageName),
+            { areTheTypesWrong: { enabled: true } },
+            new Map([[packageName, { areTheTypesWrong: { profile: 'strict' } }]])
+        );
+
+        assert.strictEqual(issues.length, 1);
+        assert.match(issues[0] ?? '', /ESM \(dynamic import only\)/u);
+    });
+
+    test('returns no issues when the emitted package has no types', async function () {
+        const packageName = 'untyped-package';
+        const issues = await runRule(packageName, createUntypedPackage(packageName), {
+            areTheTypesWrong: { enabled: true }
+        });
+
+        assert.deepStrictEqual(issues, []);
+    });
+
+    test('default esm-only profile still reports active ATTW problems for a broken package', async function () {
+        const packageName = 'broken-package';
+        const issues = await runRule(packageName, createBrokenPackage(packageName), {
+            areTheTypesWrong: { enabled: true }
+        });
+
+        assert.ok(
+            issues.some((issue) => {
+                return issue.includes('Missing `export =`');
+            })
+        );
+        assert.ok(
+            issues.some((issue) => {
+                return issue.includes('Unexpected module syntax');
+            })
+        );
+        assert.ok(
+            issues.every((issue) => {
+                return !issue.includes('ESM (dynamic import only)');
+            })
+        );
+    });
+
+    test('strict profile preserves all relevant resolution kinds for a broken package', async function () {
+        const packageName = 'strict-broken-package';
+        const issues = await runRule(packageName, createBrokenPackage(packageName), {
+            areTheTypesWrong: { enabled: true, profile: 'strict' }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "strict-broken-package" failed the Are the Types Wrong check: Missing `export =` affecting entrypoints "." in resolutions "node10", "bundler"',
+            'Package "strict-broken-package" failed the Are the Types Wrong check: ESM (dynamic import only) affecting entrypoints "." in resolutions "node16-cjs"',
+            'Package "strict-broken-package" failed the Are the Types Wrong check: Unexpected module syntax affecting entrypoints "." in resolutions "node16-esm"'
+        ]);
+    });
+
+    test('lists only the entrypoints affected by each ATTW problem kind', async function () {
+        const packageName = 'mixed-entrypoint-package';
+        const issues = await runRule(packageName, createMixedEntrypointPackage(packageName), {
+            areTheTypesWrong: { enabled: true, profile: 'strict' }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "mixed-entrypoint-package" failed the Are the Types Wrong check: Missing `export =` affecting entrypoints "." in resolutions "node10", "bundler"',
+            'Package "mixed-entrypoint-package" failed the Are the Types Wrong check: ESM (dynamic import only) affecting entrypoints "." in resolutions "node16-cjs"',
+            'Package "mixed-entrypoint-package" failed the Are the Types Wrong check: Unexpected module syntax affecting entrypoints "." in resolutions "node16-esm"',
+            'Package "mixed-entrypoint-package" failed the Are the Types Wrong check: Used fallback condition affecting entrypoints "./feature" in resolutions "node16-cjs"',
+            'Package "mixed-entrypoint-package" failed the Are the Types Wrong check: Masquerading as ESM affecting entrypoints "./feature" in resolutions "node16-cjs"'
+        ]);
+    });
+
+    test('returns a check issue when ATTW cannot find the generated package manifest', async function () {
+        const packageName = 'throwing-package';
+        const publishedPackage = {
+            ...createEsmOnlyPackage(packageName),
+            manifestFile: {
+                filePath: 'manifest.json',
+                content: createManifest(packageName),
+                isExecutable: false
+            }
+        };
+        const issues = await runRule(packageName, publishedPackage, {
+            areTheTypesWrong: { enabled: true }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "throwing-package" failed the Are the Types Wrong check: Error: File not found: /node_modules/throwing-package/package.json'
+        ]);
+    });
+
+    test('throws when the rule is enabled but the emitted package is missing', async function () {
+        await assert.rejects(async () => {
+            await areTheTypesWrongRule.run({
+                bundles: [checkBundle('missing-package', ['index.js'])],
+                settings: { areTheTypesWrong: { enabled: true } },
+                perPackageSettings: new Map(),
+                packageConfigs: {}
+            });
+        }, /Published package missing/u);
+    });
+});

--- a/source/checks/rules/are-the-types-wrong.ts
+++ b/source/checks/rules/are-the-types-wrong.ts
@@ -1,0 +1,227 @@
+import {
+    Package,
+    checkPackage,
+    type Analysis,
+    type Problem,
+    type ProblemKind,
+    type ResolutionKind
+} from '@arethetypeswrong/core';
+import {
+    problemAffectsEntrypointResolution,
+    problemAffectsResolutionKind,
+    problemKindInfo
+} from '@arethetypeswrong/core/problems';
+import { z } from 'zod/mini';
+import type { PublishedPackageWithManifest } from '../../published-package/published-package.ts';
+import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+
+const ruleName = 'areTheTypesWrong';
+const defaultProfile = 'esm-only';
+const profileValues = ['strict', 'node16', 'esm-only'] as const;
+
+const profileSchema = z.enum(profileValues);
+
+const globalSchema = z.strictObject({
+    enabled: z.boolean(),
+    profile: z.optional(profileSchema)
+});
+
+const perPackageSchema = z.strictObject({
+    profile: z.optional(profileSchema)
+});
+
+type AreTheTypesWrongProfile = z.infer<typeof profileSchema>;
+type GlobalConfig = z.infer<typeof globalSchema>;
+type PerPackageConfig = z.infer<typeof perPackageSchema>;
+type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type AreTheTypesWrongDependencies = {
+    readonly checkPackage: typeof checkPackage;
+};
+
+const requiredResolutionKindsByProfile: Readonly<Record<AreTheTypesWrongProfile, readonly ResolutionKind[]>> = {
+    strict: ['node10', 'node16-cjs', 'node16-esm', 'bundler'],
+    node16: ['node16-cjs', 'node16-esm', 'bundler'],
+    'esm-only': ['node16-esm', 'bundler']
+};
+
+function resolveProfile(
+    globalConfig: GlobalConfig,
+    perPackageConfig: PerPackageConfig | undefined
+): AreTheTypesWrongProfile {
+    return perPackageConfig?.profile ?? globalConfig.profile ?? defaultProfile;
+}
+
+function toPackageFilePath(packageName: string, filePath: string): string {
+    return `/node_modules/${packageName}/${filePath}`;
+}
+
+function createInMemoryPackage(publishedPackage: PublishedPackageWithManifest): Package {
+    const files: Record<string, Uint8Array | string> = {
+        [toPackageFilePath(publishedPackage.name, publishedPackage.manifestFile.filePath)]:
+            publishedPackage.manifestFile.content
+    };
+
+    for (const entry of publishedPackage.contents) {
+        const filePath = toPackageFilePath(publishedPackage.name, entry.fileDescription.targetFilePath);
+        files[filePath] = entry.fileDescription.content;
+    }
+
+    return new Package(files, publishedPackage.name, publishedPackage.version);
+}
+
+function groupProblemsByKind(problems: readonly Problem[]): ReadonlyMap<ProblemKind, readonly Problem[]> {
+    const grouped = new Map<ProblemKind, Problem[]>();
+
+    for (const problem of problems) {
+        const existing = grouped.get(problem.kind);
+        if (existing === undefined) {
+            grouped.set(problem.kind, [problem]);
+        } else {
+            existing.push(problem);
+        }
+    }
+
+    return grouped;
+}
+
+function listAffectedEntrypoints(
+    problems: readonly Problem[],
+    analysis: Analysis,
+    requiredResolutionKinds: readonly ResolutionKind[]
+): readonly string[] {
+    const affectedEntrypoints = new Set<string>();
+
+    for (const entrypoint of Object.keys(analysis.entrypoints)) {
+        for (const problem of problems) {
+            for (const resolutionKind of requiredResolutionKinds) {
+                if (problemAffectsEntrypointResolution(problem, entrypoint, resolutionKind, analysis)) {
+                    affectedEntrypoints.add(entrypoint);
+                }
+            }
+        }
+    }
+
+    return Array.from(affectedEntrypoints);
+}
+
+function listAffectedResolutionKinds(
+    problems: readonly Problem[],
+    analysis: Analysis,
+    requiredResolutionKinds: readonly ResolutionKind[]
+): readonly ResolutionKind[] {
+    const affectedResolutionKinds = new Set<ResolutionKind>();
+
+    for (const resolutionKind of requiredResolutionKinds) {
+        for (const problem of problems) {
+            if (problemAffectsResolutionKind(problem, resolutionKind, analysis)) {
+                affectedResolutionKinds.add(resolutionKind);
+            }
+        }
+    }
+
+    return requiredResolutionKinds.filter((resolutionKind) => {
+        return affectedResolutionKinds.has(resolutionKind);
+    });
+}
+
+function summarizeProblems(
+    packageName: string,
+    analysis: Analysis,
+    activeProblems: readonly Problem[],
+    requiredResolutionKinds: readonly ResolutionKind[]
+): readonly string[] {
+    function formatQuotedList(prefix: string, values: readonly string[]): string {
+        return values
+            .map((value, index) => {
+                const separator = index === 0 ? ` ${prefix} ` : ', ';
+                return `${separator}"${value}"`;
+            })
+            .join('');
+    }
+
+    return Array.from(groupProblemsByKind(activeProblems).entries(), ([kind, problems]) => {
+        const problemInfo = problemKindInfo[kind];
+        const entrypoints = listAffectedEntrypoints(problems, analysis, requiredResolutionKinds);
+        const resolutionKinds = listAffectedResolutionKinds(problems, analysis, requiredResolutionKinds);
+        const findings = problems.length === 1 ? '' : ` (${problems.length} findings)`;
+        const entrypointList = formatQuotedList('affecting entrypoints', entrypoints);
+        const resolutionList = formatQuotedList('in resolutions', resolutionKinds);
+        const message =
+            `Package "${packageName}" failed the Are the Types Wrong check: ` +
+            `${problemInfo.shortDescription}${findings}${entrypointList}${resolutionList}`;
+
+        return message;
+    });
+}
+
+function requiredResolutionKindsForProfile(profile: AreTheTypesWrongProfile): readonly ResolutionKind[] {
+    return requiredResolutionKindsByProfile[profile];
+}
+
+function filterActiveProblems(
+    analysis: Analysis,
+    requiredResolutionKinds: readonly ResolutionKind[]
+): readonly Problem[] {
+    return analysis.problems.filter((problem) => {
+        return requiredResolutionKinds.some((resolutionKind) => {
+            return problemAffectsResolutionKind(problem, resolutionKind, analysis);
+        });
+    });
+}
+
+async function runForPackage(
+    dependencies: AreTheTypesWrongDependencies,
+    packageName: string,
+    publishedPackage: PublishedPackageWithManifest,
+    profile: AreTheTypesWrongProfile
+): Promise<readonly string[]> {
+    try {
+        const analysis = await dependencies.checkPackage(createInMemoryPackage(publishedPackage));
+        if (analysis.types === false) {
+            return [];
+        }
+
+        const requiredResolutionKinds = requiredResolutionKindsForProfile(profile);
+        const activeProblems = filterActiveProblems(analysis, requiredResolutionKinds);
+        return summarizeProblems(packageName, analysis, activeProblems, requiredResolutionKinds);
+    } catch (error) {
+        const message = String(error);
+        return [`Package "${packageName}" failed the Are the Types Wrong check: ${message}`];
+    }
+}
+
+function createAreTheTypesWrongRule(
+    dependencies: AreTheTypesWrongDependencies = { checkPackage }
+): CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> {
+    async function run(params: RunParams): Promise<readonly string[]> {
+        const globalConfig = params.settings?.areTheTypesWrong;
+        if (globalConfig?.enabled !== true) {
+            return [];
+        }
+
+        const issuesByBundle = await Promise.all(
+            params.bundles.map(async (bundle) => {
+                const publishedPackage = params.publishedPackages?.get(bundle.name);
+                if (publishedPackage === undefined) {
+                    throw new Error(`Published package missing for "${bundle.name}"`);
+                }
+
+                const profile = resolveProfile(
+                    globalConfig,
+                    params.perPackageSettings.get(bundle.name)?.areTheTypesWrong
+                );
+                return runForPackage(dependencies, bundle.name, publishedPackage, profile);
+            })
+        );
+        return issuesByBundle.flat();
+    }
+
+    return {
+        name: ruleName,
+        globalSchema,
+        perPackageSchema,
+        run
+    };
+}
+
+export const areTheTypesWrongRule = createAreTheTypesWrongRule();

--- a/source/checks/rules/are-the-types-wrong.ts
+++ b/source/checks/rules/are-the-types-wrong.ts
@@ -34,8 +34,12 @@ type AreTheTypesWrongProfile = z.infer<typeof profileSchema>;
 type GlobalConfig = z.infer<typeof globalSchema>;
 type PerPackageConfig = z.infer<typeof perPackageSchema>;
 type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
-type AreTheTypesWrongDependencies = {
-    readonly checkPackage: typeof checkPackage;
+type ProblemSummaryInput = {
+    readonly packageName: string;
+    readonly kind: ProblemKind;
+    readonly problems: readonly Problem[];
+    readonly analysis: Analysis;
+    readonly requiredResolutionKinds: readonly ResolutionKind[];
 };
 
 const requiredResolutionKindsByProfile: Readonly<Record<AreTheTypesWrongProfile, readonly ResolutionKind[]>> = {
@@ -124,34 +128,42 @@ function listAffectedResolutionKinds(
     });
 }
 
+function formatQuotedList(prefix: string, values: readonly string[]): string {
+    return values
+        .map((value, index) => {
+            const separator = index === 0 ? ` ${prefix} ` : ', ';
+            return `${separator}"${value}"`;
+        })
+        .join('');
+}
+
+function formatProblemSummary(input: ProblemSummaryInput): string {
+    const { packageName, kind, problems, analysis, requiredResolutionKinds } = input;
+    const problemInfo = problemKindInfo[kind];
+    const entrypoints = listAffectedEntrypoints(problems, analysis, requiredResolutionKinds);
+    const resolutionKinds = listAffectedResolutionKinds(problems, analysis, requiredResolutionKinds);
+    const findings = problems.length === 1 ? '' : ` (${problems.length} findings)`;
+    const entrypointList = formatQuotedList('affecting entrypoints', entrypoints);
+    const resolutionList = formatQuotedList('in resolutions', resolutionKinds);
+    return (
+        `Package "${packageName}" failed the Are the Types Wrong check: ` +
+        `${problemInfo.shortDescription}${findings}${entrypointList}${resolutionList}`
+    );
+}
+
 function summarizeProblems(
     packageName: string,
     analysis: Analysis,
     activeProblems: readonly Problem[],
     requiredResolutionKinds: readonly ResolutionKind[]
 ): readonly string[] {
-    function formatQuotedList(prefix: string, values: readonly string[]): string {
-        return values
-            .map((value, index) => {
-                const separator = index === 0 ? ` ${prefix} ` : ', ';
-                return `${separator}"${value}"`;
-            })
-            .join('');
+    const summaries: string[] = [];
+
+    for (const [kind, problems] of groupProblemsByKind(activeProblems).entries()) {
+        summaries.push(formatProblemSummary({ packageName, kind, problems, analysis, requiredResolutionKinds }));
     }
 
-    return Array.from(groupProblemsByKind(activeProblems).entries(), ([kind, problems]) => {
-        const problemInfo = problemKindInfo[kind];
-        const entrypoints = listAffectedEntrypoints(problems, analysis, requiredResolutionKinds);
-        const resolutionKinds = listAffectedResolutionKinds(problems, analysis, requiredResolutionKinds);
-        const findings = problems.length === 1 ? '' : ` (${problems.length} findings)`;
-        const entrypointList = formatQuotedList('affecting entrypoints', entrypoints);
-        const resolutionList = formatQuotedList('in resolutions', resolutionKinds);
-        const message =
-            `Package "${packageName}" failed the Are the Types Wrong check: ` +
-            `${problemInfo.shortDescription}${findings}${entrypointList}${resolutionList}`;
-
-        return message;
-    });
+    return summaries;
 }
 
 function requiredResolutionKindsForProfile(profile: AreTheTypesWrongProfile): readonly ResolutionKind[] {
@@ -170,13 +182,12 @@ function filterActiveProblems(
 }
 
 async function runForPackage(
-    dependencies: AreTheTypesWrongDependencies,
     packageName: string,
     publishedPackage: PublishedPackageWithManifest,
     profile: AreTheTypesWrongProfile
 ): Promise<readonly string[]> {
     try {
-        const analysis = await dependencies.checkPackage(createInMemoryPackage(publishedPackage));
+        const analysis = await checkPackage(createInMemoryPackage(publishedPackage));
         if (analysis.types === false) {
             return [];
         }
@@ -190,38 +201,29 @@ async function runForPackage(
     }
 }
 
-function createAreTheTypesWrongRule(
-    dependencies: AreTheTypesWrongDependencies = { checkPackage }
-): CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> {
-    async function run(params: RunParams): Promise<readonly string[]> {
-        const globalConfig = params.settings?.areTheTypesWrong;
-        if (globalConfig?.enabled !== true) {
-            return [];
-        }
-
-        const issuesByBundle = await Promise.all(
-            params.bundles.map(async (bundle) => {
-                const publishedPackage = params.publishedPackages?.get(bundle.name);
-                if (publishedPackage === undefined) {
-                    throw new Error(`Published package missing for "${bundle.name}"`);
-                }
-
-                const profile = resolveProfile(
-                    globalConfig,
-                    params.perPackageSettings.get(bundle.name)?.areTheTypesWrong
-                );
-                return runForPackage(dependencies, bundle.name, publishedPackage, profile);
-            })
-        );
-        return issuesByBundle.flat();
+async function run(params: RunParams): Promise<readonly string[]> {
+    const globalConfig = params.settings?.areTheTypesWrong;
+    if (globalConfig?.enabled !== true) {
+        return [];
     }
 
-    return {
-        name: ruleName,
-        globalSchema,
-        perPackageSchema,
-        run
-    };
+    const issuesByBundle = await Promise.all(
+        params.bundles.map(async (bundle) => {
+            const publishedPackage = params.publishedPackages?.get(bundle.name);
+            if (publishedPackage === undefined) {
+                throw new Error(`Published package missing for "${bundle.name}"`);
+            }
+
+            const profile = resolveProfile(globalConfig, params.perPackageSettings.get(bundle.name)?.areTheTypesWrong);
+            return runForPackage(bundle.name, publishedPackage, profile);
+        })
+    );
+    return issuesByBundle.flat();
 }
 
-export const areTheTypesWrongRule = createAreTheTypesWrongRule();
+export const areTheTypesWrongRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {
+    name: ruleName,
+    globalSchema,
+    perPackageSchema,
+    run
+};

--- a/source/checks/rules/max-bundle-size.test.ts
+++ b/source/checks/rules/max-bundle-size.test.ts
@@ -17,8 +17,8 @@ suite('max-bundle-size', function () {
         assert.strictEqual(typeof maxBundleSizeRule.run, 'function');
     });
 
-    test('returns no issues when settings are missing', function () {
-        const result = maxBundleSizeRule.run({
+    test('returns no issues when settings are missing', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: undefined,
             perPackageSettings: new Map()
@@ -27,8 +27,8 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the rule is disabled', function () {
-        const result = maxBundleSizeRule.run({
+    test('returns no issues when the rule is disabled', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: { maxBundleSize: { enabled: false, bytes: 10 } },
             perPackageSettings: new Map()
@@ -37,8 +37,8 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when neither global nor per-package threshold is set', function () {
-        const result = maxBundleSizeRule.run({
+    test('returns no issues when neither global nor per-package threshold is set', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: { maxBundleSize: { enabled: true } },
             perPackageSettings: new Map()
@@ -47,8 +47,8 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports a bundle exceeding the global threshold', function () {
-        const result = maxBundleSizeRule.run({
+    test('reports a bundle exceeding the global threshold', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: { maxBundleSize: { enabled: true, bytes: 50 } },
             perPackageSettings: new Map()
@@ -57,8 +57,8 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
     });
 
-    test('passes a bundle exactly at the threshold', function () {
-        const result = maxBundleSizeRule.run({
+    test('passes a bundle exactly at the threshold', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: { maxBundleSize: { enabled: true, bytes: 100 } },
             perPackageSettings: new Map()
@@ -67,26 +67,26 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    function runWithGlobalAndOverride(globalBytes: number, override: number): readonly string[] {
-        return maxBundleSizeRule.run({
+    async function runWithGlobalAndOverride(globalBytes: number, override: number): Promise<readonly string[]> {
+        return await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: { maxBundleSize: { enabled: true, bytes: globalBytes } },
             perPackageSettings: new Map([['a', { maxBundleSize: { bytes: override } }]])
         });
     }
 
-    test('per-package bytes overrides the global default upward', function () {
-        assert.deepStrictEqual(runWithGlobalAndOverride(50, 1000), []);
+    test('per-package bytes overrides the global default upward', async function () {
+        assert.deepStrictEqual(await runWithGlobalAndOverride(50, 1000), []);
     });
 
-    test('per-package bytes overrides the global default downward', function () {
-        assert.deepStrictEqual(runWithGlobalAndOverride(1000, 50), [
+    test('per-package bytes overrides the global default downward', async function () {
+        assert.deepStrictEqual(await runWithGlobalAndOverride(1000, 50), [
             'Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)'
         ]);
     });
 
-    test('per-package bytes acts as the threshold when no global default is set', function () {
-        const result = maxBundleSizeRule.run({
+    test('per-package bytes acts as the threshold when no global default is set', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100), bundleWithBytes('b', 100)],
             settings: { maxBundleSize: { enabled: true } },
             perPackageSettings: new Map([['a', { maxBundleSize: { bytes: 50 } }]])
@@ -95,8 +95,8 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
     });
 
-    test('falls back to the global default when the per-package entry has no maxBundleSize key', function () {
-        const result = maxBundleSizeRule.run({
+    test('falls back to the global default when the per-package entry has no maxBundleSize key', async function () {
+        const result = await maxBundleSizeRule.run({
             bundles: [bundleWithBytes('a', 100)],
             settings: { maxBundleSize: { enabled: true, bytes: 50 } },
             perPackageSettings: new Map([['a', {}]])
@@ -105,7 +105,7 @@ suite('max-bundle-size', function () {
         assert.deepStrictEqual(result, ['Package "a" exceeds the maximum bundle size: 100 bytes (limit: 50 bytes)']);
     });
 
-    test('measures bundle size as the UTF-8 byte length of every resource’s content', function () {
+    test('measures bundle size as the UTF-8 byte length of every resource’s content', async function () {
         const bundle = analyzedBundle({
             name: 'multi',
             contents: [
@@ -114,7 +114,7 @@ suite('max-bundle-size', function () {
             ]
         });
 
-        const result = maxBundleSizeRule.run({
+        const result = await maxBundleSizeRule.run({
             bundles: [bundle],
             settings: { maxBundleSize: { enabled: true, bytes: 3 } },
             perPackageSettings: new Map()

--- a/source/checks/rules/max-bundle-size.ts
+++ b/source/checks/rules/max-bundle-size.ts
@@ -38,7 +38,7 @@ function checkBundle(bundle: AnalyzedBundle, threshold: number | undefined): rea
     return [`Package "${bundle.name}" exceeds the maximum bundle size: ${size} bytes (limit: ${threshold} bytes)`];
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.maxBundleSize;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/checks/rules/no-dev-dependency-imports.test.ts
+++ b/source/checks/rules/no-dev-dependency-imports.test.ts
@@ -24,8 +24,8 @@ suite('no-dev-dependency-imports', function () {
         assert.strictEqual(typeof noDevDependencyImportsRule.run, 'function');
     });
 
-    test('returns no issues when settings are missing', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('returns no issues when settings are missing', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leaked'])],
             settings: undefined,
             perPackageSettings: new Map(),
@@ -35,8 +35,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the rule is disabled', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('returns no issues when the rule is disabled', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leaked'])],
             settings: { noDevDependencyImports: { enabled: false } },
             perPackageSettings: new Map(),
@@ -46,8 +46,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when packageConfigs is omitted entirely', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('returns no issues when packageConfigs is omitted entirely', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leaked'])],
             settings: enabled,
             perPackageSettings: new Map()
@@ -56,8 +56,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when packageConfigs has no entry for the bundle', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('returns no issues when packageConfigs has no entry for the bundle', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leaked'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -67,8 +67,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the package has no main package.json', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('returns no issues when the package has no main package.json', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leaked'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -78,8 +78,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports an external dependency that is only declared in devDependencies', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('reports an external dependency that is only declared in devDependencies', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leaked'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -91,8 +91,8 @@ suite('no-dev-dependency-imports', function () {
         ]);
     });
 
-    test('does not report when the dependency is also declared in dependencies', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('does not report when the dependency is also declared in dependencies', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['shared'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -109,8 +109,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('does not report when the dependency is declared in peerDependencies', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('does not report when the dependency is declared in peerDependencies', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['peer'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -127,8 +127,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('does not report when the dependency is not in any list', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('does not report when the dependency is not in any list', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['unknown'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -138,8 +138,8 @@ suite('no-dev-dependency-imports', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports independently per bundle', function () {
-        const result = noDevDependencyImportsRule.run({
+    test('reports independently per bundle', async function () {
+        const result = await noDevDependencyImportsRule.run({
             bundles: [bundleWithExternals('a', ['leak-a']), bundleWithExternals('b', ['fine'])],
             settings: enabled,
             perPackageSettings: new Map(),

--- a/source/checks/rules/no-dev-dependency-imports.ts
+++ b/source/checks/rules/no-dev-dependency-imports.ts
@@ -38,7 +38,7 @@ function findLeakedDevDependencies(
         });
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.noDevDependencyImports;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -57,29 +57,29 @@ function consentMap(
     );
 }
 
-function runRule(args: {
+async function runRule(args: {
     readonly bundles: readonly AnalyzedBundle[];
     readonly settings:
         | { readonly noDuplicatedFiles: { readonly enabled: boolean; readonly allowList?: readonly string[] } }
         | undefined;
     readonly perPackageSettings: ReadonlyMap<string, PackageChecksSettings>;
-}): readonly string[] {
-    return noDuplicatedFilesRule.run(args);
+}): Promise<readonly string[]> {
+    return await noDuplicatedFilesRule.run(args);
 }
 
-function runWithConsent(
+async function runWithConsent(
     bundles: readonly AnalyzedBundle[],
     consenters: readonly (readonly [string, readonly string[]])[]
-): readonly string[] {
-    return runRule({
+): Promise<readonly string[]> {
+    return await runRule({
         bundles,
         settings: { noDuplicatedFiles: { enabled: true } },
         perPackageSettings: consentMap(consenters)
     });
 }
 
-function runWithMixedConsent(secondOwnerSettings: PackageChecksSettings): readonly string[] {
-    return runRule({
+async function runWithMixedConsent(secondOwnerSettings: PackageChecksSettings): Promise<readonly string[]> {
+    return await runRule({
         bundles: [bundle('a'), bundle('b')],
         settings: { noDuplicatedFiles: { enabled: true } },
         perPackageSettings: new Map([
@@ -93,7 +93,7 @@ function registerScenarioTests<TScenario>(
     scenarios: readonly TScenario[],
     defineScenario: (scenario: TScenario) => {
         readonly name: string;
-        readonly execute: () => void;
+        readonly execute: () => Promise<void>;
     }
 ): void {
     const [scenario, ...remainingScenarios] = scenarios;
@@ -133,8 +133,8 @@ suite('no-duplicated-files', function () {
     registerScenarioTests(topLevelSettingsScenarios, (scenario) => {
         return {
             name: scenario.name,
-            execute() {
-                const result = runRule(scenario);
+            async execute() {
+                const result = await runRule(scenario);
                 assert.deepStrictEqual(result, scenario.expected);
             }
         };
@@ -191,8 +191,8 @@ suite('no-duplicated-files', function () {
     registerScenarioTests(duplicateConsentScenarios, (scenario) => {
         return {
             name: scenario.name,
-            execute() {
-                const result = runWithConsent(scenario.bundles, scenario.consenters);
+            async execute() {
+                const result = await runWithConsent(scenario.bundles, scenario.consenters);
                 assert.deepStrictEqual(result, scenario.expected);
             }
         };
@@ -214,8 +214,8 @@ suite('no-duplicated-files', function () {
     registerScenarioTests(mixedConsentScenarios, (scenario) => {
         return {
             name: scenario.name,
-            execute() {
-                const result = runWithMixedConsent(scenario.secondOwnerSettings);
+            async execute() {
+                const result = await runWithMixedConsent(scenario.secondOwnerSettings);
                 assert.deepStrictEqual(result, scenario.expected);
             }
         };
@@ -237,8 +237,8 @@ suite('no-duplicated-files', function () {
     registerScenarioTests(globalAllowListScenarios, (scenario) => {
         return {
             name: scenario.name,
-            execute() {
-                const result = runRule({
+            async execute() {
+                const result = await runRule({
                     bundles: [bundle('a'), bundle('b')],
                     settings: scenario.settings,
                     perPackageSettings: new Map()
@@ -298,8 +298,8 @@ suite('no-duplicated-files', function () {
     registerScenarioTests(sharedDeclarationScenarios, (scenario) => {
         return {
             name: scenario.name,
-            execute() {
-                const result = runRule({
+            async execute() {
+                const result = await runRule({
                     bundles: scenario.bundles,
                     settings: scenario.settings,
                     perPackageSettings: new Map()
@@ -309,8 +309,8 @@ suite('no-duplicated-files', function () {
         };
     });
 
-    test('does not report when only a single bundle owns the file', function () {
-        const result = runRule({
+    test('does not report when only a single bundle owns the file', async function () {
+        const result = await runRule({
             bundles: [bundle('a')],
             settings: { noDuplicatedFiles: { enabled: true } },
             perPackageSettings: new Map()
@@ -319,8 +319,8 @@ suite('no-duplicated-files', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('falls back to path-level message when surviving bindings are unavailable for every owner', function () {
-        const result = runRule({
+    test('falls back to path-level message when surviving bindings are unavailable for every owner', async function () {
+        const result = await runRule({
             bundles: [bundle('a'), bundle('b')],
             settings: { noDuplicatedFiles: { enabled: true } },
             perPackageSettings: new Map()

--- a/source/checks/rules/no-duplicated-files.ts
+++ b/source/checks/rules/no-duplicated-files.ts
@@ -50,7 +50,7 @@ function findDuplicateIssues(
     });
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.noDuplicatedFiles;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/checks/rules/no-side-effects.test.ts
+++ b/source/checks/rules/no-side-effects.test.ts
@@ -31,11 +31,11 @@ function consentMap(
     );
 }
 
-function runWithInitSideEffect(
+async function runWithInitSideEffect(
     settings: Parameters<typeof noSideEffectsRule.run>[0]['settings'],
     perPackageSettings: ReadonlyMap<string, PackageChecksSettings>
-): readonly string[] {
-    return noSideEffectsRule.run({
+): Promise<readonly string[]> {
+    return await noSideEffectsRule.run({
         bundles: [
             bundleWithImpureResources('a', [impureResource('/init.ts', [{ line: 1, kind: 'expression statement' }])])
         ],
@@ -52,8 +52,8 @@ suite('no-side-effects', function () {
         assert.notStrictEqual(noSideEffectsRule.perPackageSchema, undefined);
     });
 
-    test('returns no issues when settings are missing entirely', function () {
-        const result = noSideEffectsRule.run({
+    test('returns no issues when settings are missing entirely', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [
                 bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])])
             ],
@@ -64,8 +64,8 @@ suite('no-side-effects', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the rule is disabled at the top level', function () {
-        const result = noSideEffectsRule.run({
+    test('returns no issues when the rule is disabled at the top level', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [
                 bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])])
             ],
@@ -76,8 +76,8 @@ suite('no-side-effects', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when no resource has side effects', function () {
-        const result = noSideEffectsRule.run({
+    test('returns no issues when no resource has side effects', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [bundleWithImpureResources('a', [analyzedBundleResource('/a.ts')])],
             settings: { noSideEffects: { enabled: true } },
             perPackageSettings: new Map()
@@ -86,8 +86,8 @@ suite('no-side-effects', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports a resource with side effects, including line numbers and statement kinds', function () {
-        const result = noSideEffectsRule.run({
+    test('reports a resource with side effects, including line numbers and statement kinds', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [
                 bundleWithImpureResources('a', [
                     impureResource('/init.ts', [
@@ -110,20 +110,26 @@ suite('no-side-effects', function () {
         ]);
     });
 
-    test('skips a resource that is on the global allowList', function () {
-        const result = runWithInitSideEffect({ noSideEffects: { enabled: true, allowList: ['/init.ts'] } }, new Map());
+    test('skips a resource that is on the global allowList', async function () {
+        const result = await runWithInitSideEffect(
+            { noSideEffects: { enabled: true, allowList: ['/init.ts'] } },
+            new Map()
+        );
 
         assert.deepStrictEqual(result, []);
     });
 
-    test('skips a resource that is on the per-package allowList', function () {
-        const result = runWithInitSideEffect({ noSideEffects: { enabled: true } }, consentMap([['a', ['/init.ts']]]));
+    test('skips a resource that is on the per-package allowList', async function () {
+        const result = await runWithInitSideEffect(
+            { noSideEffects: { enabled: true } },
+            consentMap([['a', ['/init.ts']]])
+        );
 
         assert.deepStrictEqual(result, []);
     });
 
-    test('iterates resources independently and reports only the impure ones', function () {
-        const result = noSideEffectsRule.run({
+    test('iterates resources independently and reports only the impure ones', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [
                 bundleWithImpureResources('a', [
                     analyzedBundleResource('/pure.ts'),
@@ -139,8 +145,8 @@ suite('no-side-effects', function () {
         assert.ok(issue?.includes('/impure.ts'));
     });
 
-    test('iterates bundles independently', function () {
-        const result = noSideEffectsRule.run({
+    test('iterates bundles independently', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [
                 bundleWithImpureResources('a', [impureResource('/a.ts', [{ line: 1, kind: 'expression statement' }])]),
                 bundleWithImpureResources('b', [impureResource('/b.ts', [{ line: 1, kind: 'if statement' }])])
@@ -154,8 +160,8 @@ suite('no-side-effects', function () {
         assert.ok(result.some((issue) => issue.includes('package "b"')));
     });
 
-    test('per-package allowList only suppresses for the listed package', function () {
-        const result = noSideEffectsRule.run({
+    test('per-package allowList only suppresses for the listed package', async function () {
+        const result = await noSideEffectsRule.run({
             bundles: [
                 bundleWithImpureResources('a', [
                     impureResource('/shared.ts', [{ line: 1, kind: 'expression statement' }])
@@ -173,8 +179,8 @@ suite('no-side-effects', function () {
         assert.ok(issue?.includes('package "b"'));
     });
 
-    test('reports a side effect when the per-package settings entry exists for the bundle but does not include noSideEffects', function () {
-        const result = runWithInitSideEffect(
+    test('reports a side effect when the per-package settings entry exists for the bundle but does not include noSideEffects', async function () {
+        const result = await runWithInitSideEffect(
             { noSideEffects: { enabled: true } },
             new Map<string, PackageChecksSettings>([['a', {}]])
         );

--- a/source/checks/rules/no-side-effects.ts
+++ b/source/checks/rules/no-side-effects.ts
@@ -59,7 +59,7 @@ function findSideEffectsInBundle(
     });
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.noSideEffects;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/checks/rules/no-unused-bundle-dependencies.test.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.test.ts
@@ -24,8 +24,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.strictEqual(typeof noUnusedBundleDependenciesRule.run, 'function');
     });
 
-    test('returns no issues when settings are missing', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('returns no issues when settings are missing', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: undefined,
             perPackageSettings: new Map(),
@@ -35,8 +35,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the rule is disabled', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('returns no issues when the rule is disabled', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: { noUnusedBundleDependencies: { enabled: false } },
             perPackageSettings: new Map(),
@@ -46,8 +46,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when packageConfigs is omitted entirely', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('returns no issues when packageConfigs is omitted entirely', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: enabled,
             perPackageSettings: new Map()
@@ -56,8 +56,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when no entry exists in packageConfigs for the bundle', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('returns no issues when no entry exists in packageConfigs for the bundle', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -67,8 +67,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the package declares no bundle dependencies', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('returns no issues when the package declares no bundle dependencies', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -78,8 +78,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports a declared bundleDependency that is never substituted', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('reports a declared bundleDependency that is never substituted', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -89,8 +89,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, ['Unused bundle dependency "unused" declared by package "a"']);
     });
 
-    test('reports a declared bundlePeerDependency that is never substituted', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('reports a declared bundlePeerDependency that is never substituted', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', [])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -100,8 +100,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, ['Unused bundle peer dependency "unused-peer" declared by package "a"']);
     });
 
-    test('does not report a declared bundleDependency that was substituted', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('does not report a declared bundleDependency that was substituted', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', ['used'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -111,8 +111,8 @@ suite('no-unused-bundle-dependencies', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports a mix of unused regular and peer dependencies for the same package', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('reports a mix of unused regular and peer dependencies for the same package', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', ['used'])],
             settings: enabled,
             perPackageSettings: new Map(),
@@ -127,8 +127,8 @@ suite('no-unused-bundle-dependencies', function () {
         ]);
     });
 
-    test('iterates every bundle independently', function () {
-        const result = noUnusedBundleDependenciesRule.run({
+    test('iterates every bundle independently', async function () {
+        const result = await noUnusedBundleDependenciesRule.run({
             bundles: [bundleWithLinkedDeps('a', []), bundleWithLinkedDeps('b', ['used'])],
             settings: enabled,
             perPackageSettings: new Map(),

--- a/source/checks/rules/no-unused-bundle-dependencies.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.ts
@@ -30,7 +30,7 @@ function checkBundle(bundle: AnalyzedBundle, packageConfig: RulePackageConfig | 
     return issues;
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.noUnusedBundleDependencies;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/checks/rules/registry.test.ts
+++ b/source/checks/rules/registry.test.ts
@@ -4,9 +4,10 @@ import { suite, test } from 'mocha';
 import { allRules } from './registry.ts';
 
 suite('registry', function () {
-    test('allRules exposes the seven well-known check rules by name', function () {
+    test('allRules exposes the eight well-known check rules by name', function () {
         const names = allRules.map((rule) => rule.name).toSorted();
         assert.deepStrictEqual(names, [
+            'areTheTypesWrong',
             'maxBundleSize',
             'noDevDependencyImports',
             'noDuplicatedFiles',

--- a/source/checks/rules/registry.ts
+++ b/source/checks/rules/registry.ts
@@ -1,3 +1,4 @@
+import { areTheTypesWrongRule } from './are-the-types-wrong.ts';
 import { maxBundleSizeRule } from './max-bundle-size.ts';
 import { noDevDependencyImportsRule } from './no-dev-dependency-imports.ts';
 import { noDuplicatedFilesRule } from './no-duplicated-files.ts';
@@ -7,6 +8,7 @@ import { requiredFilesRule } from './required-files.ts';
 import { uniqueTargetPathsRule } from './unique-target-paths.ts';
 
 export const allRules = [
+    areTheTypesWrongRule,
     noDuplicatedFilesRule,
     requiredFilesRule,
     maxBundleSizeRule,

--- a/source/checks/rules/required-files.test.ts
+++ b/source/checks/rules/required-files.test.ts
@@ -14,8 +14,8 @@ suite('required-files', function () {
         assert.strictEqual(typeof requiredFilesRule.run, 'function');
     });
 
-    test('returns no issues when settings are missing', function () {
-        const result = requiredFilesRule.run({
+    test('returns no issues when settings are missing', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', [])],
             settings: undefined,
             perPackageSettings: new Map()
@@ -24,8 +24,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the rule is disabled', function () {
-        const result = requiredFilesRule.run({
+    test('returns no issues when the rule is disabled', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', [])],
             settings: { requiredFiles: { enabled: false, files: ['LICENSE'] } },
             perPackageSettings: new Map()
@@ -34,8 +34,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports a missing global required file for every bundle that lacks it', function () {
-        const result = requiredFilesRule.run({
+    test('reports a missing global required file for every bundle that lacks it', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', ['LICENSE']), bundle('b', [])],
             settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
             perPackageSettings: new Map()
@@ -44,8 +44,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, ['Package "b" is missing required file "LICENSE"']);
     });
 
-    test('returns no issues when all bundles contain every globally required file', function () {
-        const result = requiredFilesRule.run({
+    test('returns no issues when all bundles contain every globally required file', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', ['LICENSE', 'readme.md']), bundle('b', ['LICENSE', 'readme.md'])],
             settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
             perPackageSettings: new Map()
@@ -54,8 +54,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('extends global required files with per-package required files', function () {
-        const result = requiredFilesRule.run({
+    test('extends global required files with per-package required files', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', ['LICENSE'])],
             settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
             perPackageSettings: new Map([['a', packageRequiring(['CHANGELOG.md'])]])
@@ -64,8 +64,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, ['Package "a" is missing required file "CHANGELOG.md"']);
     });
 
-    test('deduplicates required files when per-package config repeats a global entry', function () {
-        const result = requiredFilesRule.run({
+    test('deduplicates required files when per-package config repeats a global entry', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', [])],
             settings: { requiredFiles: { enabled: true, files: ['LICENSE'] } },
             perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
@@ -74,8 +74,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
     });
 
-    test('uses per-package required files even when the global list is empty', function () {
-        const result = requiredFilesRule.run({
+    test('uses per-package required files even when the global list is empty', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', [])],
             settings: { requiredFiles: { enabled: true } },
             perPackageSettings: new Map([['a', packageRequiring(['LICENSE'])]])
@@ -84,8 +84,8 @@ suite('required-files', function () {
         assert.deepStrictEqual(result, ['Package "a" is missing required file "LICENSE"']);
     });
 
-    test('reports multiple missing files for a single bundle', function () {
-        const result = requiredFilesRule.run({
+    test('reports multiple missing files for a single bundle', async function () {
+        const result = await requiredFilesRule.run({
             bundles: [bundle('a', [])],
             settings: { requiredFiles: { enabled: true, files: ['LICENSE', 'readme.md'] } },
             perPackageSettings: new Map()

--- a/source/checks/rules/required-files.ts
+++ b/source/checks/rules/required-files.ts
@@ -39,7 +39,7 @@ function findMissingFiles(bundle: AnalyzedBundle, requiredFiles: readonly string
     });
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.requiredFiles;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/checks/rules/unique-target-paths.test.ts
+++ b/source/checks/rules/unique-target-paths.test.ts
@@ -21,8 +21,8 @@ suite('unique-target-paths', function () {
         assert.strictEqual(typeof uniqueTargetPathsRule.run, 'function');
     });
 
-    test('returns no issues when settings are missing', function () {
-        const result = uniqueTargetPathsRule.run({
+    test('returns no issues when settings are missing', async function () {
+        const result = await uniqueTargetPathsRule.run({
             bundles: [
                 bundleWithMappings('a', [
                     ['/src/a.js', 'collide.js'],
@@ -36,8 +36,8 @@ suite('unique-target-paths', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when the rule is disabled', function () {
-        const result = uniqueTargetPathsRule.run({
+    test('returns no issues when the rule is disabled', async function () {
+        const result = await uniqueTargetPathsRule.run({
             bundles: [
                 bundleWithMappings('a', [
                     ['/src/a.js', 'collide.js'],
@@ -51,8 +51,8 @@ suite('unique-target-paths', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('returns no issues when every targetFilePath is unique', function () {
-        const result = uniqueTargetPathsRule.run({
+    test('returns no issues when every targetFilePath is unique', async function () {
+        const result = await uniqueTargetPathsRule.run({
             bundles: [
                 bundleWithMappings('a', [
                     ['/src/a.js', 'a.js'],
@@ -66,8 +66,8 @@ suite('unique-target-paths', function () {
         assert.deepStrictEqual(result, []);
     });
 
-    test('reports a collision and lists the colliding source paths sorted', function () {
-        const result = uniqueTargetPathsRule.run({
+    test('reports a collision and lists the colliding source paths sorted', async function () {
+        const result = await uniqueTargetPathsRule.run({
             bundles: [
                 bundleWithMappings('a', [
                     ['/src/b.js', 'collide.js'],
@@ -81,8 +81,8 @@ suite('unique-target-paths', function () {
         assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "collide.js": /src/a.js, /src/b.js']);
     });
 
-    test('reports collisions independently per bundle', function () {
-        const result = uniqueTargetPathsRule.run({
+    test('reports collisions independently per bundle', async function () {
+        const result = await uniqueTargetPathsRule.run({
             bundles: [
                 bundleWithMappings('a', [
                     ['/a-src/x.js', 'shared.js'],
@@ -100,8 +100,8 @@ suite('unique-target-paths', function () {
         assert.deepStrictEqual(result, ['Package "a" maps multiple sources to "shared.js": /a-src/x.js, /a-src/y.js']);
     });
 
-    test('reports each colliding target path of a bundle', function () {
-        const result = uniqueTargetPathsRule.run({
+    test('reports each colliding target path of a bundle', async function () {
+        const result = await uniqueTargetPathsRule.run({
             bundles: [
                 bundleWithMappings('a', [
                     ['/src/x1.js', 'one.js'],

--- a/source/checks/rules/unique-target-paths.ts
+++ b/source/checks/rules/unique-target-paths.ts
@@ -34,7 +34,7 @@ function findCollidingTargetPaths(bundle: AnalyzedBundle): readonly string[] {
     });
 }
 
-function run(params: RunParams): readonly string[] {
+async function run(params: RunParams): Promise<readonly string[]> {
     const globalConfig = params.settings?.uniqueTargetPaths;
     if (globalConfig?.enabled !== true) {
         return [];

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -10,6 +10,35 @@ import {
 import { checksPerPackageSchema, checksSchema } from './checks-schema.ts';
 
 suite('checks-schema', function () {
+    test('top-level schema accepts areTheTypesWrong with enabled', function () {
+        assert.strictEqual(safeParse(checksSchema, { areTheTypesWrong: { enabled: true } }).success, true);
+    });
+
+    test('top-level schema accepts an areTheTypesWrong profile override', function () {
+        assert.strictEqual(
+            safeParse(checksSchema, { areTheTypesWrong: { enabled: true, profile: 'strict' } }).success,
+            true
+        );
+    });
+
+    test('top-level schema rejects an unknown areTheTypesWrong profile', function () {
+        assert.strictEqual(
+            safeParse(checksSchema, { areTheTypesWrong: { enabled: true, profile: 'legacy' } }).success,
+            false
+        );
+    });
+
+    test('per-package schema accepts an areTheTypesWrong profile override', function () {
+        assert.strictEqual(
+            safeParse(checksPerPackageSchema, { areTheTypesWrong: { profile: 'node16' } }).success,
+            true
+        );
+    });
+
+    test('per-package schema rejects an enabled flag on areTheTypesWrong', function () {
+        assert.strictEqual(safeParse(checksPerPackageSchema, { areTheTypesWrong: { enabled: true } }).success, false);
+    });
+
     test('schema accepts valid noDuplicatedFiles settings at the top level', function () {
         assert.strictEqual(safeParse(checksSchema, { noDuplicatedFiles: { enabled: true } }).success, true);
     });

--- a/source/config/checks-schema.ts
+++ b/source/config/checks-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/mini';
+import { areTheTypesWrongRule } from '../checks/rules/are-the-types-wrong.ts';
 import { maxBundleSizeRule } from '../checks/rules/max-bundle-size.ts';
 import { noDevDependencyImportsRule } from '../checks/rules/no-dev-dependency-imports.ts';
 import { noDuplicatedFilesRule } from '../checks/rules/no-duplicated-files.ts';
@@ -8,6 +9,7 @@ import { requiredFilesRule } from '../checks/rules/required-files.ts';
 import { uniqueTargetPathsRule } from '../checks/rules/unique-target-paths.ts';
 
 export const checksSchema = z.strictObject({
+    areTheTypesWrong: z.optional(areTheTypesWrongRule.globalSchema),
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.globalSchema),
     requiredFiles: z.optional(requiredFilesRule.globalSchema),
     maxBundleSize: z.optional(maxBundleSizeRule.globalSchema),
@@ -18,6 +20,7 @@ export const checksSchema = z.strictObject({
 });
 
 export const checksPerPackageSchema = z.strictObject({
+    areTheTypesWrong: z.optional(areTheTypesWrongRule.perPackageSchema),
     noDuplicatedFiles: z.optional(noDuplicatedFilesRule.perPackageSchema),
     requiredFiles: z.optional(requiredFilesRule.perPackageSchema),
     maxBundleSize: z.optional(maxBundleSizeRule.perPackageSchema),

--- a/source/config/package-interface.test.ts
+++ b/source/config/package-interface.test.ts
@@ -17,6 +17,15 @@ suite('package-interface', function () {
         );
     });
 
+    test('packageInterfaceSchema accepts interfaces that expose only bins', function () {
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                bins: [{ root: 'cli', name: 'packtory' }]
+            }).success,
+            true
+        );
+    });
+
     test('packageInterfaceSchema rejects module export keys without a package-relative prefix', function () {
         assert.strictEqual(
             safeParse(packageInterfaceSchema, {
@@ -43,6 +52,12 @@ suite('package-interface', function () {
             safeParse(packageInterfaceSchema, {
                 modules: [{ root: 'main', export: '.' }],
                 privateRoots: []
+            }).success,
+            false
+        );
+        assert.strictEqual(
+            safeParse(packageInterfaceSchema, {
+                privateRoots: ['worker']
             }).success,
             false
         );

--- a/source/config/package-interface.ts
+++ b/source/config/package-interface.ts
@@ -26,18 +26,17 @@ const nonEmptyBinExposuresSchema = z.readonly(z.tuple([binExposureSchema], binEx
 const nonEmptyPrivateRootsSchema = z.readonly(z.tuple([nonEmptyStringSchema], nonEmptyStringSchema));
 
 export const packageInterfaceSchema = z.readonly(
-    z.union([
-        z.strictObject({
-            modules: nonEmptyModuleExposuresSchema,
+    z
+        .strictObject({
+            modules: z.optional(nonEmptyModuleExposuresSchema),
             bins: z.optional(nonEmptyBinExposuresSchema),
             privateRoots: z.optional(nonEmptyPrivateRootsSchema)
-        }),
-        z.strictObject({
-            bins: nonEmptyBinExposuresSchema,
-            modules: z.optional(nonEmptyModuleExposuresSchema),
-            privateRoots: z.optional(nonEmptyPrivateRootsSchema)
         })
-    ])
+        .check(
+            z.refine((value) => {
+                return value.modules !== undefined || value.bins !== undefined;
+            })
+        )
 );
 
 export type PackageInterface = z.infer<typeof packageInterfaceSchema>;

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -202,6 +202,7 @@ suite('schema-contracts', function () {
                 'packageInterface'
             ],
             checksShapeKeys: [
+                'areTheTypesWrong',
                 'noDuplicatedFiles',
                 'requiredFiles',
                 'maxBundleSize',

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -209,10 +209,22 @@ describe('PacktoryConfig — exposed structure', () => {
         expect<NoDuplicates['enabled']>().type.toBe<boolean>();
     });
 
+    test('checks.areTheTypesWrong is toggled at the top level via `enabled`', () => {
+        type Checks = NonNullable<PacktoryConfig['checks']>;
+        type AreTheTypesWrong = NonNullable<Checks['areTheTypesWrong']>;
+        expect<AreTheTypesWrong['enabled']>().type.toBe<boolean>();
+    });
+
     test('PackageConfig.checks.noDuplicatedFiles carries the per-package allowList', () => {
         type PackageChecks = NonNullable<PackageConfig['checks']>;
         type NoDuplicates = NonNullable<PackageChecks['noDuplicatedFiles']>;
         expect<NoDuplicates['allowList']>().type.toBe<readonly string[] | undefined>();
+    });
+
+    test('PackageConfig.checks.areTheTypesWrong carries the per-package profile override', () => {
+        type PackageChecks = NonNullable<PackageConfig['checks']>;
+        type AreTheTypesWrong = NonNullable<PackageChecks['areTheTypesWrong']>;
+        expect<AreTheTypesWrong['profile']>().type.toBe<'esm-only' | 'node16' | 'strict' | undefined>();
     });
 });
 

--- a/source/packtory/packtory-resolve.test.ts
+++ b/source/packtory/packtory-resolve.test.ts
@@ -14,7 +14,12 @@ function happyDependencies() {
         deadCodeEliminator: emptyDeadCodeEliminator,
         packageProcessor: stubPackageProcessor,
         scheduler: emptyScheduler,
-        progressBroadcaster: stubProgressBroadcaster
+        progressBroadcaster: stubProgressBroadcaster,
+        versionManager: {
+            addVersion() {
+                throw new Error('versionManager.addVersion should not run when no ATTW check is configured');
+            }
+        }
     };
 }
 

--- a/source/packtory/packtory-resolve.ts
+++ b/source/packtory/packtory-resolve.ts
@@ -1,5 +1,6 @@
 import { Result } from 'true-myth';
 import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
+import type { VersionManager } from '../version-manager/manager.ts';
 import { analyzeResolvedPackages, type PackageAnalysisDependencies } from './stages/package-analysis-stage.ts';
 import { resolvePackages, type PackageResolutionDependencies } from './stages/package-resolution-stage.ts';
 import { resolvePartialFailure, type PartialErrorResult } from './packtory-results.ts';
@@ -8,9 +9,10 @@ import { buildChecksResult, type CheckError, type ResolvedPackage } from './reso
 export type InternalResolveAndLinkFailure = CheckError | PartialErrorResult;
 
 type ResolveDependencies = PackageAnalysisDependencies & PackageResolutionDependencies;
+type CheckDependencies = ResolveDependencies & { readonly versionManager: Pick<VersionManager, 'addVersion'> };
 
 export function createResolveAndLinkAllValidated(
-    dependencies: ResolveDependencies
+    dependencies: CheckDependencies
 ): (
     config: ValidConfigWithoutRegistryResult
 ) => Promise<Result<readonly ResolvedPackage[], InternalResolveAndLinkFailure>> {
@@ -24,6 +26,6 @@ export function createResolveAndLinkAllValidated(
         }
 
         const resolvedPackages = await analyzeResolvedPackages(dependencies, config, runResult.value);
-        return buildChecksResult(config, resolvedPackages);
+        return await buildChecksResult(dependencies, config, resolvedPackages);
     };
 }

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -357,7 +357,10 @@ suite('packtory', function () {
             tryBuildAndPublish
         });
 
-        const { result } = await packtory.buildAndPublishAll(createConfigWithoutRegistry(), { dryRun: false });
+        const { result } = await packtory.buildAndPublishAll(createConfigWithoutRegistry(), {
+            dryRun: false,
+            stage: false
+        });
 
         assert.deepStrictEqual(
             result,
@@ -377,7 +380,10 @@ suite('packtory', function () {
     test('buildAndPublishAll() allows dry-run when auth is omitted (anonymous read)', async function () {
         const { packtory, tryBuildAndPublish, buildAndPublish } = createPacktoryUnderTest();
 
-        const { result } = await packtory.buildAndPublishAll(createConfigWithoutRegistry(), { dryRun: true });
+        const { result } = await packtory.buildAndPublishAll(createConfigWithoutRegistry(), {
+            dryRun: true,
+            stage: false
+        });
 
         assert.strictEqual(result.isOk, true);
         assert.strictEqual(tryBuildAndPublish.callCount, 1);

--- a/source/packtory/resolved-package.test.ts
+++ b/source/packtory/resolved-package.test.ts
@@ -4,10 +4,80 @@ import { suite, test } from 'mocha';
 import type { ConfigWithGraph } from '../config/validation.ts';
 import type { PacktoryConfigWithoutRegistry } from '../config/config.ts';
 import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
+import { analyzedBundleResource, versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { buildChecksResult, createResolvedPackage, type ResolvedPackage } from './resolved-package.ts';
 
 function validated(config: Partial<PacktoryConfigWithoutRegistry>): ConfigWithGraph<PacktoryConfigWithoutRegistry> {
     return { packtoryConfig: { packages: [], ...config } } as unknown as ConfigWithGraph<PacktoryConfigWithoutRegistry>;
+}
+
+const unusedCheckDependencies = {
+    versionManager: {
+        addVersion() {
+            throw new Error('versionManager.addVersion should not run for non-ATTW tests');
+        }
+    }
+};
+
+function packageConfig(
+    name: string,
+    overrides: Readonly<Record<string, unknown>> = {}
+): PacktoryConfigWithoutRegistry['packages'][number] {
+    return { name, roots: {}, ...overrides } as never;
+}
+
+function resolvedPackage(name: string, analyzedBundle: ResolvedPackage['analyzedBundle']): ResolvedPackage {
+    return { name, analyzedBundle, resolveOptions: {} as never };
+}
+
+function duplicateResolvedPackages(): readonly ResolvedPackage[] {
+    return [
+        resolvedPackage('pkg-a', checkBundle('pkg-a', ['shared.ts'])),
+        resolvedPackage('pkg-b', checkBundle('pkg-b', ['shared.ts']))
+    ];
+}
+
+function bundleWithExternal(packageName: string, dependencyName: string): ResolvedPackage['analyzedBundle'] {
+    return {
+        ...checkBundle(packageName, ['shared.ts']),
+        externalDependencies: new Map([[dependencyName, { name: dependencyName, referencedFrom: ['/x'] }]])
+    } as never;
+}
+
+async function runSinglePackageChecks(
+    config: Partial<PacktoryConfigWithoutRegistry>,
+    analyzedBundle: ResolvedPackage['analyzedBundle']
+) {
+    return await buildChecksResult(unusedCheckDependencies, validated(config), [
+        resolvedPackage('pkg-a', analyzedBundle)
+    ]);
+}
+
+function createPublishedPackageWithManifest(packageName: string) {
+    return versionedBundleWithManifest({
+        name: packageName,
+        version: '0.0.0',
+        contents: [
+            analyzedBundleResource('index.js', {
+                targetFilePath: 'index.js',
+                content: 'export const value = 1;\n'
+            })
+        ],
+        mainFile: {
+            sourceFilePath: 'index.js',
+            targetFilePath: 'index.js',
+            content: 'export const value = 1;\n'
+        },
+        manifestFile: {
+            filePath: 'package.json',
+            content: JSON.stringify({ name: packageName, version: '0.0.0', type: 'module' }),
+            isExecutable: false
+        },
+        packageJson: {
+            name: packageName,
+            version: '0.0.0'
+        }
+    });
 }
 
 suite('resolved-package', function () {
@@ -22,10 +92,10 @@ suite('resolved-package', function () {
         });
     });
 
-    test('buildChecksResult returns an Ok holding the resolved packages when no checks are configured', function () {
+    test('buildChecksResult returns an Ok holding the resolved packages when no checks are configured', async function () {
         const resolvedPackages: readonly ResolvedPackage[] = [];
 
-        const result = buildChecksResult(validated({}), resolvedPackages);
+        const result = await buildChecksResult(unusedCheckDependencies, validated({}), resolvedPackages);
 
         assert.strictEqual(result.isOk, true);
         if (result.isOk) {
@@ -33,18 +103,14 @@ suite('resolved-package', function () {
         }
     });
 
-    test('buildChecksResult returns a checks failure carrying every issue produced by a configured rule', function () {
-        const resolvedPackages = [
-            { name: 'pkg-a', analyzedBundle: checkBundle('pkg-a', ['shared.ts']), resolveOptions: {} as never },
-            { name: 'pkg-b', analyzedBundle: checkBundle('pkg-b', ['shared.ts']), resolveOptions: {} as never }
-        ];
-
-        const result = buildChecksResult(
+    test('buildChecksResult returns a checks failure carrying every issue produced by a configured rule', async function () {
+        const result = await buildChecksResult(
+            unusedCheckDependencies,
             validated({
                 checks: { noDuplicatedFiles: { enabled: true } },
-                packages: [{ name: 'pkg-a', roots: {} } as never, { name: 'pkg-b', roots: {} } as never]
+                packages: [packageConfig('pkg-a'), packageConfig('pkg-b')]
             }),
-            resolvedPackages
+            duplicateResolvedPackages()
         );
 
         assert.strictEqual(result.isErr, true);
@@ -56,62 +122,46 @@ suite('resolved-package', function () {
         }
     });
 
-    test('buildChecksResult threads per-package check settings to the runner so cross-package consent suppresses issues', function () {
-        const resolvedPackages = [
-            { name: 'pkg-a', analyzedBundle: checkBundle('pkg-a', ['shared.ts']), resolveOptions: {} as never },
-            { name: 'pkg-b', analyzedBundle: checkBundle('pkg-b', ['shared.ts']), resolveOptions: {} as never }
-        ];
+    test('buildChecksResult threads per-package check settings to the runner so cross-package consent suppresses issues', async function () {
         const consent = { noDuplicatedFiles: { allowList: ['shared.ts'] } };
 
-        const result = buildChecksResult(
+        const result = await buildChecksResult(
+            unusedCheckDependencies,
             validated({
                 checks: { noDuplicatedFiles: { enabled: true } },
-                packages: [
-                    { name: 'pkg-a', roots: {}, checks: consent } as never,
-                    { name: 'pkg-b', roots: {}, checks: consent } as never
-                ]
+                packages: [packageConfig('pkg-a', { checks: consent }), packageConfig('pkg-b', { checks: consent })]
             }),
-            resolvedPackages
+            duplicateResolvedPackages()
         );
 
         assert.strictEqual(result.isOk, true);
     });
 
-    test('buildChecksResult falls back to commonPackageSettings.mainPackageJson when the package does not override it', function () {
-        const bundle = {
-            ...checkBundle('pkg-a', ['shared.ts']),
-            externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
-        };
-
-        const result = buildChecksResult(
-            validated({
+    test('buildChecksResult falls back to commonPackageSettings.mainPackageJson when the package does not override it', async function () {
+        const result = await runSinglePackageChecks(
+            {
                 commonPackageSettings: {
                     mainPackageJson: { type: 'module', dependencies: { 'runtime-dep': '1.0.0' } }
                 },
                 checks: { noDevDependencyImports: { enabled: true } },
-                packages: [{ name: 'pkg-a', roots: {} } as never]
-            }),
-            [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
+                packages: [packageConfig('pkg-a')]
+            },
+            bundleWithExternal('pkg-a', 'runtime-dep')
         );
 
         assert.strictEqual(result.isOk, true);
     });
 
-    test('buildChecksResult flags a dev-only import detected through the common mainPackageJson fallback', function () {
-        const bundle = {
-            ...checkBundle('pkg-a', ['shared.ts']),
-            externalDependencies: new Map([['dev-dep', { name: 'dev-dep', referencedFrom: ['/x'] }]])
-        };
-
-        const result = buildChecksResult(
-            validated({
+    test('buildChecksResult flags a dev-only import detected through the common mainPackageJson fallback', async function () {
+        const result = await runSinglePackageChecks(
+            {
                 commonPackageSettings: {
                     mainPackageJson: { type: 'module', devDependencies: { 'dev-dep': '1.0.0' } }
                 },
                 checks: { noDevDependencyImports: { enabled: true } },
-                packages: [{ name: 'pkg-a', roots: {} } as never]
-            }),
-            [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
+                packages: [packageConfig('pkg-a')]
+            },
+            bundleWithExternal('pkg-a', 'dev-dep')
         );
 
         assert.strictEqual(result.isErr, true);
@@ -125,29 +175,67 @@ suite('resolved-package', function () {
         }
     });
 
-    test('buildChecksResult prefers the package-level mainPackageJson over commonPackageSettings.mainPackageJson', function () {
-        const bundle = {
-            ...checkBundle('pkg-a', ['shared.ts']),
-            externalDependencies: new Map([['runtime-dep', { name: 'runtime-dep', referencedFrom: ['/x'] }]])
-        };
-
-        const result = buildChecksResult(
-            validated({
+    test('buildChecksResult prefers the package-level mainPackageJson over commonPackageSettings.mainPackageJson', async function () {
+        const result = await runSinglePackageChecks(
+            {
                 commonPackageSettings: {
                     mainPackageJson: { type: 'module', devDependencies: { 'runtime-dep': '1.0.0' } }
                 },
                 checks: { noDevDependencyImports: { enabled: true } },
                 packages: [
-                    {
-                        name: 'pkg-a',
-                        roots: {},
+                    packageConfig('pkg-a', {
                         mainPackageJson: { type: 'module', dependencies: { 'runtime-dep': '1.0.0' } }
-                    } as never
+                    })
                 ]
-            }),
-            [{ name: 'pkg-a', analyzedBundle: bundle as never, resolveOptions: {} as never }]
+            },
+            bundleWithExternal('pkg-a', 'runtime-dep')
         );
 
         assert.strictEqual(result.isOk, true);
+    });
+
+    test('buildChecksResult materializes generated packages when areTheTypesWrong is enabled', async function () {
+        const analyzedBundle = checkBundle('pkg-a', ['index.js']);
+        const addVersionCalls: unknown[] = [];
+        const dependencies = {
+            versionManager: {
+                addVersion(options: unknown) {
+                    addVersionCalls.push(options);
+                    return createPublishedPackageWithManifest('pkg-a');
+                }
+            }
+        };
+        const result = await buildChecksResult(
+            dependencies,
+            validated({
+                checks: { areTheTypesWrong: { enabled: true } },
+                packages: [packageConfig('pkg-a')]
+            }),
+            [
+                {
+                    name: 'pkg-a',
+                    analyzedBundle,
+                    resolveOptions: {
+                        mainPackageJson: { type: 'module' },
+                        bundleDependencies: [{ name: 'bundle-dependency' }],
+                        bundlePeerDependencies: [{ name: 'bundle-peer-dependency' }],
+                        additionalPackageJsonAttributes: {},
+                        allowMutableSpecifiers: []
+                    } as never
+                }
+            ]
+        );
+
+        assert.strictEqual(result.isOk, true);
+        assert.strictEqual(addVersionCalls.length, 1);
+        assert.deepStrictEqual(addVersionCalls[0], {
+            bundle: analyzedBundle,
+            version: '0.0.0',
+            mainPackageJson: { type: 'module' },
+            bundleDependencies: [{ name: 'bundle-dependency', version: '0.0.0' }],
+            bundlePeerDependencies: [{ name: 'bundle-peer-dependency', version: '0.0.0' }],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: []
+        });
     });
 });

--- a/source/packtory/resolved-package.ts
+++ b/source/packtory/resolved-package.ts
@@ -4,6 +4,8 @@ import { runChecks } from '../checks/check-runner.ts';
 import type { PacktoryConfigWithoutRegistry } from '../config/config.ts';
 import type { ConfigWithGraph } from '../config/validation.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import type { PublishedPackageWithManifest } from '../published-package/published-package.ts';
+import type { VersionManager } from '../version-manager/manager.ts';
 import type { ResolveAndLinkOptions } from './map-config.ts';
 
 export type ResolvedPackage = {
@@ -17,6 +19,12 @@ export type CheckError = {
     readonly issues: readonly string[];
 };
 
+type CheckEvaluationDependencies = {
+    readonly versionManager: Pick<VersionManager, 'addVersion'>;
+};
+
+const checkManifestVersion = '0.0.0';
+
 export function createResolvedPackage(
     name: string,
     analyzedBundle: AnalyzedBundle,
@@ -25,10 +33,48 @@ export function createResolvedPackage(
     return { name, analyzedBundle, resolveOptions };
 }
 
-export function buildChecksResult(
+function buildPublishedPackagesForChecks(
+    dependencies: CheckEvaluationDependencies,
+    resolvedPackages: readonly ResolvedPackage[]
+): ReadonlyMap<string, PublishedPackageWithManifest> {
+    return new Map(
+        resolvedPackages.map((resolvedPackage) => {
+            const { analyzedBundle, resolveOptions } = resolvedPackage;
+            return [
+                resolvedPackage.name,
+                dependencies.versionManager.addVersion({
+                    bundle: analyzedBundle,
+                    version: checkManifestVersion,
+                    mainPackageJson: resolveOptions.mainPackageJson,
+                    bundleDependencies: resolveOptions.bundleDependencies.map((bundleDependency) => {
+                        return { name: bundleDependency.name, version: checkManifestVersion };
+                    }),
+                    bundlePeerDependencies: resolveOptions.bundlePeerDependencies.map((bundleDependency) => {
+                        return { name: bundleDependency.name, version: checkManifestVersion };
+                    }),
+                    additionalPackageJsonAttributes: resolveOptions.additionalPackageJsonAttributes,
+                    allowMutableSpecifiers: resolveOptions.allowMutableSpecifiers
+                })
+            ] as const;
+        })
+    );
+}
+
+function maybeBuildPublishedPackagesForChecks(
+    dependencies: CheckEvaluationDependencies,
+    config: PacktoryConfigWithoutRegistry,
+    resolvedPackages: readonly ResolvedPackage[]
+): ReadonlyMap<string, PublishedPackageWithManifest> | undefined {
+    return config.checks?.areTheTypesWrong?.enabled === true
+        ? buildPublishedPackagesForChecks(dependencies, resolvedPackages)
+        : undefined;
+}
+
+export async function buildChecksResult(
+    dependencies: CheckEvaluationDependencies,
     validated: ConfigWithGraph<PacktoryConfigWithoutRegistry>,
     resolvedPackages: readonly ResolvedPackage[]
-): Result<readonly ResolvedPackage[], CheckError> {
+): Promise<Result<readonly ResolvedPackage[], CheckError>> {
     const { packtoryConfig: config } = validated;
     const perPackageSettings = new Map<string, (typeof config.packages)[number]['checks']>();
     const commonMainPackageJson = config.commonPackageSettings?.mainPackageJson;
@@ -46,11 +92,13 @@ export function buildChecksResult(
     const bundles = resolvedPackages.map((resolvedPackage) => {
         return resolvedPackage.analyzedBundle;
     });
-    const checkIssues = runChecks({
+    const publishedPackages = maybeBuildPublishedPackagesForChecks(dependencies, config, resolvedPackages);
+    const checkIssues = await runChecks({
         settings: config.checks ?? {},
         perPackageSettings,
         packageConfigs: effectivePackageConfigs,
-        bundles
+        bundles,
+        publishedPackages
     });
 
     if (checkIssues.length > 0) {


### PR DESCRIPTION
- add `checks.areTheTypesWrong` and run Are the Types Wrong against bundled files with the generated `package.json`
- materialize versioned bundle manifests during check evaluation so ATTW sees the same package shape Packtory emits
- update docs and tests for the new check
