### PR TITLE
Pin `ci.yml`s `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
         types: [opened, reopened, synchronize]
     merge_group:
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
The repo-level default workflow token permissions are set to read-only, but a workflow that does not declare its own `permissions:` block inherits whatever the repo default happens to be at run time. Declaring `permissions: contents: read` at the workflow level pins the `GITHUB_TOKEN` minted for every CI run to the exact scope this workflow needs, so the contract survives an org- or repo-settings drift toward looser defaults.