### PR TITLE
Add configurable `changelog.outputs` destinations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@octokit/core": "7.0.6",
                 "@octokit/plugin-paginate-rest": "14.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-                "@pr-log/core": "0.0.1",
+                "@pr-log/core": "0.0.2",
                 "@schema-hub/zod-error-formatter": "0.0.11",
                 "@ts-morph/common": "0.29.0",
                 "@types/common-tags": "1.8.4",
@@ -3808,6 +3808,38 @@
                 "node": "^24 || ^26"
             }
         },
+        "node_modules/@packtory/cli/node_modules/@pr-log/core": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.1.tgz",
+            "integrity": "sha512-5reo0cOgGVeb4aEAvRe314cU0d7JohEP02BemhLz6An7htciYwleSSMkE+37aCOJpq9Mw08TwIqNEyrs51GqRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@sindresorhus/is": "8.1.0",
+                "common-tags": "1.8.2",
+                "date-fns": "4.4.0",
+                "execa": "9.6.1",
+                "semver": "7.8.2",
+                "true-myth": "9.4.0"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/semver": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@packtory/github-release-gate": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/@packtory/github-release-gate/-/github-release-gate-0.0.10.tgz",
@@ -3901,9 +3933,9 @@
             }
         },
         "node_modules/@pr-log/core": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.1.tgz",
