### PR TITLE
Host-validate `GITHUB_API_BASE_URL` and `ACTIONS_ID_TOKEN_REQUEST_URL`

### DIFF
--- a/source/github-release-gate/runner-config.test.ts
+++ b/source/github-release-gate/runner-config.test.ts
@@ -50,7 +50,6 @@ suite('github-release-gate-runner-config', function () {
                 CI_WORKFLOW_FILE: 'custom ci.yml',
                 DEFAULT_BRANCH: 'release',
                 DEPENDENCY_ONLY_MIN_AGE_DAYS: '9',
-                GITHUB_API_BASE_URL: 'https://example.invalid/api',
                 MAX_LATENCY_HOURS: '1',
                 QUIET_PERIOD_MINUTES: '3'
             }),
@@ -58,7 +57,7 @@ suite('github-release-gate-runner-config', function () {
                 ciWorkflowFile: 'custom ci.yml',
                 dependencyOnlyMinAgeDays: 9,
                 defaultBranch: 'release',
-                githubApiBaseUrl: 'https://example.invalid/api',
+                githubApiBaseUrl: 'https://api.github.com',
                 githubOutputPath: '/workspace/github-output.txt',
                 maxLatencyHours: 1,
                 quietPeriodMinutes: 3,
@@ -66,6 +65,31 @@ suite('github-release-gate-runner-config', function () {
                 token: 'token'
             }
         );
+    });
+
+    test('readGitHubReleaseGateRunnerConfig accepts a loopback GITHUB_API_BASE_URL for testing', function () {
+        assert.strictEqual(
+            readConfig({ GITHUB_API_BASE_URL: 'http://127.0.0.1:1234' }).githubApiBaseUrl,
+            'http://127.0.0.1:1234'
+        );
+    });
+
+    test('readGitHubReleaseGateRunnerConfig rejects a non-GitHub GITHUB_API_BASE_URL', function () {
+        assert.throws(() => {
+            readConfig({ GITHUB_API_BASE_URL: 'https://example.invalid/api' });
+        }, /GITHUB_API_BASE_URL hostname must be "api\.github\.com", got "example\.invalid"/u);
+    });
+
+    test('readGitHubReleaseGateRunnerConfig rejects a non-https public GITHUB_API_BASE_URL', function () {
+        assert.throws(() => {
+            readConfig({ GITHUB_API_BASE_URL: 'http://api.github.com' });
+        }, /GITHUB_API_BASE_URL must use https/u);
+    });
+
+    test('readGitHubReleaseGateRunnerConfig rejects a malformed GITHUB_API_BASE_URL', function () {
+        assert.throws(() => {
+            readConfig({ GITHUB_API_BASE_URL: 'not-a-url' });
+        }, /GITHUB_API_BASE_URL is not a valid URL/u);
     });
 
     test('readGitHubReleaseGateRunnerConfig requires GITHUB_OUTPUT', function () {

--- a/source/github-release-gate/runner-config.ts
+++ b/source/github-release-gate/runner-config.ts
@@ -1,3 +1,5 @@
+import { assertGitHubApiBaseUrl } from './validate-api-base-url.ts';
+
 export type GitHubReleaseGateRunnerConfig = {
     readonly ciWorkflowFile: string;
     readonly dependencyOnlyMinAgeDays: number;
@@ -61,7 +63,9 @@ export function readGitHubReleaseGateRunnerConfig(
             defaultDependencyOnlyMinAgeDays
         ),
         defaultBranch: getEnvironmentVariable('DEFAULT_BRANCH') ?? defaultMainBranch(),
-        githubApiBaseUrl: getEnvironmentVariable('GITHUB_API_BASE_URL') ?? defaultGitHubApiBaseUrl(),
+        githubApiBaseUrl: assertGitHubApiBaseUrl(
+            getEnvironmentVariable('GITHUB_API_BASE_URL') ?? defaultGitHubApiBaseUrl()
+        ),
         githubOutputPath: getRequiredEnvironmentVariable(getEnvironmentVariable, 'GITHUB_OUTPUT'),
         maxLatencyHours: parseInteger(getEnvironmentVariable('MAX_LATENCY_HOURS'), defaultMaxLatencyHours),
         quietPeriodMinutes: parseInteger(getEnvironmentVariable('QUIET_PERIOD_MINUTES'), defaultQuietPeriodMinutes),

--- a/source/github-release-gate/validate-api-base-url.test.ts
+++ b/source/github-release-gate/validate-api-base-url.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { assertGitHubApiBaseUrl } from './validate-api-base-url.ts';
+
+suite('validate-api-base-url', function () {
+    test('accepts the canonical api.github.com URL', function () {
+        assert.strictEqual(assertGitHubApiBaseUrl('https://api.github.com'), 'https://api.github.com');
+    });
+
+    test('accepts loopback IPv4 over http for testing', function () {
+        assert.strictEqual(assertGitHubApiBaseUrl('http://127.0.0.1:1234'), 'http://127.0.0.1:1234');
+    });
+
+    test('accepts loopback IPv6 over http for testing', function () {
+        assert.strictEqual(assertGitHubApiBaseUrl('http://[::1]:1234'), 'http://[::1]:1234');
+    });
+
+    test('accepts localhost over http for testing', function () {
+        assert.strictEqual(assertGitHubApiBaseUrl('http://localhost:1234'), 'http://localhost:1234');
+    });
+
+    test('rejects an arbitrary public host', function () {
+        assert.throws(() => {
+            assertGitHubApiBaseUrl('https://attacker.example/api');
+        }, /hostname must be "api\.github\.com", got "attacker\.example"/u);
+    });
+
+    test('rejects a lookalike host', function () {
+        assert.throws(() => {
+            assertGitHubApiBaseUrl('https://api.github.com.attacker.example');
+        }, /hostname must be "api\.github\.com", got "api\.github\.com\.attacker\.example"/u);
+    });
+
+    test('rejects an http public host', function () {
+        assert.throws(() => {
+            assertGitHubApiBaseUrl('http://api.github.com');
+        }, /must use https/u);
+    });
+
+    test('rejects a malformed URL', function () {
+        assert.throws(() => {
+            assertGitHubApiBaseUrl('not-a-url');
+        }, /is not a valid URL/u);
+    });
+});

--- a/source/github-release-gate/validate-api-base-url.test.ts
+++ b/source/github-release-gate/validate-api-base-url.test.ts
@@ -19,10 +19,17 @@ suite('validate-api-base-url', function () {
         assert.strictEqual(assertGitHubApiBaseUrl('http://localhost:1234'), 'http://localhost:1234');
     });
 
-    test('rejects an arbitrary public host', function () {
-        assert.throws(() => {
-            assertGitHubApiBaseUrl('https://attacker.example/api');
-        }, /hostname must be "api\.github\.com", got "attacker\.example"/u);
+    test('rejects an arbitrary public host with the full mismatch message', function () {
+        assert.throws(
+            () => {
+                assertGitHubApiBaseUrl('https://attacker.example/api');
+            },
+            {
+                message:
+                    'GITHUB_API_BASE_URL hostname must be "api.github.com", got "attacker.example". ' +
+                    'A non-GitHub host would receive the GITHUB_TOKEN.'
+            }
+        );
     });
 
     test('rejects a lookalike host', function () {

--- a/source/github-release-gate/validate-api-base-url.ts
+++ b/source/github-release-gate/validate-api-base-url.ts
@@ -1,5 +1,5 @@
 const expectedApiHostname = 'api.github.com';
-const loopbackHostnames = new Set(['127.0.0.1', '::1', '[::1]', 'localhost']);
+const loopbackHostnames = new Set(['127.0.0.1', '[::1]', 'localhost']);
 
 function parseOrThrow(value: string): URL {
     try {

--- a/source/github-release-gate/validate-api-base-url.ts
+++ b/source/github-release-gate/validate-api-base-url.ts
@@ -1,0 +1,37 @@
+const expectedApiHostname = 'api.github.com';
+const loopbackHostnames = new Set(['127.0.0.1', '::1', '[::1]', 'localhost']);
+
+function parseOrThrow(value: string): URL {
+    try {
+        return new URL(value);
+    } catch {
+        throw new Error(`GITHUB_API_BASE_URL is not a valid URL: "${value}"`);
+    }
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+    return loopbackHostnames.has(hostname);
+}
+
+function buildMismatchMessage(actualHostname: string): string {
+    return (
+        `GITHUB_API_BASE_URL hostname must be "${expectedApiHostname}", got "${actualHostname}". ` +
+        'A non-GitHub host would receive the GITHUB_TOKEN.'
+    );
+}
+
+export function assertGitHubApiBaseUrl(value: string): string {
+    const parsed = parseOrThrow(value);
+
+    if (isLoopbackHostname(parsed.hostname)) {
+        return value;
+    }
+    if (parsed.protocol !== 'https:') {
+        throw new Error(`GITHUB_API_BASE_URL must use https, got: "${value}"`);
+    }
+    if (parsed.hostname !== expectedApiHostname) {
+        throw new Error(buildMismatchMessage(parsed.hostname));
+    }
+
+    return value;
+}

--- a/source/npm-oidc-id-token-resolver.test.ts
+++ b/source/npm-oidc-id-token-resolver.test.ts
@@ -238,16 +238,22 @@ suite('npm-oidc-id-token-resolver', function () {
     });
 
     suite('ACTIONS_ID_TOKEN_REQUEST_URL host validation', function () {
-        test('resolver rejects a non-actions.githubusercontent.com host', async function () {
+        test('resolver rejects a non-actions.githubusercontent.com host with the full mismatch message', async function () {
             const resolveIdToken = createGitHubActionsResolver({
                 environmentVariables: {
                     ACTIONS_ID_TOKEN_REQUEST_URL: 'https://attacker.example/id-token'
                 }
             });
 
-            await expectFailure(async () => {
-                await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
-            }, /^Error: ACTIONS_ID_TOKEN_REQUEST_URL hostname must end with "\.actions\.githubusercontent\.com", got "attacker\.example"/u);
+            const expectedSuffix =
+                'ACTIONS_ID_TOKEN_REQUEST_URL hostname must end with ".actions.githubusercontent.com", ' +
+                'got "attacker.example". A non-GitHub host would receive the GitHub-issued OIDC bearer.';
+            await expectFailure(
+                async () => {
+                    await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+                },
+                new RegExp(`^Error: ${expectedSuffix.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&')}$`, 'u')
+            );
         });
 
         test('resolver rejects a lookalike host', async function () {

--- a/source/npm-oidc-id-token-resolver.test.ts
+++ b/source/npm-oidc-id-token-resolver.test.ts
@@ -9,7 +9,7 @@ type Overrides = {
 };
 
 const gitHubActionsEnvironmentVariables = {
-    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://actions.example.test/id-token',
+    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://pipelinesghub.actions.githubusercontent.com/id-token',
     ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'actions-request-token'
 } as const;
 
@@ -93,7 +93,9 @@ suite('npm-oidc-id-token-resolver', function () {
         assert.strictEqual(idToken, 'github-id-token');
         assert.deepStrictEqual(fetchCalls, [
             [
-                new URL('https://actions.example.test/id-token?audience=npm%3Aregistry.npmjs.org'),
+                new URL(
+                    'https://pipelinesghub.actions.githubusercontent.com/id-token?audience=npm%3Aregistry.npmjs.org'
+                ),
                 {
                     headers: { Authorization: 'Bearer actions-request-token' }
                 }
@@ -159,7 +161,11 @@ suite('npm-oidc-id-token-resolver', function () {
     suite('GitHub Actions missing environment variables', function () {
         for (const [missingVariable, requestUrl, requestToken] of [
             ['ACTIONS_ID_TOKEN_REQUEST_URL', undefined, 'actions-request-token'],
-            ['ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'https://actions.example.test/id-token', undefined]
+            [
+                'ACTIONS_ID_TOKEN_REQUEST_TOKEN',
+                'https://pipelinesghub.actions.githubusercontent.com/id-token',
+                undefined
+            ]
         ] as const) {
             test(`resolver rejects GitHub Actions OIDC when ${missingVariable} is missing`, async function () {
                 const resolveIdToken = createGitHubActionsResolver({
@@ -229,5 +235,55 @@ suite('npm-oidc-id-token-resolver', function () {
         await expectFailure(async () => {
             await resolveIdToken({ type: 'npm-oidc', provider: 'env', idTokenEnvVar: 'CUSTOM_ID_TOKEN' });
         }, /^Error: OIDC id_token environment variable "CUSTOM_ID_TOKEN" is missing$/u);
+    });
+
+    suite('ACTIONS_ID_TOKEN_REQUEST_URL host validation', function () {
+        test('resolver rejects a non-actions.githubusercontent.com host', async function () {
+            const resolveIdToken = createGitHubActionsResolver({
+                environmentVariables: {
+                    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://attacker.example/id-token'
+                }
+            });
+
+            await expectFailure(async () => {
+                await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+            }, /^Error: ACTIONS_ID_TOKEN_REQUEST_URL hostname must end with "\.actions\.githubusercontent\.com", got "attacker\.example"/u);
+        });
+
+        test('resolver rejects a lookalike host', async function () {
+            const resolveIdToken = createGitHubActionsResolver({
+                environmentVariables: {
+                    ACTIONS_ID_TOKEN_REQUEST_URL: 'https://actions.githubusercontent.com.attacker.example/id-token'
+                }
+            });
+
+            await expectFailure(async () => {
+                await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+            }, /hostname must end with "\.actions\.githubusercontent\.com"/u);
+        });
+
+        test('resolver rejects an http ACTIONS_ID_TOKEN_REQUEST_URL', async function () {
+            const resolveIdToken = createGitHubActionsResolver({
+                environmentVariables: {
+                    ACTIONS_ID_TOKEN_REQUEST_URL: 'http://pipelinesghub.actions.githubusercontent.com/id-token'
+                }
+            });
+
+            await expectFailure(async () => {
+                await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+            }, /^Error: ACTIONS_ID_TOKEN_REQUEST_URL must use https/u);
+        });
+
+        test('resolver rejects a malformed ACTIONS_ID_TOKEN_REQUEST_URL', async function () {
+            const resolveIdToken = createGitHubActionsResolver({
+                environmentVariables: {
+                    ACTIONS_ID_TOKEN_REQUEST_URL: 'not-a-url'
+                }
+            });
+
+            await expectFailure(async () => {
+                await resolveIdToken({ type: 'npm-oidc', provider: 'github-actions' });
+            }, /^Error: ACTIONS_ID_TOKEN_REQUEST_URL is not a valid URL/u);
+        });
     });
 });

--- a/source/npm-oidc-id-token-resolver.ts
+++ b/source/npm-oidc-id-token-resolver.ts
@@ -19,8 +19,36 @@ function defaultOidcIdTokenEnvVariableName(): string {
     return 'NPM_ID_TOKEN';
 }
 
+const trustedOidcRequestSuffix = '.actions.githubusercontent.com';
+
+function parseOidcRequestUrl(value: string): URL {
+    try {
+        return new URL(value);
+    } catch {
+        throw new Error(`ACTIONS_ID_TOKEN_REQUEST_URL is not a valid URL: "${value}"`);
+    }
+}
+
+function buildOidcHostnameMismatchMessage(actualHostname: string): string {
+    return (
+        `ACTIONS_ID_TOKEN_REQUEST_URL hostname must end with "${trustedOidcRequestSuffix}", ` +
+        `got "${actualHostname}". A non-GitHub host would receive the GitHub-issued OIDC bearer.`
+    );
+}
+
+function assertTrustedOidcRequestUrl(value: string): URL {
+    const parsed = parseOidcRequestUrl(value);
+    if (parsed.protocol !== 'https:') {
+        throw new Error(`ACTIONS_ID_TOKEN_REQUEST_URL must use https, got: "${value}"`);
+    }
+    if (!parsed.hostname.endsWith(trustedOidcRequestSuffix)) {
+        throw new Error(buildOidcHostnameMismatchMessage(parsed.hostname));
+    }
+    return parsed;
+}
+
 function getGitHubActionsRequestConfig(getEnvironmentVariable: (variableName: string) => string | undefined): {
-    readonly requestUrl: string;
+    readonly requestUrl: URL;
     readonly requestToken: string;
 } {
     const requestUrl = getEnvironmentVariable('ACTIONS_ID_TOKEN_REQUEST_URL');
@@ -30,7 +58,7 @@ function getGitHubActionsRequestConfig(getEnvironmentVariable: (variableName: st
         throw new Error('GitHub Actions OIDC requires ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN');
     }
 
-    return { requestUrl, requestToken };
+    return { requestUrl: assertTrustedOidcRequestUrl(requestUrl), requestToken };
 }
 
 function parseGitHubActionsIdTokenResponse(body: unknown): string {
@@ -62,9 +90,8 @@ export function createNpmOidcIdTokenResolver(
 
     async function fetchGitHubActionsIdToken(): Promise<string> {
         const { requestUrl, requestToken } = getGitHubActionsRequestConfig(getEnvironmentVariable);
-        const url = new URL(requestUrl);
-        url.searchParams.set('audience', githubActionsAudience());
-        const response = await fetchImplementation(url, {
+        requestUrl.searchParams.set('audience', githubActionsAudience());
+        const response = await fetchImplementation(requestUrl, {
             headers: { Authorization: `Bearer ${requestToken}` }
         });
 


### PR DESCRIPTION
`GITHUB_API_BASE_URL` and `ACTIONS_ID_TOKEN_REQUEST_URL` are normally set by the GitHub Actions runner, but a step-level `env:` override (e.g. injected by a poisoned third-party action) can replace them with attacker-controlled values. Without a host check, the Octokit base URL receives the `GITHUB_TOKEN` and the OIDC request URL receives the runner-issued OIDC bearer.

`assertGitHubApiBaseUrl` pins the Octokit base URL to `api.github.com` over `https`, with a loopback escape hatch for the integration tests that point Octokit at an in-process HTTP server.

`assertTrustedOidcRequestUrl` pins the OIDC request URL to a hostname ending in `.actions.githubusercontent.com` over `https`. Lookalike hosts like `actions.githubusercontent.com.attacker.example` are rejected because the suffix check requires the dot-prefixed form.
