### PR TITLE
Reject path traversal in `additionalFiles.targetFilePath`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,7 @@ The configuration for `packtory` is an object with the following properties:
         - Example: `{ sourceFilePath: 'LICENSE', targetFilePath: 'LICENSE' }`.
         - If defined in both per-package and common settings, they are merged.
         - Code files (`.js`, `.cjs`, `.mjs`, `.jsx`, `.ts`, `.cts`, `.mts`, `.tsx`, `.d.ts`) are rejected: code that ships in the bundle must be reachable from a root so dependency, side-effect and dead-code analyses can run on it. If you need to ship code as a static asset (e.g. a template), give it a non-code extension like `.txt`.
+        - `targetFilePath` must be a bundle-relative path. Absolute paths (POSIX `/foo` or Windows `C:\\foo`) and parent-traversing paths (`..`, `foo/../bar`) are rejected at config-validation time so a malicious or mistaken config cannot write outside the artifact target during `pack --format folder`.
 
     - **`additionalPackageJsonAttributes`** (Optional, Object):
         - An object to be merged directly into the generated `package.json`.

--- a/source/config/additional-files.test.ts
+++ b/source/config/additional-files.test.ts
@@ -153,4 +153,40 @@ suite('additional-files', function () {
             expectedMessages: ['unexpected additional property: "something"']
         })
     );
+
+    suite('safe relative targetFilePath', function () {
+        for (const accepted of ['good/path.txt', 'nested/folder/file.txt', 'just-a-file.txt']) {
+            test(
+                `validation succeeds for "${accepted}"`,
+                checkValidationSuccess({
+                    schema: additionalFileDescriptionSchema,
+                    data: { sourceFilePath: 'src', targetFilePath: accepted },
+                    expectedData: { sourceFilePath: 'src', targetFilePath: accepted }
+                })
+            );
+        }
+    });
+
+    suite('unsafe targetFilePath rejection', function () {
+        for (const rejected of [
+            '..',
+            '../escape.txt',
+            'foo/../bar.txt',
+            'foo/..',
+            '/etc/passwd',
+            'C:/Windows/System32',
+            'C:\\Windows\\System32',
+            '..\\escape.txt',
+            'foo\\..\\bar.txt'
+        ]) {
+            test(
+                `validation fails for "${rejected}"`,
+                checkValidationFailure({
+                    schema: additionalFileDescriptionSchema,
+                    data: { sourceFilePath: 'src', targetFilePath: rejected },
+                    expectedMessages: ['at targetFilePath: invalid input']
+                })
+            );
+        }
+    });
 });

--- a/source/config/additional-files.ts
+++ b/source/config/additional-files.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod/mini';
-import { nonEmptyStringSchema } from './base-validations.ts';
+import { bundleRelativePathSchema, nonEmptyStringSchema } from './base-validations.ts';
 
 export const additionalFileDescriptionSchema = z.readonly(
     z.strictObject({
         sourceFilePath: nonEmptyStringSchema,
-        targetFilePath: nonEmptyStringSchema
+        targetFilePath: bundleRelativePathSchema
     })
 );
 

--- a/source/config/base-validations.test.ts
+++ b/source/config/base-validations.test.ts
@@ -1,6 +1,18 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { nonEmptyStringSchema } from './base-validations.ts';
+import { bundleRelativePathSchema, nonEmptyStringSchema } from './base-validations.ts';
+
+function expectAccepts(value: unknown): () => void {
+    return () => {
+        assert.strictEqual(bundleRelativePathSchema.safeParse(value).success, true);
+    };
+}
+
+function expectRejects(value: unknown): () => void {
+    return () => {
+        assert.strictEqual(bundleRelativePathSchema.safeParse(value).success, false);
+    };
+}
 
 suite('base-validations', function () {
     test('nonEmptyStringSchema accepts a non-empty string', function () {
@@ -15,4 +27,31 @@ suite('base-validations', function () {
         assert.strictEqual(nonEmptyStringSchema.safeParse(null).success, false);
         assert.strictEqual(nonEmptyStringSchema.safeParse(42).success, false);
     });
+
+    suite('bundleRelativePathSchema accepts safe paths', function () {
+        for (const value of ['good/path.txt', 'nested/folder/file.txt', 'just-a-file.txt', 'foo.bar.baz']) {
+            test(`accepts "${value}"`, expectAccepts(value));
+        }
+    });
+
+    suite('bundleRelativePathSchema rejects unsafe paths', function () {
+        for (const value of [
+            '',
+            '..',
+            '../escape.txt',
+            'foo/../bar.txt',
+            'foo/..',
+            '/etc/passwd',
+            'C:/Windows/System32',
+            'C:\\Windows\\System32',
+            '..\\escape.txt',
+            'foo\\..\\bar.txt'
+        ]) {
+            test(`rejects "${value}"`, expectRejects(value));
+        }
+    });
+
+    test('bundleRelativePathSchema rejects null', expectRejects(null));
+
+    test('bundleRelativePathSchema rejects numbers', expectRejects(42));
 });

--- a/source/config/base-validations.ts
+++ b/source/config/base-validations.ts
@@ -1,3 +1,14 @@
+import path from 'node:path';
 import { z } from 'zod/mini';
 
 export const nonEmptyStringSchema = z.string().check(z.minLength(1));
+
+function isBundleRelativePath(value: string): boolean {
+    if (path.posix.isAbsolute(value) || path.win32.isAbsolute(value)) {
+        return false;
+    }
+    const segments = value.split(/[/\\]/u);
+    return !segments.includes('..');
+}
+
+export const bundleRelativePathSchema = z.string().check(z.minLength(1), z.refine(isBundleRelativePath));


### PR DESCRIPTION
`targetFilePath` in `additionalFiles` was a free-form non-empty string. `pack --format folder` then resolves the artifact destination through `path.join`, which does not strip leading `..` segments, so a config like `{ targetFilePath: '../../etc/x' }` would have written outside the artifact folder. The same shape would land in a malicious or mistaken PR that mutates `packtory.config.js`.

The new `bundleRelativePathSchema` requires a non-empty string, refuses POSIX and Windows absolute paths, and refuses any `..` segment (matching both `/` and `\` separators so the check is independent of the host OS).