-            "integrity": "sha512-5reo0cOgGVeb4aEAvRe314cU0d7JohEP02BemhLz6An7htciYwleSSMkE+37aCOJpq9Mw08TwIqNEyrs51GqRA==",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.2.tgz",
+            "integrity": "sha512-M+RhqKvyH1wwO8+dch3Pk6hK5Z1F8bAxmxD/1qoWp9+OX1PhUFvDsZTpQYQ04ygvDGK7bAho7MpKscd50LnIXA==",
             "license": "MIT",
             "dependencies": {
                 "@octokit/rest": "22.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@octokit/core": "7.0.6",
         "@octokit/plugin-paginate-rest": "14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-        "@pr-log/core": "0.0.1",
+        "@pr-log/core": "0.0.2",
         "@schema-hub/zod-error-formatter": "0.0.11",
         "@ts-morph/common": "0.29.0",
         "@types/common-tags": "1.8.4",

--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,19 @@ The configuration for `packtory` is an object with the following properties:
 3. **`checks`** (Optional, Object):
     - Toggles and configures the cross-package checks that run after every bundle has been linked. Lives at the top level (not inside `commonPackageSettings`) because every check operates over the full set of bundles. See [Checks](#checks).
 
-4. **`packages`** (Required, Array):
+4. **`changelog`** (Optional, Object):
+    - Configures outputs for `packtory changelog`.
+    - If omitted, `packtory changelog` prints grouped Markdown to the pager and writes no files.
+    - `outputs` is a non-empty array of:
+        - `{ kind: 'repository-file', path: 'CHANGELOG.md' }`: writes one grouped changelog at a repository-relative path.
+        - `{ kind: 'package-file', path: 'CHANGELOG.md' }`: writes one package-specific changelog below each changed package's effective `sourcesFolder`.
+        - `{ kind: 'github-release' }`: prints grouped release-body Markdown to the pager. Remote GitHub release creation is not implemented by `packtory changelog`.
+    - Output paths must be safe relative paths. Absolute paths and parent-traversing paths are rejected.
+    - Duplicate `github-release` outputs, duplicate repository-file paths, and package-file destinations that resolve to the same file are rejected.
+    - Generated changelog files are ignored during pull request source attribution.
+    - Changelog outputs are not automatically added to package artifacts. Use `additionalFiles` when a package artifact should include a generated changelog.
+
+5. **`packages`** (Required, Array):
     - An array of per-package configurations.
     - Each per-package configuration has the following settings:
 

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -1,0 +1,187 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
+import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
+import {
+    generatedAttributionPaths,
+    parseValidConfig,
+    shouldPageGroupedChangelog,
+    writeConfiguredChangelogs,
+    type ChangelogConfig
+} from './changelog-destinations.ts';
+
+const deps = { workingDirectory: '/repo' } as const;
+
+function config(overrides: Partial<ChangelogConfig> = {}): ChangelogConfig {
+    return {
+        changelog: {
+            outputs: [
+                { kind: 'repository-file', path: 'CHANGELOG.md' },
+                { kind: 'package-file', path: 'docs/CHANGELOG.md' },
+                { kind: 'github-release' }
+            ]
+        },
+        commonPackageSettings: { sourcesFolder: 'src' },
+        packages: [
+            { name: 'pkg-a', sourcesFolder: 'src/pkg-a' },
+            { name: 'pkg-b', sourcesFolder: '/external/pkg-b' }
+        ],
+        ...overrides
+    };
+}
+
+function generatedChangelog(
+    overrides: { readonly packageMarkdownByName?: ReadonlyMap<string, string> } = {}
+): GeneratedChangelog {
+    return {
+        groupedMarkdown: 'grouped',
+        packageMarkdownByName: overrides.packageMarkdownByName ?? new Map([['pkg-a', 'package-a']])
+    };
+}
+
+async function assertRepositoryReadFailureRethrown(error: Error, messagePattern: RegExp): Promise<void> {
+    const fileManager = createFakeFileManager({
+        simulatedReadFileResponses: [{ error }]
+    });
+
+    await assert.rejects(
+        writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            config({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
+            { updateChangelog: fake.returns('updated') },
+            generatedChangelog()
+        ),
+        messagePattern
+    );
+}
+
+suite('changelog-destinations', function () {
+    test('parseValidConfig returns undefined for invalid configs', function () {
+        assert.strictEqual(parseValidConfig({ packages: [] }), undefined);
+    });
+
+    test('generatedAttributionPaths returns no paths when outputs are absent', function () {
+        assert.deepStrictEqual(generatedAttributionPaths(deps, config({ changelog: undefined })), []);
+    });
+
+    test('generatedAttributionPaths includes repository and in-repository package files', function () {
+        assert.deepStrictEqual(generatedAttributionPaths(deps, config()), [
+            'CHANGELOG.md',
+            'src/pkg-a/docs/CHANGELOG.md'
+        ]);
+    });
+
+    test('generatedAttributionPaths uses common sourcesFolder for package files', function () {
+        assert.deepStrictEqual(
+            generatedAttributionPaths(
+                deps,
+                config({
+                    changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+                    packages: [{ name: 'pkg-a' }]
+                })
+            ),
+            ['src/CHANGELOG.md']
+        );
+    });
+
+    test('generatedAttributionPaths ignores github-release outputs', function () {
+        assert.deepStrictEqual(
+            generatedAttributionPaths(deps, config({ changelog: { outputs: [{ kind: 'github-release' }] } })),
+            []
+        );
+    });
+
+    test('generatedAttributionPaths reports package-file outputs without sourcesFolder', function () {
+        assert.throws(() => {
+            generatedAttributionPaths(
+                deps,
+                config({
+                    changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+                    commonPackageSettings: undefined,
+                    packages: [{ name: 'pkg-a' }]
+                })
+            );
+        }, /Config for package "pkg-a" is missing the sources folder/u);
+    });
+
+    test('shouldPageGroupedChangelog follows default and github-release output behavior', function () {
+        assert.strictEqual(shouldPageGroupedChangelog(undefined), true);
+        assert.strictEqual(shouldPageGroupedChangelog([{ kind: 'repository-file', path: 'CHANGELOG.md' }]), false);
+        assert.strictEqual(shouldPageGroupedChangelog([{ kind: 'github-release' }]), true);
+    });
+
+    test('writeConfiguredChangelogs does nothing when outputs are absent', async function () {
+        const fileManager = createFakeFileManager();
+
+        await writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            config({ changelog: undefined }),
+            { updateChangelog: fake.returns('updated') },
+            generatedChangelog()
+        );
+
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
+
+    test('writeConfiguredChangelogs passes empty existing markdown for missing files', async function () {
+        const missingFileError = Object.assign(new Error('missing'), { code: 'ENOENT' });
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ error: missingFileError }]
+        });
+        const updateChangelog = fake(
+            (input: { readonly existingChangelogMarkdown: string; readonly generatedChangelogMarkdown: string }) => {
+                assert.strictEqual(input.existingChangelogMarkdown, '');
+                return input.generatedChangelogMarkdown;
+            }
+        );
+
+        await writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            config({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
+            { updateChangelog },
+            generatedChangelog()
+        );
+
+        assert.strictEqual(updateChangelog.callCount, 1);
+    });
+
+    test('writeConfiguredChangelogs skips empty generated markdown', async function () {
+        const fileManager = createFakeFileManager();
+
+        await writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            config({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
+            { updateChangelog: fake.returns('updated') },
+            { groupedMarkdown: '', packageMarkdownByName: new Map() }
+        );
+
+        assert.strictEqual(fileManager.getReadFileCallCount(), 0);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
+
+    test('writeConfiguredChangelogs reports package markdown without config', async function () {
+        const fileManager = createFakeFileManager();
+
+        await assert.rejects(
+            writeConfiguredChangelogs(
+                { ...deps, fileManager },
+                config({ changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] } }),
+                { updateChangelog: fake.returns('updated') },
+                generatedChangelog({ packageMarkdownByName: new Map([['missing', 'markdown']]) })
+            ),
+            /Config for package "missing" is missing/u
+        );
+    });
+
+    test('writeConfiguredChangelogs rethrows non-missing read failures', async function () {
+        await assertRepositoryReadFailureRethrown(new Error('read failed'), /read failed/u);
+    });
+
+    test('writeConfiguredChangelogs rethrows non-missing file system failures', async function () {
+        await assertRepositoryReadFailureRethrown(
+            Object.assign(new Error('access denied'), { code: 'EACCES' }),
+            /access denied/u
+        );
+    });
+});

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -1,0 +1,212 @@
+import path from 'node:path';
+import type { PrLogEngine } from '@pr-log/core';
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import type { ChangelogOutput } from '../../config/changelog-settings.ts';
+import { packtoryConfigSchema } from '../../config/packtory-config-schema.ts';
+import type { FileManager } from '../../file-manager/file-manager.ts';
+import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
+
+type PackagePathConfig = {
+    readonly name: string;
+    readonly sourcesFolder?: string | undefined;
+};
+
+export type ChangelogConfig = {
+    readonly changelog?: { readonly outputs: readonly ChangelogOutput[] } | undefined;
+    readonly commonPackageSettings?: { readonly sourcesFolder?: string | undefined } | undefined;
+    readonly packages: readonly PackagePathConfig[];
+};
+
+type ChangelogDestinationDeps = {
+    readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
+    readonly workingDirectory: string;
+};
+
+type FileChangelogDestination = {
+    readonly filePath: string;
+    readonly generatedMarkdown: string;
+};
+
+type FileChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' | 'repository-file' }>;
+
+export function parseValidConfig(config: unknown): ChangelogConfig | undefined {
+    const result = safeParse(packtoryConfigSchema, config);
+    return result.success ? result.data : undefined;
+}
+
+function normalizedConfiguredPath(filePath: string): string {
+    return filePath.split(/[/\\]/u).join(path.sep);
+}
+
+function repositoryPath(deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>, filePath: string): string {
+    return path.resolve(deps.workingDirectory, normalizedConfiguredPath(filePath));
+}
+
+function packageSourcesFolder(packageConfig: PackagePathConfig, config: ChangelogConfig): string {
+    const sourcesFolder = packageConfig.sourcesFolder ?? config.commonPackageSettings?.sourcesFolder;
+    if (sourcesFolder === undefined) {
+        throw new Error(`Config for package "${packageConfig.name}" is missing the sources folder`);
+    }
+    return sourcesFolder;
+}
+
+function packageConfigByNameFrom(config: ChangelogConfig): ReadonlyMap<string, PackagePathConfig> {
+    return new Map(
+        config.packages.map((packageConfig) => {
+            return [packageConfig.name, packageConfig];
+        })
+    );
+}
+
+function packageFilePath(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    packageConfig: PackagePathConfig,
+    outputPath: string
+): string {
+    return path.resolve(
+        deps.workingDirectory,
+        normalizedConfiguredPath(packageSourcesFolder(packageConfig, config)),
+        normalizedConfiguredPath(outputPath)
+    );
+}
+
+function repositoryRelativePath(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    filePath: string
+): string | undefined {
+    const relativePath = path.relative(deps.workingDirectory, filePath);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        return undefined;
+    }
+    return relativePath.split(path.sep).join('/');
+}
+
+export function generatedAttributionPaths(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig
+): readonly string[] {
+    if (config.changelog === undefined) {
+        return [];
+    }
+
+    const paths = config.changelog.outputs
+        .filter((output): output is FileChangelogOutput => {
+            return output.kind !== 'github-release';
+        })
+        .flatMap((output) => {
+            if (output.kind === 'repository-file') {
+                return [repositoryPath(deps, output.path)];
+            }
+            return config.packages.map((packageConfig) => {
+                return packageFilePath(deps, config, packageConfig, output.path);
+            });
+        });
+    return Array.from(
+        new Set(
+            paths.flatMap((filePath) => {
+                const relativePath = repositoryRelativePath(deps, filePath);
+                return relativePath === undefined ? [] : [relativePath];
+            })
+        )
+    );
+}
+
+export function shouldPageGroupedChangelog(outputs: readonly ChangelogOutput[] | undefined): boolean {
+    return (
+        outputs === undefined ||
+        outputs.some((output) => {
+            return output.kind === 'github-release';
+        })
+    );
+}
+
+function repositoryDestinations(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    outputs: readonly ChangelogOutput[],
+    changelog: GeneratedChangelog
+): readonly FileChangelogDestination[] {
+    return outputs.flatMap((output) => {
+        if (output.kind !== 'repository-file') {
+            return [];
+        }
+        return [{ filePath: repositoryPath(deps, output.path), generatedMarkdown: changelog.groupedMarkdown }];
+    });
+}
+
+function packageDestinations(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    outputs: readonly ChangelogOutput[],
+    changelog: GeneratedChangelog
+): readonly FileChangelogDestination[] {
+    const packageConfigsByName = packageConfigByNameFrom(config);
+    return outputs.flatMap((output) => {
+        if (output.kind !== 'package-file') {
+            return [];
+        }
+        return Array.from(changelog.packageMarkdownByName).flatMap(([packageName, generatedMarkdown]) => {
+            const packageConfig = packageConfigsByName.get(packageName);
+            if (packageConfig === undefined) {
+                throw new Error(`Config for package "${packageName}" is missing`);
+            }
+            return [{ filePath: packageFilePath(deps, config, packageConfig, output.path), generatedMarkdown }];
+        });
+    });
+}
+
+function isMissingFileError(error: unknown): boolean {
+    return Reflect.get(new Object(error), 'code') === 'ENOENT';
+}
+
+async function existingChangelogMarkdown(
+    fileManager: Pick<FileManager, 'readFile'>,
+    filePath: string
+): Promise<string> {
+    try {
+        return await fileManager.readFile(filePath);
+    } catch (error: unknown) {
+        if (isMissingFileError(error)) {
+            return '';
+        }
+        throw error;
+    }
+}
+
+async function writeChangelogDestination(
+    deps: Pick<ChangelogDestinationDeps, 'fileManager'>,
+    prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
+    destination: FileChangelogDestination
+): Promise<void> {
+    if (destination.generatedMarkdown.length === 0) {
+        return;
+    }
+    const existingChangelogMarkdownValue = await existingChangelogMarkdown(deps.fileManager, destination.filePath);
+    await deps.fileManager.writeFile(
+        destination.filePath,
+        prLogEngine.updateChangelog({
+            existingChangelogMarkdown: existingChangelogMarkdownValue,
+            generatedChangelogMarkdown: destination.generatedMarkdown
+        })
+    );
+}
+
+export async function writeConfiguredChangelogs(
+    deps: ChangelogDestinationDeps,
+    config: ChangelogConfig,
+    prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
+    changelog: GeneratedChangelog
+): Promise<void> {
+    if (config.changelog === undefined) {
+        return;
+    }
+
+    const { outputs } = config.changelog;
+    const destinations = [
+        ...repositoryDestinations(deps, outputs, changelog),
+        ...packageDestinations(deps, config, outputs, changelog)
+    ];
+    for (const destination of destinations) {
+        await writeChangelogDestination(deps, prLogEngine, destination);
+    }
+}

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -10,6 +10,7 @@ import type {
     PullRequestWithLabel
 } from '@pr-log/core';
 import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
+import { createFakeFileManager, type FakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import type { ConfigLoader } from '../config-loader.ts';
 import { runChangelogHandler, type ChangelogHandlerDeps } from './changelog-handler.ts';
@@ -31,6 +32,18 @@ function releasePackage(overrides: Partial<ReleasePlanPackage> = {}): ReleasePla
         ...overrides
     };
 }
