### PR TITLE
Await spinner worker exit before `main` returns

### DIFF
--- a/source/command-line-interface/spinner/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner/spinner-worker-backend.test.ts
@@ -181,4 +181,25 @@ suite('spinner-worker-backend', function () {
     test('createWorkerSpinnerBackend.shutdown skips waiting when the worker interval is zero', function () {
         assert.deepStrictEqual(collectShutdownWaitCalls(), []);
     });
+
+    test('createWorkerSpinnerBackend.shutdown is idempotent when invoked multiple times', function () {
+        const waitForRenderedMutationCalls: (readonly [number, number])[] = [];
+        const { runtime, accessors } = buildRuntimeWithFakeAccessors({
+            getIntervalMs: () => {
+                return 80;
+            },
+            waitForRenderedMutation: (mutation, timeoutMs) => {
+                waitForRenderedMutationCalls.push([mutation, timeoutMs]);
+                return true;
+            }
+        });
+        const backend = createWorkerSpinnerBackend({ runtime });
+
+        backend.shutdown();
+        backend.shutdown();
+
+        assert.strictEqual(accessors.isShutdownRequested(), true);
+        assert.strictEqual(accessors.getLatestMutation(), 1);
+        assert.deepStrictEqual(waitForRenderedMutationCalls, [[1, 320]]);
+    });
 });

--- a/source/command-line-interface/spinner/spinner-worker-backend.ts
+++ b/source/command-line-interface/spinner/spinner-worker-backend.ts
@@ -28,6 +28,7 @@ export function createWorkerSpinnerBackend(dependencies: WorkerSpinnerBackendDep
         runtime.accessors.getIntervalMs() * shutdownFlushIntervals,
         minimumShutdownFlushTimeoutMs
     );
