### PR TITLE
Publish the release-gate as `@packtory/github-release-gate`

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -10,6 +10,7 @@ const sourcesFolder = path.join(projectFolder, 'target/build/source');
 const sharedLicensePath = path.join(projectFolder, 'LICENSE');
 const packtoryReadmePath = path.join(projectFolder, 'source/packages/packtory/readme.md');
 const cliReadmePath = path.join(projectFolder, 'source/packages/command-line-interface/readme.md');
+const githubReleaseGateReadmePath = path.join(projectFolder, 'source/packages/github-release-gate/readme.md');
 
 const noSideEffectsAllowList = [
     'packages/packtory/packtory.entry-point.js',
@@ -31,7 +32,8 @@ const noSideEffectsAllowList = [
     'packages/command-line-interface/command-line-interface.entry-point.js',
     'packages/command-line-interface/spinner-boot.entry-point.js',
     'command-line-interface/preview-io/preview-io.js',
-    'packages/command-line-interface/spinner-worker.entry-point.js'
+    'packages/command-line-interface/spinner-worker.entry-point.js',
+    'packages/github-release-gate/github-release-gate.entry-point.js'
 ].map((filePath) => {
     return path.join(sourcesFolder, filePath);
 });
@@ -107,6 +109,30 @@ export async function buildConfig() {
                         targetFilePath: 'readme.md'
                     }
                 ]
+            },
+            {
+                name: '@packtory/github-release-gate',
+                exportPackageJson: true,
+                roots: {
+                    main: {
+                        js: 'packages/github-release-gate/github-release-gate.entry-point.js'
+                    }
+                },
+                packageInterface: {
+                    bins: [{ root: 'main', name: 'github-release-gate' }]
+                },
+                additionalPackageJsonAttributes: {
+                    description:
+                        'GitHub Actions release gate that batches packtory publishes by waiting ' +
+                        'for repository activity to settle.'
+                },
+                additionalFiles: [
+                    {
+                        sourceFilePath: githubReleaseGateReadmePath,
+                        targetFilePath: 'readme.md'
+                    }
+                ],
+                bundleDependencies: ['packtory']
             },
             {
                 name: '@packtory/cli',

--- a/source/github-release-gate/github-api.ts
+++ b/source/github-release-gate/github-api.ts
@@ -40,8 +40,6 @@ type RawTimelineEvent = {
     readonly event?: string | undefined;
 };
 
-const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
-
 export type GitHubReleaseGateApi = {
     readonly getLatestSuccessfulMainCiRun: (
         ciWorkflowFile: string,
@@ -84,6 +82,7 @@ export function createGitHubReleaseGateApi(
     fetchImplementation: typeof globalThis.fetch,
     context: GitHubRepositoryContext
 ): GitHubReleaseGateApi {
+    const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
     const requestContext: RepositoryRequestContext = {
         headers: {
             accept: 'application/vnd.github+json',

--- a/source/packages/github-release-gate/github-release-gate.entry-point.ts
+++ b/source/packages/github-release-gate/github-release-gate.entry-point.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
-import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
+import path from 'node:path';
+import { hasProp, isPlainObject } from 'remeda';
 import { createFileManager } from '../../file-manager/file-manager.ts';
 import type * as packtoryEntryPoint from '../packtory/packtory.entry-point.ts';
 import {
@@ -14,15 +15,39 @@ function getEnvironmentVariable(variableName: string): string | undefined {
     return value === undefined || value.length === 0 ? undefined : value;
 }
 
-function createDependencies(): GitHubReleaseGateRunnerDependencies {
-    const configLoader = createConfigLoader({
-        currentWorkingDirectory: process.cwd(),
-        async importModule(modulePath) {
-            const importedModule: unknown = await import(modulePath);
-            return importedModule;
-        }
-    });
+function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
+    return typeof value === 'function';
+}
 
+function unwrapConfigModule(module: Readonly<Record<PropertyKey, unknown>>): unknown {
+    if (hasProp(module, 'config')) {
+        return module.config;
+    }
+
+    if (hasProp(module, 'buildConfig')) {
+        const { buildConfig } = module;
+        if (isFunction(buildConfig)) {
+            return buildConfig();
+        }
+
+        throw new Error('Named export of "buildConfig" config file is not a function');
+    }
+
+    throw new Error('Config file doesn’t have a named export "config" nor "buildConfig"');
+}
+
+async function loadPacktoryConfigFromCwd(): Promise<unknown> {
+    const configFilePath = path.join(process.cwd(), 'packtory.config.js');
+    const module: unknown = await import(configFilePath);
+
+    if (!isPlainObject(module)) {
+        throw new Error('Invalid config file');
+    }
+
+    return unwrapConfigModule(module);
+}
+
+function createDependencies(): GitHubReleaseGateRunnerDependencies {
     return {
         analyzeReleaseAgainstLatestPublished: async (config) => {
             const packtory: typeof packtoryEntryPoint = await import('../packtory/packtory.entry-point.ts');
@@ -31,9 +56,7 @@ function createDependencies(): GitHubReleaseGateRunnerDependencies {
         fetch: globalThis.fetch,
         fileManager: createFileManager({ hostFileSystem: fs.promises }),
         getEnvironmentVariable,
-        loadPacktoryConfig: async () => {
-            return await configLoader.load();
-        },
+        loadPacktoryConfig: loadPacktoryConfigFromCwd,
         now: () => {
             return new Date();
         },

--- a/source/packages/github-release-gate/readme.md
+++ b/source/packages/github-release-gate/readme.md
@@ -82,12 +82,22 @@ This means:
 
 When run inside GitHub Actions, the tool writes these values to `$GITHUB_OUTPUT`.
 
+## Installation
+
+```bash
+npm install -D @packtory/github-release-gate
+```
+
+The package ships a `github-release-gate` executable that writes its decision to `$GITHUB_OUTPUT` when invoked from a GitHub Actions step.
+
 ## Usage in a Workflow
 
 ```yaml
+- name: Install release gate
+  run: npm install -D --ignore-scripts @packtory/github-release-gate
 - name: Evaluate GitHub release gate
   id: release-gate
-  run: node --experimental-strip-types --enable-source-maps ./source/packages/github-release-gate/github-release-gate.entry-point.ts
+  run: npx github-release-gate
   env:
       CI_WORKFLOW_FILE: ci.yml
       DEFAULT_BRANCH: main


### PR DESCRIPTION
Adds a third published package, `@packtory/github-release-gate`, so the publish workflow can pull just the gate (and its bundled `packtory`) instead of running a full `npm clean-install` of every devDep before evaluating whether a release is allowed.

Two preparatory refactors land in the same PR because the gate's entry-point becomes part of a published bundle for the first time:

- The Octokit subclass is now built inside `createGitHubReleaseGateApi` rather than at module top-level, so the file is side-effect-free under the `noSideEffects` check.
- The release-gate entry-point inlines its own `packtory.config.js` loader instead of reusing `createConfigLoader` from the CLI source tree, so the same compiled module does not end up in both `@packtory/cli` and `@packtory/github-release-gate`.

A follow-up PR will swap `.github/workflows/publish.yml` to install only `@packtory/github-release-gate` for the gate step.
