### PR TITLE
Distinguish `ci_in_progress` from `ci_not_green` in release gate

### DIFF
--- a/source/github-release-gate/cli-runner.test.ts
+++ b/source/github-release-gate/cli-runner.test.ts
@@ -183,6 +183,7 @@ suite('github-release-gate-cli-runner', function () {
                         event: 'push',
                         head_sha: 'abc123',
                         html_url: 'https://github.com/enormora/packtory/actions/runs/1',
+                        status: 'completed',
                         updated_at: new Date(now - 10 * 60 * 1000).toISOString()
                     }
                 ]

--- a/source/github-release-gate/cli-runner.ts
+++ b/source/github-release-gate/cli-runner.ts
@@ -87,7 +87,7 @@ async function loadGitHubTimeGateDecision(
 ): Promise<{ readonly decision: GitHubReleaseGateDecision; readonly mainHeadSha: string; readonly now: Date }> {
     const githubApi = createGitHubReleaseGateApi(dependencies.fetch, createGitHubRepositoryContext(config));
     const mainHeadSha = await githubApi.getMainBranchHeadSha();
-    const successfulMainCiRun = await githubApi.getLatestSuccessfulMainCiRun(config.ciWorkflowFile, mainHeadSha);
+    const mainCiRunStatus = await githubApi.getMainCiRunStatus(config.ciWorkflowFile, mainHeadSha);
     const pullRequestActivities = await githubApi.getOpenPullRequestActivities();
     const now = dependencies.now();
 
@@ -97,12 +97,12 @@ async function loadGitHubTimeGateDecision(
         decision: evaluateGitHubReleaseGate({
             ciWorkflowFile: config.ciWorkflowFile,
             mainBranch: config.defaultBranch,
+            mainCiRunStatus,
             mainHeadSha,
             maxLatencyHours: config.maxLatencyHours,
             now,
             pullRequestActivities,
-            quietPeriodMinutes: config.quietPeriodMinutes,
-            successfulMainCiRun
+            quietPeriodMinutes: config.quietPeriodMinutes
         })
     };
 }

--- a/source/github-release-gate/github-api.test.ts
+++ b/source/github-release-gate/github-api.test.ts
@@ -78,6 +78,21 @@ async function getOpenPullRequestActivitiesForTimeline(
     return await createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext).getOpenPullRequestActivities();
 }
 
