### PR TITLE
Add `packtory release` command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,20 @@ npx packtory publish --no-dry-run --stage
 
 Staged publishing is npm-only. The package must already exist on npm, and automatic versioning in stage mode must be able to list pending staged versions before it picks the next version.
 
+For one explicit release workflow, use `release`. With no action flags it prints the computed release plan and exits:
+
+```bash
+npx packtory release
+```
+
+Actual release writes require explicit action flags and `--no-dry-run`:
+
+```bash
+npx packtory release --write-changelog --commit --publish --tag --push --github-release --no-dry-run
+```
+
+`release` writes changelogs, commits them, recomputes the final plan, publishes directly to npm, creates annotated `{packageName}@{version}` tags, pushes with `git push --follow-tags`, and creates GitHub Releases. It requires a clean Git index and worktree before writing. Commit identity and push credentials come from normal Git config and environment, such as `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, and your configured Git credential helper or CI checkout credentials.
+
 For more details about the CLI application have a look at the [full documentation](./source/packages/command-line-interface/readme.md).
 
 ## Concept

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -4,7 +4,7 @@ import { fake } from 'sinon';
 import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
-    generatedAttributionPaths,
+    collectGeneratedAttributionPaths,
     parseValidConfig,
     shouldPageGroupedChangelog,
     writeConfiguredChangelogs,
@@ -13,7 +13,7 @@ import {
 
 const deps = { workingDirectory: '/repo' } as const;
 
-function config(overrides: Partial<ChangelogConfig> = {}): ChangelogConfig {
+function createChangelogConfig(overrides: Partial<ChangelogConfig> = {}): ChangelogConfig {
     return {
         changelog: {
             outputs: [
@@ -31,7 +31,7 @@ function config(overrides: Partial<ChangelogConfig> = {}): ChangelogConfig {
     };
 }
 
-function generatedChangelog(
+function createGeneratedChangelog(
     overrides: { readonly packageMarkdownByName?: ReadonlyMap<string, string> } = {}
 ): GeneratedChangelog {
     return {
@@ -48,9 +48,9 @@ async function assertRepositoryReadFailureRethrown(error: Error, messagePattern:
     await assert.rejects(
         writeConfiguredChangelogs(
             { ...deps, fileManager },
-            config({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
+            createChangelogConfig({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
             { updateChangelog: fake.returns('updated') },
-            generatedChangelog()
+            createGeneratedChangelog()
         ),
         messagePattern
     );
@@ -61,22 +61,25 @@ suite('changelog-destinations', function () {
         assert.strictEqual(parseValidConfig({ packages: [] }), undefined);
     });
 
-    test('generatedAttributionPaths returns no paths when outputs are absent', function () {
-        assert.deepStrictEqual(generatedAttributionPaths(deps, config({ changelog: undefined })), []);
+    test('collectGeneratedAttributionPaths returns no paths when outputs are absent', function () {
+        assert.deepStrictEqual(
+            collectGeneratedAttributionPaths(deps, createChangelogConfig({ changelog: undefined })),
+            []
+        );
     });
 
-    test('generatedAttributionPaths includes repository and in-repository package files', function () {
-        assert.deepStrictEqual(generatedAttributionPaths(deps, config()), [
+    test('collectGeneratedAttributionPaths includes repository and in-repository package files', function () {
+        assert.deepStrictEqual(collectGeneratedAttributionPaths(deps, createChangelogConfig()), [
             'CHANGELOG.md',
             'src/pkg-a/docs/CHANGELOG.md'
         ]);
     });
 
-    test('generatedAttributionPaths uses common sourcesFolder for package files', function () {
+    test('collectGeneratedAttributionPaths uses common sourcesFolder for package files', function () {
         assert.deepStrictEqual(
-            generatedAttributionPaths(
+            collectGeneratedAttributionPaths(
                 deps,
-                config({
+                createChangelogConfig({
                     changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
                     packages: [{ name: 'pkg-a' }]
                 })
@@ -85,18 +88,21 @@ suite('changelog-destinations', function () {
         );
     });
 
-    test('generatedAttributionPaths ignores github-release outputs', function () {
+    test('collectGeneratedAttributionPaths ignores github-release outputs', function () {
         assert.deepStrictEqual(
-            generatedAttributionPaths(deps, config({ changelog: { outputs: [{ kind: 'github-release' }] } })),
+            collectGeneratedAttributionPaths(
+                deps,
+                createChangelogConfig({ changelog: { outputs: [{ kind: 'github-release' }] } })
+            ),
             []
         );
     });
 
-    test('generatedAttributionPaths reports package-file outputs without sourcesFolder', function () {
+    test('collectGeneratedAttributionPaths reports package-file outputs without sourcesFolder', function () {
         assert.throws(() => {
-            generatedAttributionPaths(
+            collectGeneratedAttributionPaths(
                 deps,
-                config({
+                createChangelogConfig({
                     changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
                     commonPackageSettings: undefined,
                     packages: [{ name: 'pkg-a' }]
@@ -114,13 +120,14 @@ suite('changelog-destinations', function () {
     test('writeConfiguredChangelogs does nothing when outputs are absent', async function () {
         const fileManager = createFakeFileManager();
 
-        await writeConfiguredChangelogs(
+        const writtenPaths = await writeConfiguredChangelogs(
             { ...deps, fileManager },
-            config({ changelog: undefined }),
+            createChangelogConfig({ changelog: undefined }),
             { updateChangelog: fake.returns('updated') },
-            generatedChangelog()
+            createGeneratedChangelog()
         );
 
+        assert.deepStrictEqual(writtenPaths, []);
         assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
     });
 
@@ -136,26 +143,28 @@ suite('changelog-destinations', function () {
             }
         );
 
-        await writeConfiguredChangelogs(
+        const writtenPaths = await writeConfiguredChangelogs(
             { ...deps, fileManager },
-            config({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
+            createChangelogConfig({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
             { updateChangelog },
-            generatedChangelog()
+            createGeneratedChangelog()
         );
 
+        assert.deepStrictEqual(writtenPaths, ['/repo/CHANGELOG.md']);
         assert.strictEqual(updateChangelog.callCount, 1);
     });
 
     test('writeConfiguredChangelogs skips empty generated markdown', async function () {
         const fileManager = createFakeFileManager();
 
-        await writeConfiguredChangelogs(
+        const writtenPaths = await writeConfiguredChangelogs(
             { ...deps, fileManager },
-            config({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
+            createChangelogConfig({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
             { updateChangelog: fake.returns('updated') },
             { groupedMarkdown: '', packageMarkdownByName: new Map() }
         );
 
+        assert.deepStrictEqual(writtenPaths, []);
         assert.strictEqual(fileManager.getReadFileCallCount(), 0);
         assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
     });
@@ -166,9 +175,9 @@ suite('changelog-destinations', function () {
         await assert.rejects(
             writeConfiguredChangelogs(
                 { ...deps, fileManager },
-                config({ changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] } }),
+                createChangelogConfig({ changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] } }),
                 { updateChangelog: fake.returns('updated') },
-                generatedChangelog({ packageMarkdownByName: new Map([['missing', 'markdown']]) })
+                createGeneratedChangelog({ packageMarkdownByName: new Map([['missing', 'markdown']]) })
             ),
             /Config for package "missing" is missing/u
         );

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -34,15 +34,15 @@ export function parseValidConfig(config: unknown): ChangelogConfig | undefined {
     return result.success ? result.data : undefined;
 }
 
-function normalizedConfiguredPath(filePath: string): string {
+function normalizeConfiguredPath(filePath: string): string {
     return filePath.split(/[/\\]/u).join(path.sep);
 }
 
-function repositoryPath(deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>, filePath: string): string {
-    return path.resolve(deps.workingDirectory, normalizedConfiguredPath(filePath));
+function resolveRepositoryPath(deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>, filePath: string): string {
+    return path.resolve(deps.workingDirectory, normalizeConfiguredPath(filePath));
 }
 
-function packageSourcesFolder(packageConfig: PackagePathConfig, config: ChangelogConfig): string {
+function resolvePackageSourcesFolder(packageConfig: PackagePathConfig, config: ChangelogConfig): string {
     const sourcesFolder = packageConfig.sourcesFolder ?? config.commonPackageSettings?.sourcesFolder;
     if (sourcesFolder === undefined) {
         throw new Error(`Config for package "${packageConfig.name}" is missing the sources folder`);
@@ -50,7 +50,7 @@ function packageSourcesFolder(packageConfig: PackagePathConfig, config: Changelo
     return sourcesFolder;
 }
 
-function packageConfigByNameFrom(config: ChangelogConfig): ReadonlyMap<string, PackagePathConfig> {
+function mapPackageConfigByName(config: ChangelogConfig): ReadonlyMap<string, PackagePathConfig> {
     return new Map(
         config.packages.map((packageConfig) => {
             return [packageConfig.name, packageConfig];
@@ -58,7 +58,7 @@ function packageConfigByNameFrom(config: ChangelogConfig): ReadonlyMap<string, P
     );
 }
 
-function packageFilePath(
+function resolvePackageFilePath(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     config: ChangelogConfig,
     packageConfig: PackagePathConfig,
@@ -66,12 +66,12 @@ function packageFilePath(
 ): string {
     return path.resolve(
         deps.workingDirectory,
-        normalizedConfiguredPath(packageSourcesFolder(packageConfig, config)),
-        normalizedConfiguredPath(outputPath)
+        normalizeConfiguredPath(resolvePackageSourcesFolder(packageConfig, config)),
+        normalizeConfiguredPath(outputPath)
     );
 }
 
-function repositoryRelativePath(
+function resolveRepositoryRelativePath(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     filePath: string
 ): string | undefined {
@@ -82,7 +82,7 @@ function repositoryRelativePath(
     return relativePath.split(path.sep).join('/');
 }
 
-export function generatedAttributionPaths(
+export function collectGeneratedAttributionPaths(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     config: ChangelogConfig
 ): readonly string[] {
@@ -96,16 +96,16 @@ export function generatedAttributionPaths(
         })
         .flatMap((output) => {
             if (output.kind === 'repository-file') {
-                return [repositoryPath(deps, output.path)];
+                return [resolveRepositoryPath(deps, output.path)];
             }
             return config.packages.map((packageConfig) => {
-                return packageFilePath(deps, config, packageConfig, output.path);
+                return resolvePackageFilePath(deps, config, packageConfig, output.path);
             });
         });
     return Array.from(
         new Set(
             paths.flatMap((filePath) => {
-                const relativePath = repositoryRelativePath(deps, filePath);
+                const relativePath = resolveRepositoryRelativePath(deps, filePath);
                 return relativePath === undefined ? [] : [relativePath];
             })
         )
@@ -121,7 +121,7 @@ export function shouldPageGroupedChangelog(outputs: readonly ChangelogOutput[] |
     );
 }
 
-function repositoryDestinations(
+function collectRepositoryDestinations(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     outputs: readonly ChangelogOutput[],
     changelog: GeneratedChangelog
@@ -130,17 +130,17 @@ function repositoryDestinations(
         if (output.kind !== 'repository-file') {
             return [];
         }
-        return [{ filePath: repositoryPath(deps, output.path), generatedMarkdown: changelog.groupedMarkdown }];
+        return [{ filePath: resolveRepositoryPath(deps, output.path), generatedMarkdown: changelog.groupedMarkdown }];
     });
 }
 
-function packageDestinations(
+function collectPackageDestinations(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     config: ChangelogConfig,
     outputs: readonly ChangelogOutput[],
     changelog: GeneratedChangelog
 ): readonly FileChangelogDestination[] {
-    const packageConfigsByName = packageConfigByNameFrom(config);
+    const packageConfigsByName = mapPackageConfigByName(config);
     return outputs.flatMap((output) => {
         if (output.kind !== 'package-file') {
             return [];
@@ -150,7 +150,7 @@ function packageDestinations(
             if (packageConfig === undefined) {
                 throw new Error(`Config for package "${packageName}" is missing`);
             }
-            return [{ filePath: packageFilePath(deps, config, packageConfig, output.path), generatedMarkdown }];
+            return [{ filePath: resolvePackageFilePath(deps, config, packageConfig, output.path), generatedMarkdown }];
         });
     });
 }
@@ -159,10 +159,7 @@ function isMissingFileError(error: unknown): boolean {
     return Reflect.get(new Object(error), 'code') === 'ENOENT';
 }
 
-async function existingChangelogMarkdown(
-    fileManager: Pick<FileManager, 'readFile'>,
-    filePath: string
-): Promise<string> {
+async function readChangelogMarkdown(fileManager: Pick<FileManager, 'readFile'>, filePath: string): Promise<string> {
     try {
         return await fileManager.readFile(filePath);
     } catch (error: unknown) {
@@ -177,11 +174,11 @@ async function writeChangelogDestination(
     deps: Pick<ChangelogDestinationDeps, 'fileManager'>,
     prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
     destination: FileChangelogDestination
-): Promise<void> {
+): Promise<string | undefined> {
     if (destination.generatedMarkdown.length === 0) {
-        return;
+        return undefined;
     }
-    const existingChangelogMarkdownValue = await existingChangelogMarkdown(deps.fileManager, destination.filePath);
+    const existingChangelogMarkdownValue = await readChangelogMarkdown(deps.fileManager, destination.filePath);
     await deps.fileManager.writeFile(
         destination.filePath,
         prLogEngine.updateChangelog({
@@ -189,6 +186,7 @@ async function writeChangelogDestination(
             generatedChangelogMarkdown: destination.generatedMarkdown
         })
     );
+    return destination.filePath;
 }
 
 export async function writeConfiguredChangelogs(
@@ -196,17 +194,22 @@ export async function writeConfiguredChangelogs(
     config: ChangelogConfig,
     prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
     changelog: GeneratedChangelog
-): Promise<void> {
+): Promise<readonly string[]> {
     if (config.changelog === undefined) {
-        return;
+        return [];
     }
 
     const { outputs } = config.changelog;
     const destinations = [
-        ...repositoryDestinations(deps, outputs, changelog),
-        ...packageDestinations(deps, config, outputs, changelog)
+        ...collectRepositoryDestinations(deps, outputs, changelog),
+        ...collectPackageDestinations(deps, config, outputs, changelog)
     ];
+    const writtenPaths: string[] = [];
     for (const destination of destinations) {
-        await writeChangelogDestination(deps, prLogEngine, destination);
+        const writtenPath = await writeChangelogDestination(deps, prLogEngine, destination);
+        if (writtenPath !== undefined) {
+            writtenPaths.push(writtenPath);
+        }
     }
+    return writtenPaths;
 }

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -1,25 +1,20 @@
 import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions } from '@pr-log/core';
-import { normalizeRepositoryUrl } from '../../bundle-emitter/repository-url-normalizer.ts';
 import type { FileManager } from '../../file-manager/file-manager.ts';
-import { partialFailureMessages } from '../../packtory/partial-result.ts';
 import type { Packtory, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
-import { checksErrorType, configErrorType, type ReleasePlanFailure } from '../../packtory/packtory-results.ts';
 import { generateChangelogOutputs } from '../../packtory/packtory-changelog.ts';
 import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import {
-    generatedAttributionPaths,
+    collectGeneratedAttributionPaths,
     parseValidConfig,
     shouldPageGroupedChangelog,
     writeConfiguredChangelogs
 } from './changelog-destinations.ts';
+import { formatGitHubRepositoryName } from './github-repository.ts';
+import { printReleasePlanFailure, collectReleasePlanPackages } from './release-plan-result-printing.ts';
 
 type Logger = (message: string) => void;
 type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
-type GitHubRepositoryParts = {
-    readonly owner: string;
-    readonly repo: string;
-};
 type ValidChangelogConfig = NonNullable<ReturnType<typeof parseValidConfig>>;
 
 export type ChangelogHandlerDeps = {
@@ -38,74 +33,22 @@ export type ChangelogHandlerDeps = {
 
 const labelLookupIntervalMilliseconds = 250;
 const maximumRateLimitRetryCount = 3;
-const githubRepositoryPattern = /^https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)$/u;
 
 function formatChangelogHandlerError(error: unknown): string {
     return String(error).replace(/^[A-Za-z]*Error: /u, '');
 }
 
-function githubTokenFrom(deps: Pick<ChangelogHandlerDeps, 'readEnvironmentVariable'>): string | undefined {
+function readGitHubToken(deps: Pick<ChangelogHandlerDeps, 'readEnvironmentVariable'>): string | undefined {
     return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
-}
-
-function gitHubRepositoryMatchFrom(repositoryUrl: string | undefined): RegExpExecArray | undefined {
-    return githubRepositoryPattern.exec(String(repositoryUrl)) ?? undefined;
-}
-
-function gitHubRepositoryPartsFromGroups(
-    groups: Record<string, string> | undefined
-): GitHubRepositoryParts | undefined {
-    if (groups === undefined) {
-        return undefined;
-    }
-    return { owner: String(groups.owner), repo: String(groups.repo) };
-}
-
-function gitHubRepositoryPartsFrom(repositoryUrl: string | undefined): GitHubRepositoryParts | undefined {
-    return gitHubRepositoryPartsFromGroups(gitHubRepositoryMatchFrom(repositoryUrl)?.groups);
-}
-
-function githubRepoFrom(packageInfo: Record<string, unknown>): string {
-    const repository = gitHubRepositoryPartsFrom(normalizeRepositoryUrl(packageInfo.repository));
-    if (repository === undefined) {
-        throw new Error('package.json repository must point to a GitHub repository');
-    }
-    return `${repository.owner}/${repository.repo}`;
 }
 
 function createEngine(deps: ChangelogHandlerDeps): PrLogEngine {
     return deps.createPrLogEngine({
-        githubToken: githubTokenFrom(deps),
+        githubToken: readGitHubToken(deps),
         workingDirectory: deps.workingDirectory,
         labelLookupIntervalMilliseconds,
         maximumRateLimitRetryCount
     });
-}
-
-function printIssueFailure(log: Logger, title: string, issues: readonly string[]): void {
-    log(`${title}, there are ${issues.length} issue(s)\n\n- ${issues.join('\n- ')}`);
-}
-
-function printReleasePlanFailure(log: Logger, error: ReleasePlanFailure): void {
-    if (error.type === configErrorType) {
-        printIssueFailure(log, 'Configuration issues', error.issues);
-        return;
-    }
-    if (error.type === checksErrorType) {
-        printIssueFailure(log, 'Check issues', error.issues);
-        return;
-    }
-    log(partialFailureMessages(error).join('\n'));
-}
-
-function releasePlanPackagesFrom(result: ReleasePlanResult): readonly ReleasePlanPackage[] {
-    if (result.isOk) {
-        return result.value.packages;
-    }
-    if ('succeeded' in result.error) {
-        return result.error.succeeded;
-    }
-    return [];
 }
 
 async function renderChangelog(
@@ -121,8 +64,8 @@ async function renderChangelog(
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine,
-        githubRepo: githubRepoFrom(packageInfo),
-        ignoredAttributionPaths: generatedAttributionPaths(deps, config),
+        githubRepo: formatGitHubRepositoryName(packageInfo),
+        ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
         packageInfo,
         currentDate: deps.currentDate(),
         validLabels: defaultValidLabels
@@ -133,7 +76,7 @@ async function renderChangelog(
     await writeConfiguredChangelogs(deps, config, prLogEngine, changelog);
 }
 
-function exitCodeFromReleasePlanResult(log: Logger, result: ReleasePlanResult): number {
+function resolveReleasePlanExitCode(log: Logger, result: ReleasePlanResult): number {
     if (result.isOk) {
         return 0;
     }
@@ -147,9 +90,9 @@ async function runChangelog(deps: ChangelogHandlerDeps): Promise<number> {
     deps.spinnerRenderer.stopAll();
     const validConfig = parseValidConfig(config);
     if (validConfig !== undefined) {
-        await renderChangelog(deps, validConfig, releasePlanPackagesFrom(outcome.result));
+        await renderChangelog(deps, validConfig, collectReleasePlanPackages(outcome.result));
     }
-    return exitCodeFromReleasePlanResult(deps.log, outcome.result);
+    return resolveReleasePlanExitCode(deps.log, outcome.result);
 }
 
 function stopSpinnersAndReturn(deps: ChangelogHandlerDeps, exitCode: number): number {

--- a/source/command-line-interface/runner/failure-printing.test.ts
+++ b/source/command-line-interface/runner/failure-printing.test.ts
@@ -36,7 +36,7 @@ suite('failure-printing', function () {
         const sink = captureLogger();
         const failure: PublishFailure = { type: 'config', issues: ['issue A', 'issue B'] };
 
-        printPublishFailure(sink.log, failure, { stage: false });
+        printPublishFailure(sink.log, failure, false);
 
         assert.strictEqual(sink.messages.length, 1);
         const message = sink.messages[0] ?? '';
@@ -48,7 +48,7 @@ suite('failure-printing', function () {
         const sink = captureLogger();
         const failure: PublishFailure = { type: 'checks', issues: ['check X'] };
 
-        printPublishFailure(sink.log, failure, { stage: false });
+        printPublishFailure(sink.log, failure, false);
 
         const message = sink.messages[0] ?? '';
         assert.match(message, /Checks failed, there are 1 issue\(s\)/u);
@@ -66,7 +66,7 @@ suite('failure-printing', function () {
             failures: [{ message: 'pkg-c failed' }] as never
         };
 
-        printPublishFailure(sink.log, failure, { stage: true });
+        printPublishFailure(sink.log, failure, true);
 
         assert.ok((sink.messages[0] ?? '').includes('package(s) failed'));
         assert.ok((sink.messages[0] ?? '').includes('- pkg-c failed'));
@@ -81,7 +81,7 @@ suite('failure-printing', function () {
             failures: [{ message: 'pkg-b failed' }] as never
         };
 
-        printPublishFailure(sink.log, failure, { stage: true });
+        printPublishFailure(sink.log, failure, true);
 
         assert.strictEqual(sink.messages.length, 1);
         assert.ok((sink.messages[0] ?? '').includes('- pkg-b failed'));

--- a/source/command-line-interface/runner/failure-printing.ts
+++ b/source/command-line-interface/runner/failure-printing.ts
@@ -43,12 +43,12 @@ function isStagedResult(result: BuildAndPublishResult): result is StagedResult {
     return result.publication.type === 'staged';
 }
 
-function stagedResultsFrom(results: readonly BuildAndPublishResult[]): readonly StagedResult[] {
+function selectStagedResults(results: readonly BuildAndPublishResult[]): readonly StagedResult[] {
     return results.filter(isStagedResult);
 }
 
 function printStagedPackageList(log: Logger, results: readonly BuildAndPublishResult[]): void {
-    const stagedResults = stagedResultsFrom(results);
+    const stagedResults = selectStagedResults(results);
     if (stagedResults.length === 0) {
         return;
     }
@@ -60,8 +60,8 @@ function printIssueSummary(log: Logger, title: string, issues: readonly string[]
     log(`${header}\n\n- ${issues.join('\n- ')}`);
 }
 
-function stageSuccessSummary(results: readonly BuildAndPublishResult[]): string {
-    const stagedResults = stagedResultsFrom(results);
+function formatStageSuccessSummary(results: readonly BuildAndPublishResult[]): string {
+    const stagedResults = selectStagedResults(results);
     if (stagedResults.length === 0) {
         return (
             `${getSuccessSymbol()} Success: no packages were staged; ` +
@@ -74,7 +74,7 @@ function stageSuccessSummary(results: readonly BuildAndPublishResult[]): string 
     return `${getSuccessSymbol()} Success: staged ${stagedResults.length} package(s)${unchangedSuffix}`;
 }
 
-function printPartialErrorSummary(log: Logger, error: PublishPartialError, flags: { readonly stage: boolean }): void {
+function printPartialErrorSummary(log: Logger, error: PublishPartialError, stage: boolean): void {
     const total = error.succeeded.length + error.failures.length;
     const failureCount = red(String(error.failures.length));
     const successCount = green(String(error.succeeded.length));
@@ -85,15 +85,15 @@ function printPartialErrorSummary(log: Logger, error: PublishPartialError, flags
         return `- ${message}`;
     });
     log([summary, ...details].join('\n'));
-    if (flags.stage) {
+    if (stage) {
         printStagedPackageList(log, error.succeeded);
     }
 }
 
-export function printPublishFailure(log: Logger, error: PublishFailure, flags: { readonly stage: boolean }): void {
+export function printPublishFailure(log: Logger, error: PublishFailure, stage: boolean): void {
     match(error)
         .with({ type: partialFailureType }, (partialError) => {
-            printPartialErrorSummary(log, partialError, flags);
+            printPartialErrorSummary(log, partialError, stage);
         })
         .otherwise((issueError) => {
             printIssueSummary(log, issueTitleByType[issueError.type], issueError.issues);
@@ -110,6 +110,6 @@ export function printSuccessSummary(
         return;
     }
 
-    log(stageSuccessSummary(results));
+    log(formatStageSuccessSummary(results));
     printStagedPackageList(log, results);
 }

--- a/source/command-line-interface/runner/github-api-request.ts
+++ b/source/command-line-interface/runner/github-api-request.ts
@@ -1,0 +1,47 @@
+const defaultGitHubApiVersion = '2022-11-28';
+
+function readReflectedProperty(value: unknown, property: string): unknown {
+    return Reflect.get(new Object(value), property) as unknown;
+}
+
+function readGitHubErrorStatus(error: unknown): number {
+    return Number(readReflectedProperty(error, 'status'));
+}
+
+function readGitHubErrorPath(error: unknown): string {
+    const url = String(readReflectedProperty(readReflectedProperty(error, 'request'), 'url'));
+    const parsedUrl = new URL(url);
+    return `${parsedUrl.pathname}${parsedUrl.search}`;
+}
+
+function createGitHubRequestError(error: unknown): Error {
+    return new Error(
+        `GitHub API request failed (${String(readGitHubErrorStatus(error))}) for ${readGitHubErrorPath(error)}`,
+        {
+            cause: error
+        }
+    );
+}
+
+export function createGitHubJsonRequestHeaders(token: string, userAgent: string): Readonly<Record<string, string>> {
+    return {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'user-agent': userAgent,
+        'x-github-api-version': defaultGitHubApiVersion
+    };
+}
+
+export async function resolveOptionalGitHubResponse<T>(
+    request: Promise<T>,
+    missingStatusCode: number
+): Promise<T | undefined> {
+    try {
+        return await request;
+    } catch (error) {
+        if (readGitHubErrorStatus(error) === missingStatusCode) {
+            return undefined;
+        }
+        throw createGitHubRequestError(error);
+    }
+}

--- a/source/command-line-interface/runner/github-release-client.test.ts
+++ b/source/command-line-interface/runner/github-release-client.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { createGitHubReleaseClient } from './github-release-client.ts';
+
+type RequestRecord = {
+    readonly body: string | undefined;
+    readonly headers: Readonly<Record<string, string | undefined>>;
+    readonly method: string;
+    readonly url: string;
+};
+
+function readRequestUrl(input: RequestInfo | URL): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+    if (input instanceof URL) {
+        return input.toString();
+    }
+    return input.url;
+}
+
+function readRequestHeaders(headers: HeadersInit | undefined): Readonly<Record<string, string | undefined>> {
+    const parsedHeaders = new Headers(headers);
+    return {
+        accept: parsedHeaders.get('accept') ?? undefined,
+        authorization: parsedHeaders.get('authorization') ?? undefined,
+        contentType: parsedHeaders.get('content-type') ?? undefined,
+        userAgent: parsedHeaders.get('user-agent') ?? undefined,
+        githubApiVersion: parsedHeaders.get('x-github-api-version') ?? undefined
+    };
+}
+
+function createClientWithStatuses(statuses: readonly number[]): {
+    readonly client: ReturnType<typeof createGitHubReleaseClient>;
+    readonly requests: readonly RequestRecord[];
+} {
+    const requests: RequestRecord[] = [];
+    let requestCount = 0;
+    return {
+        requests,
+        client: createGitHubReleaseClient({
+            owner: 'owner',
+            repo: 'repo',
+            token: 'token',
+            async fetch(input, init) {
+                requests.push({
+                    url: readRequestUrl(input),
+                    method: init?.method ?? 'GET',
+                    body: typeof init?.body === 'string' ? init.body : undefined,
+                    headers: readRequestHeaders(init?.headers)
+                });
+                const status = statuses[requestCount] ?? 500;
+                requestCount += 1;
+                return new Response('{}', { status });
+            }
+        })
+    };
+}
+
+suite('github-release-client', function () {
+    test('createReleaseIfMissing returns existing without rewriting release notes', async function () {
+        const { client, requests } = createClientWithStatuses([200]);
+
+        const result = await client.createReleaseIfMissing({
+            tagName: 'pkg-a@1.0.0',
+            name: 'pkg-a@1.0.0',
+            body: 'notes'
+        });
+
+        assert.strictEqual(result, 'existing');
+        assert.strictEqual(requests.length, 1);
+        const firstRequest = requests[0];
+        if (firstRequest === undefined) {
+            assert.fail('Expected a GitHub release lookup request');
+        }
+        assert.strictEqual(firstRequest.method, 'GET');
+        assert.strictEqual(firstRequest.url, 'https://api.github.com/repos/owner/repo/releases/tags/pkg-a%401.0.0');
+        assert.strictEqual(firstRequest.headers.authorization, 'Bearer token');
+        assert.strictEqual(firstRequest.headers.accept, 'application/vnd.github+json');
+        assert.strictEqual(firstRequest.headers.userAgent, 'packtory');
+        assert.strictEqual(firstRequest.headers.githubApiVersion, '2022-11-28');
+        assert.strictEqual(firstRequest.body, undefined);
+    });
+
+    test('createReleaseIfMissing creates a release when the tag has no release', async function () {
+        const { client, requests } = createClientWithStatuses([404, 201]);
+
+        const result = await client.createReleaseIfMissing({
+            tagName: 'pkg-a@1.0.0',
+            name: 'pkg-a@1.0.0',
+            body: 'notes'
+        });
+
+        assert.strictEqual(result, 'created');
+        assert.strictEqual(requests.length, 2);
+        const postRequest = requests[1];
+        if (postRequest === undefined) {
+            assert.fail('Expected a GitHub release creation request');
+        }
+        assert.strictEqual(postRequest.method, 'POST');
+        assert.strictEqual(postRequest.url, 'https://api.github.com/repos/owner/repo/releases');
+        assert.deepStrictEqual(JSON.parse(postRequest.body ?? '{}'), {
+            tag_name: 'pkg-a@1.0.0',
+            name: 'pkg-a@1.0.0',
+            body: 'notes'
+        });
+    });
+
+    test('createReleaseIfMissing rejects GitHub API failures', async function () {
+        const { client } = createClientWithStatuses([500]);
+
+        await assert.rejects(
+            client.createReleaseIfMissing({
+                tagName: 'pkg-a@1.0.0',
+                name: 'pkg-a@1.0.0',
+                body: 'notes'
+            }),
+            (error: unknown) => {
+                assert.ok(error instanceof Error);
+                assert.ok(error.cause instanceof Error);
+                assert.match(
+                    error.message,
+                    /GitHub API request failed \(500\) for \/repos\/owner\/repo\/releases\/tags\/pkg-a%401\.0\.0/u
+                );
+                return true;
+            }
+        );
+    });
+
+    test('createReleaseIfMissing rejects a failed create response', async function () {
+        const { client } = createClientWithStatuses([404, 404]);
+
+        await assert.rejects(
+            client.createReleaseIfMissing({
+                tagName: 'pkg-a@1.0.0',
+                name: 'pkg-a@1.0.0',
+                body: 'notes'
+            }),
+            /could not be created/u
+        );
+    });
+});

--- a/source/command-line-interface/runner/github-release-client.ts
+++ b/source/command-line-interface/runner/github-release-client.ts
@@ -1,0 +1,62 @@
+import { Octokit } from '@octokit/core';
+import { createGitHubJsonRequestHeaders, resolveOptionalGitHubResponse } from './github-api-request.ts';
+
+type GitHubReleaseRequest = {
+    readonly body: string;
+    readonly name: string;
+    readonly tagName: string;
+};
+
+export type GitHubReleaseClient = {
+    readonly createReleaseIfMissing: (request: GitHubReleaseRequest) => Promise<'created' | 'existing'>;
+};
+
+type GitHubReleaseClientDependencies = {
+    readonly fetch: typeof globalThis.fetch;
+    readonly owner: string;
+    readonly repo: string;
+    readonly token: string;
+};
+
+const notFoundStatusCode = 404;
+
+export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies): GitHubReleaseClient {
+    const requestHeaders = createGitHubJsonRequestHeaders(deps.token, 'packtory');
+    const octokit = new Octokit({
+        request: {
+            fetch: deps.fetch
+        }
+    });
+
+    return {
+        async createReleaseIfMissing(request) {
+            const existing = await resolveOptionalGitHubResponse(
+                octokit.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
+                    headers: requestHeaders,
+                    owner: deps.owner,
+                    repo: deps.repo,
+                    tag: request.tagName
+                }),
+                notFoundStatusCode
+            );
+            if (existing !== undefined) {
+                return 'existing';
+            }
+            const created = await resolveOptionalGitHubResponse(
+                octokit.request('POST /repos/{owner}/{repo}/releases', {
+                    headers: requestHeaders,
+                    owner: deps.owner,
+                    repo: deps.repo,
+                    tag_name: request.tagName,
+                    name: request.name,
+                    body: request.body
+                }),
+                notFoundStatusCode
+            );
+            if (created === undefined) {
+                throw new Error(`GitHub release for tag "${request.tagName}" could not be created`);
+            }
+            return 'created';
+        }
+    };
+}

--- a/source/command-line-interface/runner/github-repository.ts
+++ b/source/command-line-interface/runner/github-repository.ts
@@ -1,0 +1,22 @@
+import { normalizeRepositoryUrl } from '../../bundle-emitter/repository-url-normalizer.ts';
+
+export type GitHubRepositoryParts = {
+    readonly owner: string;
+    readonly repo: string;
+};
+
+const githubRepositoryPattern = /^https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)$/u;
+
+export function parseGitHubRepositoryParts(packageInfo: Record<string, unknown>): GitHubRepositoryParts {
+    const repositoryUrl = normalizeRepositoryUrl(packageInfo.repository);
+    const match = githubRepositoryPattern.exec(String(repositoryUrl));
+    if (match?.groups === undefined) {
+        throw new Error('package.json repository must point to a GitHub repository');
+    }
+    return { owner: String(match.groups.owner), repo: String(match.groups.repo) };
+}
+
+export function formatGitHubRepositoryName(packageInfo: Record<string, unknown>): string {
+    const repository = parseGitHubRepositoryParts(packageInfo);
+    return `${repository.owner}/${repository.repo}`;
+}

--- a/source/command-line-interface/runner/publish-handler.ts
+++ b/source/command-line-interface/runner/publish-handler.ts
@@ -26,7 +26,7 @@ async function reportOutcome(
     let exitCode = 0;
     if (outcome.result.isErr) {
         exitCode = 1;
-        printPublishFailure(log, outcome.result.error, { stage: flags.stage });
+        printPublishFailure(log, outcome.result.error, flags.stage);
     } else {
         printSuccessSummary(log, outcome.result.value, { stage: flags.stage });
     }

--- a/source/command-line-interface/runner/release-git-client.test.ts
+++ b/source/command-line-interface/runner/release-git-client.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { createReleaseGitClient } from './release-git-client.ts';
+
+type ReleaseGitCommandRunner = (
+    command: string,
+    args: readonly string[]
+) => Promise<{ readonly stdout: string; readonly stderr: string }>;
+
+type GitCall = {
+    readonly command: string;
+    readonly args: readonly string[];
+};
+
+function createGitClientWithRunner(run: ReleaseGitCommandRunner): {
+    readonly calls: readonly GitCall[];
+    readonly client: ReturnType<typeof createReleaseGitClient>;
+} {
+    const calls: GitCall[] = [];
+    return {
+        calls,
+        client: createReleaseGitClient({
+            repositoryFolder: '/repo',
+            async runGitCommand(command, args) {
+                calls.push({ command, args });
+                return run(command, args);
+            }
+        })
+    };
+}
+
+suite('release-git-client', function () {
+    test('ensureClean succeeds when git status is empty', async function () {
+        const { calls, client } = createGitClientWithRunner(async () => {
+            return { stdout: '', stderr: '' };
+        });
+
+        await client.ensureClean();
+
+        assert.deepStrictEqual(calls[0], {
+            command: 'git',
+            args: ['-C', '/repo', 'status', '--porcelain=v1']
+        });
+    });
+
+    test('ensureClean rejects dirty index and worktree output', async function () {
+        const { client } = createGitClientWithRunner(async () => {
+            return { stdout: ' M CHANGELOG.md\n', stderr: '' };
+        });
+
+        await assert.rejects(client.ensureClean(), /Git index and worktree must be clean/u);
+    });
+
+    test('ensureTag accepts an existing tag at the target head', async function () {
+        const { calls, client } = createGitClientWithRunner(async (_command, args) => {
+            if (args.includes('rev-parse')) {
+                return { stdout: 'head-a\n', stderr: '' };
+            }
+            throw new Error('unexpected write');
+        });
+
+        await client.ensureTag('pkg-a@1.0.0', 'pkg-a@1.0.0', 'head-a');
+
+        assert.deepStrictEqual(calls, [
+            {
+                command: 'git',
+                args: ['-C', '/repo', 'rev-parse', '--verify', 'refs/tags/pkg-a@1.0.0^{}']
+            }
+        ]);
+    });
+
+    test('ensureTag rejects an existing tag at another head', async function () {
+        const { client } = createGitClientWithRunner(async () => {
+            return { stdout: 'head-b\n', stderr: '' };
+        });
+
+        await assert.rejects(client.ensureTag('pkg-a@1.0.0', 'pkg-a@1.0.0', 'head-a'), /already exists/u);
+    });
+
+    test('ensureTag creates an annotated tag when none exists', async function () {
+        const { calls, client } = createGitClientWithRunner(async (_command, args) => {
+            if (args.includes('rev-parse')) {
+                throw new Error('missing tag');
+            }
+            return { stdout: '', stderr: '' };
+        });
+
+        await client.ensureTag('pkg-a@1.0.0', 'pkg-a@1.0.0', 'head-a');
+
+        assert.deepStrictEqual(calls[1], {
+            command: 'git',
+            args: ['-C', '/repo', 'tag', '-a', 'pkg-a@1.0.0', '-m', 'pkg-a@1.0.0', 'head-a']
+        });
+    });
+
+    test('commit stages changelog files and creates a release commit', async function () {
+        const { calls, client } = createGitClientWithRunner(async () => {
+            return { stdout: '', stderr: '' };
+        });
+
+        await client.commit(['/repo/CHANGELOG.md'], 'Release packages');
+
+        assert.deepStrictEqual(calls, [
+            { command: 'git', args: ['-C', '/repo', 'add', '--', '/repo/CHANGELOG.md'] },
+            { command: 'git', args: ['-C', '/repo', 'commit', '-m', 'Release packages'] }
+        ]);
+    });
+
+    test('commit rejects empty changelog file lists', async function () {
+        const { client } = createGitClientWithRunner(async () => {
+            return { stdout: '', stderr: '' };
+        });
+
+        await assert.rejects(client.commit([], 'Release packages'), /No changelog files were written/u);
+    });
+
+    test('currentHead returns a non-empty current Git head', async function () {
+        const { calls, client } = createGitClientWithRunner(async () => {
+            return { stdout: 'head-a\n', stderr: '' };
+        });
+
+        assert.strictEqual(await client.currentHead(), 'head-a');
+        assert.deepStrictEqual(calls, [{ command: 'git', args: ['-C', '/repo', 'rev-parse', '--verify', 'HEAD'] }]);
+    });
+
+    test('currentHead rejects empty Git output', async function () {
+        const { client } = createGitClientWithRunner(async () => {
+            return { stdout: '\n', stderr: '' };
+        });
+
+        await assert.rejects(client.currentHead(), /Unable to read/u);
+    });
+
+    test('pushFollowTags invokes git push with follow-tags', async function () {
+        const { calls, client } = createGitClientWithRunner(async () => {
+            return { stdout: '', stderr: '' };
+        });
+
+        await client.pushFollowTags();
+
+        assert.deepStrictEqual(calls[0], {
+            command: 'git',
+            args: ['-C', '/repo', 'push', '--follow-tags']
+        });
+    });
+});

--- a/source/command-line-interface/runner/release-git-client.ts
+++ b/source/command-line-interface/runner/release-git-client.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert';
+
+type ReleaseGitCommandRunner = (
+    command: string,
+    args: readonly string[]
+) => Promise<{ readonly stdout: string; readonly stderr: string }>;
+
+export type ReleaseGitClient = {
+    readonly commit: (filePaths: readonly string[], message: string) => Promise<void>;
+    readonly currentHead: () => Promise<string>;
+    readonly ensureClean: () => Promise<void>;
+    readonly ensureTag: (tagName: string, message: string, targetHead: string) => Promise<void>;
+    readonly pushFollowTags: () => Promise<void>;
+};
+
+type ReleaseGitClientDependencies = {
+    readonly repositoryFolder: string;
+    readonly runGitCommand: ReleaseGitCommandRunner;
+};
+type GitOutputResult = { readonly kind: 'found'; readonly value: string } | { readonly kind: 'missing' };
+
+async function runGit(deps: ReleaseGitClientDependencies, args: readonly string[]): Promise<string> {
+    const result = await deps.runGitCommand('git', ['-C', deps.repositoryFolder, ...args]);
+    return result.stdout.trim();
+}
+
+async function readGitOutputResult(
+    deps: ReleaseGitClientDependencies,
+    args: readonly string[]
+): Promise<GitOutputResult> {
+    try {
+        return { kind: 'found', value: await runGit(deps, args) };
+    } catch {
+        return { kind: 'missing' };
+    }
+}
+
+export function createReleaseGitClient(deps: ReleaseGitClientDependencies): ReleaseGitClient {
+    return {
+        async commit(filePaths, message) {
+            if (filePaths.length === 0) {
+                throw new Error('No changelog files were written; cannot create a release commit');
+            }
+            await runGit(deps, ['add', '--', ...filePaths]);
+            await runGit(deps, ['commit', '-m', message]);
+        },
+
+        async currentHead() {
+            const head = await runGit(deps, ['rev-parse', '--verify', 'HEAD']);
+            if (head.length === 0) {
+                throw new Error('Unable to read the current Git head');
+            }
+            return head;
+        },
+
+        async ensureClean() {
+            const status = await runGit(deps, ['status', '--porcelain=v1']);
+            if (status.length > 0) {
+                throw new Error('Git index and worktree must be clean before release writes');
+            }
+        },
+
+        async ensureTag(tagName, message, targetHead) {
+            const existingTag = await readGitOutputResult(deps, ['rev-parse', '--verify', `refs/tags/${tagName}^{}`]);
+            if (existingTag.kind === 'missing') {
+                await runGit(deps, ['tag', '-a', tagName, '-m', message, targetHead]);
+                return;
+            }
+            assert.strictEqual(existingTag.kind, 'found');
+            if (existingTag.value === targetHead) {
+                return;
+            }
+            throw new Error(`Tag "${tagName}" already exists at ${existingTag.value}, expected ${targetHead}`);
+        },
+
+        async pushFollowTags() {
+            await runGit(deps, ['push', '--follow-tags']);
+        }
+    };
+}

--- a/source/command-line-interface/runner/release-handler.test.ts
+++ b/source/command-line-interface/runner/release-handler.test.ts
@@ -1,0 +1,717 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import { Result } from 'true-myth';
+import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
+import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage } from '../../packtory/packtory.ts';
+import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
+import type { ConfigLoader } from '../config-loader.ts';
+import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import { runReleaseHandler, type ReleaseHandlerDeps } from './release-handler.ts';
+
+type ReleaseFlags = ReleaseHandlerDeps['flags'];
+
+const validConfig = {
+    packages: [
+        {
+            sourcesFolder: 'src/pkg-a',
+            mainPackageJson: { type: 'module' },
+            name: 'pkg-a',
+            roots: { main: { js: 'index.js' } },
+            publishSettings: { access: 'public' }
+        }
+    ],
+    changelog: {
+        outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }]
+    }
+} as const;
+
+function createReleasePackage(overrides: Partial<ReleasePlanPackage> = {}): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        changed: true,
+        previousGitHead: 'old-head',
+        currentGitHead: 'new-head',
+        latestRegistryMetadata: { version: '1.0.0', publishedAt: undefined, gitHead: 'old-head' },
+        artifactFiles: ['index.js'],
+        changedArtifactFiles: ['index.js'],
+        sourceFiles: ['source/pkg-a.ts'],
+        changelogSourceFiles: ['source/pkg-a.ts'],
+        ...overrides
+    };
+}
+
+function createCurrentHeadRetryPackage(overrides: Partial<ReleasePlanPackage> = {}): ReleasePlanPackage {
+    return createReleasePackage({
+        changed: false,
+        artifactState: 'unchanged',
+        latestRegistryMetadata: {
+            version: '1.0.1',
+            publishedAt: undefined,
+            gitHead: 'new-head'
+        },
+        ...overrides
+    });
+}
+
+function createReleasePlanOutcome(packages: readonly ReleasePlanPackage[]): ReleasePlanOutcome {
+    return {
+        result: Result.ok({ packages }),
+        getReport() {
+            return {
+                schemaVersion: 1 as const,
+                generatedAt: '2026-06-13T00:00:00.000Z',
+                packages: {},
+                aggregate: { crossBundleLinks: [] }
+            };
+        }
+    };
+}
+
+function createReleasePlanOutcomesForPackage(packagePlan: ReleasePlanPackage): readonly ReleasePlanOutcome[] {
+    return [createReleasePlanOutcome([packagePlan])];
+}
+
+function createPublishVersionSpy(order: string[], version: string): SinonSpy {
+    return fake(async () => {
+        order.push('publish');
+        return {
+            result: Result.ok([{ bundle: { name: 'pkg-a', version } }]),
+            getReport() {
+                return undefined;
+            }
+        };
+    });
+}
+
+function createEngine(): PrLogEngine {
+    return {
+        resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
+        resolveChangelogBaseRef: fake.resolves({ ref: 'old-head' }),
+        collectMergedPullRequests: fake(async (input: { readonly githubRepo: string }) => {
+            assert.strictEqual(input.githubRepo, 'enormora/packtory');
+            return [{ id: 1, title: 'Fix package' }];
+        }),
+        readPullRequestChangedFiles: fake(async (input: { readonly githubRepo: string }) => {
+            assert.strictEqual(input.githubRepo, 'enormora/packtory');
+            return new Map([[1, ['source/pkg-a.ts']]]);
+        }),
+        readPullRequestLabels: fake.resolves(new Map([[1, ['bug']]])),
+        filterPullRequestsByTargetFiles: fake((input: { readonly pullRequests: readonly unknown[] }) => {
+            return input.pullRequests;
+        }),
+        resolvePullRequestLabels: fake(async (input: { readonly githubRepo: string }) => {
+            assert.strictEqual(input.githubRepo, 'enormora/packtory');
+            return [{ id: 1, title: 'Fix package', label: 'bug' }];
+        }),
+        renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
+        renderTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
+        updateChangelog: fake((input: { readonly generatedChangelogMarkdown: string }) => {
+            return input.generatedChangelogMarkdown;
+        }),
+        renderChangelog: fake.returns('')
+    } as unknown as PrLogEngine;
+}
+
+const defaultFlags: ReleaseFlags = {
+    commit: false,
+    githubRelease: false,
+    noDryRun: false,
+    publish: false,
+    push: false,
+    tag: false,
+    writeChangelog: false
+};
+const githubReleaseFlags = { githubRelease: true, noDryRun: true, push: true, tag: true } as const;
+const noReleaseMessage = 'No packages need release.';
+
+type Scenario = {
+    readonly buildAndPublishAll?: SinonSpy;
+    readonly config?: unknown;
+    readonly configLoader?: ConfigLoader;
+    readonly createGitHubReleaseClient?: SinonSpy;
+    readonly flags?: Partial<ReleaseFlags>;
+    readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+    readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
+    readonly order?: string[];
+    readonly planOutcomes?: readonly ReleasePlanOutcome[];
+};
+
+function createReleasePlanFailureOutcome(): ReleasePlanOutcome {
+    return {
+        result: Result.err({ type: 'config', issues: ['bad config'] }),
+        getReport() {
+            return {
+                schemaVersion: 1 as const,
+                generatedAt: '2026-06-13T00:00:00.000Z',
+                packages: {},
+                aggregate: { crossBundleLinks: [] }
+            };
+        }
+    };
+}
+
+function createReleaseHandlerDeps(scenario: Scenario = {}): ReleaseHandlerDeps {
+    const order = scenario.order ?? [];
+    const planOutcomes = scenario.planOutcomes ?? [createReleasePlanOutcome([createReleasePackage()])];
+    let planCallCount = 0;
+    const stopAll = fake();
+    const planReleaseAgainstLatestPublished = fake(async () => {
+        order.push('plan');
+        const outcome = planOutcomes[planCallCount] ?? planOutcomes.at(-1);
+        planCallCount += 1;
+        return outcome as ReleasePlanOutcome;
+    });
+    return {
+        createGitHubReleaseClient:
+            scenario.createGitHubReleaseClient ??
+            fake(() => {
+                return {
+                    async createReleaseIfMissing() {
+                        order.push('github-release');
+                        return 'created' as const;
+                    }
+                };
+            }),
+        createPrLogEngine(options: Readonly<PrLogEngineOptions>) {
+            if (scenario.readEnvironmentVariable === undefined) {
+                assert.strictEqual(options.githubToken, 'gh-token');
+            }
+            return createEngine();
+        },
+        currentDate() {
+            return new Date('2026-06-13T00:00:00.000Z');
+        },
+        fileManager: createFakeFileManager(),
+        flags: { ...defaultFlags, ...scenario.flags },
+        gitClient: {
+            async commit(filePaths, message) {
+                order.push(`commit:${filePaths.join(',')}:${message}`);
+            },
+            async currentHead() {
+                order.push('head');
+                return 'new-head';
+            },
+            async ensureClean() {
+                order.push('clean');
+            },
+            async ensureTag(tagName) {
+                order.push(`tag:${tagName}`);
+            },
+            async pushFollowTags() {
+                order.push('push');
+            }
+        },
+        log: fake(),
+        packtory: {
+            buildAndPublishAll:
+                scenario.buildAndPublishAll ??
+                fake(async () => {
+                    order.push('publish');
+                    return {
+                        result: Result.ok([{ bundle: { name: 'pkg-a', version: '1.0.1' } }]),
+                        getReport() {
+                            return undefined;
+                        }
+                    };
+                }),
+            planReleaseAgainstLatestPublished
+        } as unknown as Packtory,
+        readEnvironmentVariable(name) {
+            if (scenario.readEnvironmentVariable !== undefined) {
+                return scenario.readEnvironmentVariable(name);
+            }
+            return name === 'GH_TOKEN' ? 'gh-token' : undefined;
+        },
+        readPackageInfo:
+            scenario.readPackageInfo ??
+            (async () => {
+                return { repository: { url: 'https://github.com/enormora/packtory' } };
+            }),
+        spinnerRenderer: { stopAll } as unknown as TerminalSpinnerRenderer,
+        configLoader:
+            scenario.configLoader ??
+            ({ load: fake.resolves(scenario.config ?? validConfig) } as unknown as ConfigLoader),
+        workingDirectory: '/repo'
+    };
+}
+
+async function runScenario(scenario: Scenario): Promise<{
+    readonly code: number;
+    readonly deps: ReleaseHandlerDeps;
+}> {
+    const deps = createReleaseHandlerDeps(scenario);
+    return { code: await runReleaseHandler(deps), deps };
+}
+
+function readFirstLogArgs(deps: ReleaseHandlerDeps): readonly unknown[] {
+    return (deps.log as SinonSpy).firstCall.args;
+}
+
+async function assertFlagError(flags: Partial<ReleaseFlags>, expected: string): Promise<ReleaseHandlerDeps> {
+    const { code, deps } = await runScenario({ flags });
+
+    assert.strictEqual(code, 1);
+    assert.strictEqual((deps.packtory.planReleaseAgainstLatestPublished as SinonSpy).callCount, 0);
+    assert.deepStrictEqual(readFirstLogArgs(deps), [expected]);
+    return deps;
+}
+
+async function assertNoReleaseWork(scenario: Scenario): Promise<ReleaseHandlerDeps> {
+    const { code, deps } = await runScenario(scenario);
+
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(readFirstLogArgs(deps), [noReleaseMessage]);
+    return deps;
+}
+
+async function assertFailureLog(scenario: Scenario, expected: RegExp): Promise<ReleaseHandlerDeps> {
+    const { code, deps } = await runScenario(scenario);
+
+    assert.strictEqual(code, 1);
+    assert.strictEqual((deps.log as SinonSpy).callCount, 1);
+    assert.match(String(readFirstLogArgs(deps)[0]), expected);
+    return deps;
+}
+
+async function assertCurrentHeadRetryTag(flags: Partial<ReleaseFlags>): Promise<void> {
+    const order: string[] = [];
+    const buildAndPublishAll = fake();
+    const { code, deps } = await runScenario({
+        order,
+        buildAndPublishAll,
+        flags,
+        planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+    });
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(buildAndPublishAll.callCount, 0);
+    assert.deepStrictEqual((deps.log as SinonSpy).lastCall.args, ['Release completed.']);
+    assert.deepStrictEqual(order, ['plan', 'clean', 'head', 'tag:pkg-a@1.0.1']);
+}
+
+suite('release-handler', function () {
+    test('prints the computed release plan when no action flags are set', async function () {
+        const deps = createReleaseHandlerDeps();
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.match(String((deps.log as SinonSpy).firstCall.args[0]), /Release plan:\n- pkg-a/u);
+    });
+
+    test('prints unpublished packages in the computed release plan', async function () {
+        const deps = createReleaseHandlerDeps({
+            planOutcomes: [
+                createReleasePlanOutcome([
+                    createReleasePackage({
+                        previousVersion: undefined,
+                        artifactState: 'first-publish',
+                        latestRegistryMetadata: undefined
+                    })
+                ])
+            ]
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.match(String((deps.log as SinonSpy).firstCall.args[0]), /unpublished -> 1\.0\.1/u);
+    });
+
+    test('rejects invalid flag combinations before planning', async function () {
+        await assertFlagError({ commit: true, noDryRun: true }, '--commit requires --write-changelog');
+    });
+
+    test('prints multiple invalid flag combinations on separate lines', async function () {
+        await assertFlagError(
+            { writeChangelog: true, publish: true, push: true, noDryRun: true },
+            '--write-changelog --publish requires --commit\n--push requires --commit or --tag'
+        );
+    });
+
+    test('requires --no-dry-run for release writes', async function () {
+        await assertFlagError({ publish: true }, 'Release writes require --no-dry-run');
+    });
+
+    test('rejects changelog publish without commit before planning', async function () {
+        await assertFlagError(
+            { writeChangelog: true, publish: true, noDryRun: true },
+            '--write-changelog --publish requires --commit'
+        );
+    });
+
+    test('rejects push without commit or tag before planning', async function () {
+        await assertFlagError({ push: true, noDryRun: true }, '--push requires --commit or --tag');
+    });
+
+    test('rejects GitHub release without tag and push before planning', async function () {
+        await assertFlagError({ githubRelease: true, noDryRun: true }, '--github-release requires --tag --push');
+    });
+
+    test('rejects GitHub release with tag but without push before planning', async function () {
+        await assertFlagError(
+            { tag: true, githubRelease: true, noDryRun: true },
+            '--github-release requires --tag --push'
+        );
+    });
+
+    test('rejects GitHub release with push but without tag before planning', async function () {
+        await assertFlagError(
+            { push: true, githubRelease: true, noDryRun: true },
+            '--push requires --commit or --tag\n--github-release requires --tag --push'
+        );
+    });
+
+    test('prints no-op release plans without release targets', async function () {
+        await assertNoReleaseWork({
+            planOutcomes: createReleasePlanOutcomesForPackage(
+                createReleasePackage({ changed: false, artifactState: 'unchanged' })
+            )
+        });
+    });
+
+    test('does not treat missing current Git head as retry release work', async function () {
+        await assertNoReleaseWork({
+            flags: { tag: true, noDryRun: true },
+            planOutcomes: createReleasePlanOutcomesForPackage(
+                createCurrentHeadRetryPackage({
+                    currentGitHead: undefined,
+                    latestRegistryMetadata: {
+                        version: '1.0.1',
+                        publishedAt: undefined,
+                        gitHead: undefined
+                    }
+                })
+            )
+        });
+    });
+
+    test('does not treat missing registry metadata as retry release work', async function () {
+        await assertNoReleaseWork({
+            flags: { tag: true, noDryRun: true },
+            planOutcomes: createReleasePlanOutcomesForPackage(
+                createCurrentHeadRetryPackage({
+                    latestRegistryMetadata: undefined
+                })
+            )
+        });
+    });
+
+    test('prints no-op release results when action flags have no release work', async function () {
+        await assertNoReleaseWork({
+            flags: { publish: true, noDryRun: true },
+            planOutcomes: createReleasePlanOutcomesForPackage(
+                createCurrentHeadRetryPackage({
+                    latestRegistryMetadata: {
+                        version: '1.0.1',
+                        publishedAt: undefined,
+                        gitHead: 'old-head'
+                    }
+                })
+            )
+        });
+    });
+
+    test('prints no-op release results for publish-only current-head retry packages', async function () {
+        const order: string[] = [];
+
+        await assertNoReleaseWork({
+            order,
+            flags: { publish: true, noDryRun: true },
+            planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+        });
+
+        assert.deepStrictEqual(order, ['plan']);
+    });
+
+    test('returns 1 when release planning fails', async function () {
+        await assertFailureLog({ planOutcomes: [createReleasePlanFailureOutcome()] }, /Configuration issues/u);
+    });
+
+    test('rejects tagging changed packages without publishing', async function () {
+        await assertFailureLog({ flags: { tag: true, noDryRun: true } }, /--tag requires --publish/u);
+    });
+
+    test('returns 1 when publish fails', async function () {
+        const buildAndPublishAll = fake.resolves({
+            result: Result.err({ type: 'config', issues: ['publish failed'] }),
+            getReport() {
+                return undefined;
+            }
+        });
+        const deps = createReleaseHandlerDeps({
+            flags: { publish: true, noDryRun: true },
+            buildAndPublishAll
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], {
+            dryRun: false,
+            stage: false,
+            collectReport: false
+        });
+        assert.match(String((deps.log as SinonSpy).firstCall.args[0]), /publish failed/u);
+    });
+
+    test('prints publish partial failures as non-staged failures', async function () {
+        const deps = createReleaseHandlerDeps({
+            flags: { publish: true, noDryRun: true },
+            buildAndPublishAll: fake.resolves({
+                result: Result.err({
+                    type: 'partial',
+                    succeeded: [
+                        {
+                            bundle: { name: 'pkg-a', version: '1.0.1' },
+                            publication: { type: 'staged', stageId: 'stage-a' }
+                        }
+                    ],
+                    failures: [new Error('publish failed')]
+                }),
+                getReport() {
+                    return undefined;
+                }
+            })
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 1);
+        assert.strictEqual((deps.log as SinonSpy).callCount, 1);
+        assert.match(String((deps.log as SinonSpy).firstCall.args[0]), /publish failed/u);
+        assert.doesNotMatch(String((deps.log as SinonSpy).firstCall.args[0]), /Staged packages/u);
+    });
+
+    test('ignores publish results outside the final release plan', async function () {
+        const order: string[] = [];
+        const deps = createReleaseHandlerDeps({
+            order,
+            flags: { publish: true, tag: true, noDryRun: true },
+            buildAndPublishAll: fake.resolves({
+                result: Result.ok([{ bundle: { name: 'pkg-b', version: '1.0.0' } }]),
+                getReport() {
+                    return undefined;
+                }
+            })
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(order, ['plan', 'clean', 'head']);
+    });
+
+    test('rejects GitHub releases without a GitHub token', async function () {
+        await assertFailureLog(
+            {
+                flags: githubReleaseFlags,
+                readEnvironmentVariable: () => {
+                    return undefined;
+                },
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            },
+            /GH_TOKEN or GITHUB_TOKEN/u
+        );
+    });
+
+    test('rejects GitHub releases when package metadata is not a GitHub repository', async function () {
+        await assertFailureLog(
+            {
+                flags: githubReleaseFlags,
+                readPackageInfo: async () => {
+                    return { repository: { url: 'https://example.com/owner/repo' } };
+                },
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            },
+            /package\.json repository/u
+        );
+    });
+
+    test('rejects GitHub repositories with extra path segments', async function () {
+        await assertFailureLog(
+            {
+                flags: githubReleaseFlags,
+                readPackageInfo: async () => {
+                    return { repository: { url: 'https://github.com/enormora/packtory/extra' } };
+                },
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            },
+            /package\.json repository/u
+        );
+    });
+
+    test('rejects GitHub repositories with non-URL prefixes', async function () {
+        await assertFailureLog(
+            {
+                flags: githubReleaseFlags,
+                readPackageInfo: async () => {
+                    return { repository: { url: 'prefixhttps://github.com/enormora/packtory' } };
+                },
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            },
+            /package\.json repository/u
+        );
+    });
+
+    test('rejects changelog generation when the config cannot be parsed', async function () {
+        await assertFailureLog(
+            {
+                config: { packages: [] },
+                flags: { writeChangelog: true, noDryRun: true }
+            },
+            /invalid for changelog generation/u
+        );
+    });
+
+    test('rejects GitHub release notes when the config cannot be parsed', async function () {
+        await assertFailureLog(
+            {
+                config: { packages: [] },
+                flags: githubReleaseFlags,
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            },
+            /invalid for changelog generation/u
+        );
+    });
+
+    test('writes changelogs without committing when only --write-changelog is set', async function () {
+        const order: string[] = [];
+        const deps = createReleaseHandlerDeps({ order, flags: { writeChangelog: true, noDryRun: true } });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(order, ['plan', 'clean']);
+    });
+
+    test('returns 1 when the post-commit release plan fails', async function () {
+        await assertFailureLog(
+            {
+                flags: { writeChangelog: true, commit: true, publish: true, noDryRun: true },
+                planOutcomes: [createReleasePlanOutcome([createReleasePackage()]), createReleasePlanFailureOutcome()]
+            },
+            /Configuration issues/u
+        );
+    });
+
+    test('returns 1 when loading config throws', async function () {
+        const deps = createReleaseHandlerDeps({
+            configLoader: { load: fake.rejects(new Error('load failed')) } as unknown as ConfigLoader
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual((deps.log as SinonSpy).firstCall.args, ['load failed']);
+    });
+
+    test('returns 1 when loading config throws a non-error value', async function () {
+        const deps = createReleaseHandlerDeps({
+            configLoader: {
+                async load() {
+                    await Promise.reject('string failure' as unknown as Error);
+                }
+            } as unknown as ConfigLoader
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual((deps.log as SinonSpy).firstCall.args, ['string failure']);
+    });
+
+    test('writes changelog, commits, replans, publishes, tags, pushes, and creates GitHub releases in order', async function () {
+        const order: string[] = [];
+        const deps = createReleaseHandlerDeps({
+            order,
+            flags: {
+                writeChangelog: true,
+                commit: true,
+                publish: true,
+                tag: true,
+                push: true,
+                githubRelease: true,
+                noDryRun: true
+            },
+            planOutcomes: [
+                createReleasePlanOutcome([createReleasePackage({ nextVersion: '1.0.1' })]),
+                createReleasePlanOutcome([createReleasePackage({ nextVersion: '1.0.2' })])
+            ],
+            buildAndPublishAll: createPublishVersionSpy(order, '1.0.2')
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual((deps.log as SinonSpy).lastCall.args, ['Release completed.']);
+        assert.deepStrictEqual(order, [
+            'plan',
+            'clean',
+            'commit:/repo/CHANGELOG.md:Release packages',
+            'plan',
+            'publish',
+            'head',
+            'tag:pkg-a@1.0.2',
+            'push',
+            'github-release'
+        ]);
+    });
+
+    test('tags current-head registry packages without publishing during retries', async function () {
+        await assertCurrentHeadRetryTag({ tag: true, noDryRun: true });
+    });
+
+    test('skips publish for current-head retry packages when --publish --tag is used', async function () {
+        await assertCurrentHeadRetryTag({ publish: true, tag: true, noDryRun: true });
+    });
+
+    test('creates GitHub releases with empty notes for current-head retry packages', async function () {
+        const createReleaseIfMissing = fake.resolves('created');
+        const createGitHubReleaseClient = fake(() => {
+            return { createReleaseIfMissing };
+        });
+
+        const code = await runReleaseHandler(
+            createReleaseHandlerDeps({
+                createGitHubReleaseClient,
+                flags: githubReleaseFlags,
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            })
+        );
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(createGitHubReleaseClient.firstCall.args, [
+            { owner: 'enormora', repo: 'packtory', token: 'gh-token' }
+        ]);
+        assert.deepStrictEqual(createReleaseIfMissing.firstCall.args, [
+            { tagName: 'pkg-a@1.0.1', name: 'pkg-a@1.0.1', body: '' }
+        ]);
+    });
+
+    test('uses GITHUB_TOKEN when GH_TOKEN is not set', async function () {
+        const createGitHubReleaseClient = fake(() => {
+            return { createReleaseIfMissing: fake.resolves('created') };
+        });
+
+        const code = await runReleaseHandler(
+            createReleaseHandlerDeps({
+                createGitHubReleaseClient,
+                readEnvironmentVariable(name) {
+                    return name === 'GITHUB_TOKEN' ? 'github-token' : undefined;
+                },
+                flags: githubReleaseFlags,
+                planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+            })
+        );
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(createGitHubReleaseClient.firstCall.args, [
+            { owner: 'enormora', repo: 'packtory', token: 'github-token' }
+        ]);
+    });
+});

--- a/source/command-line-interface/runner/release-handler.ts
+++ b/source/command-line-interface/runner/release-handler.ts
@@ -1,0 +1,493 @@
+import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions } from '@pr-log/core';
+import type { Packtory, ReleasePlanPackage } from '../../packtory/packtory.ts';
+import { generateChangelogOutputs, type GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
+import {
+    collectGeneratedAttributionPaths,
+    parseValidConfig,
+    writeConfiguredChangelogs
+} from './changelog-destinations.ts';
+import { printPublishFailure } from './failure-printing.ts';
+import type { GitHubReleaseClient } from './github-release-client.ts';
+import { formatGitHubRepositoryName, parseGitHubRepositoryParts } from './github-repository.ts';
+import type { ReleaseGitClient } from './release-git-client.ts';
+import { printReleasePlanFailure } from './release-plan-result-printing.ts';
+
+type Logger = (message: string) => void;
+type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
+type ReleaseTarget = {
+    readonly name: string;
+    readonly tagName: string;
+    readonly version: string;
+};
+type ValidChangelogConfig = NonNullable<ReturnType<typeof parseValidConfig>>;
+type ReleaseChangelog = {
+    readonly changelog: GeneratedChangelog;
+    readonly config: ValidChangelogConfig;
+    readonly engine: PrLogEngine;
+};
+type PlannedRelease = {
+    readonly config: unknown;
+    readonly packages: readonly ReleasePlanPackage[];
+};
+type ChangelogStepResult = {
+    readonly changelog: ReleaseChangelog | undefined;
+    readonly planned: PlannedRelease;
+};
+type MutatingReleaseStateBase = {
+    readonly changedTargets: readonly ReleaseTarget[];
+    readonly planned: PlannedRelease;
+};
+type MutatingReleaseState = MutatingReleaseStateBase &
+    (
+        | { readonly changelog: ReleaseChangelog; readonly githubRelease: true }
+        | { readonly changelog: ReleaseChangelog | undefined; readonly githubRelease: false }
+    );
+type FlagRule = {
+    readonly failed: (flags: ReleaseFlags) => boolean;
+    readonly message: string;
+};
+
+type ReleaseFlags = {
+    readonly commit: boolean;
+    readonly githubRelease: boolean;
+    readonly noDryRun: boolean;
+    readonly publish: boolean;
+    readonly push: boolean;
+    readonly tag: boolean;
+    readonly writeChangelog: boolean;
+};
+
+export type ReleaseHandlerDeps = {
+    readonly createGitHubReleaseClient: (context: {
+        readonly owner: string;
+        readonly repo: string;
+        readonly token: string;
+    }) => GitHubReleaseClient;
+    readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
+    readonly currentDate: () => Date;
+    readonly fileManager: {
+        readonly readFile: (filePath: string) => Promise<string>;
+        readonly writeFile: (filePath: string, content: string) => Promise<void>;
+    };
+    readonly flags: ReleaseFlags;
+    readonly gitClient: ReleaseGitClient;
+    readonly log: Logger;
+    readonly packtory: Packtory;
+    readonly readEnvironmentVariable: (name: EnvironmentVariableName) => string | undefined;
+    readonly readPackageInfo: () => Promise<Record<string, unknown>>;
+    readonly spinnerRenderer: { readonly stopAll: () => void };
+    readonly configLoader: { readonly load: () => Promise<unknown> };
+    readonly workingDirectory: string;
+};
+
+const releaseCommitMessage = 'Release packages';
+
+function formatReleaseHandlerError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function hasAction(flags: ReleaseFlags): boolean {
+    return flags.writeChangelog || flags.commit || flags.publish || flags.tag || flags.push || flags.githubRelease;
+}
+
+function isCommitWithoutChangelog(flags: ReleaseFlags): boolean {
+    return flags.commit && !flags.writeChangelog;
+}
+
+function isChangelogPublishWithoutCommit(flags: ReleaseFlags): boolean {
+    return flags.writeChangelog && flags.publish && !flags.commit;
+}
+
+function isPushWithoutSource(flags: ReleaseFlags): boolean {
+    return flags.push && !(flags.commit || flags.tag);
+}
+
+function isGitHubReleaseWithoutGitPublication(flags: ReleaseFlags): boolean {
+    return flags.githubRelease && !(flags.tag && flags.push);
+}
+
+function isReleaseWriteWithoutMutationApproval(flags: ReleaseFlags): boolean {
+    return hasAction(flags) && !flags.noDryRun;
+}
+
+const flagRules: readonly FlagRule[] = [
+    { failed: isCommitWithoutChangelog, message: '--commit requires --write-changelog' },
+    { failed: isChangelogPublishWithoutCommit, message: '--write-changelog --publish requires --commit' },
+    { failed: isPushWithoutSource, message: '--push requires --commit or --tag' },
+    { failed: isGitHubReleaseWithoutGitPublication, message: '--github-release requires --tag --push' },
+    { failed: isReleaseWriteWithoutMutationApproval, message: 'Release writes require --no-dry-run' }
+];
+
+function collectFlagIssues(flags: ReleaseFlags): readonly string[] {
+    return flagRules.flatMap((rule) => {
+        return rule.failed(flags) ? [rule.message] : [];
+    });
+}
+
+function createTargetFromPlanPackage(packagePlan: ReleasePlanPackage): ReleaseTarget {
+    return {
+        name: packagePlan.name,
+        version: packagePlan.nextVersion,
+        tagName: `${packagePlan.name}@${packagePlan.nextVersion}`
+    };
+}
+
+function selectChangedTargets(packages: readonly ReleasePlanPackage[]): readonly ReleaseTarget[] {
+    return packages
+        .filter((packagePlan) => {
+            return packagePlan.changed;
+        })
+        .map(createTargetFromPlanPackage);
+}
+
+function selectCurrentHeadPublishedTargets(packages: readonly ReleasePlanPackage[]): readonly ReleaseTarget[] {
+    return packages
+        .filter((packagePlan) => {
+            return (
+                packagePlan.currentGitHead !== undefined &&
+                packagePlan.latestRegistryMetadata?.gitHead === packagePlan.currentGitHead
+            );
+        })
+        .map(createTargetFromPlanPackage);
+}
+
+function mapTargetsByName(targets: readonly ReleaseTarget[]): ReadonlyMap<string, ReleaseTarget> {
+    return new Map(
+        targets.map((target) => {
+            return [target.name, target];
+        })
+    );
+}
+
+function mergeTargets(...targetGroups: readonly (readonly ReleaseTarget[])[]): readonly ReleaseTarget[] {
+    return Array.from(
+        new Map(
+            targetGroups.flatMap((targets) => {
+                return targets.map((target) => {
+                    return [target.name, target] as const;
+                });
+            })
+        ).values()
+    );
+}
+
+function assertTagRule(flags: ReleaseFlags, changedTargets: readonly ReleaseTarget[]): void {
+    if (flags.tag && !flags.publish && changedTargets.length > 0) {
+        throw new Error('--tag requires --publish unless registry latest already matches the current Git head');
+    }
+}
+
+function hasReleaseWork(flags: ReleaseFlags, packages: readonly ReleasePlanPackage[]): boolean {
+    if (selectChangedTargets(packages).length > 0) {
+        return true;
+    }
+    return (flags.tag || flags.githubRelease) && selectCurrentHeadPublishedTargets(packages).length > 0;
+}
+
+function formatPlanPackage(packagePlan: ReleasePlanPackage): string {
+    const previousVersion = packagePlan.previousVersion ?? 'unpublished';
+    return `- ${packagePlan.name}: ${previousVersion} -> ${packagePlan.nextVersion} (${packagePlan.artifactState})`;
+}
+
+function printReleasePlan(log: Logger, packages: readonly ReleasePlanPackage[]): void {
+    const changedPackages = packages.filter((packagePlan) => {
+        return packagePlan.changed;
+    });
+    if (changedPackages.length === 0) {
+        log('No packages need release.');
+        return;
+    }
+    log(['Release plan:', ...changedPackages.map(formatPlanPackage)].join('\n'));
+}
+
+function readGitHubToken(deps: Pick<ReleaseHandlerDeps, 'readEnvironmentVariable'>): string | undefined {
+    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+}
+
+function createEngine(deps: ReleaseHandlerDeps): PrLogEngine {
+    return deps.createPrLogEngine({
+        githubToken: readGitHubToken(deps),
+        workingDirectory: deps.workingDirectory,
+        labelLookupIntervalMilliseconds: 250,
+        maximumRateLimitRetryCount: 3
+    });
+}
+
+async function generateReleaseChangelog(
+    deps: ReleaseHandlerDeps,
+    config: ValidChangelogConfig,
+    packages: readonly ReleasePlanPackage[]
+): Promise<ReleaseChangelog> {
+    const packageInfo = await deps.readPackageInfo();
+    const engine = createEngine(deps);
+    const changelog = await generateChangelogOutputs({
+        packages,
+        prLogEngine: engine,
+        githubRepo: formatGitHubRepositoryName(packageInfo),
+        ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
+        packageInfo,
+        currentDate: deps.currentDate(),
+        validLabels: defaultValidLabels
+    });
+    return { changelog, config, engine };
+}
+
+async function planRelease(
+    deps: ReleaseHandlerDeps,
+    config: unknown
+): Promise<readonly ReleasePlanPackage[] | undefined> {
+    const outcome = await deps.packtory.planReleaseAgainstLatestPublished(config);
+    deps.spinnerRenderer.stopAll();
+    if (outcome.result.isErr) {
+        printReleasePlanFailure(deps.log, outcome.result.error);
+        return undefined;
+    }
+    return outcome.result.value.packages;
+}
+
+async function publishTargets(
+    deps: ReleaseHandlerDeps,
+    config: unknown,
+    changedTargets: readonly ReleaseTarget[]
+): Promise<readonly ReleaseTarget[] | undefined> {
+    if (changedTargets.length === 0) {
+        return [];
+    }
+    const changedTargetsByName = mapTargetsByName(changedTargets);
+    const outcome = await deps.packtory.buildAndPublishAll(config, {
+        dryRun: false,
+        stage: false,
+        collectReport: false
+    });
+    deps.spinnerRenderer.stopAll();
+    if (outcome.result.isErr) {
+        printPublishFailure(deps.log, outcome.result.error, false);
+        return undefined;
+    }
+    return outcome.result.value.flatMap((result) => {
+        const plannedTarget = changedTargetsByName.get(result.bundle.name);
+        if (plannedTarget === undefined) {
+            return [];
+        }
+        return [
+            {
+                name: result.bundle.name,
+                version: result.bundle.version,
+                tagName: `${result.bundle.name}@${result.bundle.version}`
+            }
+        ];
+    });
+}
+
+async function ensureTags(deps: ReleaseHandlerDeps, targets: readonly ReleaseTarget[]): Promise<void> {
+    const head = await deps.gitClient.currentHead();
+    for (const target of targets) {
+        await deps.gitClient.ensureTag(target.tagName, target.tagName, head);
+    }
+}
+
+async function createGitHubReleases(
+    deps: ReleaseHandlerDeps,
+    targets: readonly ReleaseTarget[],
+    changelog: GeneratedChangelog
+): Promise<void> {
+    const token = readGitHubToken(deps);
+    if (token === undefined) {
+        throw new Error('GH_TOKEN or GITHUB_TOKEN must be set to create GitHub releases');
+    }
+    const repository = parseGitHubRepositoryParts(await deps.readPackageInfo());
+    const client = deps.createGitHubReleaseClient({ ...repository, token });
+    for (const target of targets) {
+        await client.createReleaseIfMissing({
+            tagName: target.tagName,
+            name: target.tagName,
+            body: changelog.packageMarkdownByName.get(target.name) ?? ''
+        });
+    }
+}
+
+function reportFlagIssues(deps: ReleaseHandlerDeps): number | undefined {
+    const issues = collectFlagIssues(deps.flags);
+    if (issues.length > 0) {
+        deps.log(issues.join('\n'));
+        return 1;
+    }
+    return undefined;
+}
+
+async function loadPlannedRelease(deps: ReleaseHandlerDeps): Promise<PlannedRelease | undefined> {
+    const config = await deps.configLoader.load();
+    const packages = await planRelease(deps, config);
+    if (packages === undefined) {
+        return undefined;
+    }
+    return { config, packages };
+}
+
+function resolvePlannedReleaseExitCode(
+    deps: ReleaseHandlerDeps,
+    packages: readonly ReleasePlanPackage[]
+): number | undefined {
+    if (!hasAction(deps.flags)) {
+        printReleasePlan(deps.log, packages);
+        return 0;
+    }
+    if (!hasReleaseWork(deps.flags, packages)) {
+        deps.log('No packages need release.');
+        return 0;
+    }
+    return undefined;
+}
+
+async function generateRequiredChangelog(
+    deps: ReleaseHandlerDeps,
+    config: unknown,
+    packages: readonly ReleasePlanPackage[]
+): Promise<ReleaseChangelog> {
+    const validConfig = parseValidConfig(config);
+    if (validConfig === undefined) {
+        throw new Error('The loaded config is invalid for changelog generation');
+    }
+    return generateReleaseChangelog(deps, validConfig, packages);
+}
+
+async function commitChangelogAndReplan(
+    deps: ReleaseHandlerDeps,
+    changelog: ReleaseChangelog,
+    writtenPaths: readonly string[]
+): Promise<ChangelogStepResult | undefined> {
+    await deps.gitClient.commit(writtenPaths, releaseCommitMessage);
+    const committedPlan = await loadPlannedRelease(deps);
+    return committedPlan === undefined ? undefined : { changelog, planned: committedPlan };
+}
+
+async function writeChangelogAndMaybeCommit(
+    deps: ReleaseHandlerDeps,
+    planned: PlannedRelease
+): Promise<ChangelogStepResult | undefined> {
+    if (!deps.flags.writeChangelog) {
+        return { changelog: undefined, planned };
+    }
+    const validConfig = parseValidConfig(planned.config);
+    if (validConfig === undefined) {
+        throw new Error('The loaded config is invalid for changelog generation');
+    }
+    const changelog = await generateReleaseChangelog(deps, validConfig, planned.packages);
+    const writtenPaths = await writeConfiguredChangelogs(deps, changelog.config, changelog.engine, changelog.changelog);
+    if (!deps.flags.commit) {
+        return { changelog, planned };
+    }
+    return commitChangelogAndReplan(deps, changelog, writtenPaths);
+}
+
+async function publishOrRetryTargets(
+    deps: ReleaseHandlerDeps,
+    planned: PlannedRelease,
+    changedTargets: readonly ReleaseTarget[]
+): Promise<readonly ReleaseTarget[] | undefined> {
+    if (deps.flags.publish) {
+        return publishTargets(deps, planned.config, changedTargets);
+    }
+    return selectCurrentHeadPublishedTargets(planned.packages);
+}
+
+async function finishReleaseActions(
+    deps: ReleaseHandlerDeps,
+    state: MutatingReleaseState,
+    publishedTargets: readonly ReleaseTarget[]
+): Promise<void> {
+    const releaseTargets = mergeTargets(publishedTargets, selectCurrentHeadPublishedTargets(state.planned.packages));
+    if (deps.flags.tag) {
+        await ensureTags(deps, releaseTargets);
+    }
+    if (deps.flags.push) {
+        await deps.gitClient.pushFollowTags();
+    }
+    if (state.githubRelease) {
+        await createGitHubReleases(deps, releaseTargets, state.changelog.changelog);
+    }
+}
+
+async function createMutatingReleaseState(
+    deps: ReleaseHandlerDeps,
+    changelogStep: ChangelogStepResult
+): Promise<MutatingReleaseState> {
+    const base = {
+        changedTargets: selectChangedTargets(changelogStep.planned.packages),
+        planned: changelogStep.planned
+    };
+    if (deps.flags.githubRelease) {
+        return {
+            ...base,
+            githubRelease: true,
+            changelog:
+                changelogStep.changelog ??
+                (await generateRequiredChangelog(deps, changelogStep.planned.config, changelogStep.planned.packages))
+        };
+    }
+    return { ...base, githubRelease: false, changelog: changelogStep.changelog };
+}
+
+async function prepareMutatingRelease(
+    deps: ReleaseHandlerDeps,
+    planned: PlannedRelease
+): Promise<MutatingReleaseState | undefined> {
+    const initialChangedTargets = selectChangedTargets(planned.packages);
+    assertTagRule(deps.flags, initialChangedTargets);
+
+    await deps.gitClient.ensureClean();
+
+    const changelogStep = await writeChangelogAndMaybeCommit(deps, planned);
+    if (changelogStep === undefined) {
+        return undefined;
+    }
+    return createMutatingReleaseState(deps, changelogStep);
+}
+
+async function finishAndReportRelease(
+    deps: ReleaseHandlerDeps,
+    state: MutatingReleaseState,
+    publishedTargets: readonly ReleaseTarget[]
+): Promise<number> {
+    await finishReleaseActions(deps, state, publishedTargets);
+    deps.log('Release completed.');
+    return 0;
+}
+
+async function runMutatingRelease(deps: ReleaseHandlerDeps, planned: PlannedRelease): Promise<number> {
+    const state = await prepareMutatingRelease(deps, planned);
+    if (state === undefined) {
+        return 1;
+    }
+    const publishedTargets = await publishOrRetryTargets(deps, state.planned, state.changedTargets);
+    if (publishedTargets === undefined) {
+        return 1;
+    }
+    return finishAndReportRelease(deps, state, publishedTargets);
+}
+
+async function runRelease(deps: ReleaseHandlerDeps): Promise<number> {
+    const flagExitCode = reportFlagIssues(deps);
+    if (flagExitCode !== undefined) {
+        return flagExitCode;
+    }
+    const planned = await loadPlannedRelease(deps);
+    if (planned === undefined) {
+        return 1;
+    }
+    return resolvePlannedReleaseExitCode(deps, planned.packages) ?? runMutatingRelease(deps, planned);
+}
+
+function stopSpinnersAndReturn(deps: ReleaseHandlerDeps, exitCode: number): number {
+    deps.spinnerRenderer.stopAll();
+    return exitCode;
+}
+
+export async function runReleaseHandler(deps: ReleaseHandlerDeps): Promise<number> {
+    try {
+        return stopSpinnersAndReturn(deps, await runRelease(deps));
+    } catch (error: unknown) {
+        deps.log(formatReleaseHandlerError(error));
+        return stopSpinnersAndReturn(deps, 1);
+    }
+}

--- a/source/command-line-interface/runner/release-plan-result-printing.ts
+++ b/source/command-line-interface/runner/release-plan-result-printing.ts
@@ -1,0 +1,31 @@
+import { partialFailureMessages } from '../../packtory/partial-result.ts';
+import type { ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
+import { checksErrorType, configErrorType, type ReleasePlanFailure } from '../../packtory/packtory-results.ts';
+
+type Logger = (message: string) => void;
+
+function printIssueFailure(log: Logger, title: string, issues: readonly string[]): void {
+    log(`${title}, there are ${issues.length} issue(s)\n\n- ${issues.join('\n- ')}`);
+}
+
+export function printReleasePlanFailure(log: Logger, error: ReleasePlanFailure): void {
+    if (error.type === configErrorType) {
+        printIssueFailure(log, 'Configuration issues', error.issues);
+        return;
+    }
+    if (error.type === checksErrorType) {
+        printIssueFailure(log, 'Check issues', error.issues);
+        return;
+    }
+    log(partialFailureMessages(error).join('\n'));
+}
+
+export function collectReleasePlanPackages(result: ReleasePlanResult): readonly ReleasePlanPackage[] {
+    if (result.isOk) {
+        return result.value.packages;
+    }
+    if ('succeeded' in result.error) {
+        return result.error.succeeded;
+    }
+    return [];
+}

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -33,8 +33,10 @@ type Overrides = {
     readonly openFile?: SinonSpy;
     readonly createTemporaryFilePath?: () => string;
     readonly createPrLogEngine?: SinonSpy;
+    readonly createGitHubReleaseClient?: SinonSpy;
     readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
     readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
+    readonly releaseGitClient?: CommandLineInterfaceRunnerDependencies['releaseGitClient'];
     progressBroadcaster?: ProgressBroadcaster;
     spinnerRenderer?: {
         add?: SinonSpy;
@@ -72,7 +74,7 @@ function createSpinnerRenderer(
     };
 }
 
-function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
+function createRunner(overrides: Overrides = {}): CommandLineInterfaceRunner {
     const progressBroadcaster = overrides.progressBroadcaster ?? createProgressBroadcaster();
     const log = createSpy(overrides.log, fake);
     const pageOutput = overrides.pageOutput ?? fake.resolves(undefined);
@@ -89,6 +91,11 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
                 renderGroupedTargetChangelog: fake.returns(''),
                 renderTargetChangelog: fake.returns(''),
                 updateChangelog: fake.returns('')
+            });
+        }),
+        createGitHubReleaseClient: createSpy(overrides.createGitHubReleaseClient, () => {
+            return fake.returns({
+                createReleaseIfMissing: fake.resolves('created')
             });
         }),
         currentDate() {
@@ -151,6 +158,13 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
             (async () => {
                 return { repository: { url: 'https://github.com/enormora/packtory' } };
             }),
+        releaseGitClient: overrides.releaseGitClient ?? {
+            commit: fake.resolves(undefined),
+            currentHead: fake.resolves('new-head'),
+            ensureClean: fake.resolves(undefined),
+            ensureTag: fake.resolves(undefined),
+            pushFollowTags: fake.resolves(undefined)
+        },
         workingDirectory: '/workspace'
     };
 
@@ -160,7 +174,7 @@ function runnerFactory(overrides: Overrides = {}): CommandLineInterfaceRunner {
 async function expectCommandLoadsConfig(command: 'preview' | 'publish'): Promise<void> {
     const loadConfig = fake.resolves('the-config');
     const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ loadConfig, buildAndPublishAll });
+    const runner = createRunner({ loadConfig, buildAndPublishAll });
 
     await runner.run(['foo', 'bar', command]);
 
@@ -172,7 +186,7 @@ async function expectCommandLoadsConfig(command: 'preview' | 'publish'): Promise
 async function expectHelp(args: readonly string[]): Promise<string> {
     const log = fake();
     const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll, log });
+    const runner = createRunner({ buildAndPublishAll, log });
 
     const exitCode = await runner.run(['foo', 'bar', ...args]);
 
@@ -180,13 +194,13 @@ async function expectHelp(args: readonly string[]): Promise<string> {
     return String(log.firstCall.args[0]);
 }
 
-async function expectSubcommandHelp(command: 'preview' | 'publish'): Promise<string> {
+async function expectSubcommandHelp(command: 'preview' | 'publish' | 'release'): Promise<string> {
     return expectHelp([command, '--help']);
 }
 
 async function expectCollectReportFlag(flag: '--report-html' | '--report-json'): Promise<void> {
     const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-    const runner = runnerFactory({ buildAndPublishAll });
+    const runner = createRunner({ buildAndPublishAll });
 
     await runner.run(['foo', 'bar', 'publish', flag]);
 
@@ -199,7 +213,7 @@ async function runPreview(
 ): Promise<{ readonly exitCode: number; readonly pageOutput: SinonSpy; readonly log: SinonSpy }> {
     const pageOutput = overrides.pageOutput ?? fake.resolves(undefined);
     const log = overrides.log ?? fake();
-    const runner = runnerFactory({ buildAndPublishAll, pageOutput, log });
+    const runner = createRunner({ buildAndPublishAll, pageOutput, log });
 
     const exitCode = await runner.run(['foo', 'bar', 'preview']);
 
@@ -213,7 +227,7 @@ suite('runner', function () {
 
     test('publish command runs in dry-run mode per default', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         await runner.run(['foo', 'bar', 'publish']);
 
@@ -227,7 +241,7 @@ suite('runner', function () {
 
     test('publish command runs not in dry-run mode when no-dry-run flag is set', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         await runner.run(['foo', 'bar', 'publish', '--no-dry-run']);
 
@@ -241,7 +255,7 @@ suite('runner', function () {
 
     test('publish command enables staged publishing when --stage is set', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         await runner.run(['foo', 'bar', 'publish', '--stage']);
 
@@ -257,9 +271,88 @@ suite('runner', function () {
         await expectCommandLoadsConfig('preview');
     });
 
+    test('release command loads the config file and plans the release', async function () {
+        const loadConfig = fake.resolves('the-config');
+        const planReleaseAgainstLatestPublished = fake.resolves({
+            result: Result.ok({ packages: [] }),
+            getReport() {
+                return createBuildReportFixture();
+            }
+        });
+        const runner = createRunner({ loadConfig, planReleaseAgainstLatestPublished });
+
+        const exitCode = await runner.run(['foo', 'bar', 'release']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.deepStrictEqual(planReleaseAgainstLatestPublished.firstCall.args, ['the-config']);
+    });
+
+    test('release command parses release action flags', async function () {
+        const planReleaseAgainstLatestPublished = fake.resolves({
+            result: Result.ok({
+                packages: [
+                    {
+                        name: 'pkg-a',
+                        previousVersion: '1.0.0',
+                        nextVersion: '1.0.1',
+                        artifactState: 'changed',
+                        changed: true,
+                        previousGitHead: 'old-head',
+                        currentGitHead: 'new-head',
+                        latestRegistryMetadata: { version: '1.0.0', publishedAt: undefined, gitHead: 'old-head' },
+                        artifactFiles: [],
+                        changedArtifactFiles: [],
+                        sourceFiles: [],
+                        changelogSourceFiles: []
+                    }
+                ]
+            }),
+            getReport() {
+                return createBuildReportFixture();
+            }
+        });
+        const buildAndPublishAll = fake.resolves(
+            toOutcome(Result.ok([{ bundle: { name: 'pkg-a', version: '1.0.1' } }]))
+        );
+        const ensureTag = fake.resolves(undefined);
+        const pushFollowTags = fake.resolves(undefined);
+        const runner = createRunner({
+            buildAndPublishAll,
+            planReleaseAgainstLatestPublished,
+            releaseGitClient: {
+                commit: fake.resolves(undefined),
+                currentHead: fake.resolves('new-head'),
+                ensureClean: fake.resolves(undefined),
+                ensureTag,
+                pushFollowTags
+            }
+        });
+
+        const exitCode = await runner.run(['foo', 'bar', 'release', '--publish', '--tag', '--push', '--no-dry-run']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.deepStrictEqual(buildAndPublishAll.firstCall.args[1], {
+            dryRun: false,
+            stage: false,
+            collectReport: false
+        });
+        assert.strictEqual(ensureTag.callCount, 1);
+        assert.strictEqual(pushFollowTags.callCount, 1);
+    });
+
+    test('release command parses the commit flag', async function () {
+        const log = fake();
+        const runner = createRunner({ log });
+
+        const exitCode = await runner.run(['foo', 'bar', 'release', '--commit', '--no-dry-run']);
+
+        assert.strictEqual(exitCode, 1);
+        assert.deepStrictEqual(log.firstCall.args, ['--commit requires --write-changelog']);
+    });
+
     test('preview command always runs in dry-run mode with collectReport enabled', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         await runner.run(['foo', 'bar', 'preview']);
 
@@ -272,7 +365,7 @@ suite('runner', function () {
 
     test('returns exit code 0 when publish command had no errors', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         const exitCode = await runner.run(['foo', 'bar', 'publish']);
 
@@ -281,7 +374,7 @@ suite('runner', function () {
 
     test('returns exit code 1 when publish command has errors', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'config', issues: [] })));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         const exitCode = await runner.run(['foo', 'bar', 'publish']);
 
@@ -291,7 +384,7 @@ suite('runner', function () {
     test('returns exit code 1 instead of exiting the process when command parsing fails', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
         const log = fake();
-        const runner = runnerFactory({ buildAndPublishAll, log });
+        const runner = createRunner({ buildAndPublishAll, log });
 
         const exitCode = await runner.run(['foo', 'bar', 'not-a-command']);
 
@@ -303,7 +396,7 @@ suite('runner', function () {
 
     test('returns exit code 1 when the publish command name is misspelled', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll });
+        const runner = createRunner({ buildAndPublishAll });
 
         const exitCode = await runner.run(['foo', 'bar', 'publis']);
 
@@ -321,6 +414,7 @@ suite('runner', function () {
         );
         assert.ok(help.includes('preview'), 'Expected help output to include the preview command');
         assert.ok(help.includes('changelog'), 'Expected help output to include the changelog command');
+        assert.ok(help.includes('release'), 'Expected help output to include the release command');
     });
 
     test('prints subcommand help that includes the full publish command path', async function () {
@@ -335,8 +429,18 @@ suite('runner', function () {
         assert.match(help, /Builds all packages in fresh dry-run mode and opens a human preview\./);
     });
 
+    test('prints release subcommand help with release action flags', async function () {
+        const help = await expectSubcommandHelp('release');
+
+        assert.match(help, /packtory release/);
+        assert.match(help, /Plans or runs a release workflow\./);
+        assert.match(help, /--write-changelog/);
+        assert.match(help, /--github-release/);
+        assert.match(help, /--no-dry-run/);
+    });
+
     async function expectRunnerToRethrow(overrides: Overrides, expectedMessage: string): Promise<void> {
-        const runner = runnerFactory(overrides);
+        const runner = createRunner(overrides);
         try {
             await runner.run(['foo', 'bar', 'publish']);
             assert.fail('Expected run() should fail but it did not');
@@ -355,7 +459,7 @@ suite('runner', function () {
     ): Promise<{ readonly log: SinonSpy }> {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type, issues })));
         const log = fake();
-        const runner = runnerFactory({ buildAndPublishAll, log });
+        const runner = createRunner({ buildAndPublishAll, log });
 
         await runner.run(['foo', 'bar', 'publish']);
         return { log };
@@ -393,7 +497,7 @@ suite('runner', function () {
         extraArgs: readonly string[] = []
     ): Promise<SinonSpy> {
         const log = fake();
-        const runner = runnerFactory({ buildAndPublishAll, log });
+        const runner = createRunner({ buildAndPublishAll, log });
         await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
         return log;
     }
@@ -448,7 +552,7 @@ suite('runner', function () {
     test('stops all spinners when buildAndPublishAll finishes without errors', async function () {
         const stopAll = fake();
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { stopAll } });
+        const runner = createRunner({ buildAndPublishAll, spinnerRenderer: { stopAll } });
 
         await runner.run(['foo', 'bar', 'publish']);
         assert.strictEqual(stopAll.callCount, 1);
@@ -458,7 +562,7 @@ suite('runner', function () {
         const add = fake();
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
         const progressBroadcaster = createProgressBroadcaster();
-        const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer: { add }, progressBroadcaster });
+        const runner = createRunner({ buildAndPublishAll, spinnerRenderer: { add }, progressBroadcaster });
 
         await runner.run(['foo', 'bar', 'publish']);
         progressBroadcaster.provider.emit('scheduled', { packageName: 'foo' });
@@ -474,7 +578,7 @@ suite('runner', function () {
     ): Promise<ProgressBroadcaster> {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
         const progressBroadcaster = createProgressBroadcaster();
-        const runner = runnerFactory({ buildAndPublishAll, spinnerRenderer, progressBroadcaster });
+        const runner = createRunner({ buildAndPublishAll, spinnerRenderer, progressBroadcaster });
 
         await runner.run(['foo', 'bar', 'publish']);
         progressBroadcaster.provider.emit(eventName as never, eventPayload as never);
@@ -570,7 +674,7 @@ suite('runner', function () {
         }
     });
 
-    function outcomeWithReport(result: unknown): {
+    function createOutcomeWithReport(result: unknown): {
         readonly result: unknown;
         readonly getReport: () => typeof sampleReport;
     } {
@@ -592,8 +696,8 @@ suite('runner', function () {
 
     async function runPublishWithReport(extraArgs: readonly string[]): Promise<FakeFileManager> {
         const fileManager = createFakeFileManager();
-        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll, fileManager });
+        const buildAndPublishAll = fake.resolves(createOutcomeWithReport(Result.ok([])));
+        const runner = createRunner({ buildAndPublishAll, fileManager });
         await runner.run(['foo', 'bar', 'publish', ...extraArgs]);
         return fileManager;
     }
@@ -644,7 +748,7 @@ suite('runner', function () {
     test('publish writes no report files when getReport returns undefined even with --report-json set', async function () {
         const fileManager = createFakeFileManager();
         const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
-        const runner = runnerFactory({ buildAndPublishAll, fileManager });
+        const runner = createRunner({ buildAndPublishAll, fileManager });
 
         await runner.run(['foo', 'bar', 'publish', '--report-json']);
 
@@ -653,8 +757,10 @@ suite('runner', function () {
 
     test('publish writes the report even when the build failed', async function () {
         const fileManager = createFakeFileManager();
-        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'config', issues: ['boom'] })));
-        const runner = runnerFactory({ buildAndPublishAll, fileManager });
+        const buildAndPublishAll = fake.resolves(
+            createOutcomeWithReport(Result.err({ type: 'config', issues: ['boom'] }))
+        );
+        const runner = createRunner({ buildAndPublishAll, fileManager });
 
         const exitCode = await runner.run(['foo', 'bar', 'publish', '--report-json']);
 
@@ -663,7 +769,7 @@ suite('runner', function () {
     });
 
     test('preview pages previewable output and does not print it directly to stdout', async function () {
-        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const buildAndPublishAll = fake.resolves(createOutcomeWithReport(Result.ok([])));
         const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
 
         assert.strictEqual(exitCode, 0);
@@ -712,7 +818,9 @@ suite('runner', function () {
     });
 
     test('preview prints failure-only output directly to stdout without paging', async function () {
-        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.err({ type: 'checks', issues: ['boom'] })));
+        const buildAndPublishAll = fake.resolves(
+            createOutcomeWithReport(Result.err({ type: 'checks', issues: ['boom'] }))
+        );
         const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
 
         assert.strictEqual(exitCode, 1);
@@ -723,7 +831,7 @@ suite('runner', function () {
 
     test('preview treats partial failures with no successful packages as failure-only output', async function () {
         const buildAndPublishAll = fake.resolves(
-            outcomeWithReport(Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }))
+            createOutcomeWithReport(Result.err({ type: 'partial', succeeded: [], failures: [new Error('boom')] }))
         );
         const { exitCode, pageOutput, log } = await runPreview(buildAndPublishAll);
 
@@ -734,11 +842,11 @@ suite('runner', function () {
     });
 
     test('preview --open writes a temporary html report and invokes the opener', async function () {
-        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const buildAndPublishAll = fake.resolves(createOutcomeWithReport(Result.ok([])));
         const fileManager = createFakeFileManager();
         const openFile = fake.resolves(true);
         const log = fake();
-        const runner = runnerFactory({
+        const runner = createRunner({
             buildAndPublishAll,
             fileManager,
             openFile,
@@ -758,10 +866,10 @@ suite('runner', function () {
     });
 
     test('preview --open prints the temp path only when opening fails', async function () {
-        const buildAndPublishAll = fake.resolves(outcomeWithReport(Result.ok([])));
+        const buildAndPublishAll = fake.resolves(createOutcomeWithReport(Result.ok([])));
         const openFile = fake.resolves(false);
         const log = fake();
-        const runner = runnerFactory({
+        const runner = createRunner({
             buildAndPublishAll,
             openFile,
             log,
@@ -778,7 +886,7 @@ suite('runner', function () {
     test('preview builds an empty fallback report when getReport returns undefined', async function () {
         const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
         const log = fake();
-        const runner = runnerFactory({ buildAndPublishAll, log });
+        const runner = createRunner({ buildAndPublishAll, log });
 
         await runner.run(['foo', 'bar', 'preview']);
 
@@ -788,7 +896,7 @@ suite('runner', function () {
     test('preview --open writes an empty fallback report when getReport returns undefined', async function () {
         const fileManager = createFakeFileManager();
         const buildAndPublishAll = fake.resolves(toOutcome(Result.err({ type: 'checks', issues: ['boom'] })));
-        const runner = runnerFactory({
+        const runner = createRunner({
             buildAndPublishAll,
             fileManager,
             createTemporaryFilePath: () => '/tmp/packtory-preview-fallback.html'
@@ -808,7 +916,7 @@ suite('runner', function () {
     test('preview stops all spinners when config loading fails before the build starts', async function () {
         const stopAll = fake();
         const loadConfig = fake.rejects(new Error('config boom'));
-        const runner = runnerFactory({ loadConfig, spinnerRenderer: { stopAll } });
+        const runner = createRunner({ loadConfig, spinnerRenderer: { stopAll } });
 
         try {
             await runner.run(['foo', 'bar', 'preview']);
@@ -823,7 +931,7 @@ suite('runner', function () {
     test('release-diff command loads the config and invokes diffAgainstLatestPublished', async function () {
         const loadConfig = fake.resolves('the-config');
         const diffAgainstLatestPublished = fake.resolves(toReleaseDiffOutcome(Result.ok([])));
-        const runner = runnerFactory({ loadConfig, diffAgainstLatestPublished });
+        const runner = createRunner({ loadConfig, diffAgainstLatestPublished });
 
         const exitCode = await runner.run(['foo', 'bar', 'release-diff']);
 
@@ -837,7 +945,7 @@ suite('runner', function () {
         const diffAgainstLatestPublished = fake.resolves(
             toReleaseDiffOutcome(Result.err({ type: 'config', issues: ['invalid config'] }))
         );
-        const runner = runnerFactory({ diffAgainstLatestPublished });
+        const runner = createRunner({ diffAgainstLatestPublished });
 
         const exitCode = await runner.run(['foo', 'bar', 'release-diff']);
 
@@ -846,7 +954,7 @@ suite('runner', function () {
 
     test('release-diff --help advertises the command as a registry-diff against the latest published version', async function () {
         const log = fake();
-        const runner = runnerFactory({ log });
+        const runner = createRunner({ log });
 
         await runner.run(['foo', 'bar', 'release-diff', '--help']);
 
@@ -862,7 +970,7 @@ suite('runner', function () {
                 return createBuildReportFixture();
             }
         });
-        const runner = runnerFactory({ loadConfig, planReleaseAgainstLatestPublished });
+        const runner = createRunner({ loadConfig, planReleaseAgainstLatestPublished });
 
         const exitCode = await runner.run(['foo', 'bar', 'changelog']);
 
@@ -874,7 +982,7 @@ suite('runner', function () {
 
     test('changelog --help advertises grouped Markdown output for the next release', async function () {
         const log = fake();
-        const runner = runnerFactory({ log });
+        const runner = createRunner({ log });
 
         await runner.run(['foo', 'bar', 'changelog', '--help']);
 
@@ -885,7 +993,7 @@ suite('runner', function () {
     test('pack command loads the config and forwards the flags into packPackage', async function () {
         const loadConfig = fake.resolves('the-config');
         const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
-        const runner = runnerFactory({ loadConfig, packPackage });
+        const runner = createRunner({ loadConfig, packPackage });
 
         const exitCode = await runner.run([
             'foo',
@@ -915,7 +1023,7 @@ suite('runner', function () {
 
     test('pack command defaults the version to 0.0.0 when --version is omitted', async function () {
         const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
-        const runner = runnerFactory({ packPackage });
+        const runner = createRunner({ packPackage });
 
         await runner.run(['foo', 'bar', 'pack', 'pkg-a', '--format', 'zip', '--out', '/tmp/pkg-a.zip']);
 
@@ -930,7 +1038,7 @@ suite('runner', function () {
 
     test('pack command returns exit code 1 when packPackage reports an Err', async function () {
         const packPackage = fake.resolves(toOutcome(Result.err({ type: 'package-not-found', packageName: 'pkg-a' })));
-        const runner = runnerFactory({ packPackage });
+        const runner = createRunner({ packPackage });
 
         const exitCode = await runner.run([
             'foo',
@@ -950,7 +1058,7 @@ suite('runner', function () {
     test('pack command forwards --vendor-dependencies as true when the flag is supplied', async function () {
         const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
         const argv = 'foo,bar,pack,pkg-a,--format,zip,--out,/tmp/pkg-a.zip,--vendor-dependencies'.split(',');
-        await runnerFactory({ packPackage }).run(argv);
+        await createRunner({ packPackage }).run(argv);
 
         const forwarded = packPackage.firstCall.args[1] as { readonly vendorDependencies: boolean };
         assert.strictEqual(forwarded.vendorDependencies, true);
@@ -959,7 +1067,7 @@ suite('runner', function () {
     test('pack command accepts each of the zip, tar, and folder format values and forwards them to packPackage', async function () {
         for (const format of ['zip', 'tar', 'folder'] as const) {
             const packPackage = fake.resolves(toOutcome(Result.ok(undefined)));
-            const runner = runnerFactory({ packPackage });
+            const runner = createRunner({ packPackage });
 
             await runner.run(['foo', 'bar', 'pack', 'pkg-a', '--format', format, '--out', '/tmp/pkg-a.archive']);
 
@@ -971,7 +1079,7 @@ suite('runner', function () {
 
     test('pack --help advertises the command, positional <package>, --format, --out, and --version flags', async function () {
         const log = fake();
-        const runner = runnerFactory({ log });
+        const runner = createRunner({ log });
 
         await runner.run(['foo', 'bar', 'pack', '--help']);
 
@@ -985,7 +1093,7 @@ suite('runner', function () {
 
     test('pack command rejects --format values outside of zip, tar, or folder', async function () {
         const log = fake();
-        const runner = runnerFactory({ log });
+        const runner = createRunner({ log });
 
         const exitCode = await runner.run([
             'foo',

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/max-dependencies -- the CLI runner wires five subcommands plus shared dependencies */
+/* eslint-disable import/max-dependencies -- the CLI runner wires six subcommands plus shared dependencies */
 import { binary, command, flag, oneOf, option, positional, runSafely, string, subcommands } from 'cmd-ts';
 import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { FileManager } from '../../file-manager/file-manager.ts';
@@ -13,9 +13,17 @@ import { runPreviewHandler } from './preview-handler.ts';
 import { runReleaseDiffHandler } from './release-diff-handler.ts';
 import { registerProgressListeners } from './progress-wiring.ts';
 import { runPublishHandler } from './publish-handler.ts';
+import type { GitHubReleaseClient } from './github-release-client.ts';
+import type { ReleaseGitClient } from './release-git-client.ts';
+import { runReleaseHandler } from './release-handler.ts';
 
 export type CommandLineInterfaceRunnerDependencies = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
+    readonly createGitHubReleaseClient: (context: {
+        readonly owner: string;
+        readonly repo: string;
+        readonly token: string;
+    }) => GitHubReleaseClient;
     readonly currentDate: () => Date;
     readonly packtory: Packtory;
     readonly progressBroadcaster: ProgressBroadcastConsumer;
@@ -27,6 +35,7 @@ export type CommandLineInterfaceRunnerDependencies = {
     readonly createTemporaryFilePath: () => string;
     readonly readEnvironmentVariable: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
     readonly readPackageInfo: () => Promise<Record<string, unknown>>;
+    readonly releaseGitClient: ReleaseGitClient;
     readonly workingDirectory: string;
     log: (message: string) => void;
 };
@@ -34,6 +43,14 @@ export type CommandLineInterfaceRunnerDependencies = {
 export type CommandLineInterfaceRunner = {
     run: (programArguments: readonly string[]) => Promise<number>;
 };
+
+const publishCommandName = 'publish';
+const previewCommandName = 'preview';
+const releaseDiffCommandName = 'release-diff';
+const releaseCommandName = 'release';
+const changelogCommandName = 'changelog';
+const packCommandName = 'pack';
+const defaultPackVersion = '0.0.0';
 
 export function createCommandLineInterfaceRunner(
     dependencies: CommandLineInterfaceRunnerDependencies
@@ -48,19 +65,15 @@ export function createCommandLineInterfaceRunner(
         pageOutput,
         openFile,
         createTemporaryFilePath,
+        createGitHubReleaseClient,
         createPrLogEngine,
         currentDate,
         readEnvironmentVariable,
         readPackageInfo,
+        releaseGitClient,
         workingDirectory
     } = dependencies;
     let exitCode = 0;
-    const publishCommandName = 'publish';
-    const previewCommandName = 'preview';
-    const releaseDiffCommandName = 'release-diff';
-    const changelogCommandName = 'changelog';
-    const packCommandName = 'pack';
-    const defaultPackVersion = '0.0.0';
     const baseCommand = subcommands({
         name: 'packtory',
         cmds: {
@@ -113,6 +126,36 @@ export function createCommandLineInterfaceRunner(
                         packtory,
                         spinnerRenderer,
                         configLoader
+                    });
+                }
+            }),
+            [releaseCommandName]: command({
+                name: releaseCommandName,
+                description: 'Plans or runs a release workflow.',
+                args: {
+                    writeChangelog: flag({ long: 'write-changelog' }),
+                    commit: flag({ long: 'commit' }),
+                    publish: flag({ long: 'publish' }),
+                    tag: flag({ long: 'tag' }),
+                    push: flag({ long: 'push' }),
+                    githubRelease: flag({ long: 'github-release' }),
+                    noDryRun: flag({ long: 'no-dry-run' })
+                },
+                async handler({ writeChangelog, commit, publish, tag, push, githubRelease, noDryRun }) {
+                    exitCode = await runReleaseHandler({
+                        log,
+                        packtory,
+                        spinnerRenderer,
+                        configLoader,
+                        fileManager,
+                        createPrLogEngine,
+                        createGitHubReleaseClient,
+                        currentDate,
+                        readEnvironmentVariable,
+                        readPackageInfo,
+                        workingDirectory,
+                        gitClient: releaseGitClient,
+                        flags: { writeChangelog, commit, publish, tag, push, githubRelease, noDryRun }
                     });
                 }
             }),

--- a/source/git/current-git-head.test.ts
+++ b/source/git/current-git-head.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { createCachedCurrentGitHeadReader, createCurrentGitHeadReader } from './current-git-head.ts';
+import { createCurrentGitHeadReader } from './current-git-head.ts';
 
 suite('current-git-head', function () {
     test('reads and trims the current git head', async function () {
@@ -36,17 +36,5 @@ suite('current-git-head', function () {
         });
 
         assert.strictEqual(await reader(), undefined);
-    });
-
-    test('caches the first read result', async function () {
-        let calls = 0;
-        const reader = createCachedCurrentGitHeadReader(async () => {
-            calls += 1;
-            return 'abcdef123456';
-        });
-
-        assert.strictEqual(await reader(), 'abcdef123456');
-        assert.strictEqual(await reader(), 'abcdef123456');
-        assert.strictEqual(calls, 1);
     });
 });

--- a/source/git/current-git-head.ts
+++ b/source/git/current-git-head.ts
@@ -24,14 +24,3 @@ export function createCurrentGitHeadReader(dependencies: {
         return currentGitHead.length === 0 ? undefined : currentGitHead;
     };
 }
-
-export function createCachedCurrentGitHeadReader(readCurrentGitHead: CurrentGitHeadReader): CurrentGitHeadReader {
-    let currentGitHead: { readonly value: Promise<string | undefined> } | null = null;
-
-    return async () => {
-        if (currentGitHead === null) {
-            currentGitHead = { value: readCurrentGitHead() };
-        }
-        return currentGitHead.value;
-    };
-}

--- a/source/github-release-gate/github-api.ts
+++ b/source/github-release-gate/github-api.ts
@@ -63,17 +63,34 @@ type RepositoryRequestContext = {
     readonly repo: string;
 };
 
-async function requestGitHub<T>(request: Promise<T>): Promise<T> {
+function readReflectedProperty(value: unknown, property: string): unknown {
+    return Reflect.get(new Object(value), property) as unknown;
+}
+
+function createRequestError(error: unknown): Error {
+    const requestUrl = String(readReflectedProperty(readReflectedProperty(error, 'request'), 'url'));
+    const status = String(readReflectedProperty(error, 'status'));
+    const parsedUrl = new URL(requestUrl);
+    return new Error(`GitHub API request failed (${status}) for ${parsedUrl.pathname}${parsedUrl.search}`, {
+        cause: error
+    });
+}
+
+async function resolveGitHubResponse<T>(request: Promise<T>): Promise<T> {
     try {
         return await request;
     } catch (error) {
-        const requestUrl = String(Reflect.get(new Object(Reflect.get(new Object(error), 'request')), 'url'));
-        const status = String(Reflect.get(new Object(error), 'status'));
-        const parsedUrl = new URL(requestUrl);
-        throw new Error(`GitHub API request failed (${status}) for ${parsedUrl.pathname}${parsedUrl.search}`, {
-            cause: error
-        });
+        throw createRequestError(error);
     }
+}
+
+function createRequestHeaders(context: GitHubRepositoryContext): Readonly<Record<string, string>> {
+    return {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${context.token}`,
+        'user-agent': 'packtory-github-release-gate',
+        'x-github-api-version': '2022-11-28'
+    };
 }
 
 export function createGitHubReleaseGateApi(
@@ -82,12 +99,7 @@ export function createGitHubReleaseGateApi(
 ): GitHubReleaseGateApi {
     const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
     const requestContext: RepositoryRequestContext = {
-        headers: {
-            accept: 'application/vnd.github+json',
-            authorization: `Bearer ${context.token}`,
-            'user-agent': 'packtory-github-release-gate',
-            'x-github-api-version': '2022-11-28'
-        },
+        headers: createRequestHeaders(context),
         owner: context.owner,
         repo: context.repo
     };
@@ -101,7 +113,7 @@ export function createGitHubReleaseGateApi(
 
     return {
         async getMainBranchHeadSha() {
-            const branch = await requestGitHub<{ readonly data: BranchResponse }>(
+            const branch = await resolveGitHubResponse<{ readonly data: BranchResponse }>(
                 octokit.rest.repos.getBranch({
                     ...requestContext,
                     branch: context.defaultBranch
@@ -112,7 +124,7 @@ export function createGitHubReleaseGateApi(
         },
 
         async getMainCiRunStatus(ciWorkflowFile, headSha) {
-            const response = await requestGitHub<{ readonly data: WorkflowRunsResponse }>(
+            const response = await resolveGitHubResponse<{ readonly data: WorkflowRunsResponse }>(
                 octokit.rest.actions.listWorkflowRuns({
                     ...requestContext,
                     workflow_id: ciWorkflowFile,
@@ -151,7 +163,7 @@ export function createGitHubReleaseGateApi(
         },
 
         async getOpenPullRequestActivities() {
-            const openPullRequests = await requestGitHub<readonly PullRequest[]>(
+            const openPullRequests = await resolveGitHubResponse<readonly PullRequest[]>(
                 octokit.paginate(octokit.rest.pulls.list, {
                     ...requestContext,
                     state: 'open',
@@ -162,7 +174,7 @@ export function createGitHubReleaseGateApi(
 
             return Promise.all(
                 openPullRequests.map(async (pullRequest) => {
-                    const timeline = await requestGitHub<readonly RawTimelineEvent[]>(
+                    const timeline = await resolveGitHubResponse<readonly RawTimelineEvent[]>(
                         octokit.paginate(octokit.rest.issues.listEventsForTimeline, {
                             ...requestContext,
                             issue_number: pullRequest.number,

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -3,6 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
+import { execFile } from 'node:child_process';
 import { createPrLogEngine } from '@pr-log/core';
 import { createClock } from '../../common/clock.ts';
 import { createLineSpinnerRenderer } from '../../command-line-interface/spinner/line-spinner-renderer.ts';
@@ -17,6 +18,8 @@ import {
 import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner/spinner-worker-backend.ts';
 import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
 import { createDefaultPreviewIo } from '../../command-line-interface/preview-io/preview-io.ts';
+import { createGitHubReleaseClient } from '../../command-line-interface/runner/github-release-client.ts';
+import { createReleaseGitClient } from '../../command-line-interface/runner/release-git-client.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPacktoryComposition } from '../packtory.composition.ts';
 import { awaitSpinnerWorkerTermination, createBootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
@@ -44,6 +47,24 @@ function createSpinnerRenderer(): TerminalSpinnerRenderer {
 
     return createTerminalSpinnerRenderer({
         backend: createWorkerSpinnerBackend({ runtime: createBootedSpinnerRuntime() })
+    });
+}
+
+async function runGitCommand(
+    command: string,
+    args: readonly string[]
+): Promise<{
+    readonly stdout: string;
+    readonly stderr: string;
+}> {
+    return new Promise((resolve, reject) => {
+        execFile(command, Array.from(args), (error, stdout, stderr) => {
+            if (error !== null) {
+                reject(error instanceof Error ? error : new Error('Git command failed'));
+                return;
+            }
+            resolve({ stdout, stderr });
+        });
     });
 }
 
@@ -80,16 +101,20 @@ const { packtory, progressBroadcaster } = buildPacktoryComposition({
     promptForOneTimePassword,
     ciEnvironment: readCiEnvironment(process.env)
 });
+const workingDirectory = process.cwd();
 
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     createPrLogEngine,
+    createGitHubReleaseClient: (context) => {
+        return createGitHubReleaseClient({ ...context, fetch: globalThis.fetch });
+    },
     currentDate() {
         return new Date(clock.getCurrentTimeInMilliseconds());
     },
     packtory,
     progressBroadcaster: progressBroadcaster.consumer,
     spinnerRenderer,
-    configLoader: createConfigLoader({ currentWorkingDirectory: process.cwd(), importModule }),
+    configLoader: createConfigLoader({ currentWorkingDirectory: workingDirectory, importModule }),
     fileManager,
     pageOutput: async (content) => {
         const didPage = await previewIo.pagePreviewOutput(content);
@@ -103,9 +128,10 @@ const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
         return process.env[name];
     },
     async readPackageInfo() {
-        return parsePackageInfo(await fileManager.readFile(path.join(process.cwd(), 'package.json')));
+        return parsePackageInfo(await fileManager.readFile(path.join(workingDirectory, 'package.json')));
     },
-    workingDirectory: process.cwd(),
+    releaseGitClient: createReleaseGitClient({ repositoryFolder: workingDirectory, runGitCommand }),
+    workingDirectory,
     log: console.log
 });
 

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -21,6 +21,7 @@ packtory <command> [options]
 - **preview:** Runs a fresh dry-run build with report collection enabled and shows a human-oriented preview of the emitted package contents, file statuses, and changed-file diffs.
 - **release-diff:** Runs the same dry-run build as `preview` and shows, per package, the changes between the latest version currently published on the configured registry and the bundle the next run would publish.
 - **changelog:** Builds the next release plan, attributes merged GitHub pull requests to changed packages, and prints grouped Markdown changelog output.
+- **release:** Prints the next release plan by default, or runs one explicit release workflow when action flags and `--no-dry-run` are set.
 - **publish:** Bundles and publishes npm packages based on the configuration in `packtory.config.js`.
 - **pack:** Builds a single configured package and writes it to disk as a zip archive, tarball, or expanded folder. Intended for ad-hoc artifact use cases such as AWS Lambda deployments, container builds, or local inspection — `pack` never talks to a registry.
 
@@ -31,6 +32,12 @@ packtory <command> [options]
 - **publish --report-json:** Writes `packtory-report.json`, the machine-readable `BuildReport`.
 - **publish --report-html:** Writes `packtory-report.html`, the rich HTML report used by `packtory preview --open`.
 - **publish --stage:** Uses npm staged publishing instead of a direct publish. Successful runs print the npm `stageId` per package. Approval still happens later via `npm stage approve <stage-id>` or npmjs.com. Stage mode is npm-only, and the package must already exist on npm.
+- **release --write-changelog:** Writes configured changelog file outputs for packages in the release plan.
+- **release --commit:** Commits written changelog files. Requires `--write-changelog`.
+- **release --publish:** Publishes changed packages directly to npm. Staged publishing is not used by `release`.
+- **release --tag:** Creates one annotated tag per released package, named `{packageName}@{version}`.
+- **release --push:** Runs `git push --follow-tags`. Requires `--commit` or `--tag`.
+- **release --github-release:** Creates one GitHub Release per package tag. Requires `--tag --push`.
 - **pack &lt;package&gt; --format &lt;zip|tar|folder&gt; --out &lt;path&gt;:** Selects which package from the configuration to build and where to write it. `--format` and `--out` are required.
 - **pack --version &lt;version&gt;:** Stamps the produced manifest with the given version. Defaults to `0.0.0` when omitted, since `pack` is decoupled from the registry-driven automatic versioning used by `publish`.
 - **pack --vendor-dependencies:** Resolves every external (and bundle) dependency from the local `node_modules` and materializes them next to the package files inside the artifact. Use this for self-contained deployments where the runtime cannot run `npm install` (e.g. AWS Lambda zips). Without the flag, dependencies are recorded in the generated `package.json` only.
@@ -71,6 +78,19 @@ packtory <command> [options]
 - Generated changelog files are not automatically added to package artifacts. Use `additionalFiles` when a package artifact should include a changelog.
 - `packtory changelog` exits with code `0` on a clean run and `1` on config, release-plan, Git, GitHub, or changelog generation failures. Partial release-plan failures still render succeeded changed packages when changelog generation succeeds.
 - `changelog` never commits, tags, creates releases, creates deployments, writes registry data, or publishes packages.
+
+**Release behavior:**
+
+- `packtory release` prints the computed release plan and exits without writing.
+- Any action flag requires `--no-dry-run`.
+- Invalid combinations fail before writing: `--commit` requires `--write-changelog`; `--write-changelog --publish` requires `--commit`; `--push` requires `--commit` or `--tag`; `--github-release` requires `--tag --push`.
+- `--tag` requires `--publish` in the same run unless the registry latest `gitHead` already matches the current Git head. This allows retrying tag and GitHub Release creation after a publish succeeded.
+- Non-dry-run release writes require a clean Git index and worktree before the first write.
+- The write order is changelog files, commit, final release-plan recomputation, direct npm publish, annotated tags, `git push --follow-tags`, then GitHub Releases.
+- Existing package tags at the current head are accepted. Existing tags at another head fail.
+- Existing GitHub Releases for verified package tags are accepted and their notes are not rewritten.
+- Packtory uses inherited Git configuration, environment, and credentials. In CI, configure commit identity with standard variables such as `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL`, and configure push credentials outside Packtory.
+- GitHub Release creation reads `GH_TOKEN` first, then `GITHUB_TOKEN`.
 
 **Pack behavior:**
 

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -27,11 +27,7 @@ import { createTarballBuilder } from '../tar/tarball-builder.ts';
 import { createZipBuilder } from '../zip/zip-builder.ts';
 import { createVersionManager } from '../version-manager/manager.ts';
 import { createClock, type Clock } from '../common/clock.ts';
-import {
-    createCachedCurrentGitHeadReader,
-    createCurrentGitHeadReader,
-    type CurrentGitHeadReader
-} from '../git/current-git-head.ts';
+import { createCurrentGitHeadReader, type CurrentGitHeadReader } from '../git/current-git-head.ts';
 import { createNpmOidcIdTokenResolver } from '../npm-oidc-id-token-resolver.ts';
 import { createLicenseResolver } from '../sbom/license-resolver.ts';
 import { createSbomFileBuilder, type SbomFileBuilder } from '../sbom/sbom-file.ts';
@@ -167,12 +163,10 @@ type CompositionParts = {
 function buildCompositionParts(options: PackageProcessorCompositionOptions): CompositionParts {
     const repositoryFolder = options.repositoryFolder ?? process.cwd();
     const fileManager = createFileManager({ hostFileSystem: fs.promises });
-    const readCurrentGitHead = createCachedCurrentGitHeadReader(
-        createCurrentGitHeadReader({
-            repositoryFolder,
-            runGitCommand
-        })
-    );
+    const readCurrentGitHead = createCurrentGitHeadReader({
+        repositoryFolder,
+        runGitCommand
+    });
     const dependencyScanner = createDependencyScannerWith(fileManager);
     const progressBroadcaster = createProgressBroadcaster();
     const artifactsBuilder = createArtifactsBuilder({

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { PrLogEngine, PullRequestWithLabel, TargetChangelogSection } from '@pr-log/core';
 import { compareValues } from '../common/sort-values.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
@@ -33,38 +34,39 @@ export type GeneratedChangelog = {
 };
 
 const changelogFileName = 'CHANGELOG.md';
-const changelogFileSuffix = `/${changelogFileName}`;
 
-function changedPackagesFrom(packages: readonly ReleasePlanPackage[]): readonly ReleasePlanPackage[] {
+function selectChangedPackages(packages: readonly ReleasePlanPackage[]): readonly ReleasePlanPackage[] {
     return packages.filter((packagePlan) => {
         return packagePlan.changed;
     });
 }
 
-function sortedUnique(values: ReadonlySet<string>): readonly string[] {
+function sortUniqueValues(values: ReadonlySet<string>): readonly string[] {
     return Array.from(values).toSorted(compareValues);
 }
 
-function changelogPathsFrom(packages: readonly ReleasePlanPackage[]): readonly string[] {
-    return sortedUnique(
+function isChangelogFilePath(filePath: string): boolean {
+    return path.posix.basename(filePath) === changelogFileName;
+}
+
+function collectChangelogPaths(packages: readonly ReleasePlanPackage[]): readonly string[] {
+    return sortUniqueValues(
         new Set(
             packages.flatMap((packagePlan) => {
-                return packagePlan.changelogSourceFiles.filter((filePath) => {
-                    return filePath === changelogFileName || filePath.endsWith(changelogFileSuffix);
-                });
+                return packagePlan.changelogSourceFiles.filter(isChangelogFilePath);
             })
         )
     );
 }
 
-function mergedIgnoredAttributionPaths(
+function mergeIgnoredAttributionPaths(
     packages: readonly ReleasePlanPackage[],
     configuredPaths: readonly string[]
 ): readonly string[] {
-    return sortedUnique(new Set([...changelogPathsFrom(packages), ...configuredPaths]));
+    return sortUniqueValues(new Set([...collectChangelogPaths(packages), ...configuredPaths]));
 }
 
-async function baseRefFor(
+async function resolveBaseRefFor(
     prLogEngine: GenerateChangelogInput['prLogEngine'],
     packagePlan: ReleasePlanPackage
 ): Promise<string> {
@@ -83,12 +85,12 @@ async function baseRefFor(
     return baseRef.ref;
 }
 
-async function targetPullRequestsFor(
+async function collectTargetPullRequests(
     input: GenerateChangelogInput,
     packagePlan: ReleasePlanPackage,
     ignoredAttributionPaths: readonly string[]
 ): Promise<readonly PullRequestWithLabel[]> {
-    const baseRef = await baseRefFor(input.prLogEngine, packagePlan);
+    const baseRef = await resolveBaseRefFor(input.prLogEngine, packagePlan);
     const pullRequests = await input.prLogEngine.collectMergedPullRequests({
         githubRepo: input.githubRepo,
         baseRef
@@ -115,18 +117,18 @@ async function targetPullRequestsFor(
     });
 }
 
-async function changelogTargetFor(
+async function createChangelogTarget(
     input: GenerateChangelogInput,
     packagePlan: ReleasePlanPackage,
     ignoredAttributionPaths: readonly string[]
 ): Promise<ChangelogTarget> {
     return {
         packagePlan,
-        pullRequests: await targetPullRequestsFor(input, packagePlan, ignoredAttributionPaths)
+        pullRequests: await collectTargetPullRequests(input, packagePlan, ignoredAttributionPaths)
     };
 }
 
-function targetSectionFrom(target: ChangelogTarget): TargetChangelogSection {
+function createTargetSection(target: ChangelogTarget): TargetChangelogSection {
     return {
         targetName: target.packagePlan.name,
         unreleased: false,
@@ -135,13 +137,13 @@ function targetSectionFrom(target: ChangelogTarget): TargetChangelogSection {
     };
 }
 
-function packageMarkdownByNameFrom(
+function createPackageMarkdownByName(
     input: GenerateChangelogInput,
     targets: readonly ChangelogTarget[]
 ): ReadonlyMap<string, string> {
     return new Map(
         targets.map((target) => {
-            const targetSection = targetSectionFrom(target);
+            const targetSection = createTargetSection(target);
             return [
                 target.packagePlan.name,
                 input.prLogEngine.renderTargetChangelog({
@@ -157,11 +159,11 @@ function packageMarkdownByNameFrom(
 }
 
 export async function generateChangelogOutputs(input: GenerateChangelogInput): Promise<GeneratedChangelog> {
-    const packages = changedPackagesFrom(input.packages);
-    const ignoredAttributionPaths = mergedIgnoredAttributionPaths(packages, input.ignoredAttributionPaths);
+    const packages = selectChangedPackages(input.packages);
+    const ignoredAttributionPaths = mergeIgnoredAttributionPaths(packages, input.ignoredAttributionPaths);
     const targets = await Promise.all(
         packages.map(async (packagePlan) => {
-            return changelogTargetFor(input, packagePlan, ignoredAttributionPaths);
+            return createChangelogTarget(input, packagePlan, ignoredAttributionPaths);
         })
     );
 
@@ -171,8 +173,8 @@ export async function generateChangelogOutputs(input: GenerateChangelogInput): P
             currentDate: input.currentDate,
             validLabels: input.validLabels,
             githubRepo: input.githubRepo,
-            targets: targets.map(targetSectionFrom)
+            targets: targets.map(createTargetSection)
         }),
-        packageMarkdownByName: packageMarkdownByNameFrom(input, targets)
+        packageMarkdownByName: createPackageMarkdownByName(input, targets)
     };
 }


### PR DESCRIPTION
Adds `packtory release` as an explicit, dry-run-first release workflow. Action flags drive changelog writing, commit, direct npm publish, annotated package tags, `git push --follow-tags`, and GitHub Release creation while Git identity and credentials stay in the caller environment.

The implementation reuses the existing changelog and publish paths, shares GitHub repository parsing with `changelog`, and uses the existing `@octokit/core` dependency plus shared GitHub request handling for release API calls. Existing `changelog` and `publish` commands keep their behavior.
