### PR TITLE
Recognize `import.meta.resolve('<static-string>')` call sites in dependency analysis

### DIFF
--- a/documentation/how-it-works.md
+++ b/documentation/how-it-works.md
@@ -146,6 +146,15 @@ A few details worth highlighting:
 - The external-dependency extractor uses a small regex to pull the package name out of a `node_modules/…` path, with care for scoped packages (`@scope/name`).
 - The graph is flattened with a breadth-first walk into the `DependencyFiles` shape that downstream stages consume.
 
+### Literal sources
+
+"Import literal" above covers two syntactic shapes, both reduced to the same resolution pipeline:
+
+1. The static specifiers ts-morph already exposes through `getImportStringLiterals`: `import` / `export … from`, dynamic `import(...)`, `import = require(...)`, and type-position `import(...)`.
+2. `import.meta.resolve('<static-string>')` call sites, recognized by matching the `CallExpression → PropertyAccessExpression → MetaProperty(import)` shape and accepting the call only when its single argument is a `StringLiteral`. Any other argument shape (variable, template literal, missing or extra arguments) throws — packtory deliberately does not implement its own resolver, so non-static specifiers cannot be resolved deterministically.
+
+For `import.meta.resolve` the classifier reuses the same `external-package` / `local-asset` / `local-code` outcomes as a regular import: a resolved target inside `node_modules` adds the owning package as a dependency without tracking the individual file, `.json` / `.wasm` targets become leaf asset references, and a code target is recursed into like any other reachable source file.
+
 ### Source maps and declarations
 
 If `includeSourceMapFiles: true`, the scanner also locates the paired `.map` for every code file (`source-map-file-locator.ts`) and adds it to the graph as a leaf. If a root declares a `.d.ts`, a _second_ scan is performed with `resolveDeclarationFiles: true` so the type graph is captured alongside the JavaScript graph.

--- a/readme.md
+++ b/readme.md
@@ -104,8 +104,8 @@ Packtory guarantees minimal packages with:
 
 **How Bundling Works:**
 
-1. All source files referenced from the configured roots are resolved into a graph.
-2. Imports of `node_modules` and node built-ins are detected and tracked to create a minimal `package.json` later.
+1. All source files referenced from the configured roots are resolved into a graph. Both static `import` / `export … from` / `require` / `import(...)` literals and `import.meta.resolve('<static-string>')` call sites are recognized; the argument to `import.meta.resolve` must be a single static string literal — dynamic expressions are rejected.
+2. Imports of `node_modules` and node built-ins are detected and tracked to create a minimal `package.json` later. When `import.meta.resolve(...)` points at a file inside a `node_modules` package, the owning package is added as a dependency; individual files inside the package are not tracked.
 3. If bundle dependencies are given, some import statements will be rewritten. For example, if a file in package `first` imports a file in package `second`, the import statement will be rewritten accordingly (e.g., from `import bar from './bar.js'` to `import bar from 'second/bar.js'`).
 4. A `package.json` will be generated, and the version numbers of `node_modules` will be taken from the `mainPackageJson` provided in the configuration.
 

--- a/source/dependency-scanner/source-file-references.test.ts
+++ b/source/dependency-scanner/source-file-references.test.ts
@@ -493,6 +493,161 @@ suite('source-file-references', function () {
         assert.deepStrictEqual(result, [{ kind: 'local-code', filePath: '/value.js' }]);
     });
 
