### PR TITLE
Skip empty package changelog entries during `release`

### DIFF
--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -37,6 +37,7 @@ function createGeneratedChangelog(
 ): GeneratedChangelog {
     return {
         groupedMarkdown: 'grouped',
+        packageNamesWithoutChangelogEntries: [],
         packageMarkdownByName: overrides.packageMarkdownByName ?? new Map([['pkg-a', 'package-a']])
     };
 }
@@ -226,7 +227,7 @@ suite('changelog-destinations', function () {
             { ...deps, fileManager },
             createChangelogConfig({ changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] } }),
             { updateChangelog: fake.returns('updated') },
-            { groupedMarkdown: '', packageMarkdownByName: new Map() }
+            { groupedMarkdown: '', packageNamesWithoutChangelogEntries: [], packageMarkdownByName: new Map() }
         );
 
         assert.deepStrictEqual(writtenPaths, []);

--- a/source/command-line-interface/runner/release-handler.test.ts
+++ b/source/command-line-interface/runner/release-handler.test.ts
@@ -127,6 +127,45 @@ const defaultFlags: ReleaseFlags = {
 };
 const githubReleaseFlags = { githubRelease: true, noDryRun: true, push: true, tag: true } as const;
 const noReleaseMessage = 'No packages need release.';
+const unattributedPackageChangelogMessage =
+    'No changelog files were written; changelog attribution found no pull requests for pkg-a.';
+
+function createPackageChangelogConfig() {
+    return {
+        ...validConfig,
+        changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] }
+    };
+}
+
+function createTwoPackageChangelogConfig() {
+    return {
+        ...createPackageChangelogConfig(),
+        packages: [
+            validConfig.packages[0],
+            {
+                sourcesFolder: 'src/pkg-b',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg-b',
+                roots: { main: { js: 'index.js' } },
+                publishSettings: { access: 'public' }
+            }
+        ]
+    };
+}
+
+function createConfigWithoutChangelogOutputs() {
+    return {
+        ...validConfig,
+        changelog: {}
+    };
+}
+
+function createEngineWithoutAttributedPullRequests(): PrLogEngine {
+    return {
+        ...createEngine(),
+        resolvePullRequestLabels: fake.resolves([])
+    } as unknown as PrLogEngine;
+}
 
 type Scenario = {
     readonly buildAndPublishAll?: SinonSpy;
@@ -240,6 +279,19 @@ function createReleaseHandlerDeps(scenario: Scenario = {}): ReleaseHandlerDeps {
     };
 }
 
