### PR TITLE
Preserve entry-point re-export targets during dead-code elimination

### DIFF
--- a/source/dead-code-eliminator/reachability/local-seed-gathering.ts
+++ b/source/dead-code-eliminator/reachability/local-seed-gathering.ts
@@ -1,4 +1,4 @@
-import type { SourceFile, Statement } from 'ts-morph';
+import { Node as TsMorphNode, type SourceFile, type Statement } from 'ts-morph';
 import type { DeadCodeEliminationSettings } from '../../config/dead-code-elimination-settings.ts';
 import { bindingId, type FileBindingSet } from './binding-id.ts';
 import { collectIdentifierTargets, type DeclarationNodeIndex } from './identifier-target-collector.ts';
@@ -20,6 +20,20 @@ function addStatementSeeds(
     }
 }
 
+function addEntryPointExportDeclarationSeeds(
+    file: FileBindings,
+    declarationIndex: DeclarationNodeIndex,
+    seeds: Set<string>
+): void {
+    for (const statement of file.sourceFile.getStatements()) {
+        if (TsMorphNode.isExportDeclaration(statement)) {
+            for (const target of collectIdentifierTargets(statement, declarationIndex)) {
+                seeds.add(target);
+            }
+        }
+    }
+}
+
 export function gatherLocalSeeds(
     files: readonly FileBindings[],
     entryPointFilePaths: ReadonlySet<string>,
@@ -33,6 +47,9 @@ export function gatherLocalSeeds(
             if (isEntry && binding.isExported) {
                 seeds.add(bindingId(file.sourceFilePath, binding.name));
             }
+        }
+        if (isEntry) {
+            addEntryPointExportDeclarationSeeds(file, declarationIndex, seeds);
         }
         addStatementSeeds(collectImpureStatements(file.sourceFile, deadCodeElimination), declarationIndex, seeds);
     }

--- a/source/dead-code-eliminator/reachability/reachability.test.ts
+++ b/source/dead-code-eliminator/reachability/reachability.test.ts
@@ -27,18 +27,18 @@ function multiFileBindingsFor(
     });
 }
 
