### PR TITLE
Add `changelog` generation settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,15 +199,20 @@ The configuration for `packtory` is an object with the following properties:
     - Toggles and configures the cross-package checks that run after every bundle has been linked. Lives at the top level (not inside `commonPackageSettings`) because every check operates over the full set of bundles. See [Checks](#checks).
 
 4. **`changelog`** (Optional, Object):
-    - Configures outputs for `packtory changelog`.
+    - Configures changelog generation and outputs for `packtory changelog` and `packtory release --write-changelog`.
     - If omitted, `packtory changelog` prints grouped Markdown to the pager and writes no files.
+    - `labels` extends or overrides the default pull request label to changelog section mapping.
+    - `targetScopedLabelPattern` customizes package-specific labels. It must contain `{targetName}` and `{label}`.
+    - `packageTagFormat` customizes package tag lookup for changelog base refs. `explicitBaseRef` uses one fixed base ref instead.
     - `outputs` is a non-empty array of:
         - `{ kind: 'repository-file', path: 'CHANGELOG.md' }`: writes one grouped changelog at a repository-relative path.
         - `{ kind: 'package-file', path: 'CHANGELOG.md' }`: writes one package-specific changelog below each changed package's effective `sourcesFolder`.
         - `{ kind: 'github-release' }`: prints grouped release-body Markdown to the pager. Remote GitHub release creation is not implemented by `packtory changelog`.
+    - `outputs` can be omitted when only label or base-ref settings are configured.
     - Output paths must be safe relative paths. Absolute paths and parent-traversing paths are rejected.
     - Duplicate `github-release` outputs, duplicate repository-file paths, and package-file destinations that resolve to the same file are rejected.
     - Generated changelog files are ignored during pull request source attribution.
+    - JavaScript files are attributed through referenced source maps when they have a `sourceMappingURL`. Without that reference, the JavaScript file itself is attributed.
     - Changelog outputs are not automatically added to package artifacts. Use `additionalFiles` when a package artifact should include a generated changelog.
 
 5. **`packages`** (Required, Array):

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -5,6 +5,7 @@ import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
     collectGeneratedAttributionPaths,
+    createChangelogGenerationOptions,
     parseValidConfig,
     shouldPageGroupedChangelog,
     writeConfiguredChangelogs,
@@ -66,6 +67,32 @@ suite('changelog-destinations', function () {
             collectGeneratedAttributionPaths(deps, createChangelogConfig({ changelog: undefined })),
             []
         );
+        assert.deepStrictEqual(
+            collectGeneratedAttributionPaths(
+                deps,
+                createChangelogConfig({ changelog: { labels: { operations: 'Operations' } } })
+            ),
+            []
+        );
+    });
+
+    test('createChangelogGenerationOptions combines defaults with configured settings', function () {
+        const options = createChangelogGenerationOptions(
+            createChangelogConfig({
+                changelog: {
+                    explicitBaseRef: 'main',
+                    labels: { bug: 'Fixed Bugs', operations: 'Operations' },
+                    packageTagFormat: 'pkg/{packageName}/v{version}',
+                    targetScopedLabelPattern: 'scope:{targetName}:{label}'
+                }
+            })
+        );
+
+        assert.strictEqual(options.explicitBaseRef, 'main');
+        assert.strictEqual(options.packageTagFormat, 'pkg/{packageName}/v{version}');
+        assert.strictEqual(options.targetScopedLabelPattern, 'scope:{targetName}:{label}');
+        assert.strictEqual(options.validLabels.get('bug'), 'Fixed Bugs');
+        assert.strictEqual(options.validLabels.get('operations'), 'Operations');
     });
 
     test('collectGeneratedAttributionPaths includes repository and in-repository package files', function () {
@@ -123,6 +150,20 @@ suite('changelog-destinations', function () {
         const writtenPaths = await writeConfiguredChangelogs(
             { ...deps, fileManager },
             createChangelogConfig({ changelog: undefined }),
+            { updateChangelog: fake.returns('updated') },
+            createGeneratedChangelog()
+        );
+
+        assert.deepStrictEqual(writtenPaths, []);
+        assert.strictEqual(fileManager.getWriteFileCallCount(), 0);
+    });
+
+    test('writeConfiguredChangelogs does nothing when outputs are omitted from changelog config', async function () {
+        const fileManager = createFakeFileManager();
+
+        const writtenPaths = await writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            createChangelogConfig({ changelog: { labels: { operations: 'Operations' } } }),
             { updateChangelog: fake.returns('updated') },
             createGeneratedChangelog()
         );

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { PrLogEngine } from '@pr-log/core';
+import { defaultValidLabels, type PrLogEngine } from '@pr-log/core';
 import { safeParse } from '@schema-hub/zod-error-formatter';
 import type { ChangelogOutput } from '../../config/changelog-settings.ts';
 import { packtoryConfigSchema } from '../../config/packtory-config-schema.ts';
@@ -11,8 +11,16 @@ type PackagePathConfig = {
     readonly sourcesFolder?: string | undefined;
 };
 
+type ChangelogSettingsConfig = {
+    readonly explicitBaseRef?: string | undefined;
+    readonly labels?: Readonly<Record<string, string>> | undefined;
+    readonly outputs?: readonly ChangelogOutput[] | undefined;
+    readonly packageTagFormat?: string | undefined;
+    readonly targetScopedLabelPattern?: string | undefined;
+};
+
 export type ChangelogConfig = {
-    readonly changelog?: { readonly outputs: readonly ChangelogOutput[] } | undefined;
+    readonly changelog?: ChangelogSettingsConfig | undefined;
     readonly commonPackageSettings?: { readonly sourcesFolder?: string | undefined } | undefined;
     readonly packages: readonly PackagePathConfig[];
 };
@@ -28,10 +36,25 @@ type FileChangelogDestination = {
 };
 
 type FileChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' | 'repository-file' }>;
+export type ChangelogGenerationOptions = {
+    readonly explicitBaseRef: string | undefined;
+    readonly packageTagFormat: string | undefined;
+    readonly targetScopedLabelPattern: string | undefined;
+    readonly validLabels: ReadonlyMap<string, string>;
+};
 
 export function parseValidConfig(config: unknown): ChangelogConfig | undefined {
     const result = safeParse(packtoryConfigSchema, config);
     return result.success ? result.data : undefined;
+}
+
+export function createChangelogGenerationOptions(config: ChangelogConfig): ChangelogGenerationOptions {
+    return {
+        explicitBaseRef: config.changelog?.explicitBaseRef,
+        packageTagFormat: config.changelog?.packageTagFormat,
+        targetScopedLabelPattern: config.changelog?.targetScopedLabelPattern,
+        validLabels: new Map([...defaultValidLabels, ...Object.entries(config.changelog?.labels ?? {})])
+    };
 }
 
 function normalizeConfiguredPath(filePath: string): string {
@@ -90,7 +113,7 @@ export function collectGeneratedAttributionPaths(
         return [];
     }
 
-    const paths = config.changelog.outputs
+    const paths = (config.changelog.outputs ?? [])
         .filter((output): output is FileChangelogOutput => {
             return output.kind !== 'github-release';
         })
@@ -199,7 +222,7 @@ export async function writeConfiguredChangelogs(
         return [];
     }
 
-    const { outputs } = config.changelog;
+    const { outputs = [] } = config.changelog;
     const destinations = [
         ...collectRepositoryDestinations(deps, outputs, changelog),
         ...collectPackageDestinations(deps, config, outputs, changelog)

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -112,8 +112,11 @@ export function collectGeneratedAttributionPaths(
     if (config.changelog === undefined) {
         return [];
     }
+    if (config.changelog.outputs === undefined) {
+        return [];
+    }
 
-    const paths = (config.changelog.outputs ?? [])
+    const paths = config.changelog.outputs
         .filter((output): output is FileChangelogOutput => {
             return output.kind !== 'github-release';
         })
@@ -212,21 +215,28 @@ async function writeChangelogDestination(
     return destination.filePath;
 }
 
+function collectChangelogDestinations(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    changelog: GeneratedChangelog
+): readonly FileChangelogDestination[] {
+    const outputs = config.changelog?.outputs;
+    if (outputs === undefined) {
+        return [];
+    }
+    return [
+        ...collectRepositoryDestinations(deps, outputs, changelog),
+        ...collectPackageDestinations(deps, config, outputs, changelog)
+    ];
+}
+
 export async function writeConfiguredChangelogs(
     deps: ChangelogDestinationDeps,
     config: ChangelogConfig,
     prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
     changelog: GeneratedChangelog
 ): Promise<readonly string[]> {
-    if (config.changelog === undefined) {
-        return [];
-    }
-
-    const { outputs = [] } = config.changelog;
-    const destinations = [
-        ...collectRepositoryDestinations(deps, outputs, changelog),
-        ...collectPackageDestinations(deps, config, outputs, changelog)
-    ];
+    const destinations = collectChangelogDestinations(deps, config, changelog);
     const writtenPaths: string[] = [];
     for (const destination of destinations) {
         const writtenPath = await writeChangelogDestination(deps, prLogEngine, destination);

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -80,6 +80,7 @@ function partialFailureOutcome(spec: {
 
 type EngineOverrides = {
     readonly resolveChangelogBaseRef?: SinonSpy;
+    readonly resolvePullRequestLabels?: SinonSpy;
     readonly readPullRequestChangedFiles?: SinonSpy;
 };
 
@@ -97,7 +98,7 @@ function createEngine(overrides: EngineOverrides = {}): PrLogEngine {
         filterPullRequestsByTargetFiles: fake((input: { readonly pullRequests: readonly PullRequest[] }) => {
             return input.pullRequests;
         }),
-        resolvePullRequestLabels: fake.resolves(labeledPullRequests),
+        resolvePullRequestLabels: overrides.resolvePullRequestLabels ?? fake.resolves(labeledPullRequests),
         renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
         renderTargetChangelog: fake((input: { readonly targetName: string }) => {
             return `## ${input.targetName} 1.0.1\n`;
@@ -324,6 +325,44 @@ suite('changelog-handler', function () {
 
         assert.strictEqual(code, 0);
         assert.strictEqual(collectMergedPullRequests.callCount, 1);
+    });
+
+    test('passes configured changelog label and base-ref settings into pr-log', async function () {
+        const resolveChangelogBaseRef = fake.resolves({ ref: 'configured-base' });
+        const resolvePullRequestLabels = fake.resolves([{ id: 1, title: 'Fix package', label: 'operations' }]);
+        const engine = createEngine({ resolveChangelogBaseRef, resolvePullRequestLabels });
+        const spies = makeSpies(engine);
+
+        const code = await runChangelogHandler(
+            depsWith({
+                spies,
+                configLoader: configLoaderReturning({
+                    ...validConfig,
+                    changelog: {
+                        explicitBaseRef: 'main',
+                        labels: { operations: 'Operations' },
+                        packageTagFormat: 'pkg/{packageName}/v{version}',
+                        targetScopedLabelPattern: 'scope:{targetName}:{label}'
+                    }
+                })
+            })
+        );
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(resolveChangelogBaseRef.firstCall.args[0], {
+            packageName: 'pkg-a',
+            previousVersion: '1.0.0',
+            previousGitHead: 'old-head',
+            packageTagFormat: 'pkg/{packageName}/v{version}',
+            explicitBaseRef: 'main'
+        });
+        const labelInput = resolvePullRequestLabels.firstCall.args[0] as {
+            readonly targetScopedLabelPattern: string;
+            readonly validLabels: ReadonlyMap<string, string>;
+        };
+        assert.strictEqual(labelInput.targetScopedLabelPattern, 'scope:{targetName}:{label}');
+        assert.strictEqual(labelInput.validLabels.get('bug'), 'Bug Fixes');
+        assert.strictEqual(labelInput.validLabels.get('operations'), 'Operations');
     });
 
     test('returns 1 when package.json repository is not a GitHub repository', async function () {

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -1,10 +1,11 @@
-import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions } from '@pr-log/core';
+import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { FileManager } from '../../file-manager/file-manager.ts';
 import type { Packtory, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
 import { generateChangelogOutputs } from '../../packtory/packtory-changelog.ts';
 import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import {
+    createChangelogGenerationOptions,
     collectGeneratedAttributionPaths,
     parseValidConfig,
     shouldPageGroupedChangelog,
@@ -61,14 +62,18 @@ async function renderChangelog(
     }
     const packageInfo = await deps.readPackageInfo();
     const prLogEngine = createEngine(deps);
+    const generationOptions = createChangelogGenerationOptions(config);
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine,
+        explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
         ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
         packageInfo,
+        packageTagFormat: generationOptions.packageTagFormat,
         currentDate: deps.currentDate(),
-        validLabels: defaultValidLabels
+        targetScopedLabelPattern: generationOptions.targetScopedLabelPattern,
+        validLabels: generationOptions.validLabels
     });
     if (shouldPageGroupedChangelog(config.changelog?.outputs) && changelog.groupedMarkdown.length > 0) {
         await deps.pageOutput(changelog.groupedMarkdown);

--- a/source/command-line-interface/runner/release-handler.test.ts
+++ b/source/command-line-interface/runner/release-handler.test.ts
@@ -133,6 +133,7 @@ type Scenario = {
     readonly config?: unknown;
     readonly configLoader?: ConfigLoader;
     readonly createGitHubReleaseClient?: SinonSpy;
+    readonly engine?: PrLogEngine;
     readonly flags?: Partial<ReleaseFlags>;
     readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
     readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
@@ -180,7 +181,7 @@ function createReleaseHandlerDeps(scenario: Scenario = {}): ReleaseHandlerDeps {
             if (scenario.readEnvironmentVariable === undefined) {
                 assert.strictEqual(options.githubToken, 'gh-token');
             }
-            return createEngine();
+            return scenario.engine ?? createEngine();
         },
         currentDate() {
             return new Date('2026-06-13T00:00:00.000Z');
@@ -587,6 +588,44 @@ suite('release-handler', function () {
 
         assert.strictEqual(code, 0);
         assert.deepStrictEqual(order, ['plan', 'clean']);
+    });
+
+    test('uses configured changelog labels when writing release changelogs', async function () {
+        const resolvePullRequestLabels = fake(
+            async (input: {
+                readonly targetScopedLabelPattern: string;
+                readonly validLabels: ReadonlyMap<string, string>;
+            }) => {
+                assert.strictEqual(input.targetScopedLabelPattern, 'scope:{targetName}:{label}');
+                assert.strictEqual(input.validLabels.get('bug'), 'Bug Fixes');
+                assert.strictEqual(input.validLabels.get('operations'), 'Operations');
+                return [{ id: 1, title: 'Fix package', label: 'operations' }];
+            }
+        );
+        const engine = {
+            ...createEngine(),
+            resolvePullRequestLabels
+        } as unknown as PrLogEngine;
+
+        const code = await runReleaseHandler(
+            createReleaseHandlerDeps({
+                engine,
+                flags: { writeChangelog: true, noDryRun: true },
+                config: {
+                    ...validConfig,
+                    changelog: {
+                        explicitBaseRef: 'main',
+                        labels: { operations: 'Operations' },
+                        outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }],
+                        packageTagFormat: 'pkg/{packageName}/v{version}',
+                        targetScopedLabelPattern: 'scope:{targetName}:{label}'
+                    }
+                }
+            })
+        );
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(resolvePullRequestLabels.callCount, 1);
     });
 
     test('returns 1 when the post-commit release plan fails', async function () {

--- a/source/command-line-interface/runner/release-handler.ts
+++ b/source/command-line-interface/runner/release-handler.ts
@@ -1,8 +1,9 @@
-import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions } from '@pr-log/core';
+import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { Packtory, ReleasePlanPackage } from '../../packtory/packtory.ts';
 import { generateChangelogOutputs, type GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 import {
     collectGeneratedAttributionPaths,
+    createChangelogGenerationOptions,
     parseValidConfig,
     writeConfiguredChangelogs
 } from './changelog-destinations.ts';
@@ -220,14 +221,18 @@ async function generateReleaseChangelog(
 ): Promise<ReleaseChangelog> {
     const packageInfo = await deps.readPackageInfo();
     const engine = createEngine(deps);
+    const generationOptions = createChangelogGenerationOptions(config);
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
+        explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
         ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
         packageInfo,
         currentDate: deps.currentDate(),
-        validLabels: defaultValidLabels
+        packageTagFormat: generationOptions.packageTagFormat,
+        targetScopedLabelPattern: generationOptions.targetScopedLabelPattern,
+        validLabels: generationOptions.validLabels
     });
     return { changelog, config, engine };
 }

--- a/source/config/changelog-settings.test.ts
+++ b/source/config/changelog-settings.test.ts
@@ -51,8 +51,27 @@ suite('changelog-settings', function () {
         assert.strictEqual(result.success, true);
     });
 
+    test('schema accepts label and base-ref settings without outputs', function () {
+        const result = safeParse(changelogSettingsSchema, {
+            labels: { bug: 'Fixes', operations: 'Operations' },
+            targetScopedLabelPattern: 'scope:{targetName}:{label}',
+            packageTagFormat: 'pkg/{packageName}/v{version}',
+            explicitBaseRef: 'main'
+        });
+
+        assert.strictEqual(result.success, true);
+    });
+
     test('schema rejects empty outputs', function () {
         assert.strictEqual(safeParse(changelogSettingsSchema, { outputs: [] }).success, false);
+    });
+
+    test('schema rejects empty label, pattern and base-ref settings', function () {
+        assert.strictEqual(safeParse(changelogSettingsSchema, { labels: { bug: '' } }).success, false);
+        assert.strictEqual(safeParse(changelogSettingsSchema, { labels: { '': 'Fixes' } }).success, false);
+        assert.strictEqual(safeParse(changelogSettingsSchema, { targetScopedLabelPattern: '' }).success, false);
+        assert.strictEqual(safeParse(changelogSettingsSchema, { packageTagFormat: '' }).success, false);
+        assert.strictEqual(safeParse(changelogSettingsSchema, { explicitBaseRef: '' }).success, false);
     });
 
     test('schema rejects unsafe output paths', function () {
@@ -91,6 +110,27 @@ suite('changelog-settings', function () {
         const result = validateChangelogSettings(configWith({ outputs: [{ kind: 'github-release' }] }));
 
         assert.deepStrictEqual(result, []);
+    });
+
+    test('validation accepts target-scoped label patterns with both placeholders', function () {
+        const result = validateChangelogSettings(
+            configWith({ targetScopedLabelPattern: 'scope:{targetName}:{label}' })
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('validation rejects target-scoped label patterns without the target placeholder', function () {
+        assert.deepStrictEqual(validateChangelogSettings(configWith({ targetScopedLabelPattern: 'scope:{label}' })), [
+            'changelog.targetScopedLabelPattern must contain {targetName} and {label}'
+        ]);
+    });
+
+    test('validation rejects target-scoped label patterns without the label placeholder', function () {
+        assert.deepStrictEqual(
+            validateChangelogSettings(configWith({ targetScopedLabelPattern: 'scope:{targetName}' })),
+            ['changelog.targetScopedLabelPattern must contain {targetName} and {label}']
+        );
     });
 
     test('validation rejects duplicate repository-file paths', function () {

--- a/source/config/changelog-settings.ts
+++ b/source/config/changelog-settings.ts
@@ -107,15 +107,11 @@ function validateTargetScopedLabelPattern(pattern: string | undefined): readonly
     return [];
 }
 
-export function validateChangelogSettings(packtoryConfig: ChangelogValidationConfig): readonly string[] {
-    if (packtoryConfig.changelog === undefined) {
-        return [];
-    }
-
-    const { outputs = [] } = packtoryConfig.changelog;
-    const issues: string[] = Array.from(
-        validateTargetScopedLabelPattern(packtoryConfig.changelog.targetScopedLabelPattern)
-    );
+function collectChangelogOutputIssues(
+    packtoryConfig: ChangelogValidationConfig,
+    outputs: readonly ChangelogOutput[]
+): readonly string[] {
+    const issues: string[] = [];
     const githubReleaseCount = outputs.filter((output) => {
         return output.kind === 'github-release';
     }).length;
@@ -150,4 +146,16 @@ export function validateChangelogSettings(packtoryConfig: ChangelogValidationCon
     );
 
     return issues;
+}
+
+export function validateChangelogSettings(packtoryConfig: ChangelogValidationConfig): readonly string[] {
+    if (packtoryConfig.changelog === undefined) {
+        return [];
+    }
+
+    const patternIssues = validateTargetScopedLabelPattern(packtoryConfig.changelog.targetScopedLabelPattern);
+    const { outputs } = packtoryConfig.changelog;
+    return outputs === undefined
+        ? patternIssues
+        : [...patternIssues, ...collectChangelogOutputIssues(packtoryConfig, outputs)];
 }

--- a/source/config/changelog-settings.ts
+++ b/source/config/changelog-settings.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { z } from 'zod/mini';
-import { bundleRelativePathSchema } from './base-validations.ts';
+import { bundleRelativePathSchema, nonEmptyStringSchema } from './base-validations.ts';
 
 const repositoryFileOutputSchema = z.readonly(
     z.strictObject({
@@ -23,10 +23,15 @@ const githubReleaseOutputSchema = z.readonly(
 );
 
 const changelogOutputSchema = z.union([repositoryFileOutputSchema, packageFileOutputSchema, githubReleaseOutputSchema]);
+const validLabelsSchema = z.readonly(z.record(nonEmptyStringSchema, nonEmptyStringSchema));
 
 export const changelogSettingsSchema = z.readonly(
     z.strictObject({
-        outputs: z.readonly(z.tuple([changelogOutputSchema], changelogOutputSchema))
+        explicitBaseRef: z.optional(nonEmptyStringSchema),
+        labels: z.optional(validLabelsSchema),
+        outputs: z.optional(z.readonly(z.tuple([changelogOutputSchema], changelogOutputSchema))),
+        packageTagFormat: z.optional(nonEmptyStringSchema),
+        targetScopedLabelPattern: z.optional(nonEmptyStringSchema)
     })
 );
 
@@ -47,12 +52,12 @@ type ChangelogValidationConfig = {
     readonly packages: readonly PackageChangelogValidationConfig[];
 };
 
-function normalizedRelativePath(filePath: string): string {
+function normalizeRelativePath(filePath: string): string {
     return filePath.split(/[/\\]/u).join('/');
 }
 
-function normalizedFilePath(...filePathSegments: readonly string[]): string {
-    return path.normalize(path.join(...filePathSegments.map(normalizedRelativePath)));
+function normalizeFilePath(...filePathSegments: readonly string[]): string {
+    return path.normalize(path.join(...filePathSegments.map(normalizeRelativePath)));
 }
 
 function pushDuplicateValueIssues(
@@ -72,21 +77,34 @@ function pushDuplicateValueIssues(
     }
 }
 
-function sourcesFolderFor(
+function resolveSourcesFolder(
     packageConfig: PackageChangelogValidationConfig,
     packtoryConfig: ChangelogValidationConfig
 ): string | undefined {
     return packageConfig.sourcesFolder ?? packtoryConfig.commonPackageSettings?.sourcesFolder;
 }
 
-function packageFileDestinationPaths(packtoryConfig: ChangelogValidationConfig, outputPath: string): readonly string[] {
+function collectPackageFileDestinationPaths(
+    packtoryConfig: ChangelogValidationConfig,
+    outputPath: string
+): readonly string[] {
     return packtoryConfig.packages.flatMap((packageConfig) => {
-        const sourcesFolder = sourcesFolderFor(packageConfig, packtoryConfig);
+        const sourcesFolder = resolveSourcesFolder(packageConfig, packtoryConfig);
         if (sourcesFolder === undefined) {
             return [];
         }
-        return [normalizedFilePath(sourcesFolder, outputPath)];
+        return [normalizeFilePath(sourcesFolder, outputPath)];
     });
+}
+
+function validateTargetScopedLabelPattern(pattern: string | undefined): readonly string[] {
+    if (pattern === undefined) {
+        return [];
+    }
+    if (!pattern.includes('{targetName}') || !pattern.includes('{label}')) {
+        return ['changelog.targetScopedLabelPattern must contain {targetName} and {label}'];
+    }
+    return [];
 }
 
 export function validateChangelogSettings(packtoryConfig: ChangelogValidationConfig): readonly string[] {
@@ -94,8 +112,10 @@ export function validateChangelogSettings(packtoryConfig: ChangelogValidationCon
         return [];
     }
 
-    const { outputs } = packtoryConfig.changelog;
-    const issues: string[] = [];
+    const { outputs = [] } = packtoryConfig.changelog;
+    const issues: string[] = Array.from(
+        validateTargetScopedLabelPattern(packtoryConfig.changelog.targetScopedLabelPattern)
+    );
     const githubReleaseCount = outputs.filter((output) => {
         return output.kind === 'github-release';
     }).length;
@@ -107,7 +127,7 @@ export function validateChangelogSettings(packtoryConfig: ChangelogValidationCon
     pushDuplicateValueIssues(
         issues,
         outputs.flatMap((output) => {
-            return output.kind === 'repository-file' ? [normalizedRelativePath(output.path)] : [];
+            return output.kind === 'repository-file' ? [normalizeRelativePath(output.path)] : [];
         }),
         (duplicatePath) => {
             return `changelog.outputs must not contain duplicate repository-file path "${duplicatePath}"`;
@@ -117,7 +137,9 @@ export function validateChangelogSettings(packtoryConfig: ChangelogValidationCon
     pushDuplicateValueIssues(
         issues,
         outputs.flatMap((output) => {
-            return output.kind === 'package-file' ? packageFileDestinationPaths(packtoryConfig, output.path) : [];
+            return output.kind === 'package-file'
+                ? collectPackageFileDestinationPaths(packtoryConfig, output.path)
+                : [];
         }),
         (duplicatePath) => {
             return [

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -134,6 +134,10 @@ suite('packtory-config-schema', function () {
             data: {
                 registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 changelog: {
+                    labels: { operations: 'Operations' },
+                    targetScopedLabelPattern: 'scope:{targetName}:{label}',
+                    packageTagFormat: 'pkg/{packageName}/v{version}',
+                    explicitBaseRef: 'main',
                     outputs: [
                         { kind: 'repository-file', path: 'CHANGELOG.md' },
                         { kind: 'package-file', path: 'CHANGELOG.md' },

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -71,7 +71,10 @@ packtory <command> [options]
 - `packtory changelog` computes the same release plan used by Packtory's release planning API and skips unchanged packages.
 - Without `changelog.outputs`, it prints one grouped Markdown changelog for packages that would publish a changed artifact.
 - `changelog.outputs` can write a grouped repository file with `{ kind: 'repository-file', path }`, write package-specific files below each changed package's effective `sourcesFolder` with `{ kind: 'package-file', path }`, and print grouped release-body Markdown with `{ kind: 'github-release' }`.
+- `changelog.labels` extends or overrides the default pull request label mapping. `changelog.targetScopedLabelPattern` customizes package-specific labels and must contain `{targetName}` and `{label}`.
+- `changelog.packageTagFormat` customizes package tag lookup for changelog base refs. `changelog.explicitBaseRef` uses one fixed base ref instead.
 - Pull requests are attributed by comparing GitHub changed files against each package's attributed source files. Changelog files named `CHANGELOG.md` and configured generated changelog output paths are ignored as attribution inputs.
+- JavaScript files are attributed through referenced source maps when they have a `sourceMappingURL`. Without that reference, the JavaScript file itself is attributed.
 - The GitHub repository is read from the root `package.json` `repository` field.
 - GitHub API requests use `GH_TOKEN` when set, otherwise `GITHUB_TOKEN`.
 - Pager output is shown through `$PAGER` when possible, otherwise `less -R`, otherwise standard output.

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -33,6 +33,7 @@ type ProgressEventName =
     | 'scheduled';
 
 type PackageConfig = PacktoryConfig['packages'][number];
+type ChangelogSettings = NonNullable<PacktoryConfig['changelog']>;
 type Root = PackageConfig['roots'][string];
 type OkVariant<TResult> = Extract<TResult, { isOk: true }>;
 type ErrVariant<TResult> = Extract<TResult, { isErr: true }>;
@@ -137,6 +138,13 @@ describe('PacktoryConfig — accepted shapes', () => {
                 };
             };
             readonly checks: { readonly noDuplicatedFiles: { readonly enabled: true } };
+            readonly changelog: {
+                readonly explicitBaseRef: 'main';
+                readonly labels: { readonly operations: 'Operations' };
+                readonly outputs: readonly [{ readonly kind: 'repository-file'; readonly path: 'CHANGELOG.md' }];
+                readonly packageTagFormat: 'pkg/{packageName}/v{version}';
+                readonly targetScopedLabelPattern: 'scope:{targetName}:{label}';
+            };
             readonly commonPackageSettings: { readonly sourcesFolder: 'src'; readonly includeSourceMapFiles: true };
             readonly packages: readonly [
                 {
@@ -251,6 +259,16 @@ describe('PacktoryConfig — exposed structure', () => {
         type PackageChecks = NonNullable<PackageConfig['checks']>;
         type AreTheTypesWrong = NonNullable<PackageChecks['areTheTypesWrong']>;
         expect<AreTheTypesWrong['profile']>().type.toBe<'esm-only' | 'node16' | 'strict' | undefined>();
+    });
+});
+
+describe('PacktoryConfig changelog structure', () => {
+    test('changelog exposes generation and output settings', () => {
+        expect<ChangelogSettings['explicitBaseRef']>().type.toBe<string | undefined>();
+        expect<ChangelogSettings['labels']>().type.toBe<Readonly<Record<string, string>> | undefined>();
+        expect<ChangelogSettings['outputs']>().type.toBeAssignableTo<readonly unknown[] | undefined>();
+        expect<ChangelogSettings['packageTagFormat']>().type.toBe<string | undefined>();
+        expect<ChangelogSettings['targetScopedLabelPattern']>().type.toBe<string | undefined>();
     });
 });
 

--- a/source/packtory/changelog-source-attribution.ts
+++ b/source/packtory/changelog-source-attribution.ts
@@ -17,7 +17,7 @@ type ReferencedMap = {
 const sourceMappingPrefix = '//# sourceMappingURL=';
 const javaScriptFilePattern = /\.[cm]?jsx?$/u;
 
-function sortedUnique(values: readonly string[]): readonly string[] {
+function sortUniqueValues(values: readonly string[]): readonly string[] {
     return Array.from(new Set(values)).toSorted(compareValues);
 }
 
@@ -33,7 +33,7 @@ function toRepositoryRelativePath(repositoryFolder: string, filePath: string): s
     return relativePath.split(path.sep).join('/');
 }
 
-function sourceMappingUrlsFrom(fileContent: string): readonly string[] {
+function collectSourceMappingUrls(fileContent: string): readonly string[] {
     return fileContent.split('\n').flatMap((line) => {
         if (!line.startsWith(sourceMappingPrefix)) {
             return [];
@@ -58,7 +58,10 @@ function resolveMapSource(mapFilePath: string, traceMap: TraceMap, source: strin
     return path.resolve(path.dirname(mapFilePath), traceMap.sourceRoot ?? '', source);
 }
 
-function singleSourceMappingUrlFrom(sourceFilePath: string, sourceMappingUrls: readonly string[]): string | undefined {
+function resolveSingleSourceMappingUrl(
+    sourceFilePath: string,
+    sourceMappingUrls: readonly string[]
+): string | undefined {
     if (sourceMappingUrls.length > 1) {
         throw new Error(`Multiple sourceMappingURL references found in "${sourceFilePath}"`);
     }
@@ -82,7 +85,7 @@ async function readReferencedMap(
     sourceFilePath: string
 ): Promise<ReferencedMap | undefined> {
     const fileContent = await dependencies.fileManager.readFile(sourceFilePath);
-    const sourceMappingUrl = singleSourceMappingUrlFrom(sourceFilePath, sourceMappingUrlsFrom(fileContent));
+    const sourceMappingUrl = resolveSingleSourceMappingUrl(sourceFilePath, collectSourceMappingUrls(fileContent));
 
     if (sourceMappingUrl === undefined) {
         return undefined;
@@ -114,7 +117,7 @@ async function attributeJavaScriptFile(
     });
 }
 
-async function attributedFilesFor(
+async function collectAttributedFiles(
     dependencies: ChangelogSourceAttributionDependencies,
     entry: AnalyzedBundleResource
 ): Promise<readonly string[]> {
@@ -134,8 +137,8 @@ export async function attributeChangelogSourceFiles(
     const attributedFiles: string[] = [];
     for (const entry of analyzedBundle.contents) {
         if (!entry.isGeneratedManifest) {
-            attributedFiles.push(...(await attributedFilesFor(dependencies, entry)));
+            attributedFiles.push(...(await collectAttributedFiles(dependencies, entry)));
         }
     }
-    return sortedUnique(attributedFiles);
+    return sortUniqueValues(attributedFiles);
 }

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -83,10 +83,13 @@ async function render(packages: readonly ReleasePlanPackage[], engine: PrLogEngi
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
+        explicitBaseRef: undefined,
         githubRepo: 'owner/repo',
         packageInfo: {},
+        packageTagFormat: undefined,
         currentDate: new Date('2026-06-13T00:00:00.000Z'),
         ignoredAttributionPaths: [],
+        targetScopedLabelPattern: undefined,
         validLabels
     });
     return changelog.groupedMarkdown;
@@ -234,12 +237,45 @@ suite('packtory-changelog', function () {
             githubRepo: 'owner/repo',
             packageInfo: {},
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
+            explicitBaseRef: undefined,
             ignoredAttributionPaths: ['docs/generated.md'],
+            packageTagFormat: undefined,
+            targetScopedLabelPattern: undefined,
             validLabels
         });
 
         assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].ignoredAttributionPaths, [
             'docs/generated.md'
         ]);
+    });
+
+    test('passes configured base-ref and label options to pr-log', async function () {
+        const { engine, calls } = createEngine();
+
+        await generateChangelogOutputs({
+            packages: [releasePackage({ previousVersion: undefined, previousGitHead: undefined })],
+            prLogEngine: engine,
+            explicitBaseRef: 'release-base',
+            githubRepo: 'owner/repo',
+            packageInfo: {},
+            packageTagFormat: 'pkg/{packageName}/v{version}',
+            currentDate: new Date('2026-06-13T00:00:00.000Z'),
+            ignoredAttributionPaths: [],
+            targetScopedLabelPattern: 'scope:{targetName}:{label}',
+            validLabels
+        });
+
+        assert.strictEqual(calls.resolveLatestSemverChangelogBaseRef.callCount, 0);
+        assert.deepStrictEqual(calls.resolveChangelogBaseRef.firstCall.args[0], {
+            packageName: 'pkg-a',
+            previousVersion: undefined,
+            previousGitHead: undefined,
+            packageTagFormat: 'pkg/{packageName}/v{version}',
+            explicitBaseRef: 'release-base'
+        });
+        const labelInput = calls.resolvePullRequestLabels.firstCall.args[0] as {
+            readonly targetScopedLabelPattern: string;
+        };
+        assert.strictEqual(labelInput.targetScopedLabelPattern, 'scope:{targetName}:{label}');
     });
 });

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -10,10 +10,12 @@ type ChangelogTarget = {
 
 export type GenerateChangelogInput = {
     readonly currentDate: Date;
+    readonly explicitBaseRef: string | undefined;
     readonly githubRepo: string;
     readonly ignoredAttributionPaths: readonly string[];
     readonly packageInfo: Record<string, unknown>;
     readonly packages: readonly ReleasePlanPackage[];
+    readonly packageTagFormat: string | undefined;
     readonly prLogEngine: Pick<
         PrLogEngine,
         | 'collectMergedPullRequests'
@@ -25,6 +27,7 @@ export type GenerateChangelogInput = {
         | 'resolveLatestSemverChangelogBaseRef'
         | 'resolvePullRequestLabels'
     >;
+    readonly targetScopedLabelPattern: string | undefined;
     readonly validLabels: ReadonlyMap<string, string>;
 };
 
@@ -68,9 +71,14 @@ function mergeIgnoredAttributionPaths(
 
 async function resolveBaseRefFor(
     prLogEngine: GenerateChangelogInput['prLogEngine'],
-    packagePlan: ReleasePlanPackage
+    packagePlan: ReleasePlanPackage,
+    input: Pick<GenerateChangelogInput, 'explicitBaseRef' | 'packageTagFormat'>
 ): Promise<string> {
-    if (packagePlan.previousVersion === undefined && packagePlan.previousGitHead === undefined) {
+    if (
+        input.explicitBaseRef === undefined &&
+        packagePlan.previousVersion === undefined &&
+        packagePlan.previousGitHead === undefined
+    ) {
         const baseRef = await prLogEngine.resolveLatestSemverChangelogBaseRef();
         return baseRef.ref;
     }
@@ -79,8 +87,8 @@ async function resolveBaseRefFor(
         packageName: packagePlan.name,
         previousVersion: packagePlan.previousVersion,
         previousGitHead: packagePlan.previousGitHead,
-        packageTagFormat: undefined,
-        explicitBaseRef: undefined
+        packageTagFormat: input.packageTagFormat,
+        explicitBaseRef: input.explicitBaseRef
     });
     return baseRef.ref;
 }
@@ -90,7 +98,7 @@ async function collectTargetPullRequests(
     packagePlan: ReleasePlanPackage,
     ignoredAttributionPaths: readonly string[]
 ): Promise<readonly PullRequestWithLabel[]> {
-    const baseRef = await resolveBaseRefFor(input.prLogEngine, packagePlan);
+    const baseRef = await resolveBaseRefFor(input.prLogEngine, packagePlan, input);
     const pullRequests = await input.prLogEngine.collectMergedPullRequests({
         githubRepo: input.githubRepo,
         baseRef
@@ -113,7 +121,7 @@ async function collectTargetPullRequests(
         ignoredLabels: [],
         pullRequests: packagePullRequests,
         targetName: packagePlan.name,
-        targetScopedLabelPattern: undefined
+        targetScopedLabelPattern: input.targetScopedLabelPattern
     });
 }
 


### PR DESCRIPTION
This adds `changelog` configuration for label mappings, target-scoped labels, package tag lookup, and explicit base refs, then wires those settings through both `packtory changelog` and `packtory release --write-changelog`.

It also keeps `changelog.outputs` optional and documents that JavaScript attribution uses referenced source maps when present.