+function createPackageChangelogDeps(
+    order: string[],
+    flags: Partial<ReleaseFlags>,
+    engine: PrLogEngine
+): ReleaseHandlerDeps {
+    return createReleaseHandlerDeps({
+        order,
+        engine,
+        flags,
+        config: createPackageChangelogConfig()
+    });
+}
+
 async function runScenario(scenario: Scenario): Promise<{
     readonly code: number;
     readonly deps: ReleaseHandlerDeps;
@@ -250,6 +302,18 @@ async function runScenario(scenario: Scenario): Promise<{
 
 function readFirstLogArgs(deps: ReleaseHandlerDeps): readonly unknown[] {
     return (deps.log as SinonSpy).firstCall.args;
+}
+
+async function assertCleanChangelogNoOp(
+    deps: ReleaseHandlerDeps,
+    order: string[],
+    expectedMessage: string
+): Promise<void> {
+    const code = await runReleaseHandler(deps);
+
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(order, ['plan', 'clean']);
+    assert.deepStrictEqual(readFirstLogArgs(deps), [expectedMessage]);
 }
 
 async function assertFlagError(flags: Partial<ReleaseFlags>, expected: string): Promise<ReleaseHandlerDeps> {
@@ -588,6 +652,87 @@ suite('release-handler', function () {
 
         assert.strictEqual(code, 0);
         assert.deepStrictEqual(order, ['plan', 'clean']);
+    });
+
+    test('logs unwritten package changelogs when attribution finds no pull requests', async function () {
+        const order: string[] = [];
+        const deps = createPackageChangelogDeps(
+            order,
+            { writeChangelog: true, noDryRun: true },
+            createEngineWithoutAttributedPullRequests()
+        );
+
+        await assertCleanChangelogNoOp(deps, order, unattributedPackageChangelogMessage);
+    });
+
+    test('separates multiple unwritten package changelog names', async function () {
+        const order: string[] = [];
+        const deps = createReleaseHandlerDeps({
+            order,
+            engine: createEngineWithoutAttributedPullRequests(),
+            flags: { writeChangelog: true, noDryRun: true },
+            config: createTwoPackageChangelogConfig(),
+            planOutcomes: [
+                createReleasePlanOutcome([
+                    createReleasePackage(),
+                    createReleasePackage({ name: 'pkg-b', changelogSourceFiles: ['source/pkg-b.ts'] })
+                ])
+            ]
+        });
+
+        await assertCleanChangelogNoOp(
+            deps,
+            order,
+            'No changelog files were written; changelog attribution found no pull requests for pkg-a, pkg-b.'
+        );
+    });
+
+    test('logs unwritten changelogs when no file outputs are configured', async function () {
+        const order: string[] = [];
+        const deps = createReleaseHandlerDeps({
+            order,
+            flags: { writeChangelog: true, noDryRun: true },
+            config: createConfigWithoutChangelogOutputs()
+        });
+
+        await assertCleanChangelogNoOp(deps, order, 'No changelog files were written.');
+    });
+
+    test('rejects --commit when attribution writes no changelog files', async function () {
+        const order: string[] = [];
+        const deps = createPackageChangelogDeps(
+            order,
+            { writeChangelog: true, commit: true, noDryRun: true },
+            createEngineWithoutAttributedPullRequests()
+        );
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 1);
+        assert.deepStrictEqual(order, ['plan', 'clean']);
+        assert.deepStrictEqual((deps.log as SinonSpy).firstCall.args, [unattributedPackageChangelogMessage]);
+    });
+
+    test('writes and commits non-empty package changelog output', async function () {
+        const order: string[] = [];
+        const deps = createPackageChangelogDeps(
+            order,
+            { writeChangelog: true, commit: true, noDryRun: true },
+            createEngine()
+        );
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.deepStrictEqual(order, [
+            'plan',
+            'clean',
+            'commit:/repo/src/pkg-a/CHANGELOG.md:Release packages',
+            'plan'
+        ]);
+        assert.deepStrictEqual((deps.fileManager as ReturnType<typeof createFakeFileManager>).getAllWriteFileCalls(), [
+            { filePath: '/repo/src/pkg-a/CHANGELOG.md', content: '## pkg-a 1.0.1\n' }
+        ]);
     });
 
     test('uses configured changelog labels when writing release changelogs', async function () {

--- a/source/command-line-interface/runner/release-handler.ts
+++ b/source/command-line-interface/runner/release-handler.ts
@@ -344,16 +344,20 @@ function resolvePlannedReleaseExitCode(
     return undefined;
 }
 
+function parseRequiredChangelogConfig(config: unknown): ValidChangelogConfig {
+    const validConfig = parseValidConfig(config);
+    if (validConfig === undefined) {
+        throw new Error('The loaded config is invalid for changelog generation');
+    }
+    return validConfig;
+}
+
 async function generateRequiredChangelog(
     deps: ReleaseHandlerDeps,
     config: unknown,
     packages: readonly ReleasePlanPackage[]
 ): Promise<ReleaseChangelog> {
-    const validConfig = parseValidConfig(config);
-    if (validConfig === undefined) {
-        throw new Error('The loaded config is invalid for changelog generation');
-    }
-    return generateReleaseChangelog(deps, validConfig, packages);
+    return generateReleaseChangelog(deps, parseRequiredChangelogConfig(config), packages);
 }
 
 async function commitChangelogAndReplan(
@@ -366,6 +370,33 @@ async function commitChangelogAndReplan(
     return committedPlan === undefined ? undefined : { changelog, planned: committedPlan };
 }
 
+function formatEmptyChangelogMessage(changelog: GeneratedChangelog): string {
+    const packageNames = changelog.packageNamesWithoutChangelogEntries;
+    if (packageNames.length === 0) {
+        return 'No changelog files were written.';
+    }
+    return [
+        'No changelog files were written; changelog attribution found no pull requests for ',
+        packageNames.join(', '),
+        '.'
+    ].join('');
+}
+
+function reportUnwrittenChangelogs(
+    deps: Pick<ReleaseHandlerDeps, 'flags' | 'log'>,
+    changelog: GeneratedChangelog,
+    writtenPaths: readonly string[]
+): void {
+    if (writtenPaths.length > 0) {
+        return;
+    }
+    const message = formatEmptyChangelogMessage(changelog);
+    if (deps.flags.commit) {
+        throw new Error(message);
+    }
+    deps.log(message);
+}
+
 async function writeChangelogAndMaybeCommit(
     deps: ReleaseHandlerDeps,
     planned: PlannedRelease
@@ -373,12 +404,10 @@ async function writeChangelogAndMaybeCommit(
     if (!deps.flags.writeChangelog) {
         return { changelog: undefined, planned };
     }
-    const validConfig = parseValidConfig(planned.config);
-    if (validConfig === undefined) {
-        throw new Error('The loaded config is invalid for changelog generation');
-    }
+    const validConfig = parseRequiredChangelogConfig(planned.config);
     const changelog = await generateReleaseChangelog(deps, validConfig, planned.packages);
     const writtenPaths = await writeConfiguredChangelogs(deps, changelog.config, changelog.engine, changelog.changelog);
+    reportUnwrittenChangelogs(deps, changelog.changelog, writtenPaths);
     if (!deps.flags.commit) {
         return { changelog, planned };
     }

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -195,6 +195,35 @@ suite('packtory-changelog', function () {
         });
     });
 
+    test('omits package changelog markdown for packages without attributed pull requests', async function () {
+        const { engine, calls } = createEngine();
+        const emptyLabelResolver = fake.resolves([]);
+        const renderTargetChangelog = fake.returns('## 1.0.1 (June 13, 2026)\n');
+        const emptyEngine = {
+            ...engine,
+            resolvePullRequestLabels: emptyLabelResolver,
+            renderTargetChangelog
+        } as unknown as PrLogEngine;
+
+        const changelog = await generateChangelogOutputs({
+            packages: [releasePackage({ changelogSourceFiles: ['source/pkg-a.ts'] })],
+            prLogEngine: emptyEngine,
+            githubRepo: 'owner/repo',
+            packageInfo: {},
+            currentDate: new Date('2026-06-13T00:00:00.000Z'),
+            explicitBaseRef: undefined,
+            ignoredAttributionPaths: [],
+            packageTagFormat: undefined,
+            targetScopedLabelPattern: undefined,
+            validLabels
+        });
+
+        assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, []);
+        assert.deepStrictEqual(changelog.packageNamesWithoutChangelogEntries, ['pkg-a']);
+        assert.deepStrictEqual(changelog.packageMarkdownByName, new Map());
+        assert.strictEqual(renderTargetChangelog.callCount, 0);
+    });
+
     test('uses the package base-ref resolver when a package has a previous git head but no previous version', async function () {
         const { engine, calls } = createEngine();
 

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -33,6 +33,7 @@ export type GenerateChangelogInput = {
 
 export type GeneratedChangelog = {
     readonly groupedMarkdown: string;
+    readonly packageNamesWithoutChangelogEntries: readonly string[];
     readonly packageMarkdownByName: ReadonlyMap<string, string>;
 };
 
@@ -145,12 +146,16 @@ function createTargetSection(target: ChangelogTarget): TargetChangelogSection {
     };
 }
 
+function hasChangelogEntries(target: ChangelogTarget): boolean {
+    return target.pullRequests.length > 0;
+}
+
 function createPackageMarkdownByName(
     input: GenerateChangelogInput,
     targets: readonly ChangelogTarget[]
 ): ReadonlyMap<string, string> {
     return new Map(
-        targets.map((target) => {
+        targets.filter(hasChangelogEntries).map((target) => {
             const targetSection = createTargetSection(target);
             return [
                 target.packagePlan.name,
@@ -174,6 +179,7 @@ export async function generateChangelogOutputs(input: GenerateChangelogInput): P
             return createChangelogTarget(input, packagePlan, ignoredAttributionPaths);
         })
     );
+    const targetsWithEntries = targets.filter(hasChangelogEntries);
 
     return {
         groupedMarkdown: input.prLogEngine.renderGroupedTargetChangelog({
@@ -181,8 +187,15 @@ export async function generateChangelogOutputs(input: GenerateChangelogInput): P
             currentDate: input.currentDate,
             validLabels: input.validLabels,
             githubRepo: input.githubRepo,
-            targets: targets.map(createTargetSection)
+            targets: targetsWithEntries.map(createTargetSection)
         }),
+        packageNamesWithoutChangelogEntries: targets
+            .filter((target) => {
+                return !hasChangelogEntries(target);
+            })
+            .map((target) => {
+                return target.packagePlan.name;
+            }),
         packageMarkdownByName: createPackageMarkdownByName(input, targets)
     };
 }


### PR DESCRIPTION
Package changelog rendering now drops release targets with no attributed pull requests, so metadata-only package changes do not produce header-only files. `release --write-changelog --commit` now reports that no changelog files were written and fails before committing when attribution is empty.