+function withCiWorkflowRuns(workflowRuns: readonly unknown[]): Record<string, MockRoute> {
+    const routes = createBaseRoutes() as Record<string, MockRoute>;
+    routes[ciRunsPath] = { body: { workflow_runs: workflowRuns } };
+    return routes;
+}
+
+async function runGetMainCiRunStatus(
+    routes: Readonly<Record<string, MockRoute>>
+): Promise<Awaited<ReturnType<ReturnType<typeof createGitHubReleaseGateApi>['getMainCiRunStatus']>>> {
+    return await createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext).getMainCiRunStatus(
+        'ci.yml',
+        'abc123'
+    );
+}
+
 suite('github-release-gate-github-api', function () {
     test('getMainBranchHeadSha sends the required GitHub headers', async function () {
         const requests: RecordedRequest[] = [];
@@ -95,51 +110,96 @@ suite('github-release-gate-github-api', function () {
         });
     });
 
-    test('getLatestSuccessfulMainCiRun ignores mismatched workflow runs', async function () {
-        const routes = createBaseRoutes() as Record<string, MockRoute>;
-        routes[ciRunsPath] = {
-            body: {
-                workflow_runs: [
-                    {
-                        conclusion: 'success',
-                        event: 'push',
-                        head_sha: 'different-sha',
-                        html_url: 'https://github.com/enormora/packtory/actions/runs/1',
-                        updated_at: '2026-05-19T10:00:00.000Z'
-                    },
-                    {
-                        conclusion: 'success',
-                        event: 'merge_group',
-                        head_sha: 'abc123',
-                        html_url: 'https://github.com/enormora/packtory/actions/runs/2',
-                        updated_at: '2026-05-19T10:05:00.000Z'
-                    }
-                ]
+    test('getMainCiRunStatus returns success for a completed successful push run', async function () {
+        assert.deepStrictEqual(await runGetMainCiRunStatus(createBaseRoutes()), {
+            kind: 'success',
+            run: {
+                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
+                updatedAt: new Date('2026-05-19T10:00:00.000Z')
             }
-        };
-        const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
-
-        assert.strictEqual(await api.getLatestSuccessfulMainCiRun('ci.yml', 'abc123'), undefined);
+        });
     });
 
-    test('getLatestSuccessfulMainCiRun ignores failed runs even when the head SHA and event match', async function () {
-        const routes = createBaseRoutes() as Record<string, MockRoute>;
-        routes[ciRunsPath] = {
-            body: {
-                workflow_runs: [
-                    {
-                        conclusion: 'failure',
-                        event: 'push',
-                        head_sha: 'abc123',
-                        html_url: 'https://github.com/enormora/packtory/actions/runs/1',
-                        updated_at: '2026-05-19T10:00:00.000Z'
-                    }
-                ]
+    test('getMainCiRunStatus reports missing when only mismatched workflow runs exist', async function () {
+        const routes = withCiWorkflowRuns([
+            {
+                conclusion: 'success',
+                event: 'push',
+                head_sha: 'different-sha',
+                html_url: 'https://github.com/enormora/packtory/actions/runs/1',
+                status: 'completed',
+                updated_at: '2026-05-19T10:00:00.000Z'
+            },
+            {
+                conclusion: 'success',
+                event: 'merge_group',
+                head_sha: 'abc123',
+                html_url: 'https://github.com/enormora/packtory/actions/runs/2',
+                status: 'completed',
+                updated_at: '2026-05-19T10:05:00.000Z'
             }
-        };
-        const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
+        ]);
 
-        assert.strictEqual(await api.getLatestSuccessfulMainCiRun('ci.yml', 'abc123'), undefined);
+        assert.deepStrictEqual(await runGetMainCiRunStatus(routes), { kind: 'missing' });
+    });
+
+    test('getMainCiRunStatus reports missing when the only matching run failed', async function () {
+        const routes = withCiWorkflowRuns([
+            {
+                conclusion: 'failure',
+                event: 'push',
+                head_sha: 'abc123',
+                html_url: 'https://github.com/enormora/packtory/actions/runs/1',
+                status: 'completed',
+                updated_at: '2026-05-19T10:00:00.000Z'
+            }
+        ]);
+
+        assert.deepStrictEqual(await runGetMainCiRunStatus(routes), { kind: 'missing' });
+    });
+
+    test('getMainCiRunStatus reports in_progress when a matching run is still running', async function () {
+        const routes = withCiWorkflowRuns([
+            {
+                conclusion: null,
+                event: 'push',
+                head_sha: 'abc123',
+                html_url: 'https://github.com/enormora/packtory/actions/runs/1',
+                status: 'in_progress',
+                updated_at: '2026-05-19T10:00:00.000Z'
+            }
+        ]);
+
+        assert.deepStrictEqual(await runGetMainCiRunStatus(routes), { kind: 'in_progress' });
+    });
+
+    test('getMainCiRunStatus prefers a successful run over a parallel in-progress one', async function () {
+        const routes = withCiWorkflowRuns([
+            {
+                conclusion: null,
+                event: 'push',
+                head_sha: 'abc123',
+                html_url: 'https://github.com/enormora/packtory/actions/runs/2',
+                status: 'in_progress',
+                updated_at: '2026-05-19T10:10:00.000Z'
+            },
+            {
+                conclusion: 'success',
+                event: 'push',
+                head_sha: 'abc123',
+                html_url: 'https://github.com/enormora/packtory/actions/runs/1',
+                status: 'completed',
+                updated_at: '2026-05-19T10:00:00.000Z'
+            }
+        ]);
+
+        assert.deepStrictEqual(await runGetMainCiRunStatus(routes), {
+            kind: 'success',
+            run: {
+                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
+                updatedAt: new Date('2026-05-19T10:00:00.000Z')
+            }
+        });
     });
 
     test('getOpenPullRequestActivities follows paginated responses', async function () {

--- a/source/github-release-gate/github-api.ts
+++ b/source/github-release-gate/github-api.ts
@@ -4,9 +4,9 @@ import { paginateRest } from '@octokit/plugin-paginate-rest';
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
 import {
     selectPullRequestActivityAt,
+    type MainCiRunStatus,
     type PullRequestActivity,
-    type PullRequestTimelineEvent,
-    type SuccessfulMainCiRun
+    type PullRequestTimelineEvent
 } from './release-gate.ts';
 import type { GitHubRepositoryContext } from './runner-config.ts';
 
@@ -19,6 +19,7 @@ type WorkflowRun = {
     readonly event: string;
     readonly head_sha: string;
     readonly html_url: string;
+    readonly status: string | null;
     readonly updated_at: string;
 };
 
@@ -41,11 +42,8 @@ type RawTimelineEvent = {
 };
 
 export type GitHubReleaseGateApi = {
-    readonly getLatestSuccessfulMainCiRun: (
-        ciWorkflowFile: string,
-        headSha: string
-    ) => Promise<SuccessfulMainCiRun | undefined>;
     readonly getMainBranchHeadSha: () => Promise<string>;
+    readonly getMainCiRunStatus: (ciWorkflowFile: string, headSha: string) => Promise<MainCiRunStatus>;
     readonly getOpenPullRequestActivities: () => Promise<readonly PullRequestActivity[]>;
 };
 
@@ -113,7 +111,7 @@ export function createGitHubReleaseGateApi(
             return branch.data.commit.sha;
         },
 
-        async getLatestSuccessfulMainCiRun(ciWorkflowFile, headSha) {
+        async getMainCiRunStatus(ciWorkflowFile, headSha) {
             const response = await requestGitHub<{ readonly data: WorkflowRunsResponse }>(
                 octokit.rest.actions.listWorkflowRuns({
                     ...requestContext,
@@ -121,22 +119,35 @@ export function createGitHubReleaseGateApi(
                     branch: context.defaultBranch,
                     event: 'push',
                     head_sha: headSha,
-                    status: 'completed',
                     per_page: 100
                 })
             );
-            const matchingRun = response.data.workflow_runs.find((run) => {
-                return run.head_sha === headSha && run.conclusion === 'success' && run.event === 'push';
+            const matchingRuns = response.data.workflow_runs.filter((run) => {
+                return run.head_sha === headSha && run.event === 'push';
+            });
+            const successfulRun = matchingRuns.find((run) => {
+                return run.conclusion === 'success';
             });
 
-            if (matchingRun === undefined) {
-                return undefined;
+            if (successfulRun !== undefined) {
+                return {
+                    kind: 'success',
+                    run: {
+                        htmlUrl: successfulRun.html_url,
+                        updatedAt: parseTimestamp(successfulRun.updated_at)
+                    }
+                };
             }
 
-            return {
-                htmlUrl: matchingRun.html_url,
-                updatedAt: parseTimestamp(matchingRun.updated_at)
-            };
+            const inProgressRun = matchingRuns.find((run) => {
+                return run.status !== 'completed';
+            });
+
+            if (inProgressRun !== undefined) {
+                return { kind: 'in_progress' };
+            }
+
+            return { kind: 'missing' };
         },
 
         async getOpenPullRequestActivities() {

--- a/source/github-release-gate/release-gate.test.ts
+++ b/source/github-release-gate/release-gate.test.ts
@@ -33,15 +33,18 @@ function evaluateGitHubReleaseGateWithBaseInput(overrides: Partial<GitHubRelease
     return evaluateGitHubReleaseGate({
         ciWorkflowFile: 'ci.yml',
         mainBranch: 'main',
+        mainCiRunStatus: {
+            kind: 'success',
+            run: {
+                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
+                updatedAt: createDate('2026-05-19T11:00:00.000Z')
+            }
+        },
         mainHeadSha: 'abc123',
         maxLatencyHours: 24,
         now: createDate('2026-05-19T12:00:00.000Z'),
         pullRequestActivities: [],
         quietPeriodMinutes: 45,
-        successfulMainCiRun: {
-            htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
-            updatedAt: createDate('2026-05-19T11:00:00.000Z')
-        },
         ...overrides
     });
 }
@@ -113,18 +116,37 @@ suite('github-release-gate', function () {
         const decision = evaluateGitHubReleaseGate({
             ciWorkflowFile: 'ci.yml',
             mainBranch: 'main',
+            mainCiRunStatus: { kind: 'missing' },
             mainHeadSha: 'abc123',
             maxLatencyHours: 24,
             now: createDate('2026-05-19T12:00:00.000Z'),
             pullRequestActivities: [],
-            quietPeriodMinutes: 45,
-            successfulMainCiRun: undefined
+            quietPeriodMinutes: 45
         });
 
         assert.deepStrictEqual(decision, {
             shouldPublish: false,
             reason: 'ci_not_green',
             logs: ['Skipping publish: no successful ci.yml push run found for main HEAD abc123.']
+        });
+    });
+
+    test('evaluateGitHubReleaseGate blocks publishing while main HEAD CI is still in progress', function () {
+        const decision = evaluateGitHubReleaseGate({
+            ciWorkflowFile: 'ci.yml',
+            mainBranch: 'main',
+            mainCiRunStatus: { kind: 'in_progress' },
+            mainHeadSha: 'abc123',
+            maxLatencyHours: 24,
+            now: createDate('2026-05-19T12:00:00.000Z'),
+            pullRequestActivities: [],
+            quietPeriodMinutes: 45
+        });
+
+        assert.deepStrictEqual(decision, {
+            shouldPublish: false,
+            reason: 'ci_in_progress',
+            logs: ['Skipping publish: a ci.yml push run is still in progress for main HEAD abc123.']
         });
     });
 
@@ -153,18 +175,8 @@ suite('github-release-gate', function () {
     });
 
     test('evaluateGitHubReleaseGate allows publishing once the quiet period has elapsed', function () {
-        const decision = evaluateGitHubReleaseGate({
-            ciWorkflowFile: 'ci.yml',
-            mainBranch: 'main',
-            mainHeadSha: 'abc123',
-            maxLatencyHours: 24,
-            now: createDate('2026-05-19T12:00:00.000Z'),
-            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-19T10:00:00.000Z') })],
-            quietPeriodMinutes: 45,
-            successfulMainCiRun: {
-                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
-                updatedAt: createDate('2026-05-19T11:00:00.000Z')
-            }
+        const decision = evaluateGitHubReleaseGateWithBaseInput({
+            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-19T10:00:00.000Z') })]
         });
 
         assert.strictEqual(decision.shouldPublish, true);
@@ -173,18 +185,8 @@ suite('github-release-gate', function () {
     });
 
     test('evaluateGitHubReleaseGate allows publishing when the quiet-period boundary is reached exactly', function () {
-        const decision = evaluateGitHubReleaseGate({
-            ciWorkflowFile: 'ci.yml',
-            mainBranch: 'main',
-            mainHeadSha: 'abc123',
-            maxLatencyHours: 24,
-            now: createDate('2026-05-19T12:00:00.000Z'),
-            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-19T11:15:00.000Z') })],
-            quietPeriodMinutes: 45,
-            successfulMainCiRun: {
-                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
-                updatedAt: createDate('2026-05-19T11:00:00.000Z')
-            }
+        const decision = evaluateGitHubReleaseGateWithBaseInput({
+            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-19T11:15:00.000Z') })]
         });
 
         assert.strictEqual(decision.shouldPublish, true);
@@ -192,18 +194,9 @@ suite('github-release-gate', function () {
     });
 
     test('evaluateGitHubReleaseGate allows publishing once max latency elapses even with fresh PR activity', function () {
-        const decision = evaluateGitHubReleaseGate({
-            ciWorkflowFile: 'ci.yml',
-            mainBranch: 'main',
-            mainHeadSha: 'abc123',
-            maxLatencyHours: 24,
+        const decision = evaluateGitHubReleaseGateWithBaseInput({
             now: createDate('2026-05-20T12:00:00.000Z'),
-            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-20T11:50:00.000Z') })],
-            quietPeriodMinutes: 45,
-            successfulMainCiRun: {
-                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
-                updatedAt: createDate('2026-05-19T11:00:00.000Z')
-            }
+            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-20T11:50:00.000Z') })]
         });
 
         assert.strictEqual(decision.shouldPublish, true);
@@ -213,18 +206,16 @@ suite('github-release-gate', function () {
     });
 
     test('evaluateGitHubReleaseGate allows publishing when the max-latency boundary is reached exactly', function () {
-        const decision = evaluateGitHubReleaseGate({
-            ciWorkflowFile: 'ci.yml',
-            mainBranch: 'main',
-            mainHeadSha: 'abc123',
-            maxLatencyHours: 24,
+        const decision = evaluateGitHubReleaseGateWithBaseInput({
+            mainCiRunStatus: {
+                kind: 'success',
+                run: {
+                    htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
+                    updatedAt: createDate('2026-05-19T12:00:00.000Z')
+                }
+            },
             now: createDate('2026-05-20T12:00:00.000Z'),
-            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-20T11:59:00.000Z') })],
-            quietPeriodMinutes: 45,
-            successfulMainCiRun: {
-                htmlUrl: 'https://github.com/enormora/packtory/actions/runs/1',
-                updatedAt: createDate('2026-05-19T12:00:00.000Z')
-            }
+            pullRequestActivities: [pullRequestActivity({ activityAt: createDate('2026-05-20T11:59:00.000Z') })]
         });
 
         assert.strictEqual(decision.shouldPublish, true);

--- a/source/github-release-gate/release-gate.ts
+++ b/source/github-release-gate/release-gate.ts
@@ -11,15 +11,21 @@ export type PullRequestActivity = {
     readonly number: number;
 };
 
-export type SuccessfulMainCiRun = {
+type SuccessfulMainCiRun = {
     readonly htmlUrl: string;
     readonly updatedAt: Date;
 };
+
+export type MainCiRunStatus =
+    | { readonly kind: 'in_progress' }
+    | { readonly kind: 'missing' }
+    | { readonly kind: 'success'; readonly run: SuccessfulMainCiRun };
 
 export type GitHubReleaseGateDecision = {
     readonly logs: readonly string[];
     readonly reason:
         | 'activity_not_stale'
+        | 'ci_in_progress'
         | 'ci_not_green'
         | 'dependency_only_min_age_elapsed'
         | 'dependency_only_min_age_not_elapsed'
@@ -33,12 +39,12 @@ export type GitHubReleaseGateDecision = {
 export type GitHubReleaseGateInput = {
     readonly ciWorkflowFile: string;
     readonly mainBranch: string;
+    readonly mainCiRunStatus: MainCiRunStatus;
     readonly mainHeadSha: string;
     readonly maxLatencyHours: number;
     readonly now: Date;
     readonly pullRequestActivities: readonly PullRequestActivity[];
     readonly quietPeriodMinutes: number;
-    readonly successfulMainCiRun: SuccessfulMainCiRun | undefined;
 };
 
 const millisecondsPerMinute = 60_000;
@@ -99,6 +105,14 @@ function createMissingCiDecision(input: GitHubReleaseGateInput): GitHubReleaseGa
     return createDecision(false, 'ci_not_green', [], missingCiLog);
 }
 
+function createInProgressCiDecision(input: GitHubReleaseGateInput): GitHubReleaseGateDecision {
+    const inProgressLog =
+        `Skipping publish: a ${input.ciWorkflowFile} push run is still in progress for ${input.mainBranch} ` +
+        `HEAD ${input.mainHeadSha}.`;
+
+    return createDecision(false, 'ci_in_progress', [], inProgressLog);
+}
+
 function hasElapsed(now: Date, since: Date, elapsedMilliseconds: number): boolean {
     return now.getTime() - since.getTime() >= elapsedMilliseconds;
 }
@@ -155,12 +169,11 @@ export function selectPullRequestActivityAt(
     return maxDate(pullRequestCreatedAt, branchActivityDates);
 }
 
-export function evaluateGitHubReleaseGate(input: GitHubReleaseGateInput): GitHubReleaseGateDecision {
-    if (input.successfulMainCiRun === undefined) {
-        return createMissingCiDecision(input);
-    }
-
-    const mainHeadCiSuccessAt = input.successfulMainCiRun.updatedAt;
+function evaluateGreenCiGate(
+    input: GitHubReleaseGateInput,
+    successfulMainCiRun: SuccessfulMainCiRun
+): GitHubReleaseGateDecision {
+    const mainHeadCiSuccessAt = successfulMainCiRun.updatedAt;
     const lastRelevantActivityAt = lastRelevantActivityAtFor(input, mainHeadCiSuccessAt);
     const { quietPeriodElapsed, maxLatencyElapsed } = getElapsedFlags(
         input,
@@ -170,7 +183,7 @@ export function evaluateGitHubReleaseGate(input: GitHubReleaseGateInput): GitHub
     const logs = buildDecisionLogs({
         input,
         mainHeadCiSuccessAt,
-        mainHeadCiSuccessHtmlUrl: input.successfulMainCiRun.htmlUrl,
+        mainHeadCiSuccessHtmlUrl: successfulMainCiRun.htmlUrl,
         lastRelevantActivityAt,
         quietPeriodElapsed,
         maxLatencyElapsed
@@ -191,4 +204,16 @@ export function evaluateGitHubReleaseGate(input: GitHubReleaseGateInput): GitHub
         logs,
         'Publishing is allowed by the release gate.'
     );
+}
+
+export function evaluateGitHubReleaseGate(input: GitHubReleaseGateInput): GitHubReleaseGateDecision {
+    if (input.mainCiRunStatus.kind === 'in_progress') {
+        return createInProgressCiDecision(input);
+    }
+
+    if (input.mainCiRunStatus.kind === 'missing') {
+        return createMissingCiDecision(input);
+    }
+
+    return evaluateGreenCiGate(input, input.mainCiRunStatus.run);
 }

--- a/source/packages/github-release-gate/readme.md
+++ b/source/packages/github-release-gate/readme.md
@@ -77,8 +77,10 @@ This means:
 ## Decision Outputs
 
 - `should_publish=true|false`
-- `reason=ci_not_green|activity_not_stale|quiet_period_elapsed|max_latency_elapsed|release_unchanged|dependency_only_min_age_not_elapsed|dependency_only_min_age_elapsed|dependency_only_published_at_unknown`
+- `reason=ci_not_green|ci_in_progress|activity_not_stale|quiet_period_elapsed|max_latency_elapsed|release_unchanged|dependency_only_min_age_not_elapsed|dependency_only_min_age_elapsed|dependency_only_published_at_unknown`
 - `main_head_sha=<sha>`
+
+`ci_not_green` is reserved for the case where the latest push run for `main` HEAD failed or never started; transient gaps during which the run is still executing are reported as `ci_in_progress` so the next gate evaluation can pick the publish back up once CI completes.
 
 When run inside GitHub Actions, the tool writes these values to `$GITHUB_OUTPUT`.
 

--- a/source/test-libraries/github-release-gate-test-support.ts
+++ b/source/test-libraries/github-release-gate-test-support.ts
@@ -6,8 +6,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 export const ciRunsPath =
-    '/repos/enormora/packtory/actions/workflows/ci.yml/runs' +
-    '?branch=main&event=push&head_sha=abc123&status=completed&per_page=100';
+    '/repos/enormora/packtory/actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=abc123&per_page=100';
 export const pullsPath = '/repos/enormora/packtory/pulls?state=open&base=main&per_page=100';
 export const timelinePath = '/repos/enormora/packtory/issues/1/timeline?per_page=100';
 export const workspaceOutputPath = '/workspace/github-output.txt';
@@ -87,6 +86,7 @@ export function createBaseRoutes(): RouteMap {
                         event: 'push',
                         head_sha: 'abc123',
                         html_url: 'https://github.com/enormora/packtory/actions/runs/1',
+                        status: 'completed',
                         updated_at: '2026-05-19T10:00:00.000Z'
                     }
                 ]


### PR DESCRIPTION
When the publish workflow is dispatched right after a merge, the CI run for `main` HEAD may still be executing. `evaluateGitHubReleaseGate` was reporting that race as `ci_not_green`, the same bucket as a genuine failure, which made the log line "Skipping publish because ci_not_green" misleading.

The gate now drops the `status=completed` filter from the GitHub `listWorkflowRuns` query and classifies the matching run into a `MainCiRunStatus` discriminated union, emitting a new `ci_in_progress` reason for the transient case. A parallel success still beats an in-progress sibling. `ci_not_green` keeps its original meaning of a missing or failed run.