+
+const validConfig = {
+    packages: [
+        {
+            sourcesFolder: 'src/pkg-a',
+            mainPackageJson: { type: 'module' },
+            name: 'pkg-a',
+            roots: { main: { js: 'index.js' } },
+            publishSettings: { access: 'public' }
+        }
+    ]
+} as const;
 
 function releasePlanOutcomeFrom(result: ReleasePlanResult): ReleasePlanOutcome {
     return {
@@ -86,8 +99,13 @@ function createEngine(overrides: EngineOverrides = {}): PrLogEngine {
         }),
         resolvePullRequestLabels: fake.resolves(labeledPullRequests),
         renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
-        renderChangelog: fake.returns(''),
-        renderTargetChangelog: fake.returns('')
+        renderTargetChangelog: fake((input: { readonly targetName: string }) => {
+            return `## ${input.targetName} 1.0.1\n`;
+        }),
+        updateChangelog: fake((input: { readonly generatedChangelogMarkdown: string }) => {
+            return `merged:\n${input.generatedChangelogMarkdown}`;
+        }),
+        renderChangelog: fake.returns('')
     };
 }
 
@@ -98,6 +116,11 @@ type Spies = {
     readonly planReleaseAgainstLatestPublished: SinonSpy;
     readonly stopAll: SinonSpy;
 };
