### PR TITLE
Fix prefixed `sbom.cdx.json` canonicalization

### DIFF
--- a/source/bundle-emitter/release-artifact-canonicalizer.ts
+++ b/source/bundle-emitter/release-artifact-canonicalizer.ts
@@ -1,9 +1,8 @@
 import { isPlainObject } from 'remeda';
+import { bundleRelativePath, packageManifestFilePath } from '../common/package-layout.ts';
 import { serializeStableJson } from '../common/stable-json.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import { canonicalizeSbomInFileSet } from '../sbom/sbom-canonicalizer.ts';
-
-const manifestPaths = new Set(['package.json', 'package/package.json']);
 
 function canonicalizeManifestContent(content: string): string {
     try {
@@ -21,7 +20,7 @@ function canonicalizeManifestContent(content: string): string {
 
 function canonicalizePackageManifestInFileSet(files: readonly FileDescription[]): readonly FileDescription[] {
     return files.map((file) => {
-        if (!manifestPaths.has(file.filePath)) {
+        if (bundleRelativePath(file.filePath) !== packageManifestFilePath) {
             return file;
         }
         return { ...file, content: canonicalizeManifestContent(file.content) };

--- a/source/common/package-layout.ts
+++ b/source/common/package-layout.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 export const packageManifestFilePath = 'package.json';
+export const sbomArtifactFilePath = 'sbom.cdx.json';
 export const installedDependenciesFolderName = 'node_modules';
 
 const tarballPackageRootPrefix = 'package/';

--- a/source/packtory/release-analysis.ts
+++ b/source/packtory/release-analysis.ts
@@ -1,8 +1,7 @@
 import { isDeepStrictEqual } from 'node:util';
 import { maxDate } from '../common/max-date.ts';
-import { bundleRelativePath, packageManifestFilePath } from '../common/package-layout.ts';
+import { bundleRelativePath, packageManifestFilePath, sbomArtifactFilePath } from '../common/package-layout.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
-import { sbomFilePath } from '../sbom/sbom-file.ts';
 import type { BuildAndPublishResult } from './package-processor.ts';
 import {
     releaseAnalysisClassification,
@@ -83,7 +82,7 @@ function normalizePackageJsonForDependencyComparison(value: unknown): unknown {
 }
 
 function isDependencyDerivedFilePath(filePath: string): boolean {
-    return filePath === packageManifestFilePath || filePath === sbomFilePath();
+    return filePath === packageManifestFilePath || filePath === sbomArtifactFilePath;
 }
 
 function nonDependencyDerivedFilesMatch(

--- a/source/sbom/sbom-canonicalizer.test.ts
+++ b/source/sbom/sbom-canonicalizer.test.ts
@@ -140,6 +140,23 @@ suite('sbom-canonicalizer', function () {
             assert.strictEqual(result.isExecutable, true);
         });
 
+        test('canonicalizes SBOM entries under the npm tarball package prefix', function () {
+            const previous = createFileDescription(
+                'package/sbom.cdx.json',
+                buildSbomFixtureContent({ packtoryVersion: '1.2.3' })
+            );
+            const current = createFileDescription(
+                'package/sbom.cdx.json',
+                buildSbomFixtureContent({ packtoryVersion: '9.9.9' })
+            );
+            const [result] = canonicalizeSbomInFileSet([current]);
+            const [previousResult] = canonicalizeSbomInFileSet([previous]);
+            assert.ok(result);
+            assert.ok(previousResult);
+            assert.strictEqual(result.filePath, 'package/sbom.cdx.json');
+            assert.strictEqual(result.content, previousResult.content);
+        });
+
         test('does not modify entries whose path is not sbom.cdx.json', function () {
             const other = createFileDescription('package.json', buildSbomFixtureContent());
             const [result] = canonicalizeSbomInFileSet([other]);

--- a/source/sbom/sbom-canonicalizer.ts
+++ b/source/sbom/sbom-canonicalizer.ts
@@ -1,8 +1,8 @@
 import { isArray, isPlainObject } from 'remeda';
+import { bundleRelativePath, sbomArtifactFilePath } from '../common/package-layout.ts';
 import { serializeStableJson } from '../common/stable-json.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
 
-const sbomFilePath = 'sbom.cdx.json';
 const packtoryToolName = 'packtory';
 
 function pluckObjectField(value: unknown, key: string): unknown {
@@ -43,7 +43,7 @@ function canonicalizeSbomContent(content: string): string {
 
 export function canonicalizeSbomInFileSet(files: readonly FileDescription[]): readonly FileDescription[] {
     return files.map((file) => {
-        if (file.filePath !== sbomFilePath) {
+        if (bundleRelativePath(file.filePath) !== sbomArtifactFilePath) {
             return file;
         }
         return { ...file, content: canonicalizeSbomContent(file.content) };

--- a/source/sbom/sbom-file.ts
+++ b/source/sbom/sbom-file.ts
@@ -1,4 +1,5 @@
 import * as cdx from '@cyclonedx/cyclonedx-library';
+import { sbomArtifactFilePath } from '../common/package-layout.ts';
 import type { PublishSettings } from '../config/publish-settings.ts';
 import { createFileDescription, type FileDescription } from '../file-manager/file-description.ts';
 import type { SbomPackage, SbomSiblingPackage } from '../published-package/published-package.ts';
@@ -29,10 +30,6 @@ type DependencyEntry = {
     readonly specifier: string;
     readonly scope: cdx.Enums.ComponentScope;
 };
-
-export function sbomFilePath(): string {
-    return 'sbom.cdx.json';
-}
 
 function isSbomEnabled(publishSettings: PublishSettings): boolean {
     return publishSettings.sbom?.enabled ?? true;
@@ -84,7 +81,7 @@ export function createSbomFileBuilder(dependencies: SbomFileBuilderDependencies)
             rootComponent: { name: bundle.packageJson.name, version: bundle.packageJson.version },
             dependencies: sbomDependencies
         });
-        return createFileDescription(sbomFilePath(), sbomSerializer.serialize(bom));
+        return createFileDescription(sbomArtifactFilePath, sbomSerializer.serialize(bom));
     }
 
     return {


### PR DESCRIPTION
Release comparisons already normalize generated SBOM content, but tarball artifacts carry the `package/` prefix and bypassed that path. This moves SBOM and manifest path detection through the shared bundle-relative path logic so generated `package/sbom.cdx.json` files are canonicalized before publish and release-plan comparisons.