### PR TITLE
Reject tarball URLs whose host differs from the configured registry

### DIFF
--- a/documentation/supply-chain.md
+++ b/documentation/supply-chain.md
@@ -33,9 +33,10 @@ guarantees on top.
 
 ### Comparison
 
-| Feature                                | Defends against                            | Default | Configure                                      |
-| -------------------------------------- | ------------------------------------------ | ------- | ---------------------------------------------- |
-| [Provenance](#provenance-attestations) | Account compromise, package misattribution | off     | `publishSettings.provenance: { type: 'auto' }` |
+| Feature                                       | Defends against                                          | Default | Configure                                      |
+| --------------------------------------------- | -------------------------------------------------------- | ------- | ---------------------------------------------- |
+| [Provenance](#provenance-attestations)        | Account compromise, package misattribution               | off     | `publishSettings.provenance: { type: 'auto' }` |
+| [Tarball host pinning](#tarball-host-pinning) | Credential exfiltration via a tampered registry response | on      | always on; not configurable                    |
 
 ## Quickstart
 
@@ -166,7 +167,35 @@ npm view <pkg> --json
 The `dist.attestations` field exposes the provenance bundle URL and
 predicate type for any version published with provenance.
 
+## Tarball host pinning
+
+**Threat:** an attacker who controls the registry response (registry
+compromise, MITM through a hostile corporate proxy, a poisoned mirror)
+returns a crafted `dist.tarball` URL on a host they own. Packtory's
+auto-versioning flow downloads the latest published tarball to compare
+it against the new build, and the request carries the configured npm
+credentials. Without a host check the bearer or basic auth would be
+sent to the attacker.
+**Default:** on. Not configurable.
+
+Before downloading a tarball, packtory parses the URL returned by the
+registry and rejects the publish if its host does not match the host
+of the configured registry (or `registry.npmjs.org` when none is set).
+The port is part of the comparison, so a downgrade from `:443` to a
+different port is also rejected. The error names both hosts so the
+mismatch is immediately diagnosable.
+
 ## CLI error reference
+
+### Tarball host
+
+- `Refusing to download tarball from "<host>" because it differs from the configured registry host "<host>". A tampered registry response could redirect the request and exfiltrate publish credentials.`
+  — the registry returned a tarball URL on a different host than the
+  one configured. Investigate the registry mirror or proxy in between;
+  a legitimate registry serves tarballs from its own host.
+- `Registry returned an invalid tarball URL: "<value>"` — the registry
+  response carried a non-URL `dist.tarball`. Almost always a registry
+  bug or a tampered response.
 
 ### Provenance, auto mode
 

--- a/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
@@ -14,7 +14,7 @@ type FakeNpmFetch = SinonSpy & { json: SinonSpy };
 
 const settings: RegistrySettings = { auth: { type: 'bearer-token', token: 'tok' } };
 const latestVersion = '1.2.3';
-const tarballUrl = 'https://example.com/pkg-a-1.2.3.tgz';
+const tarballUrl = 'https://registry.npmjs.org/pkg-a/-/pkg-a-1.2.3.tgz';
 
 function fakeNpmFetch(json: SinonSpy, buffer: SinonSpy = fake.resolves(Buffer.from([]))): typeof _npmFetch {
     const npmFetch: FakeNpmFetch = fake.resolves({ buffer }) as FakeNpmFetch;
@@ -221,12 +221,56 @@ suite('package-metadata-fetcher', function () {
     test('fetchPackageTarball returns the buffered tarball contents', async function () {
         const buffer = fake.resolves(Buffer.from('tarball-bytes'));
 
+        const result = await fetchPackageTarball(fakeNpmFetch(fake(), buffer), tarballUrl, settings);
+
+        assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+    });
+
+    test('fetchPackageTarball rejects a tarball URL whose host differs from the configured registry', async function () {
+        const buffer = fake.resolves(Buffer.from('tarball-bytes'));
+        const expectedMessage =
+            'Refusing to download tarball from "attacker.example" because it differs from the configured ' +
+            'registry host "registry.npmjs.org". A tampered registry response could redirect the request and ' +
+            'exfiltrate publish credentials.';
+
+        try {
+            await fetchPackageTarball(
+                fakeNpmFetch(fake(), buffer),
+                'https://attacker.example/pkg-a-1.2.3.tgz',
+                settings
+            );
+            assert.fail('Expected fetchPackageTarball() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, expectedMessage);
+        }
+        assert.strictEqual(buffer.callCount, 0);
+    });
+
+    test('fetchPackageTarball accepts a tarball URL whose host matches a custom configured registry', async function () {
+        const customSettings: RegistrySettings = {
+            registryUrl: 'https://registry.example.test/',
+            auth: { type: 'bearer-token', token: 'tok' }
+        };
+        const buffer = fake.resolves(Buffer.from('tarball-bytes'));
+
         const result = await fetchPackageTarball(
             fakeNpmFetch(fake(), buffer),
-            'https://example.com/pkg-a-1.2.3.tgz',
-            settings
+            'https://registry.example.test/pkg-a/-/pkg-a-1.2.3.tgz',
+            customSettings
         );
 
         assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+    });
+
+    test('fetchPackageTarball rejects a malformed tarball URL', async function () {
+        const buffer = fake.resolves(Buffer.from('tarball-bytes'));
+
+        try {
+            await fetchPackageTarball(fakeNpmFetch(fake(), buffer), 'not-a-url', settings);
+            assert.fail('Expected fetchPackageTarball() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Registry returned an invalid tarball URL: "not-a-url"');
+        }
+        assert.strictEqual(buffer.callCount, 0);
     });
 });

--- a/source/bundle-emitter/registry/package-metadata-fetcher.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.ts
@@ -10,6 +10,7 @@ import {
     type AbbreviatedPackageResponse,
     type FullPackageResponse
 } from './registry-response-schemas.ts';
+import { assertTarballHostMatchesRegistry } from './validate-tarball-host.ts';
 
 const notFoundStatusCode = 404;
 const forbiddenStatusCode = 403;
@@ -230,6 +231,7 @@ export async function fetchPackageTarball(
     tarballUrl: string,
     registrySettings: RegistrySettings
 ): Promise<Buffer> {
+    assertTarballHostMatchesRegistry(tarballUrl, registrySettings);
     const auth = resolveMetadataAuthOptions(registrySettings);
     const response = await retryWithFallbackAuth(registrySettings, auth, async (options) => {
         return npmFetch(tarballUrl, options);

--- a/source/bundle-emitter/registry/registry-client.test.ts
+++ b/source/bundle-emitter/registry/registry-client.test.ts
@@ -775,6 +775,7 @@ suite('registry-client', function () {
         const registryClient = registryClientFactory({ npmFetch });
 
         const result = await registryClient.fetchTarball('https://registry.example.test/pkg.tgz', {
+            registryUrl: 'https://registry.example.test/',
             auth: {
                 publish: { type: 'basic', username: 'reader', password: 'reader-secret' },
                 metadata: 'auto'
@@ -787,7 +788,7 @@ suite('registry-client', function () {
             'https://registry.example.test/pkg.tgz',
             {
                 alwaysAuth: true,
-                registry: undefined,
+                registry: 'https://registry.example.test/',
                 forceAuth: {
                     _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
                 }

--- a/source/bundle-emitter/registry/validate-tarball-host.test.ts
+++ b/source/bundle-emitter/registry/validate-tarball-host.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { RegistrySettings } from '../../config/registry-settings.ts';
+import { assertTarballHostMatchesRegistry } from './validate-tarball-host.ts';
+
+const bearerAuth = { type: 'bearer-token', token: 'tok' } as const;
+
+function expectError(callback: () => void, expectedMessage: string): void {
+    try {
+        callback();
+        assert.fail('Expected assertTarballHostMatchesRegistry() to throw but it did not');
+    } catch (error: unknown) {
+        assert.strictEqual((error as Error).message, expectedMessage);
+    }
+}
+
+suite('validate-tarball-host', function () {
+    test('accepts a tarball URL whose host matches the default npm registry', function () {
+        const settings: RegistrySettings = { auth: bearerAuth };
+
+        assert.doesNotThrow(() => {
+            assertTarballHostMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
+        });
+    });
+
+    test('accepts a tarball URL whose host matches a configured custom registry', function () {
+        const settings: RegistrySettings = {
+            registryUrl: 'https://registry.example.test/path/',
+            auth: bearerAuth
+        };
+
+        assert.doesNotThrow(() => {
+            assertTarballHostMatchesRegistry('https://registry.example.test/pkg/-/pkg-1.0.0.tgz', settings);
+        });
+    });
+
+    test('rejects a tarball URL whose host differs from the default npm registry', function () {
+        const settings: RegistrySettings = { auth: bearerAuth };
+
+        const expectedMessage =
+            'Refusing to download tarball from "attacker.example" because it differs from the configured ' +
+            'registry host "registry.npmjs.org". A tampered registry response could redirect the request and ' +
+            'exfiltrate publish credentials.';
+        expectError(() => {
+            assertTarballHostMatchesRegistry('https://attacker.example/pkg-1.0.0.tgz', settings);
+        }, expectedMessage);
+    });
+
+    test('rejects a tarball URL whose host differs from a configured custom registry', function () {
+        const settings: RegistrySettings = {
+            registryUrl: 'https://registry.example.test/',
+            auth: bearerAuth
+        };
+
+        const expectedMessage =
+            'Refusing to download tarball from "registry.npmjs.org" because it differs from the configured ' +
+            'registry host "registry.example.test". A tampered registry response could redirect the request and ' +
+            'exfiltrate publish credentials.';
+        expectError(() => {
+            assertTarballHostMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
+        }, expectedMessage);
+    });
+
+    test('rejects a tarball URL whose host has a different port than the configured registry', function () {
+        const settings: RegistrySettings = {
+            registryUrl: 'https://registry.example.test/',
+            auth: bearerAuth
+        };
+
+        const expectedMessage =
+            'Refusing to download tarball from "registry.example.test:8443" because it differs from the configured ' +
+            'registry host "registry.example.test". A tampered registry response could redirect the request and ' +
+            'exfiltrate publish credentials.';
+        expectError(() => {
+            assertTarballHostMatchesRegistry('https://registry.example.test:8443/pkg-1.0.0.tgz', settings);
+        }, expectedMessage);
+    });
+
+    test('rejects a malformed tarball URL', function () {
+        const settings: RegistrySettings = { auth: bearerAuth };
+
+        expectError(() => {
+            assertTarballHostMatchesRegistry('not-a-url', settings);
+        }, 'Registry returned an invalid tarball URL: "not-a-url"');
+    });
+
+    test('rejects an empty tarball URL', function () {
+        const settings: RegistrySettings = { auth: bearerAuth };
+
+        expectError(() => {
+            assertTarballHostMatchesRegistry('', settings);
+        }, 'Registry returned an invalid tarball URL: ""');
+    });
+});

--- a/source/bundle-emitter/registry/validate-tarball-host.ts
+++ b/source/bundle-emitter/registry/validate-tarball-host.ts
@@ -1,0 +1,34 @@
+import type { RegistrySettings } from '../../config/registry-settings.ts';
+import { npmRegistryUrl } from './registry-auth-config.ts';
+
+function resolveConfiguredHost(registrySettings: Readonly<RegistrySettings>): string {
+    return new URL(registrySettings.registryUrl ?? npmRegistryUrl).host;
+}
+
+function parseTarballHost(tarballUrl: string): string {
+    try {
+        return new URL(tarballUrl).host;
+    } catch {
+        throw new TypeError(`Registry returned an invalid tarball URL: "${tarballUrl}"`);
+    }
+}
+
+function buildMismatchMessage(tarballHost: string, configuredHost: string): string {
+    return (
+        `Refusing to download tarball from "${tarballHost}" because it differs from the configured registry host ` +
+        `"${configuredHost}". A tampered registry response could redirect the request and exfiltrate ` +
+        'publish credentials.'
+    );
+}
+
+export function assertTarballHostMatchesRegistry(
+    tarballUrl: string,
+    registrySettings: Readonly<RegistrySettings>
+): void {
+    const tarballHost = parseTarballHost(tarballUrl);
+    const configuredHost = resolveConfiguredHost(registrySettings);
+
+    if (tarballHost !== configuredHost) {
+        throw new Error(buildMismatchMessage(tarballHost, configuredHost));
+    }
+}


### PR DESCRIPTION
A compromised or MITM'd registry can return a crafted `dist.tarball` URL on a host the attacker controls. Packtory's auto-version flow downloads that URL with the configured publish credentials, so without a host check the bearer or basic auth leaks to the attacker host. `fetchPackageTarball` now parses the tarball URL up front and refuses to fetch when its host (including port) does not match the configured registry, defaulting to `registry.npmjs.org` when none is set. Malformed URLs are rejected with a clear message too.

The defense is documented in [`documentation/supply-chain.md`](./documentation/supply-chain.md) alongside provenance.