+    function expectImportMetaResolveReferences(args: {
+        readonly mainContent: string;
+        readonly extraFiles?: readonly { readonly filePath: string; readonly content: string }[];
+        readonly expected: readonly {
+            readonly kind: string;
+            readonly filePath?: string;
+            readonly packageName?: string;
+        }[];
+    }): void {
+        const project = createProject({
+            withFiles: [{ filePath: 'main.ts', content: args.mainContent }]
+        });
+        for (const file of args.extraFiles ?? []) {
+            project.createSourceFile(file.filePath, file.content);
+        }
+        const result = getReferencedModules(project.getSourceFileOrThrow('main.ts'), packageJsonPath);
+        assert.deepStrictEqual(result, args.expected);
+    }
+
+    test('returns local code references for import.meta.resolve() pointing at a sibling source file', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const url = import.meta.resolve("./foo");',
+            extraFiles: [{ filePath: 'foo.ts', content: 'export const foo = "";' }],
+            expected: [{ kind: 'local-code', filePath: '/foo.ts' }]
+        });
+    });
+
+    test('returns local asset references for import.meta.resolve() pointing at a json file', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const url = import.meta.resolve("./data.json");',
+            extraFiles: [{ filePath: 'data.json', content: '{"ok":true}' }],
+            expected: [{ kind: 'local-asset', filePath: '/data.json' }]
+        });
+    });
+
+    test('returns local asset references for import.meta.resolve() pointing at a relative wasm file', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const url = import.meta.resolve("./module.wasm");',
+            extraFiles: [{ filePath: '/module.wasm', content: 'wasm' }],
+            expected: [{ kind: 'local-asset', filePath: '/module.wasm' }]
+        });
+    });
+
+    test('returns external package references for import.meta.resolve() pointing at a bare specifier', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const url = import.meta.resolve("foo");',
+            extraFiles: [
+                {
+                    filePath: '/node_modules/foo/index.d.ts',
+                    content: 'declare const foo: string; export default foo;'
+                }
+            ],
+            expected: [{ kind: 'external-package', packageName: 'foo' }]
+        });
+    });
+
+    test('returns external package references for import.meta.resolve() pointing at a package-owned asset', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const url = import.meta.resolve("foo/module.wasm");',
+            extraFiles: [{ filePath: '/node_modules/foo/module.wasm', content: 'wasm' }],
+            expected: [{ kind: 'external-package', packageName: 'foo' }]
+        });
+    });
+
+    test('ignores import.meta.resolve() pointing at a node-builtin module', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const url = import.meta.resolve("node:fs");',
+            expected: []
+        });
+    });
+
+    test('throws when import.meta.resolve() receives a non-literal argument', function () {
+        expectResolutionFailure(
+            'const specifier = "./foo"; const url = import.meta.resolve(specifier);',
+            'Invalid import.meta.resolve() usage in file "/main.ts": only a single static string literal argument is supported'
+        );
+    });
+
+    test('throws when import.meta.resolve() receives a template literal argument', function () {
+        expectResolutionFailure(
+            'const url = import.meta.resolve(`./foo`);',
+            'Invalid import.meta.resolve() usage in file "/main.ts": only a single static string literal argument is supported'
+        );
+    });
+
+    test('throws when import.meta.resolve() receives no arguments', function () {
+        expectResolutionFailure(
+            'const url = import.meta.resolve();',
+            'Invalid import.meta.resolve() usage in file "/main.ts": only a single static string literal argument is supported'
+        );
+    });
+
+    test('throws when import.meta.resolve() receives multiple arguments', function () {
+        expectResolutionFailure(
+            'const url = import.meta.resolve("./foo", "./parent");',
+            'Invalid import.meta.resolve() usage in file "/main.ts": only a single static string literal argument is supported'
+        );
+    });
+
+    test('throws when an import.meta.resolve() specifier is not resolvable', function () {
+        expectResolutionFailure(
+            'const url = import.meta.resolve("missing-package");',
+            'Failed to resolve import "missing-package" in file "/main.ts"'
+        );
+    });
+
+    test('does not pick up unrelated import.meta member accesses', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'const here = import.meta.url;',
+            expected: []
+        });
+    });
+
+    test('does not pick up call expressions on import.meta members other than resolve', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'function callOther() { return import.meta.foo("./bar"); }',
+            expected: []
+        });
+    });
+
+    test('does not pick up resolve() calls on non-import meta properties', function () {
+        expectImportMetaResolveReferences({
+            mainContent: 'class Subject { constructor() { new.target?.resolve("./bar"); } } void Subject;',
+            expected: []
+        });
+    });
+
+    test('does not pick up resolve() calls whose receiver is not a meta property', function () {
+        expectImportMetaResolveReferences({
+            mainContent: [
+                'const helper = { resolve(specifier: string) { return specifier; } };',
+                'helper.resolve("./bar");'
+            ].join('\n'),
+            expected: []
+        });
+    });
+
+    test('collects references from regular imports and import.meta.resolve() calls in the same file', function () {
+        expectImportMetaResolveReferences({
+            mainContent: [
+                'import { foo } from "./foo";',
+                'const url = import.meta.resolve("./bar");',
+                'void foo;'
+            ].join('\n'),
+            extraFiles: [
+                { filePath: 'foo.ts', content: 'export const foo = 1;' },
+                { filePath: 'bar.ts', content: 'export const bar = 2;' }
+            ],
+            expected: [
+                { kind: 'local-code', filePath: '/foo.ts' },
+                { kind: 'local-code', filePath: '/bar.ts' }
+            ]
+        });
+    });
+
     function resolveFirstImportLiteral(files: { readonly filePath: string; readonly content: string }[]): {
         readonly project: ReturnType<typeof createProject>;
         readonly result: ReturnType<typeof resolveSourceFileForLiteral>;

--- a/source/dependency-scanner/source-file-references.ts
+++ b/source/dependency-scanner/source-file-references.ts
@@ -1,6 +1,14 @@
 import path from 'node:path';
 import { isBuiltin } from 'node:module';
-import { ts, type SourceFile, type StringLiteral } from 'ts-morph';
+import { oneLine } from 'common-tags';
+import {
+    SyntaxKind,
+    ts,
+    type CallExpression,
+    type PropertyAccessExpression,
+    type SourceFile,
+    type StringLiteral
+} from 'ts-morph';
 import { findPackageOwnedAssetFilePath } from './package-owned-asset-file-path.ts';
 
 export const moduleReferenceKind = {
@@ -193,13 +201,56 @@ function resolveModuleReferenceForImport(
         : undefined;
 }
 
+function invalidImportMetaResolveUsage(sourceFile: Readonly<SourceFile>): Error {
+    return new Error(
+        oneLine`Invalid import.meta.resolve() usage in file "${sourceFile.getFilePath()}":
+            only a single static string literal argument is supported`
+    );
+}
+
+function isImportMetaResolveCallee(callee: Readonly<PropertyAccessExpression>): boolean {
+    const metaProperty = callee.getExpression().asKind(SyntaxKind.MetaProperty);
+    return metaProperty?.getKeywordToken() === SyntaxKind.ImportKeyword && callee.getNameNode().getText() === 'resolve';
+}
+
+function collectImportMetaResolveLiteral(
+    callExpression: Readonly<CallExpression>,
+    sourceFile: Readonly<SourceFile>
+): StringLiteral | undefined {
+    const callee = callExpression.getExpression().asKind(SyntaxKind.PropertyAccessExpression);
+    if (callee === undefined || !isImportMetaResolveCallee(callee)) {
+        return undefined;
+    }
+    const [first, second] = callExpression.getArguments();
+    if (first === undefined || second !== undefined) {
+        throw invalidImportMetaResolveUsage(sourceFile);
+    }
+    const literal = first.asKind(SyntaxKind.StringLiteral);
+    if (literal === undefined) {
+        throw invalidImportMetaResolveUsage(sourceFile);
+    }
+    return literal;
+}
+
+function getImportMetaResolveLiterals(sourceFile: Readonly<SourceFile>): readonly StringLiteral[] {
+    const literals: StringLiteral[] = [];
+    for (const callExpression of sourceFile.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+        const literal = collectImportMetaResolveLiteral(callExpression, sourceFile);
+        if (literal !== undefined) {
+            literals.push(literal);
+        }
+    }
+    return literals;
+}
+
 export function getReferencedModules(
     sourceFile: Readonly<SourceFile>,
     packageJsonPath: string
 ): readonly Readonly<ModuleReference>[] {
     const referencedModules: ModuleReference[] = [];
+    const allLiterals = [...sourceFile.getImportStringLiterals(), ...getImportMetaResolveLiterals(sourceFile)];
 
-    for (const literal of sourceFile.getImportStringLiterals()) {
+    for (const literal of allLiterals) {
         const importValue = literal.getLiteralValue();
         const referencedModule = resolveModuleReferenceForImport(importValue, sourceFile, packageJsonPath);
 


### PR DESCRIPTION
ESM code that obtains a runtime URL via `import.meta.resolve('./file')` was invisible to the dependency scanner, forcing users to declare those targets through `additionalFiles` — which itself rejects code files.

The scanner now matches `CallExpression → PropertyAccessExpression → MetaProperty(ImportKeyword)` with a single `StringLiteral` argument and feeds the literal through the existing `resolveModuleReferenceForImport` pipeline. Resolution stays delegated to `ts.resolveModuleName`, and the existing classifier outcomes carry over: targets inside `node_modules` add the owning package as a dependency, `.json` / `.wasm` targets become leaf asset references, and local code targets are recursed into like any other reachable file. Dynamic, multi, or missing arguments throw with a precise error rather than being silently ignored.