### PR TITLE
Verify `@packtory/cli` signatures and provenance before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,18 @@ jobs:
                   node-version: 26.x
             - name: Install dependencies from the lockfile
               run: npm clean-install --ignore-scripts
+            - name: Verify registry signatures for installed dependencies
+              run: npm audit signatures
+            - name: Verify `@packtory/cli` ships with a provenance attestation
+              run: |
+                  version=$(jq -r '.devDependencies["@packtory/cli"]' package.json)
+                  spec="@packtory/cli@${version}"
+                  attestation=$(npm view "${spec}" --json | jq -r '.dist.attestations // empty')
+                  if [ -z "${attestation}" ]; then
+                    echo "::error::${spec} is missing a provenance attestation; refusing to publish"
+                    exit 1
+                  fi
+                  echo "Verified ${spec} has a registered provenance attestation."
             - name: Compile TypeScript
               run: npx just compile
             - name: Publish packages


### PR DESCRIPTION
The publish workflow uses the previously-published `@packtory/cli` (a devDep) to publish the next version of `packtory`, `@packtory/cli` itself and `@packtory/github-release-gate` to npm. This bootstrap relationship means that if `@packtory/cli`'s tarball on the npm registry were ever swapped under us, the swapped code would run inside the publish job — the one job that holds the OIDC token used to mint a trusted-publishing credential.

Add two verification steps to the publish job, both running after `npm clean-install --ignore-scripts` and before `npx packtory publish`:

- **`npm audit signatures`** walks every installed dependency and verifies the tarball signature against npm's registry key, plus the sigstore-signed provenance attestation for any package that ships one. A registry-side tarball swap fails this check.
- **A small shell step** reads the lockfile-pinned version of `@packtory/cli` and asserts the registry has a provenance attestation registered for it. This catches the silent regression where a future release of `@packtory/cli` publishes without provenance (for example because the trusted-publisher config was removed) and CI keeps consuming it without noticing.

Together they make the bootstrap CLI's trust chain visible at publish time: the job refuses to run if `@packtory/cli`'s integrity or provenance cannot be confirmed.
