### PR TITLE
Add `planReleaseAgainstLatestPublished` API

### DIFF
--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -90,6 +90,12 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
             diffAgainstLatestPublished: createSpy(overrides.diffAgainstLatestPublished, () => {
                 return fake.resolves(toReleaseDiffOutcome(Result.ok([])));
             }),
+            planReleaseAgainstLatestPublished: fake.resolves({
+                result: Result.ok({ packages: [] }),
+                getReport() {
+                    return createBuildReportFixture();
+                }
+            }),
             resolveAndLinkAll: fake.resolves(toOutcome(Result.ok([]))),
             packPackage: createSpy(overrides.packPackage, () => {
                 return fake.resolves(toOutcome(Result.ok(undefined)));

--- a/source/packages/packtory/packtory.entry-point.ts
+++ b/source/packages/packtory/packtory.entry-point.ts
@@ -15,6 +15,11 @@ import {
     type ReleaseAnalysisResult as PublicReleaseAnalysisResult,
     type ReleaseDiffAllOutcome as PublicReleaseDiffAllOutcome,
     type ReleaseDiffAllResult as PublicReleaseDiffAllResult,
+    type ReleasePlan as PublicReleasePlan,
+    type ReleasePlanOutcome as PublicReleasePlanOutcome,
+    type ReleasePlanPackage as PublicReleasePlanPackage,
+    type ReleasePlanRegistryMetadata as PublicReleasePlanRegistryMetadata,
+    type ReleasePlanResult as PublicReleasePlanResult,
     type ResolveAndLinkAllOptions as PublicResolveAndLinkAllOptions,
     type ResolveAndLinkAllOutcome as PublicResolveAndLinkAllOutcome,
     type ResolveAndLinkAllResult as PublicResolveAndLinkAllResult,
@@ -57,6 +62,7 @@ export const {
     analyzeReleaseAgainstLatestPublished,
     buildAndPublishAll,
     diffAgainstLatestPublished,
+    planReleaseAgainstLatestPublished,
     resolveAndLinkAll,
     packPackage
 } = packtory;
@@ -77,6 +83,11 @@ export type ReleaseAnalysisOutcome = PublicReleaseAnalysisOutcome;
 export type ReleaseAnalysisResult = PublicReleaseAnalysisResult;
 export type ReleaseDiffAllOutcome = PublicReleaseDiffAllOutcome;
 export type ReleaseDiffAllResult = PublicReleaseDiffAllResult;
+export type ReleasePlan = PublicReleasePlan;
+export type ReleasePlanOutcome = PublicReleasePlanOutcome;
+export type ReleasePlanPackage = PublicReleasePlanPackage;
+export type ReleasePlanRegistryMetadata = PublicReleasePlanRegistryMetadata;
+export type ReleasePlanResult = PublicReleasePlanResult;
 export type ResolveAndLinkAllOptions = PublicResolveAndLinkAllOptions;
 export type ResolveAndLinkAllOutcome = PublicResolveAndLinkAllOutcome;
 export type ResolveAndLinkAllResult = PublicResolveAndLinkAllResult;

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -4,12 +4,18 @@ import type { PublicationOutcome } from '../../bundle-emitter/publication-outcom
 import type { MetadataAuthMode, PublishAuthStrategy } from '../../config/registry-settings.ts';
 import type {
     buildAndPublishAll,
+    planReleaseAgainstLatestPublished,
     progressBroadcastConsumer,
     resolveAndLinkAll,
     BuildReport,
     PacktoryConfig,
     PublishAllOutcome,
     PublishAllResult,
+    ReleasePlan,
+    ReleasePlanOutcome,
+    ReleasePlanPackage,
+    ReleasePlanRegistryMetadata,
+    ReleasePlanResult,
     ResolveAndLinkAllOutcome,
     ResolveAndLinkAllResult,
     ResolveAndLinkFailure,
@@ -33,6 +39,10 @@ type ErrVariant<TResult> = Extract<TResult, { isErr: true }>;
 type PublishOk = OkVariant<PublishAllResult>['value'];
 type PublishErr = ErrVariant<PublishAllResult>['error'];
 type BuildAndPublishResult = PublishOk[number];
+type ReleasePlanOk = OkVariant<ReleasePlanResult>['value'];
+type ReleasePlanErr = ErrVariant<ReleasePlanResult>['error'];
+type ResultFailureType = 'checks' | 'config' | 'partial';
+type ReleasePlanArtifactState = 'changed' | 'first-publish' | 'unchanged';
 
 describe('public functions', () => {
     test('buildAndPublishAll takes an unknown config and build options and returns a PublishAllOutcome', () => {
@@ -47,6 +57,12 @@ describe('public functions', () => {
     test('resolveAndLinkAll takes an unknown config and returns a ResolveAndLinkAllOutcome', () => {
         expect<typeof resolveAndLinkAll>().type.toBe<
             (config: unknown, options?: { readonly collectReport?: boolean }) => Promise<ResolveAndLinkAllOutcome>
+        >();
+    });
+
+    test('planReleaseAgainstLatestPublished takes an unknown config and returns a ReleasePlanOutcome', () => {
+        expect<typeof planReleaseAgainstLatestPublished>().type.toBe<
+            (config: unknown) => Promise<ReleasePlanOutcome>
         >();
     });
 });
@@ -68,6 +84,16 @@ describe('ResolveAndLinkAllOutcome', () => {
 
     test('exposes a getReport method that returns BuildReport or undefined', () => {
         expect<ResolveAndLinkAllOutcome['getReport']>().type.toBe<() => BuildReport | undefined>();
+    });
+});
+
+describe('ReleasePlanOutcome', () => {
+    test('exposes the wrapped result', () => {
+        expect<ReleasePlanOutcome['result']>().type.toBe<ReleasePlanResult>();
+    });
+
+    test('exposes a getReport method that returns BuildReport', () => {
+        expect<ReleasePlanOutcome['getReport']>().type.toBe<() => BuildReport>();
     });
 });
 
@@ -252,7 +278,7 @@ describe('PublishAllResult', () => {
     });
 
     test('the failure variant is a discriminated union keyed by `type`', () => {
-        expect<PublishErr['type']>().type.toBe<'checks' | 'config' | 'partial'>();
+        expect<PublishErr['type']>().type.toBe<ResultFailureType>();
     });
 
     test('a checks failure exposes a readonly issues array of strings', () => {
@@ -278,7 +304,41 @@ describe('ResolveAndLinkAllResult', () => {
     });
 
     test('the failure variant is a discriminated union keyed by `type`', () => {
-        expect<ResolveAndLinkFailure['type']>().type.toBe<'checks' | 'config' | 'partial'>();
+        expect<ResolveAndLinkFailure['type']>().type.toBe<ResultFailureType>();
+    });
+});
+
+describe('ReleasePlanResult', () => {
+    test('is a Result of a release plan with a discriminated failure union', () => {
+        expect<ReleasePlanResult>().type.toBe<Result<ReleasePlan, ReleasePlanErr>>();
+        expect<ReleasePlanErr['type']>().type.toBe<ResultFailureType>();
+    });
+
+    test('the ok value exposes release-plan packages', () => {
+        expect<ReleasePlanOk['packages']>().type.toBe<readonly ReleasePlanPackage[]>();
+    });
+
+    test('each package exposes planned versions, artifacts, registry metadata, and sources', () => {
+        expect<ReleasePlanPackage['name']>().type.toBe<string>();
+        expect<ReleasePlanPackage['previousVersion']>().type.toBe<string | undefined>();
+        expect<ReleasePlanPackage['nextVersion']>().type.toBe<string>();
+        expect<ReleasePlanPackage['artifactState']>().type.toBe<ReleasePlanArtifactState>();
+        expect<ReleasePlanPackage['changed']>().type.toBe<boolean>();
+        expect<ReleasePlanPackage['latestRegistryMetadata']>().type.toBe<ReleasePlanRegistryMetadata | undefined>();
+        expect<ReleasePlanPackage['artifactFiles']>().type.toBe<readonly string[]>();
+        expect<ReleasePlanPackage['changedArtifactFiles']>().type.toBe<readonly string[]>();
+        expect<ReleasePlanPackage['sourceFiles']>().type.toBe<readonly string[]>();
+    });
+
+    test('registry metadata exposes the latest version and optional publish date', () => {
+        expect<ReleasePlanRegistryMetadata['version']>().type.toBe<string>();
+        expect<ReleasePlanRegistryMetadata['publishedAt']>().type.toBe<Date | undefined>();
+    });
+
+    test('a partial failure carries succeeded package plans and a list of errors', () => {
+        type PartialFailure = Extract<ReleasePlanErr, { type: 'partial' }>;
+        expect<PartialFailure['succeeded']>().type.toBe<readonly ReleasePlanPackage[]>();
+        expect<PartialFailure['failures']>().type.toBe<readonly Error[]>();
     });
 });
 

--- a/source/packages/packtory/readme.md
+++ b/source/packages/packtory/readme.md
@@ -7,6 +7,7 @@ This package provides an API for the `packtory` tool, enabling programmatic usag
 - `buildAndPublishAll(config, options)` – validates the configuration, builds every package, runs the enabled checks, and (optionally) publishes the results.
 - `resolveAndLinkAll(config)` – performs the validation, resolve, link, and checks phases without publishing. This is useful for custom workflows and integration tests that only need the prepared bundles.
 - `diffAgainstLatestPublished(config)` – validates and builds every package without publishing, then per package computes the file-level diff between the bundle the next publish would produce and the version currently tagged `latest` on the configured registry.
+- `planReleaseAgainstLatestPublished(config)` – validates and builds every package without publishing, then returns per-package release state, planned versions, artifact file paths, changed artifact file paths, latest registry metadata, and source file paths.
 - `packPackage(config, options)` – validates the configuration, runs the same resolve / link / checks pipeline as `buildAndPublishAll`, and writes a single configured package to disk as a zip, tarball, or expanded folder. Useful when you need an artifact you control (Lambda zip, container build context, local inspection) instead of a registry publish.
 
 **Installation:**
@@ -18,7 +19,7 @@ npm install packtory
 **Usage:**
 
 ```javascript
-import { buildAndPublishAll, resolveAndLinkAll, packPackage } from 'packtory';
+import { buildAndPublishAll, resolveAndLinkAll, planReleaseAgainstLatestPublished, packPackage } from 'packtory';
 
 const config = {
     /* your packtory configuration */
@@ -30,6 +31,9 @@ const config = {
 
     const resolvedOutcome = await resolveAndLinkAll(config);
     console.log(resolvedOutcome.result);
+
+    const releasePlanOutcome = await planReleaseAgainstLatestPublished(config);
+    console.log(releasePlanOutcome.result);
 
     const packOutcome = await packPackage(config, {
         packageName: 'image-resizer-cli',
@@ -57,6 +61,7 @@ const config = {
 - Stage mode is npm-only. The package must already exist on npm, and automatic versioning in stage mode must be able to list pending staged versions before choosing the next version. If publish auth uses npm OIDC/trusted publishing, provide token-based metadata auth for that lookup.
 - `resolveAndLinkAll` returns a `ResolveAndLinkAllOutcome` whose `result` carries the resolved package information or details about the failure (validation errors, check failures, or partial execution issues).
 - `diffAgainstLatestPublished` returns a `ReleaseDiffAllOutcome` whose `result` carries the per-package release diff list or a failure variant.
+- `planReleaseAgainstLatestPublished` returns a `ReleasePlanOutcome` whose `result` carries `{ packages }` or a failure variant. Each package plan includes `previousVersion`, `nextVersion`, `artifactState`, `changed`, `latestRegistryMetadata`, `artifactFiles`, `changedArtifactFiles`, and `sourceFiles`.
 - `packPackage` returns a `PackOutcome` whose `result` is `Ok(undefined)` on success or a `PackFailure`. `PackFailure` is a discriminated union covering configuration errors, check failures, partial resolve failures, and the pack-specific variants `package-not-found`, `bundle-dependencies-unsupported` (rejected when `vendorDependencies` is `false` and the target declares `bundleDependencies`), and `peer-dependencies-unsatisfied` (raised when a vendored dependency declares a peer that no other vendored package satisfies).
 
 **Note:** Refer to the [full documentation](../../../readme.md) for additional details.

--- a/source/packtory/packtory-release-analysis.test.ts
+++ b/source/packtory/packtory-release-analysis.test.ts
@@ -1,10 +1,17 @@
 import assert from 'node:assert';
 import vm from 'node:vm';
 import { suite, test } from 'mocha';
-import { Maybe, Result } from 'true-myth';
-import { validateConfig, type ValidConfigResult } from '../config/validation.ts';
-import { createIteratingScheduler } from '../test-libraries/iterating-scheduler.ts';
-import { analyzedBundle, versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
+import { Result } from 'true-myth';
+import {
+    buildResultFor,
+    createReleaseTestDependencies,
+    packageProcessorCheckingStage,
+    packageProcessorWithFailure,
+    previousReleaseArtifactsFor,
+    resolvedPackagesFor,
+    validatedReleaseConfigFor,
+    type ReleaseFileCollection
+} from '../test-libraries/release-orchestrator-fixtures.ts';
 import {
     createAnalyzeReleaseAgainstLatestPublishedValidated,
     type ReleaseAnalysisOrchestratorDependencies
@@ -16,107 +23,7 @@ type BuildAndPublishResult = Awaited<
     ReturnType<ReleaseAnalysisOrchestratorDependencies['packageProcessor']['tryBuildAndPublish']>
 >;
 type PackageProcessor = ReleaseAnalysisOrchestratorDependencies['packageProcessor'];
-type FileCollection = ReleaseAnalysisOrchestratorDependencies['artifactsBuilder']['collectContents'];
-const noPublicationOutcome = { type: 'none' } as const;
-
-function validatedConfigFor(packageNames: readonly string[]): ValidConfigResult {
-    const result = validateConfig({
-        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-        packages: packageNames.map((name) => {
-            return {
-                mainPackageJson: { type: 'module' },
-                name,
-                publishSettings: { access: 'public' },
-                roots: { main: { js: `source/${name}.js` } },
-                sourcesFolder: 'source'
-            };
-        })
-    });
-
-    if (result.isErr) {
-        assert.fail(`Expected config to validate: ${result.error.join(', ')}`);
-    }
-
-    return result.value;
-}
-
-function packageProcessorFor(
-    buildResults: readonly BuildAndPublishResult[],
-    onMissingResult: () => never
-): PackageProcessor {
-    let invocation = 0;
-
-    return {
-        async build() {
-            throw new Error('build() should not be called in release-analysis tests');
-        },
-        async buildAndPublish() {
-            throw new Error('buildAndPublish() should not be called in release-analysis dry runs');
-        },
-        async resolveAndLink() {
-            throw new Error('resolveAndLink() should not be called in release-analysis tests');
-        },
-        async tryBuildAndPublish() {
-            const result = buildResults[invocation];
-            invocation += 1;
-            if (result === undefined) {
-                return onMissingResult();
-            }
-
-            return result;
-        }
-    };
-}
-
-function packageProcessorWith(buildResults: readonly BuildAndPublishResult[]): PackageProcessor {
-    return packageProcessorFor(buildResults, () => {
-        throw new Error('Missing build result fixture');
-    });
-}
-
-function packageProcessorWithFailure(buildResults: readonly BuildAndPublishResult[], failure: Error): PackageProcessor {
-    return packageProcessorFor(buildResults, () => {
-        throw failure;
-    });
-}
-
-function buildResultFor(
-    overrides: Partial<BuildAndPublishResult> & { readonly packageName?: string } = {}
-): BuildAndPublishResult {
-    const packageName = overrides.packageName ?? 'pkg-a';
-
-    return {
-        status: 'new-version',
-        publication: noPublicationOutcome,
-        bundle: versionedBundleWithManifest({
-            name: packageName,
-            version: '1.0.1',
-            packageJson: { name: packageName, version: '1.0.1' }
-        }),
-        extraFiles: [],
-        previousReleaseArtifacts: Maybe.nothing(),
-        ...overrides
-    };
-}
-
-const progressBroadcaster: ReleaseAnalysisOrchestratorDependencies['progressBroadcaster'] = {
-    consumer: {
-        off() {
-            return undefined;
-        },
-        on() {
-            return undefined;
-        }
-    },
-    provider: {
-        emit() {
-            return undefined;
-        },
-        hasSubscribers() {
-            return false;
-        }
-    }
-};
+type FileCollection = ReleaseFileCollection;
 
 function createAnalyzer(spec: {
     readonly packageNames: readonly string[];
@@ -124,20 +31,7 @@ function createAnalyzer(spec: {
     readonly collectContents?: ReleaseAnalysisOrchestratorDependencies['artifactsBuilder']['collectContents'];
     readonly packageProcessor?: PackageProcessor;
 }) {
-    const dependencies: ReleaseAnalysisOrchestratorDependencies = {
-        artifactsBuilder: {
-            collectContents:
-                spec.collectContents ??
-                (() => {
-                    return [];
-                })
-        },
-        packageProcessor: spec.packageProcessor ?? packageProcessorWith(spec.buildResults ?? []),
-        progressBroadcaster,
-        scheduler: createIteratingScheduler(spec.packageNames)
-    };
-
-    return createAnalyzeReleaseAgainstLatestPublishedValidated(dependencies);
+    return createAnalyzeReleaseAgainstLatestPublishedValidated(createReleaseTestDependencies(spec));
 }
 
 function expectPartialFailure(result: ReleaseAnalysisResult) {
@@ -148,37 +42,11 @@ function expectPartialFailure(result: ReleaseAnalysisResult) {
     return result.error;
 }
 
-function resolvedPackagesFor(validated: ValidConfigResult): readonly ResolvedPackage[] {
-    return validated.packtoryConfig.packages.map((packageConfig) => {
-        const resolvedPackage: ResolvedPackage = {
-            name: packageConfig.name,
-            analyzedBundle: analyzedBundle({ name: packageConfig.name }),
-            resolveOptions: {
-                name: packageConfig.name,
-                exportPackageJson: packageConfig.exportPackageJson,
-                roots: packageConfig.roots,
-                surface: undefined,
-                sourcesFolder: packageConfig.sourcesFolder ?? 'source',
-                includeSourceMapFiles: packageConfig.includeSourceMapFiles ?? false,
-                additionalFiles: packageConfig.additionalFiles ?? [],
-                mainPackageJson: packageConfig.mainPackageJson ?? { type: 'module' },
-                additionalPackageJsonAttributes: packageConfig.additionalPackageJsonAttributes ?? {},
-                allowMutableSpecifiers: [],
-                deadCodeElimination: packageConfig.deadCodeElimination,
-                bundleDependencies: [],
-                bundlePeerDependencies: []
-            }
-        };
-
-        return resolvedPackage;
-    });
-}
-
 function publishedBuildResultFor(status: BuildAndPublishResult['status'] = 'new-version'): BuildAndPublishResult {
     return buildResultFor({
         status,
         packageName: 'pkg-a',
-        previousReleaseArtifacts: Maybe.just({
+        previousReleaseArtifacts: previousReleaseArtifactsFor({
             version: '1.0.0',
             publishedAt: new Date('2026-05-01T00:00:00.000Z'),
             files: [{ filePath: 'package.json', content: '{"name":"pkg-a","version":"1.0.0"}', isExecutable: false }]
@@ -195,7 +63,7 @@ async function analyzePublishedBuildResult(spec: {
         buildResults: [publishedBuildResultFor(spec.status)],
         collectContents: spec.collectContents
     });
-    const validated = validatedConfigFor(['pkg-a']);
+    const validated = validatedReleaseConfigFor(['pkg-a']);
 
     return analyze(validated, async () => {
         return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
@@ -205,7 +73,7 @@ async function analyzePublishedBuildResult(spec: {
 async function analyzePartialPublishFailure(
     collectContents: FileCollection
 ): Promise<ReturnType<typeof expectPartialFailure>> {
-    const validated = validatedConfigFor(['pkg-a', 'pkg-b']);
+    const validated = validatedReleaseConfigFor(['pkg-a', 'pkg-b']);
     const analyze = createAnalyzer({
         packageNames: ['pkg-a', 'pkg-b'],
         packageProcessor: packageProcessorWithFailure([publishedBuildResultFor()], new Error('publish failed')),
@@ -229,24 +97,10 @@ function dependencyOnlyFiles(version: string): readonly {
 
 suite('packtory-release-analysis', function () {
     test('runs dry-run publish analysis with staged publishing disabled', async function () {
-        const validated = validatedConfigFor(['pkg-a']);
+        const validated = validatedReleaseConfigFor(['pkg-a']);
         const analyze = createAnalyzer({
             packageNames: ['pkg-a'],
-            packageProcessor: {
-                async build() {
-                    throw new Error('build() should not be called in release-analysis tests');
-                },
-                async buildAndPublish() {
-                    throw new Error('buildAndPublish() should not be called in release-analysis dry runs');
-                },
-                async resolveAndLink() {
-                    throw new Error('resolveAndLink() should not be called in release-analysis tests');
-                },
-                async tryBuildAndPublish(options) {
-                    assert.strictEqual(options.stage, false);
-                    return buildResultFor();
-                }
-            }
+            packageProcessor: packageProcessorCheckingStage(false)
         });
 
         const result = await analyze(validated, async () => {
@@ -258,7 +112,7 @@ suite('packtory-release-analysis', function () {
 
     test('passes non-partial resolve failures through unchanged', async function () {
         const analyze = createAnalyzer({ packageNames: [] });
-        const validated = validatedConfigFor(['pkg-a']);
+        const validated = validatedReleaseConfigFor(['pkg-a']);
 
         const result = await analyze(validated, async () => {
             return Result.err<readonly ResolvedPackage[], ResolveAndLinkFailure>({
@@ -277,7 +131,7 @@ suite('packtory-release-analysis', function () {
     test('maps partial resolve failures to release-analysis partial failures with empty succeeded entries', async function () {
         const analyze = createAnalyzer({ packageNames: [] });
         const failure = new Error('resolve failed');
-        const validated = validatedConfigFor(['pkg-a']);
+        const validated = validatedReleaseConfigFor(['pkg-a']);
 
         const result = await analyze(validated, async () => {
             const resolvedPackages: readonly ResolvedPackage[] = [];
@@ -331,15 +185,14 @@ suite('packtory-release-analysis', function () {
             buildResults: [
                 buildResultFor({
                     status: 'already-published',
-                    packageName: 'pkg-a',
-                    previousReleaseArtifacts: Maybe.nothing()
+                    packageName: 'pkg-a'
                 })
             ],
             collectContents() {
                 throw new Error('collectContents() should not be called');
             }
         });
-        const validated = validatedConfigFor(['pkg-a']);
+        const validated = validatedReleaseConfigFor(['pkg-a']);
 
         const result = await analyze(validated, async () => {
             return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -1,0 +1,353 @@
+import assert from 'node:assert';
+import vm from 'node:vm';
+import { suite, test } from 'mocha';
+import { Result } from 'true-myth';
+import type { ValidConfigResult } from '../config/validation.ts';
+import { analyzedBundleResource } from '../test-libraries/bundle-fixtures.ts';
+import {
+    buildResultFor,
+    createReleaseTestDependencies,
+    packageProcessorCheckingStage,
+    packageProcessorWithFailure,
+    previousReleaseArtifactsFor,
+    resolvedPackagesFor as sharedResolvedPackagesFor,
+    validatedReleaseConfigFor,
+    type ReleaseFileCollection
+} from '../test-libraries/release-orchestrator-fixtures.ts';
+import {
+    createPlanReleaseAgainstLatestPublishedValidated,
+    type ReleasePlanOrchestratorDependencies
+} from './packtory-release-plan.ts';
+import type { ReleasePlanResult, ResolveAndLinkFailure } from './packtory-results.ts';
+import type { ResolvedPackage } from './resolved-package.ts';
+
+type BuildAndPublishResult = Awaited<
+    ReturnType<ReleasePlanOrchestratorDependencies['packageProcessor']['tryBuildAndPublish']>
+>;
+type PackageProcessor = ReleasePlanOrchestratorDependencies['packageProcessor'];
+type FileCollection = ReleaseFileCollection;
+
+function createPlanner(spec: {
+    readonly packageNames: readonly string[];
+    readonly buildResults?: readonly BuildAndPublishResult[];
+    readonly collectContents?: FileCollection;
+    readonly packageProcessor?: PackageProcessor;
+}) {
+    return createPlanReleaseAgainstLatestPublishedValidated(createReleaseTestDependencies(spec));
+}
+
+function resolvedPackagesFor(
+    validated: ValidConfigResult,
+    bundleContents: Readonly<Record<string, readonly ReturnType<typeof analyzedBundleResource>[]>> = {}
+): readonly ResolvedPackage[] {
+    return sharedResolvedPackagesFor(validated, {
+        bundleContents,
+        defaultContents(packageName) {
+            return [analyzedBundleResource(`/source/${packageName}.js`)];
+        }
+    });
+}
+
+async function planFor(spec: {
+    readonly packageNames: readonly string[];
+    readonly buildResults: readonly BuildAndPublishResult[];
+    readonly collectContents: FileCollection;
+    readonly bundleContents?: Readonly<Record<string, readonly ReturnType<typeof analyzedBundleResource>[]>>;
+}): Promise<ReleasePlanResult> {
+    const validated = validatedReleaseConfigFor(spec.packageNames);
+    const plan = createPlanner({
+        packageNames: spec.packageNames,
+        buildResults: spec.buildResults,
+        collectContents: spec.collectContents
+    });
+
+    return plan(validated, async () => {
+        return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(
+            resolvedPackagesFor(validated, spec.bundleContents)
+        );
+    });
+}
+
+function publishedBuildResultFor(status: BuildAndPublishResult['status'] = 'new-version'): BuildAndPublishResult {
+    return buildResultFor({
+        status,
+        packageName: 'pkg-a',
+        previousReleaseArtifacts: previousReleaseArtifactsFor({
+            version: '1.0.0',
+            publishedAt: new Date('2026-05-01T00:00:00.000Z'),
+            files: [
+                { filePath: 'package/index.js', content: 'old', isExecutable: false },
+                { filePath: 'package/removed.js', content: 'removed', isExecutable: false }
+            ]
+        })
+    });
+}
+
+function expectPlan(result: ReleasePlanResult) {
+    if (result.isErr) {
+        assert.fail(`Expected release plan, got ${result.error.type}`);
+    }
+    return result.value;
+}
+
+function expectPartialFailure(result: ReleasePlanResult) {
+    if (result.isOk || result.error.type !== 'partial') {
+        assert.fail('Expected a partial release-plan failure');
+    }
+    return result.error;
+}
+
+suite('packtory-release-plan', function () {
+    test('runs dry-run release planning with staged publishing disabled', async function () {
+        const validated = validatedReleaseConfigFor(['pkg-a']);
+        const plan = createPlanner({
+            packageNames: ['pkg-a'],
+            packageProcessor: packageProcessorCheckingStage(false)
+        });
+
+        const result = await plan(validated, async () => {
+            return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
+        });
+
+        assert.strictEqual(result.isOk, true);
+    });
+
+    test('plans first publishes with all current artifact files marked as changed', async function () {
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [buildResultFor({ status: 'initial-version', version: '0.1.0' })],
+            collectContents(_bundle, prefix) {
+                assert.strictEqual(prefix, 'package');
+                return [
+                    { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                    { filePath: 'package/index.js', content: 'new', isExecutable: false },
+                    { filePath: 'readme.md', content: 'readme', isExecutable: false }
+                ];
+            }
+        });
+
+        assert.deepStrictEqual(expectPlan(result).packages, [
+            {
+                name: 'pkg-a',
+                previousVersion: undefined,
+                nextVersion: '0.1.0',
+                artifactState: 'first-publish',
+                changed: true,
+                latestRegistryMetadata: undefined,
+                artifactFiles: ['index.js', 'package.json', 'readme.md'],
+                changedArtifactFiles: ['index.js', 'package.json', 'readme.md'],
+                sourceFiles: ['/source/pkg-a.js']
+            }
+        ]);
+    });
+
+    test('plans changed packages from added, removed, and modified artifact paths', async function () {
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [publishedBuildResultFor()],
+            collectContents() {
+                return [
+                    { filePath: 'package/index.js', content: 'new', isExecutable: false },
+                    { filePath: 'package/extra.js', content: 'extra', isExecutable: false }
+                ];
+            }
+        });
+
+        assert.deepStrictEqual(expectPlan(result).packages[0], {
+            name: 'pkg-a',
+            previousVersion: '1.0.0',
+            nextVersion: '1.0.1',
+            artifactState: 'changed',
+            changed: true,
+            latestRegistryMetadata: {
+                version: '1.0.0',
+                publishedAt: new Date('2026-05-01T00:00:00.000Z')
+            },
+            artifactFiles: ['extra.js', 'index.js'],
+            changedArtifactFiles: ['extra.js', 'index.js', 'removed.js'],
+            sourceFiles: ['/source/pkg-a.js']
+        });
+    });
+
+    test('plans unchanged packages with current artifact files and no changed files', async function () {
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [publishedBuildResultFor('already-published')],
+            collectContents() {
+                return [{ filePath: 'package/index.js', content: 'old', isExecutable: false }];
+            }
+        });
+
+        assert.deepStrictEqual(expectPlan(result).packages[0], {
+            name: 'pkg-a',
+            previousVersion: '1.0.0',
+            nextVersion: '1.0.1',
+            artifactState: 'unchanged',
+            changed: false,
+            latestRegistryMetadata: {
+                version: '1.0.0',
+                publishedAt: new Date('2026-05-01T00:00:00.000Z')
+            },
+            artifactFiles: ['index.js'],
+            changedArtifactFiles: [],
+            sourceFiles: ['/source/pkg-a.js']
+        });
+    });
+
+    test('preserves succeeded package plans when a later dry-run publish fails', async function () {
+        const validated = validatedReleaseConfigFor(['pkg-a', 'pkg-b']);
+        const failure = new Error('publish failed');
+        const plan = createPlanner({
+            packageNames: ['pkg-a', 'pkg-b'],
+            packageProcessor: packageProcessorWithFailure([buildResultFor({ packageName: 'pkg-a' })], failure),
+            collectContents() {
+                return [{ filePath: 'package/index.js', content: 'new', isExecutable: false }];
+            }
+        });
+
+        const partial = expectPartialFailure(
+            await plan(validated, async () => {
+                return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
+            })
+        );
+
+        assert.strictEqual(partial.succeeded.length, 1);
+        assert.strictEqual(partial.succeeded[0]?.name, 'pkg-a');
+        assert.deepStrictEqual(partial.failures, [failure]);
+    });
+
+    test('returns a partial failure when building a package plan throws after publish succeeds', async function () {
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [buildResultFor()],
+            collectContents() {
+                throw new Error('collect failed');
+            }
+        });
+
+        const partial = expectPartialFailure(result);
+        assert.deepStrictEqual(partial.succeeded, []);
+        assert.match(partial.failures[0]?.message ?? '', /collect failed/u);
+    });
+
+    test('returns a partial failure when a publish result has no matching analyzed bundle', async function () {
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [buildResultFor({ packageName: 'pkg-other' })],
+            collectContents() {
+                return [{ filePath: 'package/index.js', content: 'new', isExecutable: false }];
+            }
+        });
+
+        const partial = expectPartialFailure(result);
+        assert.deepStrictEqual(partial.succeeded, []);
+        assert.match(partial.failures[0]?.message ?? '', /Analyzed bundle for package "pkg-other" is missing/u);
+    });
+
+    test('wraps non-Error plan failures in Error objects', async function () {
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [buildResultFor()],
+            collectContents() {
+                return vm.runInNewContext("throw 'collect failed'") as readonly {
+                    readonly content: string;
+                    readonly filePath: string;
+                    readonly isExecutable: false;
+                }[];
+            }
+        });
+
+        const partial = expectPartialFailure(result);
+        assert.match(partial.failures[0]?.message ?? '', /collect failed/u);
+    });
+
+    test('falls back to plan-stage succeeded entries when publish and plan mapping both fail', async function () {
+        const validated = validatedReleaseConfigFor(['pkg-a', 'pkg-b']);
+        const plan = createPlanner({
+            packageNames: ['pkg-a', 'pkg-b'],
+            packageProcessor: packageProcessorWithFailure(
+                [buildResultFor({ packageName: 'pkg-a' })],
+                new Error('publish failed')
+            ),
+            collectContents() {
+                throw new Error('collect failed');
+            }
+        });
+
+        const partial = expectPartialFailure(
+            await plan(validated, async () => {
+                return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
+            })
+        );
+
+        assert.deepStrictEqual(partial.succeeded, []);
+        assert.match(partial.failures[0]?.message ?? '', /publish failed/u);
+    });
+
+    test('passes non-partial resolve failures through unchanged', async function () {
+        const releasePlan = createPlanner({ packageNames: [] });
+        const validated = validatedReleaseConfigFor(['pkg-a']);
+        const stopWithConfigFailure = async () => {
+            return Result.err<readonly ResolvedPackage[], ResolveAndLinkFailure>({
+                type: 'config',
+                issues: ['bad']
+            });
+        };
+
+        const result = await releasePlan(validated, stopWithConfigFailure);
+
+        if (result.isErr) {
+            assert.strictEqual(result.error.type, 'config');
+            return;
+        }
+
+        assert.fail('Expected an error result');
+    });
+
+    test('excludes generated manifests and includes substituted and additional source files', async function () {
+        const generatedManifest = {
+            ...analyzedBundleResource('/source/package.json', { targetFilePath: 'package.json' }),
+            isGeneratedManifest: true as const
+        };
+        const result = await planFor({
+            packageNames: ['pkg-a'],
+            buildResults: [buildResultFor()],
+            collectContents() {
+                return [{ filePath: 'package/index.js', content: 'new', isExecutable: false }];
+            },
+            bundleContents: {
+                'pkg-a': [
+                    generatedManifest,
+                    analyzedBundleResource('/source/index.js'),
+                    analyzedBundleResource('/source/index.js'),
+                    analyzedBundleResource('/source/substituted.js', { isSubstituted: true }),
+                    analyzedBundleResource('/assets/readme.md', { targetFilePath: 'readme.md' })
+                ]
+            }
+        });
+
+        assert.deepStrictEqual(expectPlan(result).packages[0]?.sourceFiles, [
+            '/assets/readme.md',
+            '/source/index.js',
+            '/source/substituted.js'
+        ]);
+    });
+
+    test('maps partial resolve failures to release-plan partial failures with empty succeeded entries', async function () {
+        const plan = createPlanner({ packageNames: [] });
+        const failure = new Error('resolve failed');
+        const validated = validatedReleaseConfigFor(['pkg-a']);
+
+        const partial = expectPartialFailure(
+            await plan(validated, async () => {
+                return Result.err<readonly ResolvedPackage[], ResolveAndLinkFailure>({
+                    type: 'partial',
+                    error: { succeeded: [], failures: [failure] }
+                });
+            })
+        );
+
+        assert.deepStrictEqual(partial.succeeded, []);
+        assert.deepStrictEqual(partial.failures, [failure]);
+    });
+});

--- a/source/packtory/packtory-release-plan.ts
+++ b/source/packtory/packtory-release-plan.ts
@@ -1,0 +1,133 @@
+import { Result } from 'true-myth';
+import type { ValidConfigResult } from '../config/validation.ts';
+import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import {
+    partialFailureType,
+    releasePlanPartialFailure,
+    type ReleasePlanFailure,
+    type ReleasePlanPackage,
+    type ReleasePlanResult,
+    type ResolveAndLinkFailure
+} from './packtory-results.ts';
+import type { BuildAndPublishResult } from './package-processor.ts';
+import { mapResolvePartialFailure, succeededResultsFrom } from './partial-result.ts';
+import { createReleasePlanPackage, type ReleasePlanMapperDependencies } from './release-plan.ts';
+import type { ResolvedPackage } from './resolved-package.ts';
+import { determineVersionAndPublishAll, type PublishStageDependencies } from './stages/publish-stage.ts';
+
+type ResolveAndLinkAllValidated = (
+    config: ValidConfigResult
+) => Promise<Result<readonly ResolvedPackage[], ResolveAndLinkFailure>>;
+
+export type ReleasePlanOrchestratorDependencies = PublishStageDependencies & ReleasePlanMapperDependencies;
+
+type PublishStageOutcome = Awaited<ReturnType<typeof determineVersionAndPublishAll>>;
+type PlanStageError = {
+    readonly failures: readonly Error[];
+    readonly succeeded: readonly ReleasePlanPackage[];
+};
+
+function toReleasePlanError(error: unknown): Error {
+    return error instanceof Error ? error : new Error(String(error));
+}
+
+function analyzedBundlesByNameFrom(resolvedPackages: readonly ResolvedPackage[]): ReadonlyMap<string, AnalyzedBundle> {
+    return new Map(
+        resolvedPackages.map((resolvedPackage) => {
+            return [resolvedPackage.name, resolvedPackage.analyzedBundle] as const;
+        })
+    );
+}
+
+function appendPackagePlan(args: {
+    readonly artifactsBuilder: ReleasePlanOrchestratorDependencies['artifactsBuilder'];
+    readonly analyzedBundlesByName: ReadonlyMap<string, AnalyzedBundle>;
+    readonly buildResult: BuildAndPublishResult;
+    readonly packages: ReleasePlanPackage[];
+}): void {
+    const analyzedBundle = args.analyzedBundlesByName.get(args.buildResult.bundle.name);
+    if (analyzedBundle === undefined) {
+        throw new Error(`Analyzed bundle for package "${args.buildResult.bundle.name}" is missing`);
+    }
+    args.packages.push(createReleasePlanPackage(args, analyzedBundle, args.buildResult));
+}
+
+async function planSucceededPublishes(
+    artifactsBuilder: ReleasePlanOrchestratorDependencies['artifactsBuilder'],
+    resolvedPackages: readonly ResolvedPackage[],
+    succeededPublish: readonly BuildAndPublishResult[]
+): Promise<Result<readonly ReleasePlanPackage[], PlanStageError>> {
+    const analyzedBundlesByName = analyzedBundlesByNameFrom(resolvedPackages);
+    const packages: ReleasePlanPackage[] = [];
+    const failures: Error[] = [];
+
+    for (const buildResult of succeededPublish) {
+        try {
+            appendPackagePlan({ artifactsBuilder, analyzedBundlesByName, buildResult, packages });
+        } catch (error: unknown) {
+            failures.push(toReleasePlanError(error));
+        }
+    }
+
+    return failures.length === 0 ? Result.ok(packages) : Result.err({ failures, succeeded: packages });
+}
+
+function mapResolveFailureToReleasePlanFailure(error: ResolveAndLinkFailure): ReleasePlanFailure {
+    if (error.type === partialFailureType) {
+        return mapResolvePartialFailure<ReleasePlanPackage>(error);
+    }
+    return error;
+}
+
+function buildPartialFromPublish(
+    publishResult: Extract<PublishStageOutcome, { isErr: true }>,
+    packages: readonly ReleasePlanPackage[]
+): ReleasePlanFailure {
+    return {
+        type: partialFailureType,
+        succeeded: packages,
+        failures: publishResult.error.failures
+    };
+}
+
+function toFinalReleasePlanResult(
+    publishResult: PublishStageOutcome,
+    planResult: Awaited<ReturnType<typeof planSucceededPublishes>>
+): ReleasePlanResult {
+    if (publishResult.isErr) {
+        return Result.err(
+            buildPartialFromPublish(publishResult, planResult.isOk ? planResult.value : planResult.error.succeeded)
+        );
+    }
+
+    if (planResult.isErr) {
+        return Result.err(releasePlanPartialFailure(planResult.error));
+    }
+
+    return Result.ok({ packages: planResult.value });
+}
+
+export function createPlanReleaseAgainstLatestPublishedValidated(
+    dependencies: ReleasePlanOrchestratorDependencies
+): (
+    validated: ValidConfigResult,
+    resolveAndLinkAllValidated: ResolveAndLinkAllValidated
+) => Promise<ReleasePlanResult> {
+    return async function planReleaseAgainstLatestPublishedValidated(validated, resolveAndLinkAllValidated) {
+        const resolved = await resolveAndLinkAllValidated(validated);
+        if (resolved.isErr) {
+            return Result.err(mapResolveFailureToReleasePlanFailure(resolved.error));
+        }
+
+        const publishResult = await determineVersionAndPublishAll(dependencies, validated, resolved.value, {
+            dryRun: true,
+            stage: false
+        });
+        const planResult = await planSucceededPublishes(
+            dependencies.artifactsBuilder,
+            resolved.value,
+            succeededResultsFrom(publishResult)
+        );
+        return toFinalReleasePlanResult(publishResult, planResult);
+    };
+}

--- a/source/packtory/packtory-results.test.ts
+++ b/source/packtory/packtory-results.test.ts
@@ -7,15 +7,19 @@ import {
     configError,
     createPublishAllOutcome,
     createReleaseAnalysisOutcome,
+    createReleasePlanOutcome,
     createResolveAndLinkAllOutcome,
     publishPartialFailure,
     type PublishFailure,
     releaseAnalysisPartialFailure,
+    releasePlanPartialFailure,
     type ReleaseAnalysisFailure,
     resolvePartialFailure,
     type BuildReport,
     type PublishAllResult,
     type ReleaseAnalysisResult,
+    type ReleasePlanPackage,
+    type ReleasePlanResult,
     type ResolveAndLinkAllResult
 } from './packtory-results.ts';
 
@@ -60,6 +64,16 @@ suite('packtory-results', function () {
         );
     });
 
+    test('releasePlanPartialFailure tags a PartialError as a release-plan partial failure', function () {
+        const failure = releasePlanPartialFailure({
+            succeeded: [] as readonly ReleasePlanPackage[],
+            failures: createFailureStub()
+        });
+
+        assert.strictEqual(failure.type, 'partial');
+        assert.deepStrictEqual(failure.failures, [{ message: 'boom' }]);
+    });
+
     test('createPublishAllOutcome captures the result and the report getter', function () {
         const result = Result.err({ type: 'config', issues: [] }) as PublishAllResult;
         const report: BuildReport = {
@@ -85,6 +99,14 @@ suite('packtory-results', function () {
     test('createReleaseAnalysisOutcome captures the result and the report getter', function () {
         const result = Result.err({ type: 'config', issues: [] }) as ReleaseAnalysisResult;
         const outcome = createReleaseAnalysisOutcome(result, () => undefined as never);
+
+        assert.strictEqual(outcome.result, result);
+        assert.strictEqual(outcome.getReport(), undefined);
+    });
+
+    test('createReleasePlanOutcome captures the result and the report getter', function () {
+        const result = Result.err({ type: 'config', issues: [] }) as ReleasePlanResult;
+        const outcome = createReleasePlanOutcome(result, () => undefined as never);
 
         assert.strictEqual(outcome.result, result);
         assert.strictEqual(outcome.getReport(), undefined);

--- a/source/packtory/packtory-results.ts
+++ b/source/packtory/packtory-results.ts
@@ -184,11 +184,51 @@ export function createReleaseAnalysisOutcome(
     return { result, getReport };
 }
 
+export type ReleasePlanRegistryMetadata = {
+    readonly version: string;
+    readonly publishedAt: Date | undefined;
+};
+
+export type ReleasePlanPackage = {
+    readonly name: string;
+    readonly previousVersion: string | undefined;
+    readonly nextVersion: string;
+    readonly artifactState: 'changed' | 'first-publish' | 'unchanged';
+    readonly changed: boolean;
+    readonly latestRegistryMetadata: ReleasePlanRegistryMetadata | undefined;
+    readonly artifactFiles: readonly string[];
+    readonly changedArtifactFiles: readonly string[];
+    readonly sourceFiles: readonly string[];
+};
+
+export type ReleasePlan = {
+    readonly packages: readonly ReleasePlanPackage[];
+};
+
+export type ReleasePlanFailure =
+    | CheckError
+    | ConfigError
+    | (PartialError<ReleasePlanPackage> & { type: typeof partialFailureType });
+export type ReleasePlanResult = Result<ReleasePlan, ReleasePlanFailure>;
+
+export type ReleasePlanOutcome = {
+    readonly result: ReleasePlanResult;
+    readonly getReport: () => BuildReport;
+};
+
+export function createReleasePlanOutcome(result: ReleasePlanResult, getReport: () => BuildReport): ReleasePlanOutcome {
+    return { result, getReport };
+}
+
 export function releaseDiffPartialFailure(error: PartialError<PackageReleaseDiff>): ReleaseDiffFailure {
     return { type: partialFailureType, ...error };
 }
 
 export function releaseAnalysisPartialFailure(error: PartialError<PackageReleaseAnalysis>): ReleaseAnalysisFailure {
+    return { type: partialFailureType, ...error };
+}
+
+export function releasePlanPartialFailure(error: PartialError<ReleasePlanPackage>): ReleasePlanFailure {
     return { type: partialFailureType, ...error };
 }
 
@@ -216,6 +256,7 @@ export type Packtory = {
     analyzeReleaseAgainstLatestPublished: (config: unknown) => Promise<ReleaseAnalysisOutcome>;
     buildAndPublishAll: (config: unknown, options: BuildAndPublishAllOptions) => Promise<PublishAllOutcome>;
     diffAgainstLatestPublished: (config: unknown) => Promise<ReleaseDiffAllOutcome>;
+    planReleaseAgainstLatestPublished: (config: unknown) => Promise<ReleasePlanOutcome>;
     resolveAndLinkAll: (config: unknown, options?: ResolveAndLinkAllOptions) => Promise<ResolveAndLinkAllOutcome>;
     packPackage: (config: unknown, options: PackPublicOptions) => Promise<PackOutcome>;
 };

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -734,6 +734,55 @@ suite('packtory', function () {
         assert.ok(outcome.getReport().packages['package-a']);
     });
 
+    test('planReleaseAgainstLatestPublished() returns config issues when the config with registry is invalid', async function () {
+        const { packtory } = createPacktoryUnderTest();
+
+        const { result } = await packtory.planReleaseAgainstLatestPublished({ invalid: true });
+
+        if (result.isOk) {
+            assert.fail('expected an Err result');
+        }
+        assert.strictEqual(result.error.type, 'config');
+    });
+
+    test('planReleaseAgainstLatestPublished() builds a release plan through the dry-run publish path', async function () {
+        const { packtory, tryBuildAndPublish, buildAndPublish } = createPacktoryUnderTest({
+            collectContents() {
+                return [{ filePath: 'package/index.js', content: 'new', isExecutable: false }];
+            }
+        });
+
+        const { result } = await packtory.planReleaseAgainstLatestPublished(createConfig());
+
+        if (result.isErr) {
+            assert.fail(`expected an Ok result, got ${JSON.stringify(result.error)}`);
+        }
+        assert.deepStrictEqual(result.value.packages, [
+            {
+                name: 'package-a',
+                previousVersion: undefined,
+                nextVersion: '1.0.0',
+                artifactState: 'first-publish',
+                changed: true,
+                latestRegistryMetadata: undefined,
+                artifactFiles: ['index.js'],
+                changedArtifactFiles: ['index.js'],
+                sourceFiles: ['/package-a/index.js']
+            }
+        ]);
+        assert.strictEqual(tryBuildAndPublish.callCount, 1);
+        assert.strictEqual(buildAndPublish.callCount, 0);
+    });
+
+    test('planReleaseAgainstLatestPublished() exposes a getReport and disposes the report aggregator', async function () {
+        const { packtory, progressBroadcaster } = createPacktoryUnderTest();
+
+        const outcome = await packtory.planReleaseAgainstLatestPublished(createConfig());
+
+        assert.ok(outcome.getReport().packages['package-a']);
+        assert.strictEqual(progressBroadcaster.provider.hasSubscribers('inputsResolved'), false);
+    });
+
     const packPublicOptions = {
         packageName: 'package-a',
         format: 'zip' as const,

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -8,6 +8,7 @@ import type { VendorMaterializer } from '../vendor-materializer/vendor-materiali
 import type { VersionManager } from '../version-manager/manager.ts';
 import { createAnalyzeReleaseAgainstLatestPublishedValidated } from './packtory-release-analysis.ts';
 import { createDiffAgainstLatestPublishedValidated } from './packtory-release-diff.ts';
+import { createPlanReleaseAgainstLatestPublishedValidated } from './packtory-release-plan.ts';
 import { createRunPackValidated } from './packtory-pack.ts';
 import { attachAggregator, emitEffectiveConfigPerPackage, maybeAttachAggregator } from './report-attachment.ts';
 import { createResolveAndLinkAllValidated } from './packtory-resolve.ts';
@@ -16,6 +17,7 @@ import {
     createReleaseAnalysisOutcome,
     configError,
     createPackOutcome,
+    createReleasePlanOutcome,
     createPublishAllOutcome,
     createReleaseDiffAllOutcome,
     createResolveAndLinkAllOutcome,
@@ -35,6 +37,11 @@ import {
     type ReleaseAnalysisResult as ReleaseAnalysisResultBase,
     type ReleaseDiffAllOutcome as ReleaseDiffAllOutcomeBase,
     type ReleaseDiffAllResult as ReleaseDiffAllResultBase,
+    type ReleasePlan as ReleasePlanBase,
+    type ReleasePlanOutcome as ReleasePlanOutcomeBase,
+    type ReleasePlanPackage as ReleasePlanPackageBase,
+    type ReleasePlanRegistryMetadata as ReleasePlanRegistryMetadataBase,
+    type ReleasePlanResult as ReleasePlanResultBase,
     type ResolveAndLinkFailure as ResolveAndLinkFailureBase,
     type ResolveAndLinkAllOptions as ResolveAndLinkAllOptionsBase,
     type ResolveAndLinkAllOutcome as ResolveAndLinkAllOutcomeBase,
@@ -50,6 +57,7 @@ export type PublishAllOutcome = PublishAllOutcomeBase;
 export type ResolveAndLinkAllOutcome = ResolveAndLinkAllOutcomeBase;
 export type ReleaseDiffAllOutcome = ReleaseDiffAllOutcomeBase;
 export type ReleaseAnalysisOutcome = ReleaseAnalysisOutcomeBase;
+export type ReleasePlanOutcome = ReleasePlanOutcomeBase;
 export type PackOutcome = PackOutcomeBase;
 export type PackResult = PackResultBase;
 export type PackPublicOptions = PackPublicOptionsBase;
@@ -57,7 +65,11 @@ export type PublishAllResult = PublishAllResultBase;
 export type ResolveAndLinkAllResult = ResolveAndLinkAllResultBase;
 export type ReleaseDiffAllResult = ReleaseDiffAllResultBase;
 export type ReleaseAnalysisResult = ReleaseAnalysisResultBase;
+export type ReleasePlanResult = ReleasePlanResultBase;
 export type ReleaseAnalysis = ReleaseAnalysisBase;
+export type ReleasePlan = ReleasePlanBase;
+export type ReleasePlanPackage = ReleasePlanPackageBase;
+export type ReleasePlanRegistryMetadata = ReleasePlanRegistryMetadataBase;
 export type PackageReleaseAnalysis = PackageReleaseAnalysisBase;
 export type PackageReleaseAnalysisClassification = PackageReleaseAnalysisClassificationBase;
 export type ResolveAndLinkFailure = ResolveAndLinkFailureBase;
@@ -81,6 +93,9 @@ type ValidatedRunners = {
     readonly analyzeReleaseAgainstLatestPublishedValidated: ReturnType<
         typeof createAnalyzeReleaseAgainstLatestPublishedValidated
     >;
+    readonly planReleaseAgainstLatestPublishedValidated: ReturnType<
+        typeof createPlanReleaseAgainstLatestPublishedValidated
+    >;
     readonly runPackValidated: ReturnType<typeof createRunPackValidated>;
 };
 
@@ -91,6 +106,7 @@ function createValidatedRunners(dependencies: PacktoryDependencies): ValidatedRu
         diffAgainstLatestPublishedValidated: createDiffAgainstLatestPublishedValidated(dependencies),
         analyzeReleaseAgainstLatestPublishedValidated:
             createAnalyzeReleaseAgainstLatestPublishedValidated(dependencies),
+        planReleaseAgainstLatestPublishedValidated: createPlanReleaseAgainstLatestPublishedValidated(dependencies),
         runPackValidated: createRunPackValidated(dependencies)
     };
 }
@@ -114,12 +130,12 @@ function ensureAuthConfiguredForRealPublish(
 }
 
 export function createPacktory(dependencies: PacktoryDependencies): Packtory {
-    const { progressBroadcaster } = dependencies;
     const {
         resolveAndLinkAllValidated,
         runBuildAndPublishValidated,
         diffAgainstLatestPublishedValidated,
         analyzeReleaseAgainstLatestPublishedValidated,
+        planReleaseAgainstLatestPublishedValidated,
         runPackValidated
     } = createValidatedRunners(dependencies);
 
@@ -151,7 +167,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         return runReportedOperation({
             config,
             attachReporting() {
-                return maybeAttachAggregator(progressBroadcaster, options?.collectReport);
+                return maybeAttachAggregator(dependencies.progressBroadcaster, options?.collectReport);
             },
             validate: validateConfigWithoutRegistry,
             runValidated: resolveAndLinkAllValidated,
@@ -166,7 +182,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         validated: ValidConfigResult,
         options: BuildAndPublishAllOptions
     ): Promise<PublishAllResult> {
-        emitEffectiveConfigPerPackage(progressBroadcaster, validated.packtoryConfig);
+        emitEffectiveConfigPerPackage(dependencies.progressBroadcaster, validated.packtoryConfig);
         return runBuildAndPublishValidated(validated, options, resolveAndLinkAllValidated);
     }
 
@@ -177,7 +193,7 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         return runReportedOperation({
             config,
             attachReporting() {
-                return maybeAttachAggregator(progressBroadcaster, options.collectReport);
+                return maybeAttachAggregator(dependencies.progressBroadcaster, options.collectReport);
             },
             validate: validateConfig,
             async runValidated(validated) {
@@ -208,11 +224,11 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         return runReportedOperation({
             config,
             attachReporting() {
-                return attachAggregator(progressBroadcaster);
+                return attachAggregator(dependencies.progressBroadcaster);
             },
             validate: validateConfig,
             async runValidated(validated) {
-                emitEffectiveConfigPerPackage(progressBroadcaster, validated.packtoryConfig);
+                emitEffectiveConfigPerPackage(dependencies.progressBroadcaster, validated.packtoryConfig);
                 return diffAgainstLatestPublishedValidated(validated, resolveAndLinkAllValidated);
             },
             createValidationErrorResult(issues) {
@@ -226,11 +242,11 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         return runReportedOperation({
             config,
             attachReporting() {
-                return attachAggregator(progressBroadcaster);
+                return attachAggregator(dependencies.progressBroadcaster);
             },
             validate: validateConfig,
             async runValidated(validated) {
-                emitEffectiveConfigPerPackage(progressBroadcaster, validated.packtoryConfig);
+                emitEffectiveConfigPerPackage(dependencies.progressBroadcaster, validated.packtoryConfig);
                 return analyzeReleaseAgainstLatestPublishedValidated(validated, resolveAndLinkAllValidated);
             },
             createValidationErrorResult(issues) {
@@ -240,10 +256,29 @@ export function createPacktory(dependencies: PacktoryDependencies): Packtory {
         });
     }
 
+    async function planReleaseAgainstLatestPublishedPublic(config: unknown): Promise<ReleasePlanOutcome> {
+        return runReportedOperation({
+            config,
+            attachReporting() {
+                return attachAggregator(dependencies.progressBroadcaster);
+            },
+            validate: validateConfig,
+            async runValidated(validated) {
+                emitEffectiveConfigPerPackage(dependencies.progressBroadcaster, validated.packtoryConfig);
+                return planReleaseAgainstLatestPublishedValidated(validated, resolveAndLinkAllValidated);
+            },
+            createValidationErrorResult(issues) {
+                return Result.err(configError(issues));
+            },
+            createOutcome: createReleasePlanOutcome
+        });
+    }
+
     return {
         analyzeReleaseAgainstLatestPublished: analyzeReleaseAgainstLatestPublishedPublic,
         buildAndPublishAll: buildAndPublishAllPublic,
         diffAgainstLatestPublished: diffAgainstLatestPublishedPublic,
+        planReleaseAgainstLatestPublished: planReleaseAgainstLatestPublishedPublic,
         resolveAndLinkAll: resolveAndLinkAllPublic,
         packPackage: packPackagePublic
     };

--- a/source/packtory/release-plan.ts
+++ b/source/packtory/release-plan.ts
@@ -1,0 +1,112 @@
+import { bundleRelativePath } from '../common/package-layout.ts';
+import { compareValues } from '../common/sort-values.ts';
+import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import type { FileDescription } from '../file-manager/file-description.ts';
+import { buildFileSetDiff } from '../report/release-diff/file-set-diff.ts';
+import { canonicalizeSbomInFileSet } from '../sbom/sbom-canonicalizer.ts';
+import type { ReleasePlanPackage, ReleasePlanRegistryMetadata } from './packtory-results.ts';
+import type { BuildAndPublishResult } from './package-processor.ts';
+import { publishedReleaseArtifactsOf, wasAlreadyPublished } from './published-release-state.ts';
+
+type ReleasePlanArtifactState = ReleasePlanPackage['artifactState'];
+type CollectArtifactContents = (
+    bundle: BuildAndPublishResult['bundle'],
+    prefix: string | undefined,
+    extraFiles: BuildAndPublishResult['extraFiles']
+) => readonly FileDescription[];
+
+export type ReleasePlanMapperDependencies = {
+    readonly artifactsBuilder: { readonly collectContents: CollectArtifactContents };
+};
+
+function sortedUnique(values: readonly string[]): readonly string[] {
+    return Array.from(new Set(values)).toSorted(compareValues);
+}
+
+function packageRelativeFiles(files: readonly FileDescription[]): readonly string[] {
+    return sortedUnique(
+        files.map((file) => {
+            return bundleRelativePath(file.filePath);
+        })
+    );
+}
+
+function sourceFilesFrom(analyzedBundle: AnalyzedBundle): readonly string[] {
+    return sortedUnique(
+        analyzedBundle.contents.flatMap((entry) => {
+            return entry.isGeneratedManifest ? [] : [entry.fileDescription.sourceFilePath];
+        })
+    );
+}
+
+function registryMetadataFrom(buildResult: BuildAndPublishResult): ReleasePlanRegistryMetadata | undefined {
+    const publishedReleaseArtifacts = publishedReleaseArtifactsOf(buildResult);
+    if (publishedReleaseArtifacts === undefined) {
+        return undefined;
+    }
+    return {
+        version: publishedReleaseArtifacts.version,
+        publishedAt: publishedReleaseArtifacts.publishedAt
+    };
+}
+
+function artifactStateFrom(buildResult: BuildAndPublishResult): ReleasePlanArtifactState {
+    if (wasAlreadyPublished(buildResult)) {
+        return 'unchanged';
+    }
+    return publishedReleaseArtifactsOf(buildResult) === undefined ? 'first-publish' : 'changed';
+}
+
+function changedArtifactFilesFrom(
+    artifactState: ReleasePlanArtifactState,
+    buildResult: BuildAndPublishResult,
+    newFiles: readonly FileDescription[]
+): readonly string[] {
+    if (artifactState === 'unchanged') {
+        return [];
+    }
+    const publishedReleaseArtifacts = publishedReleaseArtifactsOf(buildResult);
+    if (publishedReleaseArtifacts === undefined) {
+        return packageRelativeFiles(newFiles);
+    }
+    const diff = buildFileSetDiff(
+        canonicalizeSbomInFileSet(publishedReleaseArtifacts.files),
+        canonicalizeSbomInFileSet(newFiles)
+    );
+    return sortedUnique([
+        ...diff.added.map((file) => {
+            return bundleRelativePath(file.path);
+        }),
+        ...diff.removed.map((file) => {
+            return bundleRelativePath(file.path);
+        }),
+        ...diff.modified.map((file) => {
+            return bundleRelativePath(file.path);
+        })
+    ]);
+}
+
+export function createReleasePlanPackage(
+    dependencies: ReleasePlanMapperDependencies,
+    analyzedBundle: AnalyzedBundle,
+    buildResult: BuildAndPublishResult
+): ReleasePlanPackage {
+    const newFiles = dependencies.artifactsBuilder.collectContents(
+        buildResult.bundle,
+        'package',
+        buildResult.extraFiles
+    );
+    const artifactState = artifactStateFrom(buildResult);
+    const latestRegistryMetadata = registryMetadataFrom(buildResult);
+    return {
+        name: buildResult.bundle.name,
+        previousVersion: latestRegistryMetadata?.version,
+        nextVersion: buildResult.bundle.version,
+        artifactState,
+        changed: artifactState !== 'unchanged',
+        latestRegistryMetadata,
+        artifactFiles: packageRelativeFiles(newFiles),
+        changedArtifactFiles: changedArtifactFilesFrom(artifactState, buildResult, newFiles),
+        sourceFiles: sourceFilesFrom(analyzedBundle)
+    };
+}

--- a/source/test-libraries/release-orchestrator-fixtures.ts
+++ b/source/test-libraries/release-orchestrator-fixtures.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert';
+import { Maybe } from 'true-myth';
+import type { ArtifactsBuilder } from '../artifacts/artifacts-builder.ts';
+import { validateConfig, type ValidConfigResult } from '../config/validation.ts';
+import type { ProgressBroadcaster } from '../packtory/packtory-results.ts';
+import type { BuildAndPublishResult, PackageProcessor } from '../packtory/package-processor.ts';
+import type { ResolvedPackage } from '../packtory/resolved-package.ts';
+import { analyzedBundle, versionedBundleWithManifest } from './bundle-fixtures.ts';
+import { createIteratingScheduler } from './iterating-scheduler.ts';
+
+export type ReleaseFileCollection = ArtifactsBuilder['collectContents'];
+
+type ReleaseArtifactFile = {
+    readonly content: string;
+    readonly filePath: string;
+    readonly isExecutable: boolean;
+};
+
+export type ReleaseTestDependencies = {
+    readonly artifactsBuilder: { readonly collectContents: ReleaseFileCollection };
+    readonly packageProcessor: PackageProcessor;
+    readonly progressBroadcaster: ProgressBroadcaster;
+    readonly scheduler: ReturnType<typeof createIteratingScheduler>;
+};
+
+type ReleaseTestDependencySpec = {
+    readonly packageNames: readonly string[];
+    readonly buildResults?: readonly BuildAndPublishResult[];
+    readonly collectContents?: ReleaseFileCollection;
+    readonly packageProcessor?: PackageProcessor;
+};
+
+type BuildResultOverrides = Partial<BuildAndPublishResult> & {
+    readonly packageName?: string;
+    readonly version?: string;
+};
+
+const noPublicationOutcome = { type: 'none' } as const;
+
+const releaseProgressBroadcaster: ProgressBroadcaster = {
+    consumer: {
+        off() {
+            return undefined;
+        },
+        on() {
+            return undefined;
+        }
+    },
+    provider: {
+        emit() {
+            return undefined;
+        },
+        hasSubscribers() {
+            return false;
+        }
+    }
+};
+
+export function validatedReleaseConfigFor(packageNames: readonly string[]): ValidConfigResult {
+    const result = validateConfig({
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        packages: packageNames.map((name) => {
+            return {
+                mainPackageJson: { type: 'module' },
+                name,
+                publishSettings: { access: 'public' },
+                roots: { main: { js: `source/${name}.js` } },
+                sourcesFolder: 'source'
+            };
+        })
+    });
+
+    if (result.isErr) {
+        assert.fail(`Expected config to validate: ${result.error.join(', ')}`);
+    }
+
+    return result.value;
+}
+
+function packageProcessorFor(
+    buildResults: readonly BuildAndPublishResult[],
+    onMissingResult: () => never
+): PackageProcessor {
+    let invocation = 0;
+
+    return {
+        async build() {
+            throw new Error('build() should not be called in release tests');
+        },
+        async buildAndPublish() {
+            throw new Error('buildAndPublish() should not be called in release dry runs');
+        },
+        async resolveAndLink() {
+            throw new Error('resolveAndLink() should not be called in release tests');
+        },
+        async tryBuildAndPublish() {
+            const result = buildResults[invocation];
+            invocation += 1;
+            if (result === undefined) {
+                return onMissingResult();
+            }
+
+            return result;
+        }
+    };
+}
+
+function packageProcessorWith(buildResults: readonly BuildAndPublishResult[]): PackageProcessor {
+    return packageProcessorFor(buildResults, () => {
+        throw new Error('Missing build result fixture');
+    });
+}
+
+export function packageProcessorWithFailure(
+    buildResults: readonly BuildAndPublishResult[],
+    failure: Error
+): PackageProcessor {
+    return packageProcessorFor(buildResults, () => {
+        throw failure;
+    });
+}
+
+export function buildResultFor(overrides: BuildResultOverrides = {}): BuildAndPublishResult {
+    const packageName = overrides.packageName ?? 'pkg-a';
+    const version = overrides.version ?? '1.0.1';
+
+    return {
+        status: 'new-version',
+        publication: noPublicationOutcome,
+        bundle: versionedBundleWithManifest({
+            name: packageName,
+            version,
+            packageJson: { name: packageName, version }
+        }),
+        extraFiles: [],
+        previousReleaseArtifacts: Maybe.nothing(),
+        ...overrides
+    };
+}
+
+export function packageProcessorCheckingStage(expectedStage: boolean): PackageProcessor {
+    return {
+        async build() {
+            throw new Error('build() should not be called in release tests');
+        },
+        async buildAndPublish() {
+            throw new Error('buildAndPublish() should not be called in release dry runs');
+        },
+        async resolveAndLink() {
+            throw new Error('resolveAndLink() should not be called in release tests');
+        },
+        async tryBuildAndPublish(options) {
+            assert.strictEqual(options.stage, expectedStage);
+            return buildResultFor();
+        }
+    };
+}
+
+export function previousReleaseArtifactsFor(spec: {
+    readonly version: string;
+    readonly publishedAt: Date;
+    readonly files: readonly ReleaseArtifactFile[];
+}): BuildAndPublishResult['previousReleaseArtifacts'] {
+    return Maybe.just({
+        version: spec.version,
+        publishedAt: spec.publishedAt,
+        files: spec.files
+    });
+}
+
+export function createReleaseTestDependencies(spec: ReleaseTestDependencySpec): ReleaseTestDependencies {
+    return {
+        artifactsBuilder: {
+            collectContents:
+                spec.collectContents ??
+                (() => {
+                    return [];
+                })
+        },
+        packageProcessor: spec.packageProcessor ?? packageProcessorWith(spec.buildResults ?? []),
+        progressBroadcaster: releaseProgressBroadcaster,
+        scheduler: createIteratingScheduler(spec.packageNames)
+    };
+}
+
+export function resolvedPackagesFor(
+    validated: ValidConfigResult,
+    options: {
+        readonly bundleContents?: Readonly<Record<string, ReturnType<typeof analyzedBundle>['contents']>>;
+        readonly defaultContents?: (packageName: string) => ReturnType<typeof analyzedBundle>['contents'];
+    } = {}
+): readonly ResolvedPackage[] {
+    return validated.packtoryConfig.packages.map((packageConfig) => {
+        const contents =
+            options.bundleContents?.[packageConfig.name] ?? options.defaultContents?.(packageConfig.name) ?? [];
+        return {
+            name: packageConfig.name,
+            analyzedBundle: analyzedBundle({ name: packageConfig.name, contents }),
+            resolveOptions: {
+                name: packageConfig.name,
+                exportPackageJson: packageConfig.exportPackageJson,
+                roots: packageConfig.roots,
+                surface: undefined,
+                sourcesFolder: packageConfig.sourcesFolder ?? 'source',
+                includeSourceMapFiles: packageConfig.includeSourceMapFiles ?? false,
+                additionalFiles: packageConfig.additionalFiles ?? [],
+                mainPackageJson: packageConfig.mainPackageJson ?? { type: 'module' },
+                additionalPackageJsonAttributes: packageConfig.additionalPackageJsonAttributes ?? {},
+                allowMutableSpecifiers: [],
+                deadCodeElimination: packageConfig.deadCodeElimination,
+                bundleDependencies: [],
+                bundlePeerDependencies: []
+            }
+        };
+    });
+}


### PR DESCRIPTION
Adds a side-effect-light release planning API that reuses the existing validate, resolve, check, dry-run publish, and artifact comparison flow. The plan reports per-package version transitions, artifact state and file paths, latest registry metadata, changed artifact files, and source files without publishing or writing release artifacts.