### PR TITLE
Pin GitHub Actions to commit SHAs and lint workflows with `zizmor`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,27 @@ on:
         types: [opened, reopened, synchronize]
     merge_group:
 
-permissions:
-    contents: read
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
         strategy:
             matrix:
                 node-version: [24.x, 26.x]
         name: Node.js v${{ matrix.node-version }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Use Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Install dependencies
@@ -40,10 +47,14 @@ jobs:
     mutation-testing:
         runs-on: ubuntu-latest
         name: Mutation testing
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Use Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 26.x
             - name: Install dependencies
@@ -54,13 +65,44 @@ jobs:
     benchmarks:
         runs-on: ubuntu-latest
         name: Benchmarks
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
             - name: Use Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 26.x
             - name: Install dependencies
               run: npm clean-install
             - name: Run benchmarks
               run: npx just benchmark
+
+    workflow-security:
+        runs-on: ubuntu-latest
+        name: Workflow security analysis
+        permissions:
+            contents: read # required for actions/checkout to read the workflow source
+            security-events: write # required by zizmor-action to upload SARIF to code scanning
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+            - name: Run zizmor
+              id: zizmor
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  version: 1.25.2
+                  persona: pedantic
+                  min-severity: informational
+                  min-confidence: low
+                  config: .github/zizmor.yml
+            - name: Fail if zizmor reported findings
+              env:
+                  SARIF_FILE: ${{ steps.zizmor.outputs.output-file }}
+              run: |
+                  count="$(jq '[.runs[].results[]] | length' "$SARIF_FILE")"
+                  echo "zizmor findings: $count"
+                  test "$count" -eq 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,26 +4,30 @@ name: Publish
 on:
     workflow_dispatch:
 
+permissions: {}
+
 concurrency:
     group: publish-main
 
 jobs:
     evaluate-gate:
         runs-on: ubuntu-latest
+        name: Evaluate GitHub release gate
         permissions:
-            contents: read
-            issues: read
-            pull-requests: read
+            contents: read # required for actions/checkout to read the workflow source
+            issues: read # required by the release gate to inspect open issues for activity
+            pull-requests: read # required by the release gate to inspect open PRs for activity
         outputs:
             should_publish: ${{ steps.release-gate.outputs.should_publish }}
             reason: ${{ steps.release-gate.outputs.reason }}
             main_head_sha: ${{ steps.release-gate.outputs.main_head_sha }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: main
+                  persist-credentials: false
             - name: Use Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 26.x
             - name: Install dependencies from the lockfile
@@ -42,21 +46,25 @@ jobs:
                   QUIET_PERIOD_MINUTES: '45'
             - name: Log gate decision when publish is skipped
               if: steps.release-gate.outputs.should_publish != 'true'
-              run: echo "Skipping publish because ${{ steps.release-gate.outputs.reason }}."
+              env:
+                  GATE_REASON: ${{ steps.release-gate.outputs.reason }}
+              run: echo "Skipping publish because ${GATE_REASON}."
 
     publish:
         needs: evaluate-gate
         if: needs.evaluate-gate.outputs.should_publish == 'true'
         runs-on: ubuntu-latest
+        name: Publish packages
         permissions:
-            contents: read
-            id-token: write
+            contents: read # required for actions/checkout to read the workflow source
+            id-token: write # required by npm trusted publishing to mint the OIDC token
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ needs.evaluate-gate.outputs.main_head_sha }}
+                  persist-credentials: false
             - name: Use Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 26.x
             - name: Install dependencies from the lockfile

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -10,15 +10,18 @@ on:
         - cron: '47 * * * *'
     workflow_dispatch:
 
+permissions: {}
+
 concurrency:
     group: publish-scheduler
 
 jobs:
     dispatch:
         runs-on: ubuntu-latest
+        name: Dispatch publish workflow
         permissions:
-            actions: write
-            contents: read
+            actions: write # required to dispatch the publish workflow via gh CLI
+            contents: read # required by gh CLI to look up workflow metadata
         steps:
             - name: Dispatch publish workflow
               env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+---
+# All audits run with defaults; only the configurable audits are overridden
+# below. Persona, severity floor, and confidence floor are set on the
+# zizmor action invocation in .github/workflows/ci.yml.
+
+rules:
+    unpinned-uses:
+        config:
+            policies:
+                '*': hash-pin
+
+    secrets-outside-env:
+        config:
+            allow: []

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["config:base"],
+    "extends": ["config:base", "helpers:pinGitHubActionDigests"],
     "ignorePaths": ["**/node_modules/**", "**/integration-tests/**"],
     "commitMessagePrefix": "⬆️ ",
     "labels": ["renovate", "upgrade"],


### PR DESCRIPTION
Three related changes that together harden the GitHub Actions surface against compromise of upstream actions.

**Pin actions to commit SHAs.** A tag reference like `actions/checkout@v6` is a mutable pointer — the action's maintainer (or anyone who compromises their account or release pipeline) can silently change the code that runs inside CI by repointing the tag. Replace every action reference in `ci.yml`, `publish.yml` and `scheduler.yml` with the 40-character commit SHA that the current tag resolves to, with a trailing `# v6.0.2`-style comment so reviewers can still read the intended version at a glance. This is the same mitigation pattern that the `tj-actions/changed-files`, `reviewdog/action-setup` and similar incidents would have made impossible.

**Lint workflows with [`zizmor`](https://woodruffw.github.io/zizmor/) on every PR.** A new `Workflow security analysis` job runs the official `zizmorcore/zizmor-action` (itself pinned to a SHA) against the repo. The action is configured through a checked-in `.github/zizmor.yml` to enforce a `hash-pin` policy on every `uses:` and to forbid secrets used outside of `env:` blocks. It runs at `persona: pedantic`, `min-severity: informational`, `min-confidence: low` — every audit zizmor knows about, at maximum strictness. The post-step counts the SARIF results and fails the job on any finding.

The audit surfaced concrete drift to fix in the existing workflows:

- Every `actions/checkout` call now sets `persist-credentials: false` so the OAuth token used by the checkout is not left on disk for later steps to read (`artipacked`).
- Each workflow declares a top-level `permissions: {}` and each job declares its own `permissions:` block with `# required for ...` comments explaining the scope (`excessive-permissions`, `undocumented-permissions`).
- Every job carries an explicit `name:` (`anonymous-definition`).
- `ci.yml` carries a top-level `concurrency:` group with `cancel-in-progress` enabled for pull requests (`concurrency-limits`).
- The `Log gate decision` step in `publish.yml` reads the gate output through an `env:` variable instead of interpolating it into a `run:` script, so the value cannot be smuggled into a shell command (`template-injection`).

**Keep the SHA pins current with Renovate.** Extend `renovate.json` with the `helpers:pinGitHubActionDigests` preset so Renovate automatically rewrites future action references to pinned SHAs and bumps existing pins as upstream releases ship.

The same `permissions: contents: read` block from #678 is included here too because `zizmor`'s `excessive-permissions` audit would otherwise flag this workflow. Whichever PR merges first, the other will rebase cleanly — the block is identical.