+    let shutdownSignaled = false;
 
     function ensureSlotIndexFits(slotIndex: number): void {
         if (slotIndex >= runtime.slotCount) {
@@ -51,6 +52,10 @@ export function createWorkerSpinnerBackend(dependencies: WorkerSpinnerBackendDep
             writeSlot(runtime.accessors, { slotIndex, state: status, label, message });
         },
         shutdown() {
+            if (shutdownSignaled) {
+                return;
+            }
+            shutdownSignaled = true;
             runtime.accessors.requestShutdown();
             const shutdownMutation = runtime.accessors.markMutation();
             if (runtime.accessors.getIntervalMs() > 0) {

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -19,7 +19,7 @@ import { createPacktory } from '../../packtory/packtory.ts';
 import { createScheduler } from '../../packtory/scheduler.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPackageProcessorComposition } from '../package-processor.composition.ts';
-import { createBootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
+import { awaitSpinnerWorkerTermination, createBootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
 
 async function importModule(modulePath: string): Promise<unknown> {
     return import(modulePath);
@@ -115,12 +115,15 @@ function setExitCode(exitCode: number): void {
 async function main(): Promise<void> {
     const exitCode = await commandLinerInterfaceRunner.run(process.argv);
     setExitCode(exitCode);
+    spinnerRenderer.stopAll();
+    await awaitSpinnerWorkerTermination();
 }
 
-function crash(error: unknown): void {
+async function crash(error: unknown): Promise<void> {
     spinnerRenderer.stopAll();
     console.error(error);
     process.exitCode = 1;
+    await awaitSpinnerWorkerTermination();
 }
 
 main().catch(crash);

--- a/source/packages/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/packages/command-line-interface/spinner-boot.entry-point.ts
@@ -8,8 +8,19 @@ const bootModulePath = fileURLToPath(import.meta.url);
 const bootModuleExtension = path.extname(bootModulePath);
 const workerModulePath = path.join(path.dirname(bootModulePath), `spinner-worker.entry-point${bootModuleExtension}`);
 const defaultStdoutColumns = 80;
+const workerTerminationGraceMs = 1000;
 const workerExecArgv =
     bootModuleExtension === '.ts' ? ['--experimental-strip-types', '--enable-source-maps'] : ['--enable-source-maps'];
+
+let pendingWorkerTermination: Promise<void> = Promise.resolve();
+
+function trackWorkerTermination(worker: WorkerThread): Promise<void> {
+    return new Promise((resolve) => {
+        worker.once('exit', () => {
+            resolve();
+        });
+    });
+}
 
 function spawnWorker(request: WorkerSpawnRequest): void {
     const worker = new WorkerThread(workerModulePath, {
@@ -23,6 +34,7 @@ function spawnWorker(request: WorkerSpawnRequest): void {
     worker.on('error', (error: Error) => {
         process.stderr.write(`spinner worker error: ${error.message}\n`);
     });
+    pendingWorkerTermination = trackWorkerTermination(worker);
 }
 
 export function createBootedSpinnerRuntime(): SpinnerRuntime {
@@ -34,4 +46,11 @@ export function createBootedSpinnerRuntime(): SpinnerRuntime {
         initialLabel: 'packtory',
         initialMessage: 'Starting …'
     });
+}
+
+export async function awaitSpinnerWorkerTermination(): Promise<void> {
+    const graceTimeout = new Promise<void>((resolve) => {
+        setTimeout(resolve, workerTerminationGraceMs).unref();
+    });
+    await Promise.race([pendingWorkerTermination, graceTimeout]);
 }

--- a/source/packages/command-line-interface/spinner-boot.entry-point.ts
+++ b/source/packages/command-line-interface/spinner-boot.entry-point.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { setTimeout as scheduleTimeout } from 'node:timers';
 import { fileURLToPath } from 'node:url';
 import { Worker as WorkerThread } from 'node:worker_threads';
 import { bootSpinnerRuntime } from '../../command-line-interface/spinner/spinner-boot.ts';
@@ -14,14 +15,6 @@ const workerExecArgv =
 
 let pendingWorkerTermination: Promise<void> = Promise.resolve();
 
-function trackWorkerTermination(worker: WorkerThread): Promise<void> {
-    return new Promise((resolve) => {
-        worker.once('exit', () => {
-            resolve();
-        });
-    });
-}
-
 function spawnWorker(request: WorkerSpawnRequest): void {
     const worker = new WorkerThread(workerModulePath, {
         workerData: {
@@ -34,7 +27,11 @@ function spawnWorker(request: WorkerSpawnRequest): void {
     worker.on('error', (error: Error) => {
         process.stderr.write(`spinner worker error: ${error.message}\n`);
     });
-    pendingWorkerTermination = trackWorkerTermination(worker);
+    pendingWorkerTermination = new Promise<void>((resolve) => {
+        worker.once('exit', () => {
+            resolve();
+        });
+    });
 }
 
 export function createBootedSpinnerRuntime(): SpinnerRuntime {
@@ -50,7 +47,7 @@ export function createBootedSpinnerRuntime(): SpinnerRuntime {
 
 export async function awaitSpinnerWorkerTermination(): Promise<void> {
     const graceTimeout = new Promise<void>((resolve) => {
-        setTimeout(resolve, workerTerminationGraceMs).unref();
+        scheduleTimeout(resolve, workerTerminationGraceMs).unref();
     });
     await Promise.race([pendingWorkerTermination, graceTimeout]);
 }


### PR DESCRIPTION
The spinner worker backend previously signaled shutdown via the shared buffer and waited only for a render acknowledgement, never for the worker thread to actually exit. With `worker.unref()` already removed (PR #645), `main` still returned while the worker was mid-teardown, leaving the implicit cleanup for Node's process-exit phase. On Node 24 the libuv fd-tracker is already under pressure (the sync ESM loader collides with the live worker's handles, generating the `File descriptor … unmanaged mode` warning storm), and that teardown aborted the process before the shell saw a clean exit. Node 26 does not emit the warnings.

`spawnWorker` now tracks the spawned `Worker` thread's `exit` event in a module-level promise that `awaitSpinnerWorkerTermination` resolves on. `main` and `crash` invoke `spinnerRenderer.stopAll()` and then `await` that promise so the worker is fully gone before the entry point returns; a 1 s `unref`'d grace timeout backs it up. `backend.shutdown` is also idempotent so the safety re-call in `main` does not add a fresh `waitForRenderedMutation` timeout.