### PR TITLE
Set `GH_REPO` for `gh workflow run` in `scheduler.yml`

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -25,11 +25,13 @@ jobs:
         steps:
             - name: Dispatch publish workflow
               env:
+                  GH_REPO: ${{ github.repository }}
                   GH_TOKEN: ${{ github.token }}
               run: gh workflow run publish.yml --ref main
             - name: Wait then redispatch the scheduler as a cron-drift fallback
               if: always()
               env:
+                  GH_REPO: ${{ github.repository }}
                   GH_TOKEN: ${{ github.token }}
               run: |
                   sleep 1800


### PR DESCRIPTION
The `Schedule publish` workflow has no `actions/checkout` step, so `gh workflow run` falls back to git-based repository discovery and exits with `fatal: not a git repository`. Every cron-triggered run since 2026-05-30 ~20:39 UTC has failed on this, leaving the publish pipeline only reachable through manual `workflow_dispatch`.

Pass the repository through `GH_REPO` (mirroring the existing `GH_TOKEN` env wiring) so `gh` skips git discovery on both the dispatch step and the cron-drift self-redispatch step.
