### PR TITLE
Enable `engines-strict=true` in `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save-exact=true
+engines-strict=true
 


### PR DESCRIPTION
package.json declares `engines.node = "^24 || ^26"` but without `engines-strict` set, npm only emits a warning when a contributor runs the install on an unsupported Node version. Setting `engines-strict=true` makes npm refuse the install outright when the engine constraint is not satisfied, so a contributor on an older Node sees the problem at install time instead of as a downstream runtime error.