### PR TITLE
Split publish into a gate-eval job and an OIDC-only publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,26 +2,22 @@
 name: Publish
 
 on:
-    schedule:
-        # GitHub Actions throttles scheduled workflows hard at the top of the hour.
-        # Spreading entries across off-peak minutes gives the cron a better shot at
-        # firing as a fallback for the self-rechain below.
-        - cron: '17 * * * *'
-        - cron: '47 * * * *'
     workflow_dispatch:
 
 concurrency:
     group: publish-main
 
 jobs:
-    publish:
+    evaluate-gate:
         runs-on: ubuntu-latest
         permissions:
-            actions: write
             contents: read
-            id-token: write
             issues: read
             pull-requests: read
+        outputs:
+            should_publish: ${{ steps.release-gate.outputs.should_publish }}
+            reason: ${{ steps.release-gate.outputs.reason }}
+            main_head_sha: ${{ steps.release-gate.outputs.main_head_sha }}
         steps:
             - uses: actions/checkout@v6
               with:
@@ -30,13 +26,13 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: 26.x
-            - name: Install dependencies for release gate
-              run: npm clean-install
-            - name: Compile TypeScript for release gate
+            - name: Install dependencies from the lockfile
+              run: npm clean-install --ignore-scripts
+            - name: Compile TypeScript
               run: npx just compile
             - name: Evaluate GitHub release gate
               id: release-gate
-              run: node --experimental-strip-types --enable-source-maps ./source/packages/github-release-gate/github-release-gate.entry-point.ts
+              run: npx github-release-gate
               env:
                   CI_WORKFLOW_FILE: ci.yml
                   DEFAULT_BRANCH: main
@@ -44,26 +40,28 @@ jobs:
                   GITHUB_TOKEN: ${{ github.token }}
                   MAX_LATENCY_HOURS: '24'
                   QUIET_PERIOD_MINUTES: '45'
-            - name: Stop when release gate is closed
+            - name: Log gate decision when publish is skipped
               if: steps.release-gate.outputs.should_publish != 'true'
               run: echo "Skipping publish because ${{ steps.release-gate.outputs.reason }}."
+
+    publish:
+        needs: evaluate-gate
+        if: needs.evaluate-gate.outputs.should_publish == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
             - uses: actions/checkout@v6
-              if: steps.release-gate.outputs.should_publish == 'true'
               with:
-                  ref: ${{ steps.release-gate.outputs.main_head_sha }}
-            - name: Install dependencies
-              if: steps.release-gate.outputs.should_publish == 'true'
-              run: npm clean-install
+                  ref: ${{ needs.evaluate-gate.outputs.main_head_sha }}
+            - name: Use Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 26.x
+            - name: Install dependencies from the lockfile
+              run: npm clean-install --ignore-scripts
             - name: Compile TypeScript
-              if: steps.release-gate.outputs.should_publish == 'true'
               run: npx just compile
             - name: Publish packages
-              if: steps.release-gate.outputs.should_publish == 'true'
               run: npx packtory publish --no-dry-run
-            - name: Schedule next tick
-              if: always()
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  sleep 1800
-                  gh workflow run publish.yml --ref main

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,0 +1,33 @@
+---
+name: Schedule publish
+
+on:
+    schedule:
+        # GitHub Actions throttles scheduled workflows hard at the top of the hour.
+        # Spreading entries across off-peak minutes gives the cron a better shot at firing
+        # as a fallback for the self-rechain below.
+        - cron: '17 * * * *'
+        - cron: '47 * * * *'
+    workflow_dispatch:
+
+concurrency:
+    group: publish-scheduler
+
+jobs:
+    dispatch:
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+            contents: read
+        steps:
+            - name: Dispatch publish workflow
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: gh workflow run publish.yml --ref main
+            - name: Wait then redispatch the scheduler as a cron-drift fallback
+              if: always()
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  sleep 1800
+                  gh workflow run scheduler.yml --ref main

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
                 "@enormora/objectory": "0.0.7",
                 "@ls-lint/ls-lint": "2.3.1",
                 "@packtory/cli": "0.0.29",
+                "@packtory/github-release-gate": "0.0.3",
                 "@stryker-mutator/core": "9.6.1",
                 "@stryker-mutator/mocha-runner": "9.6.1",
                 "@types/mocha": "10.0.10",
