### PR TITLE
Retry `packtory publish` once on transient sigstore Rekor 409s

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,4 +84,18 @@ jobs:
             - name: Compile TypeScript
               run: npx just compile
             - name: Publish packages
+              id: publish-packages
+              continue-on-error: true
               run: npx packtory publish --no-dry-run
+            # The `sigstore` wrapper used by `libnpmpublish` hardcodes
+            # `fetchOnConflict: false`, so a retried Rekor POST after a
+            # transient blip surfaces as
+            # `error creating tlog entry - (409) an equivalent entry already exists`
+            # even though the original submission landed. Re-running publish
+            # mints a fresh OIDC cert, so the next signature differs and
+            # Rekor accepts it.
+            - name: Re-publish after a transient sigstore failure
+              if: steps.publish-packages.outcome == 'failure'
+              run: |
+                  sleep 10
+                  npx packtory publish --no-dry-run


### PR DESCRIPTION
`libnpmpublish` calls into `sigstore.attest()` whose initializer hardcodes `fetchOnConflict: false` (`sigstore/dist/config.js:105`). When `@sigstore/sign` retries a Rekor POST after a transient blip the original submission silently lands and the retry surfaces as `error creating tlog entry - (409) an equivalent entry already exists`. Each fresh workflow run mints a new GitHub OIDC token and Fulcio cert, so a re-run produces a new signature and Rekor accepts it.

Mark `Publish packages` as `continue-on-error: true` and add `Re-publish after a transient sigstore failure`, gated on `outcome == 'failure'`. `packtory`'s release analysis skips packages that already landed in the partial attempt, so the retry is idempotent.

The same root cause was acknowledged by the Sigstore maintainer on [`actions/attest-build-provenance#110`](https://github.com/actions/attest-build-provenance/issues/110); `actions/toolkit` works around it by bypassing the `sigstore` wrapper and calling `@sigstore/sign` directly with `fetchOnConflict: true`. That path is not reachable through `libnpmpublish`, so a job-level retry is the narrowest in-tree workaround.
