### PR TITLE
Add `packtory changelog` command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@octokit/core": "7.0.6",
                 "@octokit/plugin-paginate-rest": "14.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "17.0.0",
+                "@pr-log/core": "0.0.1",
                 "@schema-hub/zod-error-formatter": "0.0.11",
                 "@ts-morph/common": "0.29.0",
                 "@types/common-tags": "1.8.4",
@@ -3027,6 +3028,18 @@
                 "@octokit/core": ">=6"
             }
         },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+            "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
             "version": "17.0.0",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
@@ -3066,6 +3079,21 @@
             "license": "MIT",
             "dependencies": {
                 "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "22.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+            "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "^7.0.6",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-request-log": "^6.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
             },
             "engines": {
                 "node": ">= 20"
@@ -3871,6 +3899,48 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@pr-log/core": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.1.tgz",
+            "integrity": "sha512-5reo0cOgGVeb4aEAvRe314cU0d7JohEP02BemhLz6An7htciYwleSSMkE+37aCOJpq9Mw08TwIqNEyrs51GqRA==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@sindresorhus/is": "8.1.0",
+                "common-tags": "1.8.2",
+                "date-fns": "4.4.0",
+                "execa": "9.6.1",
+                "semver": "7.8.2",
+                "true-myth": "9.4.0"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/@sindresorhus/is": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+            "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/@pr-log/core/node_modules/semver": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@schema-hub/zod-error-formatter": {
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.11.tgz",
@@ -3887,7 +3957,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
             "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@sigstore/bundle": {
@@ -4128,7 +4197,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
             "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -7343,7 +7411,6 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -7491,6 +7558,16 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/date-fns": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+            "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/dayjs": {
@@ -8691,7 +8768,6 @@
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
             "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^4.0.0",
@@ -9399,7 +9475,6 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
             "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sec-ant/readable-stream": "^0.4.1",
@@ -9826,7 +9901,6 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
             "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
@@ -10336,7 +10410,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
             "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -10390,7 +10463,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/isstream": {
@@ -12217,7 +12289,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
             "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^4.0.0",
@@ -12234,7 +12305,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
             "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -12601,7 +12671,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
             "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -12640,7 +12709,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12903,7 +12971,6 @@
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
             "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "parse-ms": "^4.0.0"
@@ -14046,7 +14113,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -14059,7 +14125,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -14145,7 +14210,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -14578,7 +14642,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
             "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -15386,7 +15449,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
             "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -15898,7 +15960,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "@octokit/core": "7.0.6",
         "@octokit/plugin-paginate-rest": "14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "17.0.0",
+        "@pr-log/core": "0.0.1",
         "@schema-hub/zod-error-formatter": "0.0.11",
         "@ts-morph/common": "0.29.0",
         "@types/common-tags": "1.8.4",

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -1,0 +1,423 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import { Result } from 'true-myth';
+import type {
+    CollectMergedPullRequestsOptions,
+    PrLogEngine,
+    PrLogEngineOptions,
+    PullRequest,
+    PullRequestWithLabel
+} from '@pr-log/core';
+import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
+import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import type { ConfigLoader } from '../config-loader.ts';
+import { runChangelogHandler, type ChangelogHandlerDeps } from './changelog-handler.ts';
+
+function releasePackage(overrides: Partial<ReleasePlanPackage> = {}): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        changed: true,
+        previousGitHead: 'old-head',
+        currentGitHead: 'new-head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: ['index.js'],
+        changedArtifactFiles: ['index.js'],
+        sourceFiles: ['source/pkg-a.ts'],
+        changelogSourceFiles: ['source/pkg-a.ts'],
+        ...overrides
+    };
+}
+
+function releasePlanOutcomeFrom(result: ReleasePlanResult): ReleasePlanOutcome {
+    return {
+        result,
+        getReport() {
+            return {
+                schemaVersion: 1 as const,
+                generatedAt: '2026-06-13T00:00:00.000Z',
+                packages: {},
+                aggregate: { crossBundleLinks: [] }
+            };
+        }
+    };
+}
+
+function outcome(packages: readonly ReleasePlanPackage[]): ReleasePlanOutcome {
+    return releasePlanOutcomeFrom(Result.ok({ packages }));
+}
+
+function configFailureOutcome(issues: readonly string[]): ReleasePlanOutcome {
+    return releasePlanOutcomeFrom(Result.err({ type: 'config', issues }));
+}
+
+function checkFailureOutcome(issues: readonly string[]): ReleasePlanOutcome {
+    return releasePlanOutcomeFrom(Result.err({ type: 'checks', issues }));
+}
+
+function partialFailureOutcome(spec: {
+    readonly succeeded: readonly ReleasePlanPackage[];
+    readonly failures: readonly Error[];
+}): ReleasePlanOutcome {
+    return releasePlanOutcomeFrom(Result.err({ type: 'partial', succeeded: spec.succeeded, failures: spec.failures }));
+}
+
+type EngineOverrides = {
+    readonly resolveChangelogBaseRef?: SinonSpy;
+    readonly readPullRequestChangedFiles?: SinonSpy;
+};
+
+function createEngine(overrides: EngineOverrides = {}): PrLogEngine {
+    const pullRequests: readonly PullRequest[] = [{ id: 1, title: 'Fix package' }];
+    const labeledPullRequests: readonly PullRequestWithLabel[] = [{ id: 1, title: 'Fix package', label: 'bug' }];
+
+    return {
+        resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
+        resolveChangelogBaseRef: overrides.resolveChangelogBaseRef ?? fake.resolves({ ref: 'old-head' }),
+        collectMergedPullRequests: fake.resolves(pullRequests),
+        readPullRequestChangedFiles:
+            overrides.readPullRequestChangedFiles ?? fake.resolves(new Map([[1, ['source/pkg-a.ts']]])),
+        readPullRequestLabels: fake.resolves(new Map([[1, ['bug']]])),
+        filterPullRequestsByTargetFiles: fake((input: { readonly pullRequests: readonly PullRequest[] }) => {
+            return input.pullRequests;
+        }),
+        resolvePullRequestLabels: fake.resolves(labeledPullRequests),
+        renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
+        renderChangelog: fake.returns(''),
+        renderTargetChangelog: fake.returns('')
+    };
+}
+
+type Spies = {
+    readonly createPrLogEngine: SinonSpy;
+    readonly log: SinonSpy;
+    readonly pageOutput: SinonSpy;
+    readonly planReleaseAgainstLatestPublished: SinonSpy;
+    readonly stopAll: SinonSpy;
+};
+
+function spinnerRendererCapturing(stopAll: SinonSpy): TerminalSpinnerRenderer {
+    return { stopAll } as unknown as TerminalSpinnerRenderer;
+}
+
+function configLoaderReturning(config: unknown): ConfigLoader {
+    return { load: fake.resolves(config) } as unknown as ConfigLoader;
+}
+
+function configLoaderRejecting(error: unknown): ConfigLoader {
+    return {
+        async load(): Promise<unknown> {
+            throw error;
+        }
+    } as unknown as ConfigLoader;
+}
+
+function depsWith(spec: {
+    readonly spies: Spies;
+    readonly configLoader?: ConfigLoader;
+    readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
+    readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+}): ChangelogHandlerDeps {
+    return {
+        log(message) {
+            spec.spies.log(message);
+        },
+        pageOutput: spec.spies.pageOutput,
+        packtory: {
+            planReleaseAgainstLatestPublished: spec.spies.planReleaseAgainstLatestPublished
+        } as unknown as Packtory,
+        spinnerRenderer: spinnerRendererCapturing(spec.spies.stopAll),
+        configLoader: spec.configLoader ?? configLoaderReturning('the-config'),
+        createPrLogEngine: spec.spies.createPrLogEngine,
+        currentDate() {
+            return new Date('2026-06-13T00:00:00.000Z');
+        },
+        readEnvironmentVariable:
+            spec.readEnvironmentVariable ??
+            ((name) => {
+                return name === 'GH_TOKEN' ? 'gh-token' : undefined;
+            }),
+        readPackageInfo:
+            spec.readPackageInfo ??
+            (async () => {
+                return { repository: { url: 'git+https://github.com/Owner/Repo.git' } };
+            }),
+        workingDirectory: '/repo'
+    };
+}
+
+function makeSpies(
+    engine: PrLogEngine = createEngine(),
+    releasePlanOutcome: ReleasePlanOutcome = outcome([releasePackage()])
+): Spies {
+    return {
+        createPrLogEngine: fake((options: Readonly<PrLogEngineOptions>) => {
+            assert.strictEqual(options.githubToken, 'gh-token');
+            assert.strictEqual(options.workingDirectory, '/repo');
+            return engine;
+        }),
+        log: fake(),
+        pageOutput: fake.resolves(undefined),
+        planReleaseAgainstLatestPublished: fake.resolves(releasePlanOutcome),
+        stopAll: fake()
+    };
+}
+
+suite('changelog-handler', function () {
+    test('loads config, plans the release, and renders changelog markdown through the pager', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(spies.planReleaseAgainstLatestPublished.firstCall.args, ['the-config']);
+        assert.strictEqual(spies.createPrLogEngine.callCount, 1);
+        assert.deepStrictEqual(spies.pageOutput.firstCall.args, ['## pkg-a 1.0.1\n']);
+        assert.strictEqual(spies.stopAll.callCount, 2);
+    });
+
+    test('returns 1 and logs release-plan config failures without creating pr-log', async function () {
+        const releasePlanOutcome = configFailureOutcome(['bad config', 'worse config']);
+        const spies = makeSpies(createEngine(), releasePlanOutcome);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 1);
+        assert.strictEqual(spies.createPrLogEngine.callCount, 0);
+        assert.deepStrictEqual(spies.log.firstCall.args, [
+            'Configuration issues, there are 2 issue(s)\n\n- bad config\n- worse config'
+        ]);
+    });
+
+    test('returns 1 and logs release-plan check failures without creating pr-log', async function () {
+        const releasePlanOutcome = checkFailureOutcome(['bad package', 'worse package']);
+        const spies = makeSpies(createEngine(), releasePlanOutcome);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 1);
+        assert.strictEqual(spies.createPrLogEngine.callCount, 0);
+        assert.deepStrictEqual(spies.log.firstCall.args, [
+            'Check issues, there are 2 issue(s)\n\n- bad package\n- worse package'
+        ]);
+    });
+
+    test('returns 1 and still renders succeeded changed packages for partial release-plan failures', async function () {
+        const releasePlanOutcome = partialFailureOutcome({
+            succeeded: [releasePackage()],
+            failures: [new Error('pkg-b failed'), new Error('pkg-c failed')]
+        });
+        const spies = makeSpies(createEngine(), releasePlanOutcome);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 1);
+        assert.strictEqual(spies.pageOutput.callCount, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['pkg-b failed\npkg-c failed']);
+    });
+
+    test('uses GITHUB_TOKEN when GH_TOKEN is not set', async function () {
+        const engine = createEngine();
+        const createPrLogEngine = fake((options: Readonly<PrLogEngineOptions>) => {
+            assert.strictEqual(options.githubToken, 'github-token');
+            return engine;
+        });
+        const spies: Spies = {
+            ...makeSpies(engine),
+            createPrLogEngine
+        };
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                readEnvironmentVariable(name) {
+                    return name === 'GITHUB_TOKEN' ? 'github-token' : undefined;
+                }
+            })
+        );
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(createPrLogEngine.callCount, 1);
+    });
+
+    test('passes the GitHub repo from package metadata into pr-log', async function () {
+        const collectMergedPullRequests = fake(async (input: CollectMergedPullRequestsOptions) => {
+            assert.strictEqual(input.githubRepo, 'owner/repo');
+            return [];
+        });
+        const engine = {
+            ...createEngine(),
+            collectMergedPullRequests
+        };
+        const spies = makeSpies(engine);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(collectMergedPullRequests.callCount, 1);
+    });
+
+    test('returns 1 when package.json repository is not a GitHub repository', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                async readPackageInfo() {
+                    return { repository: { url: 'https://example.com/owner/repo' } };
+                }
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['package.json repository must point to a GitHub repository']);
+        assert.strictEqual(spies.pageOutput.callCount, 0);
+    });
+
+    test('returns 1 when package.json repository is missing', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                async readPackageInfo() {
+                    return {};
+                }
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['package.json repository must point to a GitHub repository']);
+    });
+
+    test('returns 1 when package.json repository has a GitHub owner but no repo', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                async readPackageInfo() {
+                    return { repository: { url: 'https://github.com/owner' } };
+                }
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['package.json repository must point to a GitHub repository']);
+    });
+
+    test('returns 1 when package.json repository only contains a GitHub URL suffix', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                async readPackageInfo() {
+                    return { repository: { url: 'https://example.com/https://github.com/owner/repo' } };
+                }
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['package.json repository must point to a GitHub repository']);
+    });
+
+    test('returns 1 when package.json repository contains extra path segments after repo', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                async readPackageInfo() {
+                    return { repository: { url: 'https://github.com/owner/repo/extra' } };
+                }
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['package.json repository must point to a GitHub repository']);
+    });
+
+    test('does not page empty changelog output for changed packages', async function () {
+        const engine = {
+            ...createEngine(),
+            renderGroupedTargetChangelog: fake.returns('')
+        };
+        const spies = makeSpies(engine);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(spies.pageOutput.callCount, 0);
+    });
+
+    test('returns 1 and stops spinners when config loading fails', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                configLoader: configLoaderRejecting(new Error('config failed'))
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['config failed']);
+        assert.strictEqual(spies.stopAll.callCount, 1);
+    });
+
+    test('formats TypeError changelog failures without their constructor prefix', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                configLoader: configLoaderRejecting(new TypeError('typed config failed'))
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['typed config failed']);
+    });
+
+    test('does not strip inner Error text from changelog failures', async function () {
+        const spies = makeSpies();
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                configLoader: configLoaderRejecting('prefix Error: still relevant')
+            })
+        );
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['prefix Error: still relevant']);
+    });
+
+    test('returns 1 when a package base ref cannot be resolved', async function () {
+        const engine = createEngine({ resolveChangelogBaseRef: fake.rejects(new Error('missing base ref')) });
+        const spies = makeSpies(engine);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['missing base ref']);
+        assert.strictEqual(spies.pageOutput.callCount, 0);
+    });
+
+    test('returns 1 when GitHub changed-file lookup fails', async function () {
+        const engine = createEngine({
+            readPullRequestChangedFiles: fake.rejects(new Error('github failed'))
+        });
+        const spies = makeSpies(engine);
+
+        const code = await runChangelogHandler(depsWith({ spies }));
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['github failed']);
+        assert.strictEqual(spies.pageOutput.callCount, 0);
+    });
+});

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -1,0 +1,148 @@
+import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions } from '@pr-log/core';
+import { normalizeRepositoryUrl } from '../../bundle-emitter/repository-url-normalizer.ts';
+import { partialFailureMessages } from '../../packtory/partial-result.ts';
+import type { Packtory, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
+import { checksErrorType, configErrorType, type ReleasePlanFailure } from '../../packtory/packtory-results.ts';
+import { generateChangelog } from '../../packtory/packtory-changelog.ts';
+import type { ConfigLoader } from '../config-loader.ts';
+import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+
+type Logger = (message: string) => void;
+type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
+type GitHubRepositoryParts = {
+    readonly owner: string;
+    readonly repo: string;
+};
+
+export type ChangelogHandlerDeps = {
+    readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
+    readonly currentDate: () => Date;
+    readonly log: Logger;
+    readonly pageOutput: (content: string) => Promise<void>;
+    readonly packtory: Packtory;
+    readonly readEnvironmentVariable: (name: EnvironmentVariableName) => string | undefined;
+    readonly readPackageInfo: () => Promise<Record<string, unknown>>;
+    readonly spinnerRenderer: TerminalSpinnerRenderer;
+    readonly configLoader: ConfigLoader;
+    readonly workingDirectory: string;
+};
+
+const labelLookupIntervalMilliseconds = 250;
+const maximumRateLimitRetryCount = 3;
+const githubRepositoryPattern = /^https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)$/u;
+
+function formatChangelogHandlerError(error: unknown): string {
+    return String(error).replace(/^[A-Za-z]*Error: /u, '');
+}
+
+function githubTokenFrom(deps: Pick<ChangelogHandlerDeps, 'readEnvironmentVariable'>): string | undefined {
+    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+}
+
+function gitHubRepositoryMatchFrom(repositoryUrl: string | undefined): RegExpExecArray | undefined {
+    return githubRepositoryPattern.exec(String(repositoryUrl)) ?? undefined;
+}
+
+function gitHubRepositoryPartsFromGroups(
+    groups: Record<string, string> | undefined
+): GitHubRepositoryParts | undefined {
+    if (groups === undefined) {
+        return undefined;
+    }
+    return { owner: String(groups.owner), repo: String(groups.repo) };
+}
+
+function gitHubRepositoryPartsFrom(repositoryUrl: string | undefined): GitHubRepositoryParts | undefined {
+    return gitHubRepositoryPartsFromGroups(gitHubRepositoryMatchFrom(repositoryUrl)?.groups);
+}
+
+function githubRepoFrom(packageInfo: Record<string, unknown>): string {
+    const repository = gitHubRepositoryPartsFrom(normalizeRepositoryUrl(packageInfo.repository));
+    if (repository === undefined) {
+        throw new Error('package.json repository must point to a GitHub repository');
+    }
+    return `${repository.owner}/${repository.repo}`;
+}
+
+function createEngine(deps: ChangelogHandlerDeps): PrLogEngine {
+    return deps.createPrLogEngine({
+        githubToken: githubTokenFrom(deps),
+        workingDirectory: deps.workingDirectory,
+        labelLookupIntervalMilliseconds,
+        maximumRateLimitRetryCount
+    });
+}
+
+function printIssueFailure(log: Logger, title: string, issues: readonly string[]): void {
+    log(`${title}, there are ${issues.length} issue(s)\n\n- ${issues.join('\n- ')}`);
+}
+
+function printReleasePlanFailure(log: Logger, error: ReleasePlanFailure): void {
+    if (error.type === configErrorType) {
+        printIssueFailure(log, 'Configuration issues', error.issues);
+        return;
+    }
+    if (error.type === checksErrorType) {
+        printIssueFailure(log, 'Check issues', error.issues);
+        return;
+    }
+    log(partialFailureMessages(error).join('\n'));
+}
+
+function releasePlanPackagesFrom(result: ReleasePlanResult): readonly ReleasePlanPackage[] {
+    if (result.isOk) {
+        return result.value.packages;
+    }
+    if ('succeeded' in result.error) {
+        return result.error.succeeded;
+    }
+    return [];
+}
+
+async function renderChangelog(deps: ChangelogHandlerDeps, packages: readonly ReleasePlanPackage[]): Promise<void> {
+    if (packages.length === 0) {
+        return;
+    }
+    const packageInfo = await deps.readPackageInfo();
+    const markdown = await generateChangelog({
+        packages,
+        prLogEngine: createEngine(deps),
+        githubRepo: githubRepoFrom(packageInfo),
+        packageInfo,
+        currentDate: deps.currentDate(),
+        validLabels: defaultValidLabels
+    });
+    if (markdown.length > 0) {
+        await deps.pageOutput(markdown);
+    }
+}
+
+function exitCodeFromReleasePlanResult(log: Logger, result: ReleasePlanResult): number {
+    if (result.isOk) {
+        return 0;
+    }
+    printReleasePlanFailure(log, result.error);
+    return 1;
+}
+
+async function runChangelog(deps: ChangelogHandlerDeps): Promise<number> {
+    const config = await deps.configLoader.load();
+    const outcome = await deps.packtory.planReleaseAgainstLatestPublished(config);
+    deps.spinnerRenderer.stopAll();
+    await renderChangelog(deps, releasePlanPackagesFrom(outcome.result));
+    return exitCodeFromReleasePlanResult(deps.log, outcome.result);
+}
+
+function stopSpinnersAndReturn(deps: ChangelogHandlerDeps, exitCode: number): number {
+    deps.spinnerRenderer.stopAll();
+    return exitCode;
+}
+
+export async function runChangelogHandler(deps: ChangelogHandlerDeps): Promise<number> {
+    try {
+        return stopSpinnersAndReturn(deps, await runChangelog(deps));
+    } catch (error: unknown) {
+        deps.log(formatChangelogHandlerError(error));
+        return stopSpinnersAndReturn(deps, 1);
+    }
+}

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -24,6 +24,7 @@ const noPublicationOutcome = { type: 'none' } as const;
 type Overrides = {
     readonly buildAndPublishAll?: SinonSpy;
     readonly diffAgainstLatestPublished?: SinonSpy;
+    readonly planReleaseAgainstLatestPublished?: SinonSpy;
     readonly packPackage?: SinonSpy;
     readonly loadConfig?: SinonSpy;
     readonly log?: SinonSpy;
@@ -31,6 +32,9 @@ type Overrides = {
     readonly pageOutput?: SinonSpy;
     readonly openFile?: SinonSpy;
     readonly createTemporaryFilePath?: () => string;
+    readonly createPrLogEngine?: SinonSpy;
+    readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+    readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
     progressBroadcaster?: ProgressBroadcaster;
     spinnerRenderer?: {
         add?: SinonSpy;
@@ -74,6 +78,20 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
     const pageOutput = overrides.pageOutput ?? fake.resolves(undefined);
     const fileManager = overrides.fileManager ?? createFakeFileManager();
     const dependencies: CommandLineInterfaceRunnerDependencies = {
+        createPrLogEngine: createSpy(overrides.createPrLogEngine, () => {
+            return fake.returns({
+                resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
+                resolveChangelogBaseRef: fake.resolves({ ref: 'previous-ref' }),
+                collectMergedPullRequests: fake.resolves([]),
+                readPullRequestChangedFiles: fake.resolves(new Map()),
+                filterPullRequestsByTargetFiles: fake.returns([]),
+                resolvePullRequestLabels: fake.resolves([]),
+                renderGroupedTargetChangelog: fake.returns('')
+            });
+        }),
+        currentDate() {
+            return new Date('2026-06-13T00:00:00.000Z');
+        },
         packtory: {
             analyzeReleaseAgainstLatestPublished: fake.resolves(
                 toReleaseAnalysisOutcome(
@@ -90,11 +108,13 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
             diffAgainstLatestPublished: createSpy(overrides.diffAgainstLatestPublished, () => {
                 return fake.resolves(toReleaseDiffOutcome(Result.ok([])));
             }),
-            planReleaseAgainstLatestPublished: fake.resolves({
-                result: Result.ok({ packages: [] }),
-                getReport() {
-                    return createBuildReportFixture();
-                }
+            planReleaseAgainstLatestPublished: createSpy(overrides.planReleaseAgainstLatestPublished, () => {
+                return fake.resolves({
+                    result: Result.ok({ packages: [] }),
+                    getReport() {
+                        return createBuildReportFixture();
+                    }
+                });
             }),
             resolveAndLinkAll: fake.resolves(toOutcome(Result.ok([]))),
             packPackage: createSpy(overrides.packPackage, () => {
@@ -118,7 +138,18 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
         openFile: createSpy(overrides.openFile, () => {
             return fake.resolves(true);
         }),
-        createTemporaryFilePath: overrides.createTemporaryFilePath ?? (() => '/tmp/packtory-preview.html')
+        createTemporaryFilePath: overrides.createTemporaryFilePath ?? (() => '/tmp/packtory-preview.html'),
+        readEnvironmentVariable:
+            overrides.readEnvironmentVariable ??
+            ((name) => {
+                return name === 'GH_TOKEN' ? 'gh-token' : undefined;
+            }),
+        readPackageInfo:
+            overrides.readPackageInfo ??
+            (async () => {
+                return { repository: { url: 'https://github.com/enormora/packtory' } };
+            }),
+        workingDirectory: '/workspace'
     };
 
     return createCommandLineInterfaceRunner(dependencies);
@@ -287,6 +318,7 @@ suite('runner', function () {
             'Expected help output to include the publish command description'
         );
         assert.ok(help.includes('preview'), 'Expected help output to include the preview command');
+        assert.ok(help.includes('changelog'), 'Expected help output to include the changelog command');
     });
 
     test('prints subcommand help that includes the full publish command path', async function () {
@@ -818,6 +850,34 @@ suite('runner', function () {
 
         const helpText = String(log.firstCall.args[0]);
         assert.match(helpText, /Compares the next dry-run build against the latest published version, per package\./u);
+    });
+
+    test('changelog command loads the config and invokes planReleaseAgainstLatestPublished', async function () {
+        const loadConfig = fake.resolves('the-config');
+        const planReleaseAgainstLatestPublished = fake.resolves({
+            result: Result.ok({ packages: [] }),
+            getReport() {
+                return createBuildReportFixture();
+            }
+        });
+        const runner = runnerFactory({ loadConfig, planReleaseAgainstLatestPublished });
+
+        const exitCode = await runner.run(['foo', 'bar', 'changelog']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(loadConfig.callCount, 1);
+        assert.strictEqual(planReleaseAgainstLatestPublished.callCount, 1);
+        assert.strictEqual(planReleaseAgainstLatestPublished.firstCall.args[0], 'the-config');
+    });
+
+    test('changelog --help advertises grouped Markdown output for the next release', async function () {
+        const log = fake();
+        const runner = runnerFactory({ log });
+
+        await runner.run(['foo', 'bar', 'changelog', '--help']);
+
+        const helpText = String(log.firstCall.args[0]);
+        assert.match(helpText, /Generates grouped Markdown changelog output for the next release\./u);
     });
 
     test('pack command loads the config and forwards the flags into packPackage', async function () {

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -1,10 +1,12 @@
-/* eslint-disable import/max-dependencies -- the CLI runner wires four subcommands plus shared dependencies */
+/* eslint-disable import/max-dependencies -- the CLI runner wires five subcommands plus shared dependencies */
 import { binary, command, flag, oneOf, option, positional, runSafely, string, subcommands } from 'cmd-ts';
+import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { FileManager } from '../../file-manager/file-manager.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
 import type { ProgressBroadcastConsumer } from '../../progress/progress-broadcaster.ts';
 import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import { runChangelogHandler } from './changelog-handler.ts';
 import { getParseExitCode } from './command-parsing.ts';
 import { runPackHandler } from './pack-handler.ts';
 import { runPreviewHandler } from './preview-handler.ts';
@@ -13,6 +15,8 @@ import { registerProgressListeners } from './progress-wiring.ts';
 import { runPublishHandler } from './publish-handler.ts';
 
 export type CommandLineInterfaceRunnerDependencies = {
+    readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
+    readonly currentDate: () => Date;
     readonly packtory: Packtory;
     readonly progressBroadcaster: ProgressBroadcastConsumer;
     readonly spinnerRenderer: TerminalSpinnerRenderer;
@@ -21,6 +25,9 @@ export type CommandLineInterfaceRunnerDependencies = {
     readonly pageOutput: (content: string) => Promise<void>;
     readonly openFile: (filePath: string) => Promise<boolean>;
     readonly createTemporaryFilePath: () => string;
+    readonly readEnvironmentVariable: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+    readonly readPackageInfo: () => Promise<Record<string, unknown>>;
+    readonly workingDirectory: string;
     log: (message: string) => void;
 };
 
@@ -40,12 +47,18 @@ export function createCommandLineInterfaceRunner(
         fileManager,
         pageOutput,
         openFile,
-        createTemporaryFilePath
+        createTemporaryFilePath,
+        createPrLogEngine,
+        currentDate,
+        readEnvironmentVariable,
+        readPackageInfo,
+        workingDirectory
     } = dependencies;
     let exitCode = 0;
     const publishCommandName = 'publish';
     const previewCommandName = 'preview';
     const releaseDiffCommandName = 'release-diff';
+    const changelogCommandName = 'changelog';
     const packCommandName = 'pack';
     const defaultPackVersion = '0.0.0';
     const baseCommand = subcommands({
@@ -100,6 +113,25 @@ export function createCommandLineInterfaceRunner(
                         packtory,
                         spinnerRenderer,
                         configLoader
+                    });
+                }
+            }),
+            [changelogCommandName]: command({
+                name: changelogCommandName,
+                description: 'Generates grouped Markdown changelog output for the next release.',
+                args: {},
+                async handler() {
+                    exitCode = await runChangelogHandler({
+                        log,
+                        pageOutput,
+                        packtory,
+                        spinnerRenderer,
+                        configLoader,
+                        createPrLogEngine,
+                        currentDate,
+                        readEnvironmentVariable,
+                        readPackageInfo,
+                        workingDirectory
                     });
                 }
             }),

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import path from 'node:path';
 import readline from 'node:readline/promises';
+import { createPrLogEngine } from '@pr-log/core';
 import { createClock } from '../../common/clock.ts';
 import { createLineSpinnerRenderer } from '../../command-line-interface/spinner/line-spinner-renderer.ts';
 import { createOneTimePasswordPrompt } from '../../command-line-interface/one-time-password-prompt.ts';
@@ -21,6 +23,18 @@ import { awaitSpinnerWorkerTermination, createBootedSpinnerRuntime } from './spi
 
 async function importModule(modulePath: string): Promise<unknown> {
     return import(modulePath);
+}
+
+function isPackageInfo(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parsePackageInfo(content: string): Record<string, unknown> {
+    const parsed: unknown = JSON.parse(content);
+    if (isPackageInfo(parsed)) {
+        return parsed;
+    }
+    throw new Error('package.json must contain an object');
 }
 
 function createSpinnerRenderer(): TerminalSpinnerRenderer {
@@ -68,6 +82,10 @@ const { packtory, progressBroadcaster } = buildPacktoryComposition({
 });
 
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
+    createPrLogEngine,
+    currentDate() {
+        return new Date(clock.getCurrentTimeInMilliseconds());
+    },
     packtory,
     progressBroadcaster: progressBroadcaster.consumer,
     spinnerRenderer,
@@ -81,6 +99,13 @@ const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     },
     openFile: previewIo.openPreviewFile,
     createTemporaryFilePath: previewIo.createTemporaryPreviewHtmlPath,
+    readEnvironmentVariable(name) {
+        return process.env[name];
+    },
+    async readPackageInfo() {
+        return parsePackageInfo(await fileManager.readFile(path.join(process.cwd(), 'package.json')));
+    },
+    workingDirectory: process.cwd(),
     log: console.log
 });
 

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -20,6 +20,7 @@ packtory <command> [options]
 
 - **preview:** Runs a fresh dry-run build with report collection enabled and shows a human-oriented preview of the emitted package contents, file statuses, and changed-file diffs.
 - **release-diff:** Runs the same dry-run build as `preview` and shows, per package, the changes between the latest version currently published on the configured registry and the bundle the next run would publish.
+- **changelog:** Builds the next release plan, attributes merged GitHub pull requests to changed packages, and prints grouped Markdown changelog output.
 - **publish:** Bundles and publishes npm packages based on the configuration in `packtory.config.js`.
 - **pack:** Builds a single configured package and writes it to disk as a zip archive, tarball, or expanded folder. Intended for ad-hoc artifact use cases such as AWS Lambda deployments, container builds, or local inspection — `pack` never talks to a registry.
 
@@ -57,6 +58,16 @@ packtory <command> [options]
 - Previewable runs are shown through `$PAGER` when possible, otherwise `less -R`, otherwise standard output. Failure-only runs go directly to standard output.
 - `packtory release-diff` exits with code `0` on a clean run and `1` on config errors, check failures, or partial failures.
 - `release-diff` is read-only: it never publishes and never writes to the registry. It is currently terminal-only; an HTML/`--open` variant and an `--against <version>` selector are not part of this release.
+
+**Changelog behavior:**
+
+- `packtory changelog` computes the same release plan used by Packtory's release planning API, skips unchanged packages, and prints one grouped Markdown changelog for packages that would publish a changed artifact.
+- Pull requests are attributed by comparing GitHub changed files against each package's attributed source files. Changelog files named `CHANGELOG.md` are ignored as attribution inputs.
+- The GitHub repository is read from the root `package.json` `repository` field.
+- GitHub API requests use `GH_TOKEN` when set, otherwise `GITHUB_TOKEN`.
+- Output is shown through `$PAGER` when possible, otherwise `less -R`, otherwise standard output.
+- `packtory changelog` exits with code `0` on a clean run and `1` on config, release-plan, Git, GitHub, or changelog generation failures. Partial release-plan failures still render succeeded changed packages when changelog generation succeeds.
+- `changelog` is read-only: it never writes changelog files, commits, tags, releases, deployments, registry data, or packages.
 
 **Pack behavior:**
 

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import type {
+    FilterPullRequestsByTargetFilesInput,
+    PrLogEngine,
+    PullRequest,
+    PullRequestWithLabel,
+    RenderGroupedTargetChangelogMarkdownInput
+} from '@pr-log/core';
+import { generateChangelog } from './packtory-changelog.ts';
+import type { ReleasePlanPackage } from './packtory-results.ts';
+
+const validLabels = new Map([['bug', 'Bug Fixes']]);
+
+function releasePackage(overrides: Partial<ReleasePlanPackage>): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'current-head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: ['dist/index.js'],
+        changedArtifactFiles: ['dist/index.js'],
+        sourceFiles: ['source/pkg-a.ts'],
+        changelogSourceFiles: ['source/pkg-a.ts'],
+        ...overrides
+    };
+}
+
+type EngineCalls = {
+    readonly collectMergedPullRequests: SinonSpy;
+    readonly filterPullRequestsByTargetFiles: SinonSpy<[FilterPullRequestsByTargetFilesInput], readonly PullRequest[]>;
+    readonly readPullRequestChangedFiles: SinonSpy;
+    readonly renderGroupedTargetChangelog: SinonSpy<[RenderGroupedTargetChangelogMarkdownInput], string>;
+    readonly resolveChangelogBaseRef: SinonSpy;
+    readonly resolveLatestSemverChangelogBaseRef: SinonSpy;
+    readonly resolvePullRequestLabels: SinonSpy;
+};
+
+function createEngine(): { readonly engine: PrLogEngine; readonly calls: EngineCalls } {
+    const pullRequests: readonly PullRequest[] = [
+        { id: 1, title: 'Fix package' },
+        { id: 2, title: 'Update changelog only' }
+    ];
+    const labeledPullRequests: readonly PullRequestWithLabel[] = [{ id: 1, title: 'Fix package', label: 'bug' }];
+    const calls: EngineCalls = {
+        collectMergedPullRequests: fake.resolves(pullRequests),
+        filterPullRequestsByTargetFiles: fake((input: FilterPullRequestsByTargetFilesInput) => {
+            return input.pullRequests.slice(0, 1);
+        }),
+        readPullRequestChangedFiles: fake.resolves(
+            new Map([
+                [1, ['source/pkg-a.ts']],
+                [2, ['CHANGELOG.md']]
+            ])
+        ),
+        renderGroupedTargetChangelog: fake((input: RenderGroupedTargetChangelogMarkdownInput) => {
+            return input.targets
+                .map((target) => {
+                    return target.targetName;
+                })
+                .join('\n');
+        }),
+        resolveChangelogBaseRef: fake(async (input: { readonly packageName: string }) => {
+            return { ref: `${input.packageName}-base` };
+        }),
+        resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
+        resolvePullRequestLabels: fake.resolves(labeledPullRequests)
+    };
+
+    return { engine: calls as unknown as PrLogEngine, calls };
+}
+
+async function render(packages: readonly ReleasePlanPackage[], engine: PrLogEngine): Promise<string> {
+    return generateChangelog({
+        packages,
+        prLogEngine: engine,
+        githubRepo: 'owner/repo',
+        packageInfo: {},
+        currentDate: new Date('2026-06-13T00:00:00.000Z'),
+        validLabels
+    });
+}
+
+suite('packtory-changelog', function () {
+    test('excludes unchanged packages from pr-log targets', async function () {
+        const { engine, calls } = createEngine();
+
+        await render([releasePackage({ changed: false, artifactState: 'unchanged' })], engine);
+
+        assert.strictEqual(calls.collectMergedPullRequests.callCount, 0);
+        assert.strictEqual(calls.renderGroupedTargetChangelog.callCount, 1);
+        assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, []);
+    });
+
+    test('renders changed and first-publish packages as released targets with their next versions', async function () {
+        const { engine, calls } = createEngine();
+        const packages = [
+            releasePackage({ name: 'pkg-a', nextVersion: '1.0.1' }),
+            releasePackage({
+                name: 'pkg-b',
+                previousVersion: undefined,
+                previousGitHead: undefined,
+                nextVersion: '0.1.0',
+                artifactState: 'first-publish'
+            })
+        ];
+
+        await render(packages, engine);
+
+        assert.strictEqual(calls.resolveChangelogBaseRef.callCount, 1);
+        assert.deepStrictEqual(calls.resolveChangelogBaseRef.firstCall.args[0], {
+            packageName: 'pkg-a',
+            previousVersion: '1.0.0',
+            previousGitHead: undefined,
+            packageTagFormat: undefined,
+            explicitBaseRef: undefined
+        });
+        assert.strictEqual(calls.resolveLatestSemverChangelogBaseRef.callCount, 1);
+        assert.deepStrictEqual(calls.collectMergedPullRequests.firstCall.args[0], {
+            githubRepo: 'owner/repo',
+            baseRef: 'pkg-a-base'
+        });
+        assert.deepStrictEqual(calls.readPullRequestChangedFiles.firstCall.args[0], {
+            githubRepo: 'owner/repo',
+            pullRequests: [
+                { id: 1, title: 'Fix package' },
+                { id: 2, title: 'Update changelog only' }
+            ]
+        });
+        assert.deepStrictEqual(calls.resolvePullRequestLabels.firstCall.args[0], {
+            githubRepo: 'owner/repo',
+            validLabels,
+            pullRequests: [{ id: 1, title: 'Fix package' }],
+            targetName: 'pkg-a',
+            targetScopedLabelPattern: undefined
+        });
+        assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, [
+            {
+                targetName: 'pkg-a',
+                unreleased: false,
+                versionNumber: '1.0.1',
+                mergedPullRequests: [{ id: 1, title: 'Fix package', label: 'bug' }]
+            },
+            {
+                targetName: 'pkg-b',
+                unreleased: false,
+                versionNumber: '0.1.0',
+                mergedPullRequests: [{ id: 1, title: 'Fix package', label: 'bug' }]
+            }
+        ]);
+    });
+
+    test('filters pull requests with changelog source files and ignored changelog paths', async function () {
+        const { engine, calls } = createEngine();
+
+        await render(
+            [
+                releasePackage({
+                    artifactFiles: ['dist/index.js'],
+                    changedArtifactFiles: ['dist/index.js'],
+                    sourceFiles: ['source/pkg-a.ts'],
+                    changelogSourceFiles: ['source/pkg-a.ts', 'CHANGELOG.md']
+                })
+            ],
+            engine
+        );
+
+        assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0], {
+            targetName: 'pkg-a',
+            targetSourceFiles: ['source/pkg-a.ts', 'CHANGELOG.md'],
+            pullRequests: [
+                { id: 1, title: 'Fix package' },
+                { id: 2, title: 'Update changelog only' }
+            ],
+            changedFilesByPullRequest: new Map([
+                [1, ['source/pkg-a.ts']],
+                [2, ['CHANGELOG.md']]
+            ]),
+            ignoredAttributionPaths: ['CHANGELOG.md']
+        });
+    });
+
+    test('uses the package base-ref resolver when a package has a previous git head but no previous version', async function () {
+        const { engine, calls } = createEngine();
+
+        await render([releasePackage({ previousVersion: undefined, previousGitHead: 'previous-head' })], engine);
+
+        assert.strictEqual(calls.resolveLatestSemverChangelogBaseRef.callCount, 0);
+        assert.deepStrictEqual(calls.resolveChangelogBaseRef.firstCall.args[0], {
+            packageName: 'pkg-a',
+            previousVersion: undefined,
+            previousGitHead: 'previous-head',
+            packageTagFormat: undefined,
+            explicitBaseRef: undefined
+        });
+    });
+
+    test('does not ignore files whose name only starts with CHANGELOG.md', async function () {
+        const { engine, calls } = createEngine();
+
+        await render([releasePackage({ changelogSourceFiles: ['docs/CHANGELOG.md.bak'] })], engine);
+
+        assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].ignoredAttributionPaths, []);
+    });
+
+    test('ignores nested CHANGELOG.md files', async function () {
+        const { engine, calls } = createEngine();
+
+        await render([releasePackage({ changelogSourceFiles: ['docs/CHANGELOG.md'] })], engine);
+
+        assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].ignoredAttributionPaths, [
+            'docs/CHANGELOG.md'
+        ]);
+    });
+});

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -1,0 +1,134 @@
+import type { PrLogEngine, PullRequestWithLabel, TargetChangelogSection } from '@pr-log/core';
+import type { ReleasePlanPackage } from './packtory-results.ts';
+
+type ChangelogTarget = {
+    readonly packagePlan: ReleasePlanPackage;
+    readonly pullRequests: readonly PullRequestWithLabel[];
+};
+
+export type GenerateChangelogInput = {
+    readonly currentDate: Date;
+    readonly githubRepo: string;
+    readonly packageInfo: Record<string, unknown>;
+    readonly packages: readonly ReleasePlanPackage[];
+    readonly prLogEngine: Pick<
+        PrLogEngine,
+        | 'collectMergedPullRequests'
+        | 'filterPullRequestsByTargetFiles'
+        | 'readPullRequestChangedFiles'
+        | 'renderGroupedTargetChangelog'
+        | 'resolveChangelogBaseRef'
+        | 'resolveLatestSemverChangelogBaseRef'
+        | 'resolvePullRequestLabels'
+    >;
+    readonly validLabels: ReadonlyMap<string, string>;
+};
+
+const changelogFileName = 'CHANGELOG.md';
+const changelogFileSuffix = `/${changelogFileName}`;
+
+function changedPackagesFrom(packages: readonly ReleasePlanPackage[]): readonly ReleasePlanPackage[] {
+    return packages.filter((packagePlan) => {
+        return packagePlan.changed;
+    });
+}
+
+function changelogPathsFrom(packages: readonly ReleasePlanPackage[]): readonly string[] {
+    return Array.from(
+        new Set(
+            packages.flatMap((packagePlan) => {
+                return packagePlan.changelogSourceFiles.filter((filePath) => {
+                    return filePath === changelogFileName || filePath.endsWith(changelogFileSuffix);
+                });
+            })
+        )
+    );
+}
+
+async function baseRefFor(
+    prLogEngine: GenerateChangelogInput['prLogEngine'],
+    packagePlan: ReleasePlanPackage
+): Promise<string> {
+    if (packagePlan.previousVersion === undefined && packagePlan.previousGitHead === undefined) {
+        const baseRef = await prLogEngine.resolveLatestSemverChangelogBaseRef();
+        return baseRef.ref;
+    }
+
+    const baseRef = await prLogEngine.resolveChangelogBaseRef({
+        packageName: packagePlan.name,
+        previousVersion: packagePlan.previousVersion,
+        previousGitHead: packagePlan.previousGitHead,
+        packageTagFormat: undefined,
+        explicitBaseRef: undefined
+    });
+    return baseRef.ref;
+}
+
+async function targetPullRequestsFor(
+    input: GenerateChangelogInput,
+    packagePlan: ReleasePlanPackage,
+    ignoredAttributionPaths: readonly string[]
+): Promise<readonly PullRequestWithLabel[]> {
+    const baseRef = await baseRefFor(input.prLogEngine, packagePlan);
+    const pullRequests = await input.prLogEngine.collectMergedPullRequests({
+        githubRepo: input.githubRepo,
+        baseRef
+    });
+    const changedFilesByPullRequest = await input.prLogEngine.readPullRequestChangedFiles({
+        githubRepo: input.githubRepo,
+        pullRequests
+    });
+    const packagePullRequests = input.prLogEngine.filterPullRequestsByTargetFiles({
+        targetName: packagePlan.name,
+        targetSourceFiles: packagePlan.changelogSourceFiles,
+        pullRequests,
+        changedFilesByPullRequest,
+        ignoredAttributionPaths
+    });
+
+    return input.prLogEngine.resolvePullRequestLabels({
+        githubRepo: input.githubRepo,
+        validLabels: input.validLabels,
+        pullRequests: packagePullRequests,
+        targetName: packagePlan.name,
+        targetScopedLabelPattern: undefined
+    });
+}
+
+async function changelogTargetFor(
+    input: GenerateChangelogInput,
+    packagePlan: ReleasePlanPackage,
+    ignoredAttributionPaths: readonly string[]
+): Promise<ChangelogTarget> {
+    return {
+        packagePlan,
+        pullRequests: await targetPullRequestsFor(input, packagePlan, ignoredAttributionPaths)
+    };
+}
+
+function targetSectionFrom(target: ChangelogTarget): TargetChangelogSection {
+    return {
+        targetName: target.packagePlan.name,
+        unreleased: false,
+        versionNumber: target.packagePlan.nextVersion,
+        mergedPullRequests: target.pullRequests
+    };
+}
+
+export async function generateChangelog(input: GenerateChangelogInput): Promise<string> {
+    const packages = changedPackagesFrom(input.packages);
+    const ignoredAttributionPaths = changelogPathsFrom(packages);
+    const targets = await Promise.all(
+        packages.map(async (packagePlan) => {
+            return changelogTargetFor(input, packagePlan, ignoredAttributionPaths);
+        })
+    );
+
+    return input.prLogEngine.renderGroupedTargetChangelog({
+        packageInfo: input.packageInfo,
+        currentDate: input.currentDate,
+        validLabels: input.validLabels,
+        githubRepo: input.githubRepo,
+        targets: targets.map(targetSectionFrom)
+    });
+}


### PR DESCRIPTION
Adds a read-only `packtory changelog` command that builds the release plan, maps merged PRs to changed packages through `@pr-log/core`, and renders grouped Markdown through the existing pager path. The command skips unchanged packages, uses `GH_TOKEN` or `GITHUB_TOKEN` for GitHub requests, reads the GitHub repository from root `package.json`, and leaves file outputs for a later phase.