-function reachabilityForCspellConfigExport(entryPointExportDeclaration: string): ReachabilityIndex {
+function reachabilityForReExportTarget(entryPointExportDeclaration: string): ReachabilityIndex {
     const files = multiFileBindingsFor([
         {
             filePath: 'entry.ts',
             content: entryPointExportDeclaration
         },
         {
-            filePath: 'cspell-config.ts',
+            filePath: 'target.ts',
             content: [
-                'function buildWords() { return 1; }',
-                'export function withCspellWords() { return buildWords(); }',
-                'export function unusedWords() { return 2; }'
+                'function helper() { return 1; }',
+                'export function used() { return helper(); }',
+                'export function unused() { return 2; }'
             ].join('\n')
         }
     ]);
@@ -60,10 +60,10 @@ function reachabilityForLocalValueExport(entryPointExportDeclaration: string): R
     return buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
 }
 
-function assertCspellConfigExportIsReachable(index: ReachabilityIndex): void {
-    assert.ok(index.localReachable.has(bindingId('cspell-config.ts', 'withCspellWords')));
-    assert.ok(index.localReachable.has(bindingId('cspell-config.ts', 'buildWords')));
-    assert.strictEqual(index.localReachable.has(bindingId('cspell-config.ts', 'unusedWords')), false);
+function assertReExportTargetIsReachable(index: ReachabilityIndex): void {
+    assert.ok(index.localReachable.has(bindingId('target.ts', 'used')));
+    assert.ok(index.localReachable.has(bindingId('target.ts', 'helper')));
+    assert.strictEqual(index.localReachable.has(bindingId('target.ts', 'unused')), false);
 }
 
 function assertLocalValueExportIsReachable(index: ReachabilityIndex): void {
@@ -165,18 +165,16 @@ suite('reachability', function () {
     });
 
     test('keeps a named re-export target from an entry point reachable', function () {
-        const index = reachabilityForCspellConfigExport('export { withCspellWords } from "./cspell-config.ts";');
+        const index = reachabilityForReExportTarget('export { used } from "./target.ts";');
 
-        assertCspellConfigExportIsReachable(index);
+        assertReExportTargetIsReachable(index);
     });
 
     test('keeps an aliased named re-export target from an entry point reachable', function () {
-        const index = reachabilityForCspellConfigExport(
-            'export { withCspellWords as withWords } from "./cspell-config.ts";'
-        );
+        const index = reachabilityForReExportTarget('export { used as renamed } from "./target.ts";');
 
-        assertCspellConfigExportIsReachable(index);
-        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'withWords')), false);
+        assertReExportTargetIsReachable(index);
+        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'renamed')), false);
     });
 
     test('does not keep a named re-export target from a non-entry file reachable', function () {

--- a/source/dead-code-eliminator/reachability/reachability.test.ts
+++ b/source/dead-code-eliminator/reachability/reachability.test.ts
@@ -5,7 +5,7 @@ import { createProject } from '../../test-libraries/typescript-project.ts';
 import { extractTopLevelBindings } from './binding-extractor.ts';
 import { bindingId } from './binding-id.ts';
 import type { FileBindings } from './local-seed-gathering.ts';
-import { buildReachabilityIndex } from './reachability.ts';
+import { buildReachabilityIndex, type ReachabilityIndex } from './reachability.ts';
 
 const probeTestTimeoutMs = 10_000;
 
@@ -25,6 +25,51 @@ function multiFileBindingsFor(
         const sourceFile = project.getSourceFileOrThrow(file.filePath);
         return { sourceFilePath: file.filePath, sourceFile, bindings: extractTopLevelBindings(sourceFile) };
     });
+}
+
+function reachabilityForCspellConfigExport(entryPointExportDeclaration: string): ReachabilityIndex {
+    const files = multiFileBindingsFor([
+        {
+            filePath: 'entry.ts',
+            content: entryPointExportDeclaration
+        },
+        {
+            filePath: 'cspell-config.ts',
+            content: [
+                'function buildWords() { return 1; }',
+                'export function withCspellWords() { return buildWords(); }',
+                'export function unusedWords() { return 2; }'
+            ].join('\n')
+        }
+    ]);
+    return buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+}
+
+function reachabilityForLocalValueExport(entryPointExportDeclaration: string): ReachabilityIndex {
+    const files = [
+        fileBindingsFor(
+            'entry.ts',
+            [
+                'function buildValue() { return 1; }',
+                'const localValue = buildValue();',
+                'const unusedValue = 2;',
+                entryPointExportDeclaration
+            ].join('\n')
+        )
+    ];
+    return buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+}
+
+function assertCspellConfigExportIsReachable(index: ReachabilityIndex): void {
+    assert.ok(index.localReachable.has(bindingId('cspell-config.ts', 'withCspellWords')));
+    assert.ok(index.localReachable.has(bindingId('cspell-config.ts', 'buildWords')));
+    assert.strictEqual(index.localReachable.has(bindingId('cspell-config.ts', 'unusedWords')), false);
+}
+
+function assertLocalValueExportIsReachable(index: ReachabilityIndex): void {
+    assert.ok(index.localReachable.has(bindingId('entry.ts', 'localValue')));
+    assert.ok(index.localReachable.has(bindingId('entry.ts', 'buildValue')));
+    assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'unusedValue')), false);
 }
 
 suite('reachability', function () {
@@ -117,6 +162,54 @@ suite('reachability', function () {
 
         assert.ok(index.localReachable.has(bindingId('helpers.ts', 'used')));
         assert.strictEqual(index.localReachable.has(bindingId('helpers.ts', 'unused')), false);
+    });
+
+    test('keeps a named re-export target from an entry point reachable', function () {
+        const index = reachabilityForCspellConfigExport('export { withCspellWords } from "./cspell-config.ts";');
+
+        assertCspellConfigExportIsReachable(index);
+    });
+
+    test('keeps an aliased named re-export target from an entry point reachable', function () {
+        const index = reachabilityForCspellConfigExport(
+            'export { withCspellWords as withWords } from "./cspell-config.ts";'
+        );
+
+        assertCspellConfigExportIsReachable(index);
+        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'withWords')), false);
+    });
+
+    test('does not keep a named re-export target from a non-entry file reachable', function () {
+        const files = multiFileBindingsFor([
+            {
+                filePath: 'entry.ts',
+                content: ''
+            },
+            {
+                filePath: 'internal.ts',
+                content: 'export { usedValue } from "./values.ts";'
+            },
+            {
+                filePath: 'values.ts',
+                content: 'export const usedValue = 1;'
+            }
+        ]);
+        const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set(['entry.ts']) });
+
+        assert.strictEqual(index.localReachable.has(bindingId('values.ts', 'usedValue')), false);
+    });
+
+    test('keeps a local binding exported through an entry-point export list reachable', function () {
+        const index = reachabilityForLocalValueExport('export { localValue };');
+
+        assertLocalValueExportIsReachable(index);
+    });
+
+    test('keeps a local binding exported through an aliased entry-point export list reachable', function () {
+        const index = reachabilityForLocalValueExport('export { localValue as publicValue };');
+
+        assertLocalValueExportIsReachable(index);
+        assert.strictEqual(index.localReachable.has(bindingId('entry.ts', 'publicValue')), false);
     });
 
     test('keeps every binding reachable that an impure top-level statement references', function () {


### PR DESCRIPTION
Entry points can expose public API through re-export declarations, not only through bindings declared directly in the entry file.

Before this change, dead-code elimination seeded directly exported entry-point bindings, but it did not seed the target bindings behind named re-exports such as:

export { withCspellWords } from './cspell-config.js';

That could leave the public re-export in place while removing the actual exported binding from the target file. The generated package was then syntactically valid but semantically broken, because Node could not link the module graph anymore.

This change treats entry-point export declarations as public API seeds. The target binding behind a named re-export is preserved, including aliased re-exports and local export lists.

Unused bindings in the same target file are still removable. The intent is not to disable dead-code elimination or preserve whole files. The intent is to make the reachability model match the package surface that ES modules expose.