@@ -3773,6 +3774,62 @@
             },
             "bin": {
                 "packtory": "packages/command-line-interface/command-line-interface.entry-point.js"
+            },
+            "engines": {
+                "node": "^24 || ^26"
+            }
+        },
+        "node_modules/@packtory/github-release-gate": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@packtory/github-release-gate/-/github-release-gate-0.0.3.tgz",
+            "integrity": "sha512-TKgbeuayW3JIXwnoV4hamwqRPfry7ejTYMPqb39S9rTj/YRLUBHQGQURvnN8qGdLDahocezFXl2RiWDJOhN1rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "7.0.6",
+                "@octokit/plugin-paginate-rest": "14.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "17.0.0",
+                "packtory": "0.0.30",
+                "remeda": "2.37.0"
+            },
+            "bin": {
+                "github-release-gate": "packages/github-release-gate/github-release-gate.entry-point.js"
+            },
+            "engines": {
+                "node": "^24 || ^26"
+            }
+        },
+        "node_modules/@packtory/github-release-gate/node_modules/packtory": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.30.tgz",
+            "integrity": "sha512-w63364UqtfHp87TSvLd9fDw4kX0s3YXBpQFzJgPL00vjKStCUsRdX5gw4RYx7uygyNGAamXqJDy6CEdrAdd4Hg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@arethetypeswrong/core": "0.18.3",
+                "@cyclonedx/cyclonedx-library": "10.0.0",
+                "@jridgewell/gen-mapping": "0.3.13",
+                "@jridgewell/trace-mapping": "0.3.31",
+                "@schema-hub/zod-error-formatter": "0.0.11",
+                "@ts-morph/common": "0.29.0",
+                "@types/npm-registry-fetch": "8.0.9",
+                "common-tags": "1.8.2",
+                "diff": "9.0.0",
+                "fflate": "0.8.3",
+                "hosted-git-info": "10.1.1",
+                "libnpmpublish": "11.2.0",
+                "npm-package-arg": "14.0.0",
+                "npm-registry-fetch": "20.0.0",
+                "remeda": "2.37.0",
+                "semver": "7.8.1",
+                "spdx-expression-parse": "4.0.0",
+                "tar-stream": "3.1.8",
+                "true-myth": "9.4.0",
+                "ts-morph": "27.0.2",
+                "ts-pattern": "5.9.0",
+                "type-fest": "5.6.0",
+                "unix-permissions": "6.0.1",
+                "zod": "4.4.3"
             },
             "engines": {
                 "node": "^24 || ^26"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "@enormora/objectory": "0.0.7",
         "@ls-lint/ls-lint": "2.3.1",
         "@packtory/cli": "0.0.29",
+        "@packtory/github-release-gate": "0.0.3",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/mocha-runner": "9.6.1",
         "@types/mocha": "10.0.10",


### PR DESCRIPTION
Addresses the two highest-severity findings from the supply-chain audit (H1 + M1).

Before: a single `publish` job carried `actions: write` and `id-token: write` for the whole run, and ran `npm clean-install` (twice) with install scripts enabled while those credentials were live. A compromised transitive `postinstall` could mint the trusted-publisher OIDC token before the gate had even decided whether to publish (H1), and could trigger arbitrary workflow runs through the same job's `actions: write` (M1).

After:

- **`evaluate-gate` job** — `contents: read`, `issues: read`, `pull-requests: read`. No `id-token`, no `actions: write`. Checks out main, runs `npm clean-install --ignore-scripts` against the project lockfile (so every dep is integrity-checked and no install script can execute), compiles, and runs `npx github-release-gate` — the gate is now resolved from the newly-added `@packtory/github-release-gate` devDep rather than the local-source entry-point.
- **`publish` job** — `contents: read`, `id-token: write`. `needs: evaluate-gate`, conditional on `should_publish == 'true'`. Checks out the SHA the gate decided about, runs the same `npm clean-install --ignore-scripts` + compile, then `npx packtory publish --no-dry-run`. The install-script vector is closed even inside this privileged job.
- **`scheduler.yml`** — new workflow, `actions: write` (+ `contents: read` for `gh` CLI). Holds the two cron entries that used to live on publish, dispatches `publish.yml`, then self-rechains via the 30-minute sleep to compensate for GitHub cron drift. `publish.yml` is now `workflow_dispatch`-only and no longer needs `actions: write`.

No artifact passing between jobs, no `--no-package-lock`, no `node_modules` shipped around. Each job's install is the project's full lockfile-pinned tree with scripts disabled, and the privileged publish job loses both `actions: write` and the install-script attack surface.