+
+type ChangelogOutputConfig =
+    | { readonly kind: 'github-release' }
+    | { readonly kind: 'package-file'; readonly path: string }
+    | { readonly kind: 'repository-file'; readonly path: string };
 
 function spinnerRendererCapturing(stopAll: SinonSpy): TerminalSpinnerRenderer {
     return { stopAll } as unknown as TerminalSpinnerRenderer;
@@ -118,6 +141,7 @@ function configLoaderRejecting(error: unknown): ConfigLoader {
 function depsWith(spec: {
     readonly spies: Spies;
     readonly configLoader?: ConfigLoader;
+    readonly fileManager?: FakeFileManager;
     readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
     readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
 }): ChangelogHandlerDeps {
@@ -129,8 +153,9 @@ function depsWith(spec: {
         packtory: {
             planReleaseAgainstLatestPublished: spec.spies.planReleaseAgainstLatestPublished
         } as unknown as Packtory,
+        fileManager: spec.fileManager ?? createFakeFileManager(),
         spinnerRenderer: spinnerRendererCapturing(spec.spies.stopAll),
-        configLoader: spec.configLoader ?? configLoaderReturning('the-config'),
+        configLoader: spec.configLoader ?? configLoaderReturning(validConfig),
         createPrLogEngine: spec.spies.createPrLogEngine,
         currentDate() {
             return new Date('2026-06-13T00:00:00.000Z');
@@ -166,6 +191,44 @@ function makeSpies(
     };
 }
 
+async function assertReleasePlanFailureLogged(spec: {
+    readonly releasePlanOutcome: ReleasePlanOutcome;
+    readonly expectedLog: string;
+}): Promise<void> {
+    const spies = makeSpies(createEngine(), spec.releasePlanOutcome);
+
+    const code = await runChangelogHandler(depsWith({ spies }));
+
+    assert.strictEqual(code, 1);
+    assert.strictEqual(spies.createPrLogEngine.callCount, 0);
+    assert.deepStrictEqual(spies.log.firstCall.args, [spec.expectedLog]);
+}
+
+function configWithChangelogOutputs(outputs: readonly ChangelogOutputConfig[]): unknown {
+    return {
+        ...validConfig,
+        changelog: { outputs }
+    } as const;
+}
+
+async function runWithChangelogOutputs(spec: {
+    readonly outputs: readonly ChangelogOutputConfig[];
+    readonly fileManager?: FakeFileManager;
+    readonly spies?: Spies;
+}): Promise<{ readonly code: number; readonly fileManager: FakeFileManager; readonly spies: Spies }> {
+    const fileManager = spec.fileManager ?? createFakeFileManager();
+    const spies = spec.spies ?? makeSpies();
+    const code = await runChangelogHandler(
+        depsWith({
+            spies,
+            fileManager,
+            configLoader: configLoaderReturning(configWithChangelogOutputs(spec.outputs))
+        })
+    );
+
+    return { code, fileManager, spies };
+}
+
 suite('changelog-handler', function () {
     test('loads config, plans the release, and renders changelog markdown through the pager', async function () {
         const spies = makeSpies();
@@ -173,36 +236,39 @@ suite('changelog-handler', function () {
         const code = await runChangelogHandler(depsWith({ spies }));
 
         assert.strictEqual(code, 0);
-        assert.deepStrictEqual(spies.planReleaseAgainstLatestPublished.firstCall.args, ['the-config']);
+        assert.deepStrictEqual(spies.planReleaseAgainstLatestPublished.firstCall.args, [validConfig]);
         assert.strictEqual(spies.createPrLogEngine.callCount, 1);
         assert.deepStrictEqual(spies.pageOutput.firstCall.args, ['## pkg-a 1.0.1\n']);
         assert.strictEqual(spies.stopAll.callCount, 2);
     });
 
     test('returns 1 and logs release-plan config failures without creating pr-log', async function () {
-        const releasePlanOutcome = configFailureOutcome(['bad config', 'worse config']);
-        const spies = makeSpies(createEngine(), releasePlanOutcome);
-
-        const code = await runChangelogHandler(depsWith({ spies }));
-
-        assert.strictEqual(code, 1);
-        assert.strictEqual(spies.createPrLogEngine.callCount, 0);
-        assert.deepStrictEqual(spies.log.firstCall.args, [
-            'Configuration issues, there are 2 issue(s)\n\n- bad config\n- worse config'
-        ]);
+        await assertReleasePlanFailureLogged({
+            releasePlanOutcome: configFailureOutcome(['bad config', 'worse config']),
+            expectedLog: 'Configuration issues, there are 2 issue(s)\n\n- bad config\n- worse config'
+        });
     });
 
     test('returns 1 and logs release-plan check failures without creating pr-log', async function () {
-        const releasePlanOutcome = checkFailureOutcome(['bad package', 'worse package']);
-        const spies = makeSpies(createEngine(), releasePlanOutcome);
+        await assertReleasePlanFailureLogged({
+            releasePlanOutcome: checkFailureOutcome(['bad package', 'worse package']),
+            expectedLog: 'Check issues, there are 2 issue(s)\n\n- bad package\n- worse package'
+        });
+    });
 
-        const code = await runChangelogHandler(depsWith({ spies }));
+    test('does not render changelog output when the loaded config cannot be parsed', async function () {
+        const spies = makeSpies();
 
-        assert.strictEqual(code, 1);
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                configLoader: configLoaderReturning({ packages: [] })
+            })
+        );
+
+        assert.strictEqual(code, 0);
         assert.strictEqual(spies.createPrLogEngine.callCount, 0);
-        assert.deepStrictEqual(spies.log.firstCall.args, [
-            'Check issues, there are 2 issue(s)\n\n- bad package\n- worse package'
-        ]);
+        assert.strictEqual(spies.pageOutput.callCount, 0);
     });
 
     test('returns 1 and still renders succeeded changed packages for partial release-plan failures', async function () {
@@ -352,6 +418,85 @@ suite('changelog-handler', function () {
 
         assert.strictEqual(code, 0);
         assert.strictEqual(spies.pageOutput.callCount, 0);
+    });
+
+    test('writes repository-file changelog output through FileManager', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: '# Existing\n' }]
+        });
+
+        const { code, spies } = await runWithChangelogOutputs({
+            fileManager,
+            outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }]
+        });
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(spies.pageOutput.callCount, 0);
+        assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/repo/CHANGELOG.md' });
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+            filePath: '/repo/CHANGELOG.md',
+            content: 'merged:\n## pkg-a 1.0.1\n'
+        });
+    });
+
+    test('writes package-file changelog output under the effective sourcesFolder', async function () {
+        const { code, fileManager } = await runWithChangelogOutputs({
+            outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }]
+        });
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+            filePath: '/repo/src/pkg-a/CHANGELOG.md',
+            content: 'merged:\n## pkg-a 1.0.1\n'
+        });
+    });
+
+    test('supports repository-file, package-file, and github-release outputs together', async function () {
+        const { code, fileManager, spies } = await runWithChangelogOutputs({
+            outputs: [
+                { kind: 'repository-file', path: 'CHANGELOG.md' },
+                { kind: 'package-file', path: 'CHANGELOG.md' },
+                { kind: 'github-release' }
+            ]
+        });
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(spies.pageOutput.firstCall.args, ['## pkg-a 1.0.1\n']);
+        assert.deepStrictEqual(
+            fileManager.getAllWriteFileCalls().map((call) => {
+                return call.filePath;
+            }),
+            ['/repo/CHANGELOG.md', '/repo/src/pkg-a/CHANGELOG.md']
+        );
+    });
+
+    test('treats missing existing changelog files as empty', async function () {
+        const missingFileError = Object.assign(new Error('missing'), { code: 'ENOENT' });
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ error: missingFileError }]
+        });
+
+        const { code } = await runWithChangelogOutputs({
+            fileManager,
+            outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }]
+        });
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
+    });
+
+    test('returns 1 when writing a changelog file fails', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedWriteFileResponses: [{ error: new Error('write failed') }]
+        });
+
+        const { code, spies } = await runWithChangelogOutputs({
+            fileManager,
+            outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }]
+        });
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(spies.log.firstCall.args, ['write failed']);
     });
 
     test('returns 1 and stops spinners when config loading fails', async function () {

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -1,11 +1,18 @@
 import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions } from '@pr-log/core';
 import { normalizeRepositoryUrl } from '../../bundle-emitter/repository-url-normalizer.ts';
+import type { FileManager } from '../../file-manager/file-manager.ts';
 import { partialFailureMessages } from '../../packtory/partial-result.ts';
 import type { Packtory, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
 import { checksErrorType, configErrorType, type ReleasePlanFailure } from '../../packtory/packtory-results.ts';
-import { generateChangelog } from '../../packtory/packtory-changelog.ts';
+import { generateChangelogOutputs } from '../../packtory/packtory-changelog.ts';
 import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import {
+    generatedAttributionPaths,
+    parseValidConfig,
+    shouldPageGroupedChangelog,
+    writeConfiguredChangelogs
+} from './changelog-destinations.ts';
 
 type Logger = (message: string) => void;
 type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
@@ -13,10 +20,12 @@ type GitHubRepositoryParts = {
     readonly owner: string;
     readonly repo: string;
 };
+type ValidChangelogConfig = NonNullable<ReturnType<typeof parseValidConfig>>;
 
 export type ChangelogHandlerDeps = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
     readonly currentDate: () => Date;
+    readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
     readonly log: Logger;
     readonly pageOutput: (content: string) => Promise<void>;
     readonly packtory: Packtory;
@@ -99,22 +108,29 @@ function releasePlanPackagesFrom(result: ReleasePlanResult): readonly ReleasePla
     return [];
 }
 
-async function renderChangelog(deps: ChangelogHandlerDeps, packages: readonly ReleasePlanPackage[]): Promise<void> {
+async function renderChangelog(
+    deps: ChangelogHandlerDeps,
+    config: ValidChangelogConfig,
+    packages: readonly ReleasePlanPackage[]
+): Promise<void> {
     if (packages.length === 0) {
         return;
     }
     const packageInfo = await deps.readPackageInfo();
-    const markdown = await generateChangelog({
+    const prLogEngine = createEngine(deps);
+    const changelog = await generateChangelogOutputs({
         packages,
-        prLogEngine: createEngine(deps),
+        prLogEngine,
         githubRepo: githubRepoFrom(packageInfo),
+        ignoredAttributionPaths: generatedAttributionPaths(deps, config),
         packageInfo,
         currentDate: deps.currentDate(),
         validLabels: defaultValidLabels
     });
-    if (markdown.length > 0) {
-        await deps.pageOutput(markdown);
+    if (shouldPageGroupedChangelog(config.changelog?.outputs) && changelog.groupedMarkdown.length > 0) {
+        await deps.pageOutput(changelog.groupedMarkdown);
     }
+    await writeConfiguredChangelogs(deps, config, prLogEngine, changelog);
 }
 
 function exitCodeFromReleasePlanResult(log: Logger, result: ReleasePlanResult): number {
@@ -129,7 +145,10 @@ async function runChangelog(deps: ChangelogHandlerDeps): Promise<number> {
     const config = await deps.configLoader.load();
     const outcome = await deps.packtory.planReleaseAgainstLatestPublished(config);
     deps.spinnerRenderer.stopAll();
-    await renderChangelog(deps, releasePlanPackagesFrom(outcome.result));
+    const validConfig = parseValidConfig(config);
+    if (validConfig !== undefined) {
+        await renderChangelog(deps, validConfig, releasePlanPackagesFrom(outcome.result));
+    }
     return exitCodeFromReleasePlanResult(deps.log, outcome.result);
 }
 

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -86,7 +86,9 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
                 readPullRequestChangedFiles: fake.resolves(new Map()),
                 filterPullRequestsByTargetFiles: fake.returns([]),
                 resolvePullRequestLabels: fake.resolves([]),
-                renderGroupedTargetChangelog: fake.returns('')
+                renderGroupedTargetChangelog: fake.returns(''),
+                renderTargetChangelog: fake.returns(''),
+                updateChangelog: fake.returns('')
             });
         }),
         currentDate() {

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -127,6 +127,7 @@ export function createCommandLineInterfaceRunner(
                         packtory,
                         spinnerRenderer,
                         configLoader,
+                        fileManager,
                         createPrLogEngine,
                         currentDate,
                         readEnvironmentVariable,

--- a/source/config/changelog-settings.test.ts
+++ b/source/config/changelog-settings.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert';
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import { suite, test } from 'mocha';
+import { changelogSettingsSchema, validateChangelogSettings } from './changelog-settings.ts';
+import type { PacktoryConfigWithoutRegistry } from './config.ts';
+
+function configWith(changelog: PacktoryConfigWithoutRegistry['changelog']): PacktoryConfigWithoutRegistry {
+    return {
+        changelog,
+        packages: [
+            {
+                sourcesFolder: 'src/pkg-a',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg-a',
+                roots: { main: { js: 'index.js' } },
+                publishSettings: { access: 'public' }
+            },
+            {
+                sourcesFolder: 'src/pkg-b',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg-b',
+                roots: { main: { js: 'index.js' } },
+                publishSettings: { access: 'public' }
+            }
+        ]
+    };
+}
+
+function packageWithoutSources(name: string, jsFile: string) {
+    return {
+        name,
+        mainPackageJson: { type: 'module' },
+        roots: { main: { js: jsFile } }
+    } as const;
+}
+
+function packagesWithoutSources() {
+    return [packageWithoutSources('pkg-a', 'a.js'), packageWithoutSources('pkg-b', 'b.js')] as const;
+}
+
+suite('changelog-settings', function () {
+    test('schema accepts all output kinds', function () {
+        const result = safeParse(changelogSettingsSchema, {
+            outputs: [
+                { kind: 'repository-file', path: 'CHANGELOG.md' },
+                { kind: 'package-file', path: 'docs/CHANGELOG.md' },
+                { kind: 'github-release' }
+            ]
+        });
+
+        assert.strictEqual(result.success, true);
+    });
+
+    test('schema rejects empty outputs', function () {
+        assert.strictEqual(safeParse(changelogSettingsSchema, { outputs: [] }).success, false);
+    });
+
+    test('schema rejects unsafe output paths', function () {
+        assert.strictEqual(
+            safeParse(changelogSettingsSchema, {
+                outputs: [{ kind: 'repository-file', path: '../CHANGELOG.md' }]
+            }).success,
+            false
+        );
+        assert.strictEqual(
+            safeParse(changelogSettingsSchema, {
+                outputs: [{ kind: 'package-file', path: '/CHANGELOG.md' }]
+            }).success,
+            false
+        );
+    });
+
+    test('schema rejects extra output object properties', function () {
+        assert.strictEqual(
+            safeParse(changelogSettingsSchema, {
+                outputs: [{ kind: 'github-release', path: 'CHANGELOG.md' }]
+            }).success,
+            false
+        );
+    });
+
+    test('validation rejects duplicate github-release outputs', function () {
+        const result = validateChangelogSettings(
+            configWith({ outputs: [{ kind: 'github-release' }, { kind: 'github-release' }] })
+        );
+
+        assert.deepStrictEqual(result, ['changelog.outputs must not contain duplicate github-release outputs']);
+    });
+
+    test('validation accepts a single github-release output', function () {
+        const result = validateChangelogSettings(configWith({ outputs: [{ kind: 'github-release' }] }));
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('validation rejects duplicate repository-file paths', function () {
+        const result = validateChangelogSettings(
+            configWith({
+                outputs: [
+                    { kind: 'repository-file', path: 'docs/CHANGELOG.md' },
+                    { kind: 'repository-file', path: 'docs\\CHANGELOG.md' }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(result, [
+            'changelog.outputs must not contain duplicate repository-file path "docs/CHANGELOG.md"'
+        ]);
+    });
+
+    test('validation rejects package-file destinations that resolve to the same file', function () {
+        const result = validateChangelogSettings({
+            changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+            commonPackageSettings: { sourcesFolder: 'src', publishSettings: { access: 'public' } },
+            packages: packagesWithoutSources()
+        });
+
+        assert.deepStrictEqual(result, [
+            'changelog.outputs package-file destinations must resolve to unique files; "src/CHANGELOG.md" is duplicated'
+        ]);
+    });
+
+    test('validation skips package-file destination checks when sourcesFolder is unavailable', function () {
+        const result = validateChangelogSettings({
+            changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+            packages: packagesWithoutSources()
+        });
+
+        assert.deepStrictEqual(result, []);
+    });
+});

--- a/source/config/changelog-settings.ts
+++ b/source/config/changelog-settings.ts
@@ -1,0 +1,131 @@
+import path from 'node:path';
+import { z } from 'zod/mini';
+import { bundleRelativePathSchema } from './base-validations.ts';
+
+const repositoryFileOutputSchema = z.readonly(
+    z.strictObject({
+        kind: z.literal('repository-file'),
+        path: bundleRelativePathSchema
+    })
+);
+
+const packageFileOutputSchema = z.readonly(
+    z.strictObject({
+        kind: z.literal('package-file'),
+        path: bundleRelativePathSchema
+    })
+);
+
+const githubReleaseOutputSchema = z.readonly(
+    z.strictObject({
+        kind: z.literal('github-release')
+    })
+);
+
+const changelogOutputSchema = z.union([repositoryFileOutputSchema, packageFileOutputSchema, githubReleaseOutputSchema]);
+
+export const changelogSettingsSchema = z.readonly(
+    z.strictObject({
+        outputs: z.readonly(z.tuple([changelogOutputSchema], changelogOutputSchema))
+    })
+);
+
+export type ChangelogOutput = z.infer<typeof changelogOutputSchema>;
+export type ChangelogSettings = z.infer<typeof changelogSettingsSchema>;
+
+type PackageChangelogValidationConfig = {
+    readonly [key: string]: unknown;
+    readonly sourcesFolder?: string | undefined;
+};
+
+type ChangelogValidationConfig = {
+    readonly [key: string]: unknown;
+    readonly changelog?: ChangelogSettings | undefined;
+    readonly commonPackageSettings?:
+        | { readonly [key: string]: unknown; readonly sourcesFolder?: string | undefined }
+        | undefined;
+    readonly packages: readonly PackageChangelogValidationConfig[];
+};
+
+function normalizedRelativePath(filePath: string): string {
+    return filePath.split(/[/\\]/u).join('/');
+}
+
+function normalizedFilePath(...filePathSegments: readonly string[]): string {
+    return path.normalize(path.join(...filePathSegments.map(normalizedRelativePath)));
+}
+
+function pushDuplicateValueIssues(
+    issues: string[],
+    values: readonly string[],
+    messageFor: (value: string) => string
+): void {
+    const seenValues = new Set<string>();
+    const reportedValues = new Set<string>();
+
+    for (const value of values) {
+        if (seenValues.has(value) && !reportedValues.has(value)) {
+            issues.push(messageFor(value));
+            reportedValues.add(value);
+        }
+        seenValues.add(value);
+    }
+}
+
+function sourcesFolderFor(
+    packageConfig: PackageChangelogValidationConfig,
+    packtoryConfig: ChangelogValidationConfig
+): string | undefined {
+    return packageConfig.sourcesFolder ?? packtoryConfig.commonPackageSettings?.sourcesFolder;
+}
+
+function packageFileDestinationPaths(packtoryConfig: ChangelogValidationConfig, outputPath: string): readonly string[] {
+    return packtoryConfig.packages.flatMap((packageConfig) => {
+        const sourcesFolder = sourcesFolderFor(packageConfig, packtoryConfig);
+        if (sourcesFolder === undefined) {
+            return [];
+        }
+        return [normalizedFilePath(sourcesFolder, outputPath)];
+    });
+}
+
+export function validateChangelogSettings(packtoryConfig: ChangelogValidationConfig): readonly string[] {
+    if (packtoryConfig.changelog === undefined) {
+        return [];
+    }
+
+    const { outputs } = packtoryConfig.changelog;
+    const issues: string[] = [];
+    const githubReleaseCount = outputs.filter((output) => {
+        return output.kind === 'github-release';
+    }).length;
+
+    if (githubReleaseCount > 1) {
+        issues.push('changelog.outputs must not contain duplicate github-release outputs');
+    }
+
+    pushDuplicateValueIssues(
+        issues,
+        outputs.flatMap((output) => {
+            return output.kind === 'repository-file' ? [normalizedRelativePath(output.path)] : [];
+        }),
+        (duplicatePath) => {
+            return `changelog.outputs must not contain duplicate repository-file path "${duplicatePath}"`;
+        }
+    );
+
+    pushDuplicateValueIssues(
+        issues,
+        outputs.flatMap((output) => {
+            return output.kind === 'package-file' ? packageFileDestinationPaths(packtoryConfig, output.path) : [];
+        }),
+        (duplicatePath) => {
+            return [
+                'changelog.outputs package-file destinations must resolve to unique files;',
+                `"${duplicatePath}" is duplicated`
+            ].join(' ');
+        }
+    );
+
+    return issues;
+}

--- a/source/config/config.ts
+++ b/source/config/config.ts
@@ -8,6 +8,7 @@ import {
     type PackageConfig as PackageConfigBase,
     type PackageConfigsByName as PackageConfigsByNameBase
 } from './package-config.ts';
+import type { ChangelogSettings } from './changelog-settings.ts';
 import type { RegistrySettings } from './registry-settings.ts';
 
 export type ChecksSettings = ChecksSettingsBase;
@@ -15,6 +16,7 @@ export type PackageChecksSettings = PackageChecksSettingsBase;
 export type PackageConfig = PackageConfigBase;
 export type PackageConfigsByName = PackageConfigsByNameBase;
 export type PacktoryConfigWithoutRegistry = {
+    readonly changelog?: ChangelogSettings | undefined;
     readonly checks?: ChecksSettings | undefined;
     readonly commonPackageSettings?: CommonPackageSettingsBase | undefined;
     readonly packages: readonly PackageConfig[];

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -126,4 +126,30 @@ suite('packtory-config-schema', function () {
             }
         })
     );
+
+    test(
+        'packtory config schema: accepts changelog outputs',
+        checkValidationSuccess({
+            schema: packtoryConfigSchema,
+            data: {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                changelog: {
+                    outputs: [
+                        { kind: 'repository-file', path: 'CHANGELOG.md' },
+                        { kind: 'package-file', path: 'CHANGELOG.md' },
+                        { kind: 'github-release' }
+                    ]
+                },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'foo',
+                        roots: { main: { js: 'foo' } },
+                        publishSettings: { access: 'public' }
+                    }
+                ]
+            }
+        })
+    );
 });

--- a/source/config/packtory-config-without-registry-schema.ts
+++ b/source/config/packtory-config-without-registry-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/mini';
+import { changelogSettingsSchema } from './changelog-settings.ts';
 import { checksSchema } from './checks-schema.ts';
 import {
     commonPackageSettingsMainPackageJsonRequiredSchema,
@@ -14,9 +15,14 @@ import {
     packageSchemaWithPartialCommonSettings
 } from './package-schemas.ts';
 
+const topLevelSettingsSchemaShape = {
+    changelog: z.optional(changelogSettingsSchema),
+    checks: z.optional(checksSchema)
+};
+
 const packageConfigWithOptionalCommonPackageSettingsSchema = z.readonly(
     z.object({
-        checks: z.optional(checksSchema),
+        ...topLevelSettingsSchemaShape,
         commonPackageSettings: z.optional(
             z.extend(optionalCommonPackageSettingsSchema, optionalPackageSettingsSchema.shape)
         ),
@@ -26,7 +32,7 @@ const packageConfigWithOptionalCommonPackageSettingsSchema = z.readonly(
 
 const packageConfigWithRequiredCommonPackageSettingsSchema = z.readonly(
     z.object({
-        checks: z.optional(checksSchema),
+        ...topLevelSettingsSchemaShape,
         commonPackageSettings: z.extend(requiredCommonPackageSettingsSchema, optionalPackageSettingsSchema.shape),
         packages: z.readonly(z.tuple([packageSchemaWithPartialCommonSettings], packageSchemaWithPartialCommonSettings))
     })
@@ -34,7 +40,7 @@ const packageConfigWithRequiredCommonPackageSettingsSchema = z.readonly(
 
 const packageConfigWithRequiredMainPackageJsonSchema = z.readonly(
     z.object({
-        checks: z.optional(checksSchema),
+        ...topLevelSettingsSchemaShape,
         commonPackageSettings: z.extend(
             commonPackageSettingsMainPackageJsonRequiredSchema,
             optionalPackageSettingsSchema.shape
@@ -47,7 +53,7 @@ const packageConfigWithRequiredMainPackageJsonSchema = z.readonly(
 
 const packageConfigWithRequiredSourcesFolderSchema = z.readonly(
     z.object({
-        checks: z.optional(checksSchema),
+        ...topLevelSettingsSchemaShape,
         commonPackageSettings: z.extend(
             commonPackageSettingsSourcesFolderRequiredSchema,
             optionalPackageSettingsSchema.shape

--- a/source/config/pre-graph-validation.ts
+++ b/source/config/pre-graph-validation.ts
@@ -1,5 +1,6 @@
 import { indexBy } from 'remeda';
 import type { PackageConfig, PackageConfigsByName, PacktoryConfigWithoutRegistry } from './config.ts';
+import { validateChangelogSettings } from './changelog-settings.ts';
 import { validateDependenciesExist } from './dependency-existence-validation.ts';
 import { validatePackageSurfaceRules } from './root-config-validation.ts';
 import { validateAllowScriptsConsistency, validatePublishSettingsArePlaced } from './settings-validation.ts';
@@ -13,6 +14,7 @@ export function packageListToRecord(packages: readonly PackageConfig[]): Package
 export function collectPreGraphIssues(packtoryConfig: PacktoryConfigWithoutRegistry): readonly string[] {
     const packageConfigs = packageListToRecord(packtoryConfig.packages);
     return [
+        ...validateChangelogSettings(packtoryConfig),
         ...validatePublishSettingsArePlaced(packtoryConfig),
         ...validateAllowScriptsConsistency(packtoryConfig),
         ...validateDependenciesExist(packageConfigs),

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -175,10 +175,10 @@ suite('schema-contracts', function () {
         assert.deepStrictEqual(result, {
             optionCount: 4,
             topLevelKeys: [
-                ['checks', 'commonPackageSettings', 'packages'],
-                ['checks', 'commonPackageSettings', 'packages'],
-                ['checks', 'commonPackageSettings', 'packages'],
-                ['checks', 'commonPackageSettings', 'packages']
+                ['changelog', 'checks', 'commonPackageSettings', 'packages'],
+                ['changelog', 'checks', 'commonPackageSettings', 'packages'],
+                ['changelog', 'checks', 'commonPackageSettings', 'packages'],
+                ['changelog', 'checks', 'commonPackageSettings', 'packages']
             ],
             packageTupleItemCounts: [1, 1, 1, 1],
             packageTupleHasRest: [true, true, true, true],

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -61,13 +61,16 @@ packtory <command> [options]
 
 **Changelog behavior:**
 
-- `packtory changelog` computes the same release plan used by Packtory's release planning API, skips unchanged packages, and prints one grouped Markdown changelog for packages that would publish a changed artifact.
-- Pull requests are attributed by comparing GitHub changed files against each package's attributed source files. Changelog files named `CHANGELOG.md` are ignored as attribution inputs.
+- `packtory changelog` computes the same release plan used by Packtory's release planning API and skips unchanged packages.
+- Without `changelog.outputs`, it prints one grouped Markdown changelog for packages that would publish a changed artifact.
+- `changelog.outputs` can write a grouped repository file with `{ kind: 'repository-file', path }`, write package-specific files below each changed package's effective `sourcesFolder` with `{ kind: 'package-file', path }`, and print grouped release-body Markdown with `{ kind: 'github-release' }`.
+- Pull requests are attributed by comparing GitHub changed files against each package's attributed source files. Changelog files named `CHANGELOG.md` and configured generated changelog output paths are ignored as attribution inputs.
 - The GitHub repository is read from the root `package.json` `repository` field.
 - GitHub API requests use `GH_TOKEN` when set, otherwise `GITHUB_TOKEN`.
-- Output is shown through `$PAGER` when possible, otherwise `less -R`, otherwise standard output.
+- Pager output is shown through `$PAGER` when possible, otherwise `less -R`, otherwise standard output.
+- Generated changelog files are not automatically added to package artifacts. Use `additionalFiles` when a package artifact should include a changelog.
 - `packtory changelog` exits with code `0` on a clean run and `1` on config, release-plan, Git, GitHub, or changelog generation failures. Partial release-plan failures still render succeeded changed packages when changelog generation succeeds.
-- `changelog` is read-only: it never writes changelog files, commits, tags, releases, deployments, registry data, or packages.
+- `changelog` never commits, tags, creates releases, creates deployments, writes registry data, or publishes packages.
 
 **Pack behavior:**
 

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -197,7 +197,7 @@ describe('PacktoryConfig — rejected shapes', () => {
 describe('PacktoryConfig — exposed structure', () => {
     test('exposes the documented top-level keys', () => {
         expect<keyof PacktoryConfig>().type.toBe<
-            'checks' | 'commonPackageSettings' | 'packages' | 'registrySettings'
+            'changelog' | 'checks' | 'commonPackageSettings' | 'packages' | 'registrySettings'
         >();
     });
 

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -8,7 +8,7 @@ import type {
     PullRequestWithLabel,
     RenderGroupedTargetChangelogMarkdownInput
 } from '@pr-log/core';
-import { generateChangelog } from './packtory-changelog.ts';
+import { generateChangelogOutputs } from './packtory-changelog.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
 
 const validLabels = new Map([['bug', 'Bug Fixes']]);
@@ -36,6 +36,7 @@ type EngineCalls = {
     readonly filterPullRequestsByTargetFiles: SinonSpy<[FilterPullRequestsByTargetFilesInput], readonly PullRequest[]>;
     readonly readPullRequestChangedFiles: SinonSpy;
     readonly renderGroupedTargetChangelog: SinonSpy<[RenderGroupedTargetChangelogMarkdownInput], string>;
+    readonly renderTargetChangelog: SinonSpy;
     readonly resolveChangelogBaseRef: SinonSpy;
     readonly resolveLatestSemverChangelogBaseRef: SinonSpy;
     readonly resolvePullRequestLabels: SinonSpy;
@@ -65,6 +66,9 @@ function createEngine(): { readonly engine: PrLogEngine; readonly calls: EngineC
                 })
                 .join('\n');
         }),
+        renderTargetChangelog: fake((input: { readonly targetName: string }) => {
+            return `# ${input.targetName}\n`;
+        }),
         resolveChangelogBaseRef: fake(async (input: { readonly packageName: string }) => {
             return { ref: `${input.packageName}-base` };
         }),
@@ -76,14 +80,16 @@ function createEngine(): { readonly engine: PrLogEngine; readonly calls: EngineC
 }
 
 async function render(packages: readonly ReleasePlanPackage[], engine: PrLogEngine): Promise<string> {
-    return generateChangelog({
+    const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
         githubRepo: 'owner/repo',
         packageInfo: {},
         currentDate: new Date('2026-06-13T00:00:00.000Z'),
+        ignoredAttributionPaths: [],
         validLabels
     });
+    return changelog.groupedMarkdown;
 }
 
 suite('packtory-changelog', function () {
@@ -135,6 +141,7 @@ suite('packtory-changelog', function () {
         assert.deepStrictEqual(calls.resolvePullRequestLabels.firstCall.args[0], {
             githubRepo: 'owner/repo',
             validLabels,
+            ignoredLabels: [],
             pullRequests: [{ id: 1, title: 'Fix package' }],
             targetName: 'pkg-a',
             targetScopedLabelPattern: undefined
@@ -215,6 +222,24 @@ suite('packtory-changelog', function () {
 
         assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].ignoredAttributionPaths, [
             'docs/CHANGELOG.md'
+        ]);
+    });
+
+    test('adds generated changelog paths to ignored attribution paths', async function () {
+        const { engine, calls } = createEngine();
+
+        await generateChangelogOutputs({
+            packages: [releasePackage({ changelogSourceFiles: ['source/pkg-a.ts'] })],
+            prLogEngine: engine,
+            githubRepo: 'owner/repo',
+            packageInfo: {},
+            currentDate: new Date('2026-06-13T00:00:00.000Z'),
+            ignoredAttributionPaths: ['docs/generated.md'],
+            validLabels
+        });
+
+        assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].ignoredAttributionPaths, [
+            'docs/generated.md'
         ]);
     });
 });

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -1,4 +1,5 @@
 import type { PrLogEngine, PullRequestWithLabel, TargetChangelogSection } from '@pr-log/core';
+import { compareValues } from '../common/sort-values.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
 
 type ChangelogTarget = {
@@ -9,6 +10,7 @@ type ChangelogTarget = {
 export type GenerateChangelogInput = {
     readonly currentDate: Date;
     readonly githubRepo: string;
+    readonly ignoredAttributionPaths: readonly string[];
     readonly packageInfo: Record<string, unknown>;
     readonly packages: readonly ReleasePlanPackage[];
     readonly prLogEngine: Pick<
@@ -17,11 +19,17 @@ export type GenerateChangelogInput = {
         | 'filterPullRequestsByTargetFiles'
         | 'readPullRequestChangedFiles'
         | 'renderGroupedTargetChangelog'
+        | 'renderTargetChangelog'
         | 'resolveChangelogBaseRef'
         | 'resolveLatestSemverChangelogBaseRef'
         | 'resolvePullRequestLabels'
     >;
     readonly validLabels: ReadonlyMap<string, string>;
+};
+
+export type GeneratedChangelog = {
+    readonly groupedMarkdown: string;
+    readonly packageMarkdownByName: ReadonlyMap<string, string>;
 };
 
 const changelogFileName = 'CHANGELOG.md';
@@ -33,8 +41,12 @@ function changedPackagesFrom(packages: readonly ReleasePlanPackage[]): readonly 
     });
 }
 
+function sortedUnique(values: ReadonlySet<string>): readonly string[] {
+    return Array.from(values).toSorted(compareValues);
+}
+
 function changelogPathsFrom(packages: readonly ReleasePlanPackage[]): readonly string[] {
-    return Array.from(
+    return sortedUnique(
         new Set(
             packages.flatMap((packagePlan) => {
                 return packagePlan.changelogSourceFiles.filter((filePath) => {
@@ -43,6 +55,13 @@ function changelogPathsFrom(packages: readonly ReleasePlanPackage[]): readonly s
             })
         )
     );
+}
+
+function mergedIgnoredAttributionPaths(
+    packages: readonly ReleasePlanPackage[],
+    configuredPaths: readonly string[]
+): readonly string[] {
+    return sortedUnique(new Set([...changelogPathsFrom(packages), ...configuredPaths]));
 }
 
 async function baseRefFor(
@@ -89,6 +108,7 @@ async function targetPullRequestsFor(
     return input.prLogEngine.resolvePullRequestLabels({
         githubRepo: input.githubRepo,
         validLabels: input.validLabels,
+        ignoredLabels: [],
         pullRequests: packagePullRequests,
         targetName: packagePlan.name,
         targetScopedLabelPattern: undefined
@@ -115,20 +135,44 @@ function targetSectionFrom(target: ChangelogTarget): TargetChangelogSection {
     };
 }
 
-export async function generateChangelog(input: GenerateChangelogInput): Promise<string> {
+function packageMarkdownByNameFrom(
+    input: GenerateChangelogInput,
+    targets: readonly ChangelogTarget[]
+): ReadonlyMap<string, string> {
+    return new Map(
+        targets.map((target) => {
+            const targetSection = targetSectionFrom(target);
+            return [
+                target.packagePlan.name,
+                input.prLogEngine.renderTargetChangelog({
+                    packageInfo: input.packageInfo,
+                    currentDate: input.currentDate,
+                    validLabels: input.validLabels,
+                    githubRepo: input.githubRepo,
+                    ...targetSection
+                })
+            ] as const;
+        })
+    );
+}
+
+export async function generateChangelogOutputs(input: GenerateChangelogInput): Promise<GeneratedChangelog> {
     const packages = changedPackagesFrom(input.packages);
-    const ignoredAttributionPaths = changelogPathsFrom(packages);
+    const ignoredAttributionPaths = mergedIgnoredAttributionPaths(packages, input.ignoredAttributionPaths);
     const targets = await Promise.all(
         packages.map(async (packagePlan) => {
             return changelogTargetFor(input, packagePlan, ignoredAttributionPaths);
         })
     );
 
-    return input.prLogEngine.renderGroupedTargetChangelog({
-        packageInfo: input.packageInfo,
-        currentDate: input.currentDate,
-        validLabels: input.validLabels,
-        githubRepo: input.githubRepo,
-        targets: targets.map(targetSectionFrom)
-    });
+    return {
+        groupedMarkdown: input.prLogEngine.renderGroupedTargetChangelog({
+            packageInfo: input.packageInfo,
+            currentDate: input.currentDate,
+            validLabels: input.validLabels,
+            githubRepo: input.githubRepo,
+            targets: targets.map(targetSectionFrom)
+        }),
+        packageMarkdownByName: packageMarkdownByNameFrom(input, targets)
+    };
 }


### PR DESCRIPTION
Adds configurable `repository-file`, `package-file`, and `github-release` outputs for `packtory changelog`, using `@pr-log/core` to merge generated Markdown into existing changelog files.

The default no-output behavior still renders to the pager, while configured file outputs resolve repository and package changelog paths through the existing config and file I/O boundaries.