### PR TITLE
Add explicit package changelog paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,7 @@ The configuration for `packtory` is an object with the following properties:
     - `outputs` is a non-empty array of:
         - `{ kind: 'repository-file', path: 'CHANGELOG.md' }`: writes one grouped changelog at a repository-relative path.
         - `{ kind: 'package-file', path: 'CHANGELOG.md' }`: writes one package-specific changelog below each changed package's effective `sourcesFolder`.
+        - `{ kind: 'package-file', paths: { 'pkg-a': 'packages/pkg-a/CHANGELOG.md' } }`: writes package-specific changelogs to explicit repository-relative paths. Every changed package must have a configured path.
         - `{ kind: 'github-release' }`: prints grouped release-body Markdown to the pager. Remote GitHub release creation is not implemented by `packtory changelog`.
     - `outputs` can be omitted when only label or base-ref settings are configured.
     - Output paths must be safe relative paths. Absolute paths and parent-traversing paths are rejected.

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -115,6 +115,30 @@ suite('changelog-destinations', function () {
         );
     });
 
+    test('collectGeneratedAttributionPaths includes explicit package file paths', function () {
+        assert.deepStrictEqual(
+            collectGeneratedAttributionPaths(
+                deps,
+                createChangelogConfig({
+                    changelog: {
+                        outputs: [
+                            {
+                                kind: 'package-file',
+                                paths: {
+                                    'pkg-a': 'packages/pkg-a/CHANGELOG.md',
+                                    'pkg-b': 'packages/pkg-b/CHANGELOG.md'
+                                }
+                            }
+                        ]
+                    },
+                    commonPackageSettings: undefined,
+                    packages: [{ name: 'pkg-a' }, { name: 'pkg-b' }]
+                })
+            ),
+            ['packages/pkg-a/CHANGELOG.md', 'packages/pkg-b/CHANGELOG.md']
+        );
+    });
+
     test('collectGeneratedAttributionPaths ignores github-release outputs', function () {
         assert.deepStrictEqual(
             collectGeneratedAttributionPaths(
@@ -221,6 +245,75 @@ suite('changelog-destinations', function () {
                 createGeneratedChangelog({ packageMarkdownByName: new Map([['missing', 'markdown']]) })
             ),
             /Config for package "missing" is missing/u
+        );
+    });
+
+    test('writeConfiguredChangelogs writes explicit package-file changelog outputs', async function () {
+        const fileManager = createFakeFileManager();
+
+        const writtenPaths = await writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            createChangelogConfig({
+                changelog: {
+                    outputs: [
+                        {
+                            kind: 'package-file',
+                            paths: {
+                                'pkg-a': 'packages/pkg-a/CHANGELOG.md',
+                                'pkg-b': 'packages/pkg-b/CHANGELOG.md'
+                            }
+                        }
+                    ]
+                }
+            }),
+            {
+                updateChangelog: fake(
+                    (input: { readonly generatedChangelogMarkdown: string }) => input.generatedChangelogMarkdown
+                )
+            },
+            createGeneratedChangelog({
+                packageMarkdownByName: new Map([
+                    ['pkg-a', 'package-a'],
+                    ['pkg-b', 'package-b']
+                ])
+            })
+        );
+
+        assert.deepStrictEqual(writtenPaths, [
+            '/repo/packages/pkg-a/CHANGELOG.md',
+            '/repo/packages/pkg-b/CHANGELOG.md'
+        ]);
+        assert.deepStrictEqual(fileManager.getAllWriteFileCalls(), [
+            { filePath: '/repo/packages/pkg-a/CHANGELOG.md', content: 'package-a' },
+            { filePath: '/repo/packages/pkg-b/CHANGELOG.md', content: 'package-b' }
+        ]);
+    });
+
+    test('writeConfiguredChangelogs reports package markdown without an explicit path', async function () {
+        const fileManager = createFakeFileManager();
+
+        await assert.rejects(
+            writeConfiguredChangelogs(
+                { ...deps, fileManager },
+                createChangelogConfig({
+                    changelog: {
+                        outputs: [
+                            {
+                                kind: 'package-file',
+                                paths: { 'pkg-a': 'packages/pkg-a/CHANGELOG.md' }
+                            }
+                        ]
+                    }
+                }),
+                { updateChangelog: fake.returns('updated') },
+                createGeneratedChangelog({
+                    packageMarkdownByName: new Map([
+                        ['pkg-a', 'package-a'],
+                        ['pkg-b', 'package-b']
+                    ])
+                })
+            ),
+            /Changelog output path for package "pkg-b" is missing/u
         );
     });
 

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -36,6 +36,11 @@ type FileChangelogDestination = {
 };
 
 type FileChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' | 'repository-file' }>;
+type PackageChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' }>;
+type PackageChangelogOutputWithSharedPath = PackageChangelogOutput & { readonly path: string };
+type PackageChangelogOutputWithExplicitPaths = PackageChangelogOutput & {
+    readonly paths: Readonly<Record<string, string>>;
+};
 export type ChangelogGenerationOptions = {
     readonly explicitBaseRef: string | undefined;
     readonly packageTagFormat: string | undefined;
@@ -94,6 +99,26 @@ function resolvePackageFilePath(
     );
 }
 
+function resolveExplicitPackageFilePath(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    output: PackageChangelogOutputWithExplicitPaths,
+    packageName: string
+): string {
+    const outputPath = output.paths[packageName];
+    if (outputPath === undefined) {
+        throw new Error(`Changelog output path for package "${packageName}" is missing`);
+    }
+    return resolveRepositoryPath(deps, outputPath);
+}
+
+function hasSharedPackagePath(output: PackageChangelogOutput): output is PackageChangelogOutputWithSharedPath {
+    return 'path' in output;
+}
+
+function hasExplicitPackagePaths(output: PackageChangelogOutput): output is PackageChangelogOutputWithExplicitPaths {
+    return 'paths' in output;
+}
+
 function resolveRepositoryRelativePath(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     filePath: string
@@ -123,6 +148,11 @@ export function collectGeneratedAttributionPaths(
         .flatMap((output) => {
             if (output.kind === 'repository-file') {
                 return [resolveRepositoryPath(deps, output.path)];
+            }
+            if (hasExplicitPackagePaths(output)) {
+                return Object.values(output.paths).map((outputPath) => {
+                    return resolveRepositoryPath(deps, outputPath);
+                });
             }
             return config.packages.map((packageConfig) => {
                 return resolvePackageFilePath(deps, config, packageConfig, output.path);
@@ -160,24 +190,46 @@ function collectRepositoryDestinations(
     });
 }
 
+function collectPackageDestinationsWithSharedPath(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    output: PackageChangelogOutputWithSharedPath,
+    changelog: GeneratedChangelog
+): readonly FileChangelogDestination[] {
+    const packageConfigsByName = mapPackageConfigByName(config);
+    return Array.from(changelog.packageMarkdownByName, ([packageName, generatedMarkdown]) => {
+        const packageConfig = packageConfigsByName.get(packageName);
+        if (packageConfig === undefined) {
+            throw new Error(`Config for package "${packageName}" is missing`);
+        }
+        return { filePath: resolvePackageFilePath(deps, config, packageConfig, output.path), generatedMarkdown };
+    });
+}
+
+function collectPackageDestinationsWithExplicitPaths(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    output: PackageChangelogOutputWithExplicitPaths,
+    changelog: GeneratedChangelog
+): readonly FileChangelogDestination[] {
+    return Array.from(changelog.packageMarkdownByName, ([packageName, generatedMarkdown]) => {
+        return { filePath: resolveExplicitPackageFilePath(deps, output, packageName), generatedMarkdown };
+    });
+}
+
 function collectPackageDestinations(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     config: ChangelogConfig,
     outputs: readonly ChangelogOutput[],
     changelog: GeneratedChangelog
 ): readonly FileChangelogDestination[] {
-    const packageConfigsByName = mapPackageConfigByName(config);
     return outputs.flatMap((output) => {
         if (output.kind !== 'package-file') {
             return [];
         }
-        return Array.from(changelog.packageMarkdownByName).flatMap(([packageName, generatedMarkdown]) => {
-            const packageConfig = packageConfigsByName.get(packageName);
-            if (packageConfig === undefined) {
-                throw new Error(`Config for package "${packageName}" is missing`);
-            }
-            return [{ filePath: resolvePackageFilePath(deps, config, packageConfig, output.path), generatedMarkdown }];
-        });
+        if (hasSharedPackagePath(output)) {
+            return collectPackageDestinationsWithSharedPath(deps, config, output, changelog);
+        }
+        return collectPackageDestinationsWithExplicitPaths(deps, output, changelog);
     });
 }
 

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -121,6 +121,7 @@ type Spies = {
 type ChangelogOutputConfig =
     | { readonly kind: 'github-release' }
     | { readonly kind: 'package-file'; readonly path: string }
+    | { readonly kind: 'package-file'; readonly paths: Readonly<Record<string, string>> }
     | { readonly kind: 'repository-file'; readonly path: string };
 
 function spinnerRendererCapturing(stopAll: SinonSpy): TerminalSpinnerRenderer {
@@ -486,6 +487,18 @@ suite('changelog-handler', function () {
         assert.strictEqual(code, 0);
         assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
             filePath: '/repo/src/pkg-a/CHANGELOG.md',
+            content: 'merged:\n## pkg-a 1.0.1\n'
+        });
+    });
+
+    test('writes explicit package-file changelog output paths', async function () {
+        const { code, fileManager } = await runWithChangelogOutputs({
+            outputs: [{ kind: 'package-file', paths: { 'pkg-a': 'packages/pkg-a/CHANGELOG.md' } }]
+        });
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(fileManager.getWriteFileCall(0), {
+            filePath: '/repo/packages/pkg-a/CHANGELOG.md',
             content: 'merged:\n## pkg-a 1.0.1\n'
         });
     });

--- a/source/config/changelog-settings.test.ts
+++ b/source/config/changelog-settings.test.ts
@@ -44,6 +44,13 @@ suite('changelog-settings', function () {
             outputs: [
                 { kind: 'repository-file', path: 'CHANGELOG.md' },
                 { kind: 'package-file', path: 'docs/CHANGELOG.md' },
+                {
+                    kind: 'package-file',
+                    paths: {
+                        'pkg-a': 'packages/pkg-a/CHANGELOG.md',
+                        'pkg-b': 'packages/pkg-b/CHANGELOG.md'
+                    }
+                },
                 { kind: 'github-release' }
             ]
         });
@@ -87,12 +94,33 @@ suite('changelog-settings', function () {
             }).success,
             false
         );
+        assert.strictEqual(
+            safeParse(changelogSettingsSchema, {
+                outputs: [{ kind: 'package-file', paths: { 'pkg-a': '../CHANGELOG.md' } }]
+            }).success,
+            false
+        );
+    });
+
+    test('schema rejects empty explicit package-file paths', function () {
+        assert.strictEqual(
+            safeParse(changelogSettingsSchema, {
+                outputs: [{ kind: 'package-file', paths: {} }]
+            }).success,
+            false
+        );
     });
 
     test('schema rejects extra output object properties', function () {
         assert.strictEqual(
             safeParse(changelogSettingsSchema, {
                 outputs: [{ kind: 'github-release', path: 'CHANGELOG.md' }]
+            }).success,
+            false
+        );
+        assert.strictEqual(
+            safeParse(changelogSettingsSchema, {
+                outputs: [{ kind: 'package-file', path: 'CHANGELOG.md', paths: { 'pkg-a': 'CHANGELOG.md' } }]
             }).success,
             false
         );
@@ -157,6 +185,29 @@ suite('changelog-settings', function () {
 
         assert.deepStrictEqual(result, [
             'changelog.outputs package-file destinations must resolve to unique files; "src/CHANGELOG.md" is duplicated'
+        ]);
+    });
+
+    test('validation rejects duplicate explicit package-file destinations', function () {
+        const result = validateChangelogSettings(
+            configWith({
+                outputs: [
+                    {
+                        kind: 'package-file',
+                        paths: {
+                            'pkg-a': 'packages/pkg-a/CHANGELOG.md',
+                            'pkg-b': 'packages\\pkg-a\\CHANGELOG.md'
+                        }
+                    }
+                ]
+            })
+        );
+
+        assert.deepStrictEqual(result, [
+            [
+                'changelog.outputs package-file destinations must resolve to unique files;',
+                '"packages/pkg-a/CHANGELOG.md" is duplicated'
+            ].join(' ')
         ]);
     });
 

--- a/source/config/changelog-settings.ts
+++ b/source/config/changelog-settings.ts
@@ -16,13 +16,29 @@ const packageFileOutputSchema = z.readonly(
     })
 );
 
+const explicitPackageFileOutputSchema = z.readonly(
+    z.strictObject({
+        kind: z.literal('package-file'),
+        paths: z.readonly(z.record(nonEmptyStringSchema, bundleRelativePathSchema)).check(
+            z.refine((value) => {
+                return Object.keys(value).length > 0;
+            })
+        )
+    })
+);
+
 const githubReleaseOutputSchema = z.readonly(
     z.strictObject({
         kind: z.literal('github-release')
     })
 );
 
-const changelogOutputSchema = z.union([repositoryFileOutputSchema, packageFileOutputSchema, githubReleaseOutputSchema]);
+const changelogOutputSchema = z.union([
+    repositoryFileOutputSchema,
+    packageFileOutputSchema,
+    explicitPackageFileOutputSchema,
+    githubReleaseOutputSchema
+]);
 const validLabelsSchema = z.readonly(z.record(nonEmptyStringSchema, nonEmptyStringSchema));
 
 export const changelogSettingsSchema = z.readonly(
@@ -60,6 +76,10 @@ function normalizeFilePath(...filePathSegments: readonly string[]): string {
     return path.normalize(path.join(...filePathSegments.map(normalizeRelativePath)));
 }
 
+function normalizeChangelogOutputPath(filePath: string): string {
+    return path.normalize(normalizeRelativePath(filePath));
+}
+
 function pushDuplicateValueIssues(
     issues: string[],
     values: readonly string[],
@@ -86,14 +106,20 @@ function resolveSourcesFolder(
 
 function collectPackageFileDestinationPaths(
     packtoryConfig: ChangelogValidationConfig,
-    outputPath: string
+    output: ChangelogOutput
 ): readonly string[] {
+    if (output.kind !== 'package-file') {
+        return [];
+    }
+    if ('paths' in output) {
+        return Object.values(output.paths).map(normalizeChangelogOutputPath);
+    }
     return packtoryConfig.packages.flatMap((packageConfig) => {
         const sourcesFolder = resolveSourcesFolder(packageConfig, packtoryConfig);
         if (sourcesFolder === undefined) {
             return [];
         }
-        return [normalizeFilePath(sourcesFolder, outputPath)];
+        return [normalizeFilePath(sourcesFolder, output.path)];
     });
 }
 
@@ -133,9 +159,7 @@ function collectChangelogOutputIssues(
     pushDuplicateValueIssues(
         issues,
         outputs.flatMap((output) => {
-            return output.kind === 'package-file'
-                ? collectPackageFileDestinationPaths(packtoryConfig, output.path)
-                : [];
+            return collectPackageFileDestinationPaths(packtoryConfig, output);
         }),
         (duplicatePath) => {
             return [

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -141,6 +141,7 @@ suite('packtory-config-schema', function () {
                     outputs: [
                         { kind: 'repository-file', path: 'CHANGELOG.md' },
                         { kind: 'package-file', path: 'CHANGELOG.md' },
+                        { kind: 'package-file', paths: { foo: 'packages/foo/CHANGELOG.md' } },
                         { kind: 'github-release' }
                     ]
                 },

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -70,7 +70,7 @@ packtory <command> [options]
 
 - `packtory changelog` computes the same release plan used by Packtory's release planning API and skips unchanged packages.
 - Without `changelog.outputs`, it prints one grouped Markdown changelog for packages that would publish a changed artifact.
-- `changelog.outputs` can write a grouped repository file with `{ kind: 'repository-file', path }`, write package-specific files below each changed package's effective `sourcesFolder` with `{ kind: 'package-file', path }`, and print grouped release-body Markdown with `{ kind: 'github-release' }`.
+- `changelog.outputs` can write a grouped repository file with `{ kind: 'repository-file', path }`, write package-specific files below each changed package's effective `sourcesFolder` with `{ kind: 'package-file', path }`, write package-specific files to explicit repository-relative paths with `{ kind: 'package-file', paths }`, and print grouped release-body Markdown with `{ kind: 'github-release' }`.
 - `changelog.labels` extends or overrides the default pull request label mapping. `changelog.targetScopedLabelPattern` customizes package-specific labels and must contain `{targetName}` and `{label}`.
 - `changelog.packageTagFormat` customizes package tag lookup for changelog base refs. `changelog.explicitBaseRef` uses one fixed base ref instead.
 - Pull requests are attributed by comparing GitHub changed files against each package's attributed source files. Changelog files named `CHANGELOG.md` and configured generated changelog output paths are ignored as attribution inputs.

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -141,7 +141,13 @@ describe('PacktoryConfig — accepted shapes', () => {
             readonly changelog: {
                 readonly explicitBaseRef: 'main';
                 readonly labels: { readonly operations: 'Operations' };
-                readonly outputs: readonly [{ readonly kind: 'repository-file'; readonly path: 'CHANGELOG.md' }];
+                readonly outputs: readonly [
+                    { readonly kind: 'repository-file'; readonly path: 'CHANGELOG.md' },
+                    {
+                        readonly kind: 'package-file';
+                        readonly paths: { readonly pkg: 'packages/pkg/CHANGELOG.md' };
+                    }
+                ];
                 readonly packageTagFormat: 'pkg/{packageName}/v{version}';
                 readonly targetScopedLabelPattern: 'scope:{targetName}:{label}';
             };


### PR DESCRIPTION
This lets `changelog.outputs` write package changelogs to explicit repository-relative paths instead of deriving them from each package `sourcesFolder`.\n\nThe existing shared `package-file` path form still works, while the new `paths` form validates duplicate destinations and missing package paths before writing.