### PR TITLE
Add `provideVersion` manual version provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,22 @@ Packtory supports two versioning modes:
     - If no version is available in the registry, an initial version will be built and published with version `0.0.1` (default but can be changed in the configuration).
 
 2. **Manual Versioning:**
-    - Provide the exact version number in the configuration.
+    - Provide the exact version number in the configuration with `{ automatic: false, version: '1.2.3' }`.
+    - Or provide an async callback with `{ automatic: false, provideVersion }`.
+    - `provideVersion(input)` runs after Packtory has calculated the package attribution files. The input contains `packageName`, `currentVersion`, `targetSourceFiles`, `ignoredAttributionPaths`, `registrySettings`, and `stage`.
+    - The returned version is validated like a static manual version. Returning `currentVersion` keeps the package on the current registry version when no release is needed.
+
+```javascript
+versioning: {
+    automatic: false,
+    async provideVersion({ currentVersion, targetSourceFiles }) {
+        const touchedRuntimeSource = targetSourceFiles.some((filePath) => {
+            return filePath.startsWith('src/');
+        });
+        return touchedRuntimeSource ? '1.2.4' : (currentVersion ?? '1.2.3');
+    }
+}
+```
 
 ### Pack (on-disk artifacts)
 

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -237,7 +237,7 @@ suite('emitter', function () {
         assert.deepStrictEqual(result, Maybe.just('the-version'));
     });
 
-    test('determineCurrentVersion() doesn’t fetches the latest version when manual versioning is enabled', async function () {
+    test('determineCurrentVersion() doesn’t fetch the latest version when static manual versioning is enabled', async function () {
         const fetchLatestVersion = fake.resolves(Maybe.nothing());
         const emitter = emitterFactory({ fetchLatestVersion });
 
@@ -249,7 +249,7 @@ suite('emitter', function () {
         assert.strictEqual(fetchLatestVersion.callCount, 0);
     });
 
-    test('determineCurrentVersion() returns the given version when manual versioning is enabled', async function () {
+    test('determineCurrentVersion() returns the given version when static manual versioning is enabled', async function () {
         const emitter = emitterFactory({});
 
         const result = await determineCurrentVersion(emitter, {
@@ -258,6 +258,19 @@ suite('emitter', function () {
         });
 
         assert.deepStrictEqual(result, Maybe.just('manual-version'));
+    });
+
+    test('determineCurrentVersion() fetches the latest version when provider manual versioning is enabled', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3' }));
+        const emitter = emitterFactory({ fetchLatestVersion });
+
+        const result = await determineCurrentVersion(emitter, {
+            stage: false,
+            versioning: { automatic: false, provideVersion: () => '9.9.9' }
+        });
+
+        assert.deepStrictEqual(result, Maybe.just('1.2.3'));
+        assert.deepStrictEqual(fetchLatestVersion.firstCall.args, ['the-name', registrySettings]);
     });
 
     test('determineCurrentVersion() selects the highest staged version in stage mode', async function () {
@@ -291,6 +304,20 @@ suite('emitter', function () {
 
         assert.deepStrictEqual(result, Maybe.just('9.9.9'));
         assert.strictEqual(fetchStagedVersions.callCount, 0);
+    });
+
+    test('determineCurrentVersion() selects the highest staged version for provider manual versioning in stage mode', async function () {
+        const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3' }));
+        const fetchStagedVersions = fake.resolves(['1.2.5', '1.2.4']);
+        const emitter = emitterFactory({ fetchLatestVersion, fetchStagedVersions });
+
+        const result = await determineCurrentVersion(emitter, {
+            stage: true,
+            versioning: { automatic: false, provideVersion: () => '9.9.9' }
+        });
+
+        assert.deepStrictEqual(result, Maybe.just('1.2.5'));
+        assert.deepStrictEqual(fetchStagedVersions.firstCall.args, ['the-name', registrySettings]);
     });
 
     test('determineCurrentVersion() rejects an invalid staged version returned by the registry', async function () {

--- a/source/bundle-emitter/emitter.ts
+++ b/source/bundle-emitter/emitter.ts
@@ -30,7 +30,10 @@ type ExtraFiles = readonly FileDescription[];
 type PublicationOutcome = Awaited<ReturnType<RegistryClient['publishPackage']>>;
 type PublishSettings = Fourth<RegistryClientPublishArguments>;
 type RegistrySettings = Second<Parameters<RegistryClient['fetchLatestVersion']>>;
-type VersioningSettings = { readonly automatic: false; readonly version: string } | { readonly automatic: true };
+type VersioningSettings =
+    | { readonly automatic: false; readonly provideVersion: unknown }
+    | { readonly automatic: false; readonly version: string }
+    | { readonly automatic: true };
 type PreviousReleaseArtifacts = Awaited<ReturnType<typeof fetchPublishedArtifacts>>;
 
 export type BundleEmitterDependencies = {
@@ -102,6 +105,12 @@ function highestVersion(firstVersion: string, laterVersions: readonly string[]):
     return highest;
 }
 
+function hasVersionProvider(
+    versioning: VersioningSettings
+): versioning is Extract<VersioningSettings, { readonly provideVersion: unknown }> {
+    return 'provideVersion' in versioning;
+}
+
 export function createBundleEmitter(dependencies: BundleEmitterDependencies): BundleEmitter {
     const { artifactsBuilder, registryClient, ciRepositoryUrl, readCurrentGitHead } = dependencies;
 
@@ -119,7 +128,7 @@ export function createBundleEmitter(dependencies: BundleEmitterDependencies): Bu
             throw new Error(stageFirstPublishUnsupportedMessage);
         }
 
-        if (!versioning.automatic) {
+        if (!versioning.automatic && !hasVersionProvider(versioning)) {
             return Maybe.just(versioning.version);
         }
 
@@ -135,7 +144,7 @@ export function createBundleEmitter(dependencies: BundleEmitterDependencies): Bu
                 return determineCurrentVersionForStageMode(name, registrySettings, versioning);
             }
 
-            if (versioning.automatic) {
+            if (versioning.automatic || hasVersionProvider(versioning)) {
                 const latestVersion = await registryClient.fetchLatestVersion(name, registrySettings);
                 return latestVersion.map((version) => {
                     return version.version;

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -249,6 +249,40 @@ suite('changelog-destinations', function () {
         );
     });
 
+    test('writeConfiguredChangelogs reports package-file outputs without sourcesFolder', async function () {
+        const fileManager = createFakeFileManager();
+
+        await assert.rejects(
+            writeConfiguredChangelogs(
+                { ...deps, fileManager },
+                createChangelogConfig({
+                    changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+                    commonPackageSettings: undefined,
+                    packages: [{ name: 'pkg-a' }]
+                }),
+                { updateChangelog: fake.returns('updated') },
+                createGeneratedChangelog({ packageMarkdownByName: new Map([['pkg-a', 'markdown']]) })
+            ),
+            /Config for package "pkg-a" is missing the sources folder/u
+        );
+    });
+
+    test('writeConfiguredChangelogs uses common sourcesFolder for package-file outputs', async function () {
+        const fileManager = createFakeFileManager();
+
+        const writtenPaths = await writeConfiguredChangelogs(
+            { ...deps, fileManager },
+            createChangelogConfig({
+                changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+                packages: [{ name: 'pkg-a' }]
+            }),
+            { updateChangelog: fake.returns('updated') },
+            createGeneratedChangelog({ packageMarkdownByName: new Map([['pkg-a', 'markdown']]) })
+        );
+
+        assert.deepStrictEqual(writtenPaths, ['/repo/src/CHANGELOG.md']);
+    });
+
     test('writeConfiguredChangelogs writes explicit package-file changelog outputs', async function () {
         const fileManager = createFakeFileManager();
 

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -4,6 +4,7 @@ import { safeParse } from '@schema-hub/zod-error-formatter';
 import type { ChangelogOutput } from '../../config/changelog-settings.ts';
 import { packtoryConfigSchema } from '../../config/packtory-config-schema.ts';
 import type { FileManager } from '../../file-manager/file-manager.ts';
+import * as generatedAttributionPaths from '../../packtory/generated-attribution-paths.ts';
 import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 
 type PackagePathConfig = {
@@ -35,7 +36,6 @@ type FileChangelogDestination = {
     readonly generatedMarkdown: string;
 };
 
-type FileChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' | 'repository-file' }>;
 type PackageChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' }>;
 type PackageChangelogOutputWithSharedPath = PackageChangelogOutput & { readonly path: string };
 type PackageChangelogOutputWithExplicitPaths = PackageChangelogOutput & {
@@ -115,57 +115,11 @@ function hasSharedPackagePath(output: PackageChangelogOutput): output is Package
     return 'path' in output;
 }
 
-function hasExplicitPackagePaths(output: PackageChangelogOutput): output is PackageChangelogOutputWithExplicitPaths {
-    return 'paths' in output;
-}
-
-function resolveRepositoryRelativePath(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
-    filePath: string
-): string | undefined {
-    const relativePath = path.relative(deps.workingDirectory, filePath);
-    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
-        return undefined;
-    }
-    return relativePath.split(path.sep).join('/');
-}
-
 export function collectGeneratedAttributionPaths(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     config: ChangelogConfig
 ): readonly string[] {
-    if (config.changelog === undefined) {
-        return [];
-    }
-    if (config.changelog.outputs === undefined) {
-        return [];
-    }
-
-    const paths = config.changelog.outputs
-        .filter((output): output is FileChangelogOutput => {
-            return output.kind !== 'github-release';
-        })
-        .flatMap((output) => {
-            if (output.kind === 'repository-file') {
-                return [resolveRepositoryPath(deps, output.path)];
-            }
-            if (hasExplicitPackagePaths(output)) {
-                return Object.values(output.paths).map((outputPath) => {
-                    return resolveRepositoryPath(deps, outputPath);
-                });
-            }
-            return config.packages.map((packageConfig) => {
-                return resolvePackageFilePath(deps, config, packageConfig, output.path);
-            });
-        });
-    return Array.from(
-        new Set(
-            paths.flatMap((filePath) => {
-                const relativePath = resolveRepositoryRelativePath(deps, filePath);
-                return relativePath === undefined ? [] : [relativePath];
-            })
-        )
-    );
+    return generatedAttributionPaths.collectGeneratedAttributionPaths(deps.workingDirectory, config);
 }
 
 export function shouldPageGroupedChangelog(outputs: readonly ChangelogOutput[] | undefined): boolean {

--- a/source/config/manual-versioning-settings.test.ts
+++ b/source/config/manual-versioning-settings.test.ts
@@ -4,10 +4,19 @@ import { suite, test } from 'mocha';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { manualVersioningSettingsSchema } from './manual-versioning-settings.ts';
 
+const provideVersion = () => '1.0.0';
+
 suite('manual-versioning-settings', function () {
     test('manual versioning schema accepts automatic false', function () {
         assert.strictEqual(
             safeParse(manualVersioningSettingsSchema, { automatic: false, version: '1.0.0' }).success,
+            true
+        );
+    });
+
+    test('manual versioning schema accepts provider versioning', function () {
+        assert.strictEqual(
+            safeParse(manualVersioningSettingsSchema, { automatic: false, provideVersion }).success,
             true
         );
     });
@@ -29,11 +38,47 @@ suite('manual-versioning-settings', function () {
     );
 
     test(
+        'manual versioning: validation succeeds with provider versioning',
+        checkValidationSuccess({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false, provideVersion },
+            expectedData: { automatic: false, provideVersion }
+        })
+    );
+
+    test(
+        'manual versioning: validation fails when provideVersion is not a function',
+        checkValidationFailure({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false, provideVersion: '1.0.0' },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'manual versioning: validation fails when neither version nor provideVersion is given',
+        checkValidationFailure({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'manual versioning: validation fails when both version and provideVersion are given',
+        checkValidationFailure({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false, version: '1.0.0', provideVersion },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
         'manual versioning: validation fails with automatic true',
         checkValidationFailure({
             schema: manualVersioningSettingsSchema,
             data: { automatic: true, version: '1.0.0' },
-            expectedMessages: ['at automatic: invalid literal: expected false, but got boolean']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -42,7 +87,7 @@ suite('manual-versioning-settings', function () {
         checkValidationFailure({
             schema: manualVersioningSettingsSchema,
             data: { automatic: false, minimumVersion: '1.0.0' },
-            expectedMessages: ['at version: missing property', 'unexpected additional property: "minimumVersion"']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 });

--- a/source/config/manual-versioning-settings.ts
+++ b/source/config/manual-versioning-settings.ts
@@ -1,9 +1,54 @@
 import { z } from 'zod/mini';
+import type { RegistrySettings } from './registry-settings.ts';
 import { nonEmptyStringSchema } from './base-validations.ts';
 
-export const manualVersioningSettingsSchema = z.readonly(
+export type VersionProviderInput = {
+    readonly packageName: string;
+    readonly currentVersion: string | undefined;
+    readonly targetSourceFiles: readonly string[];
+    readonly ignoredAttributionPaths: readonly string[];
+    readonly registrySettings: RegistrySettings;
+    readonly stage: boolean;
+};
+
+type VersionProvider = (input: VersionProviderInput) => Promise<string> | string;
+
+type StaticManualVersioningSettings = {
+    readonly automatic: false;
+    readonly version: string;
+};
+
+type ProviderManualVersioningSettings = {
+    readonly automatic: false;
+    readonly provideVersion: VersionProvider;
+};
+
+const staticManualVersioningSettingsSchema = z.readonly(
     z.strictObject({
         automatic: z.literal(false),
         version: nonEmptyStringSchema
     })
 );
+
+const providerManualVersioningSettingsSchema = z.readonly(
+    z.strictObject({
+        automatic: z.literal(false),
+        provideVersion: z.custom<VersionProvider>((value) => {
+            return typeof value === 'function';
+        })
+    })
+);
+
+export const manualVersioningSettingsSchema = z.readonly(
+    z.union([staticManualVersioningSettingsSchema, providerManualVersioningSettingsSchema])
+);
+
+export type ManualVersioningSettings = ProviderManualVersioningSettings | StaticManualVersioningSettings;
+
+export function validateManualVersion(version: unknown): string {
+    const result = z.safeParse(nonEmptyStringSchema, version);
+    if (!result.success) {
+        throw new Error('Manual version provider must return a non-empty string');
+    }
+    return result.data;
+}

--- a/source/config/per-package-settings-schema.test.ts
+++ b/source/config/per-package-settings-schema.test.ts
@@ -40,12 +40,57 @@ suite('per-package-settings-schema', function () {
         expectedFieldType: 'record'
     });
 
-    createTestCasesForOptionalField({
-        schema: perPackageSettingsSchema,
-        data: validPerPackageSettings,
-        path: 'versioning',
-        expectedFieldType: 'object'
-    });
+    test(
+        'per package settings schema: validation succeeds when versioning is missing',
+        checkValidationSuccess({
+            schema: perPackageSettingsSchema,
+            data: {
+                name: validPerPackageSettings.name,
+                roots: validPerPackageSettings.roots,
+                bundleDependencies: validPerPackageSettings.bundleDependencies,
+                bundlePeerDependencies: validPerPackageSettings.bundlePeerDependencies
+            },
+            expectedData: {
+                name: validPerPackageSettings.name,
+                roots: validPerPackageSettings.roots,
+                bundleDependencies: validPerPackageSettings.bundleDependencies,
+                bundlePeerDependencies: validPerPackageSettings.bundlePeerDependencies
+            }
+        })
+    );
+
+    test(
+        'per package settings schema: validation succeeds when versioning is undefined',
+        checkValidationSuccess({
+            schema: perPackageSettingsSchema,
+            data: {
+                ...validPerPackageSettings,
+                versioning: undefined
+            },
+            expectedData: {
+                ...validPerPackageSettings,
+                versioning: undefined
+            }
+        })
+    );
+
+    test(
+        'per package settings schema: validation fails when versioning is null',
+        checkValidationFailure({
+            schema: perPackageSettingsSchema,
+            data: { ...validPerPackageSettings, versioning: null },
+            expectedMessages: ['at versioning: invalid value: expected object, but got null']
+        })
+    );
+
+    test(
+        'per package settings schema: validation fails when versioning is not an object',
+        checkValidationFailure({
+            schema: perPackageSettingsSchema,
+            data: { ...validPerPackageSettings, versioning: 42 },
+            expectedMessages: ['at versioning: invalid value: expected object, but got number']
+        })
+    );
 
     createTestCasesForOptionalField({
         schema: perPackageSettingsSchema,

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -34,25 +34,34 @@ suite('schema-contracts', function () {
         });
     }).timeout(probeTestTimeoutMs);
 
-    test('versioning schema keeps the discriminant and both branches', async function () {
+    test('versioning schema keeps the automatic, static manual, and provider manual branches', async function () {
         const result = await runNodeProbe(`
             import { safeParse } from '@schema-hub/zod-error-formatter';
             import { versioningSettingsSchema } from './source/config/versioning-settings.ts';
 
             const unionDef = versioningSettingsSchema._zod.def.innerType.def;
+            function optionKeys(option) {
+                const optionDef = option.def.innerType.def;
+                if (optionDef.type === 'union') {
+                    return optionDef.options.map((nestedOption) => Object.keys(nestedOption.def.innerType.def.shape));
+                }
+                return Object.keys(optionDef.shape);
+            }
 
             console.log(JSON.stringify({
-                discriminator: unionDef.discriminator,
                 optionCount: unionDef.options.length,
-                branchKeys: unionDef.options.map((option) => Object.keys(option.def.innerType.def.shape)),
-                branchLiterals: unionDef.options.map((option) => {
-                    return option.def.innerType.def.shape.automatic.def.values[0];
-                }),
+                branchKeys: unionDef.options.map(optionKeys),
                 automaticSuccess: safeParse(versioningSettingsSchema, {
                     automatic: true,
                     minimumVersion: '1.0.0'
                 }).success,
                 manualSuccess: safeParse(versioningSettingsSchema, { automatic: false, version: '1.0.0' }).success,
+                providerSuccess: safeParse(versioningSettingsSchema, {
+                    automatic: false,
+                    provideVersion() {
+                        return '1.0.0';
+                    }
+                }).success,
                 invalidAutomaticBranchSuccess: safeParse(versioningSettingsSchema, {
                     automatic: true,
                     version: '1.0.0'
@@ -65,15 +74,17 @@ suite('schema-contracts', function () {
         `);
 
         assert.deepStrictEqual(result, {
-            discriminator: 'automatic',
             optionCount: 2,
             branchKeys: [
                 ['automatic', 'minimumVersion'],
-                ['automatic', 'version']
+                [
+                    ['automatic', 'version'],
+                    ['automatic', 'provideVersion']
+                ]
             ],
-            branchLiterals: [true, false],
             automaticSuccess: true,
             manualSuccess: true,
+            providerSuccess: true,
             invalidAutomaticBranchSuccess: false,
             invalidManualBranchSuccess: false
         });

--- a/source/config/versioning-settings.test.ts
+++ b/source/config/versioning-settings.test.ts
@@ -16,6 +16,13 @@ suite('versioning-settings', function () {
         assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: false, version: '1' }).success, true);
     });
 
+    test('schema accepts the provider manual versioning branch', function () {
+        assert.strictEqual(
+            safeParse(versioningSettingsSchema, { automatic: false, provideVersion: () => '1' }).success,
+            true
+        );
+    });
+
     test('schema rejects mixing automatic with manual-only fields', function () {
         assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, version: '1' }).success, false);
     });
@@ -47,12 +54,22 @@ suite('versioning-settings', function () {
         })
     );
 
+    test('validation succeeds when valid provider manual versioning settings are given', function () {
+        const provideVersion = () => '1';
+        const result = safeParse(versioningSettingsSchema, { automatic: false, provideVersion });
+
+        if (!result.success) {
+            assert.fail(`Validation failed with: ${result.error.message}`);
+        }
+        assert.deepStrictEqual(result.data, { automatic: false, provideVersion });
+    });
+
     test(
         'validation fails when a non-object is given',
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: 'foo',
-            expectedMessages: ['expected object, but got string']
+            expectedMessages: ['invalid value: expected object, but got string']
         })
     );
 
@@ -61,7 +78,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: {},
-            expectedMessages: ['at automatic: missing property']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -70,7 +87,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: 'yes' },
-            expectedMessages: ['at automatic: invalid value doesn’t match expected union']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -79,7 +96,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: undefined },
-            expectedMessages: ['at automatic: invalid value doesn’t match expected union']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -88,7 +105,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: null },
-            expectedMessages: ['at automatic: invalid value doesn’t match expected union']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -97,7 +114,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: true, version: '1' },
-            expectedMessages: ['unexpected additional property: "version"']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -115,7 +132,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: true, minimumVersion: '1', foo: 'bar' },
-            expectedMessages: ['unexpected additional property: "foo"']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -124,7 +141,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: true, minimumVersion: 42 },
-            expectedMessages: ['at minimumVersion: expected string, but got number']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -133,7 +150,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: true, minimumVersion: null },
-            expectedMessages: ['at minimumVersion: expected string, but got null']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -151,7 +168,16 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: false, version: '1', minimumVersion: '2' },
-            expectedMessages: ['unexpected additional property: "minimumVersion"']
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and both manual version sources are given',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, version: '1', provideVersion: () => '2' },
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -160,7 +186,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: false, version: '1', foo: 'bar' },
-            expectedMessages: ['unexpected additional property: "foo"']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -169,7 +195,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: false, version: 42 },
-            expectedMessages: ['at version: expected string, but got number']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -178,7 +204,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: false, version: undefined },
-            expectedMessages: ['at version: expected string, but got undefined']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 
@@ -187,7 +213,7 @@ suite('versioning-settings', function () {
         checkValidationFailure({
             schema: versioningSettingsSchema,
             data: { automatic: false, version: null },
-            expectedMessages: ['at version: expected string, but got null']
+            expectedMessages: ['invalid value doesn’t match expected union']
         })
     );
 

--- a/source/config/versioning-settings.ts
+++ b/source/config/versioning-settings.ts
@@ -1,9 +1,17 @@
 import { z } from 'zod/mini';
 import { automaticVersioningSettingsSchema } from './automatic-versioning-settings.ts';
-import { manualVersioningSettingsSchema } from './manual-versioning-settings.ts';
+import { manualVersioningSettingsSchema, type ManualVersioningSettings } from './manual-versioning-settings.ts';
 
 export const versioningSettingsSchema = z.readonly(
-    z.discriminatedUnion('automatic', [automaticVersioningSettingsSchema, manualVersioningSettingsSchema])
+    z.union([automaticVersioningSettingsSchema, manualVersioningSettingsSchema])
 );
 
-export type VersioningSettings = z.infer<typeof versioningSettingsSchema>;
+type AutomaticVersioningSettings = z.infer<typeof automaticVersioningSettingsSchema>;
+
+export type VersioningSettings = AutomaticVersioningSettings | ManualVersioningSettings;
+
+export function hasVersionProvider(
+    versioning: VersioningSettings
+): versioning is Extract<VersioningSettings, { readonly provideVersion: unknown }> {
+    return 'provideVersion' in versioning;
+}

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -200,7 +200,9 @@ export function buildPackageProcessorComposition(
         linker: createBundleLinker(),
         resourceResolver: parts.resourceResolver,
         sbomFileBuilder: parts.sbomFileBuilder,
-        deadCodeEliminator: parts.deadCodeEliminator
+        deadCodeEliminator: parts.deadCodeEliminator,
+        fileManager: parts.fileManager,
+        repositoryFolder: parts.repositoryFolder
     });
     const packageProcessor = withStageTimings(basePackageProcessor, parts.progressBroadcaster.provider);
     const packEmitter = createPackEmitter({

--- a/source/packages/packtory/packtory.entry-point.ts
+++ b/source/packages/packtory/packtory.entry-point.ts
@@ -1,4 +1,5 @@
 import type { PacktoryConfig as PublicPacktoryConfig } from '../../config/config.ts';
+import type { VersionProviderInput as PublicVersionProviderInput } from '../../config/manual-versioning-settings.ts';
 import type {
     BuildAndPublishAllOptions as PublicBuildAndPublishAllOptions,
     BuildReport as PublicBuildReport,
@@ -44,6 +45,7 @@ export const {
 export const progressBroadcastConsumer: PublicProgressBroadcastConsumer = progressBroadcaster.consumer;
 
 export type PacktoryConfig = PublicPacktoryConfig;
+export type VersionProviderInput = PublicVersionProviderInput;
 export type BuildAndPublishAllOptions = PublicBuildAndPublishAllOptions;
 export type BuildReport = PublicBuildReport;
 export type PackageReleaseAnalysis = PublicPackageReleaseAnalysis;

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -19,7 +19,8 @@ import type {
     ResolveAndLinkAllOutcome,
     ResolveAndLinkAllResult,
     ResolveAndLinkFailure,
-    ResolvedPackage
+    ResolvedPackage,
+    VersionProviderInput
 } from './packtory.entry-point.ts';
 
 type ProgressEventName =
@@ -168,6 +169,24 @@ describe('PacktoryConfig — accepted shapes', () => {
             ];
         }>();
     });
+
+    test('accepts provider manual versioning', () => {
+        expect<PacktoryConfig>().type.toBeAssignableFrom<{
+            readonly registrySettings: {
+                readonly auth: { readonly type: 'bearer-token'; readonly token: 'any-token' };
+            };
+            readonly packages: readonly [
+                {
+                    readonly name: 'pkg';
+                    readonly roots: { readonly main: { readonly js: 'index.js' } };
+                    readonly versioning: {
+                        readonly automatic: false;
+                        readonly provideVersion: (input: VersionProviderInput) => Promise<string>;
+                    };
+                }
+            ];
+        }>();
+    });
 });
 
 describe('PacktoryConfig — rejected shapes', () => {
@@ -265,6 +284,17 @@ describe('PacktoryConfig — exposed structure', () => {
         type PackageChecks = NonNullable<PackageConfig['checks']>;
         type AreTheTypesWrong = NonNullable<PackageChecks['areTheTypesWrong']>;
         expect<AreTheTypesWrong['profile']>().type.toBe<'esm-only' | 'node16' | 'strict' | undefined>();
+    });
+});
+
+describe('VersionProviderInput', () => {
+    test('exposes package attribution inputs', () => {
+        expect<VersionProviderInput['packageName']>().type.toBe<string>();
+        expect<VersionProviderInput['currentVersion']>().type.toBe<string | undefined>();
+        expect<VersionProviderInput['targetSourceFiles']>().type.toBe<readonly string[]>();
+        expect<VersionProviderInput['ignoredAttributionPaths']>().type.toBe<readonly string[]>();
+        expect<VersionProviderInput['registrySettings']>().type.toBe<NonNullable<PacktoryConfig['registrySettings']>>();
+        expect<VersionProviderInput['stage']>().type.toBe<boolean>();
     });
 });
 

--- a/source/packtory/generated-attribution-paths.ts
+++ b/source/packtory/generated-attribution-paths.ts
@@ -1,0 +1,99 @@
+import path from 'node:path';
+import type { ChangelogOutput } from '../config/changelog-settings.ts';
+
+type PackagePathConfig = {
+    readonly name: string;
+    readonly sourcesFolder?: string | undefined;
+};
+
+type ChangelogSettingsConfig = {
+    readonly outputs?: readonly ChangelogOutput[] | undefined;
+};
+
+export type GeneratedAttributionPathConfig = {
+    readonly changelog?: ChangelogSettingsConfig | undefined;
+    readonly commonPackageSettings?: { readonly sourcesFolder?: string | undefined } | undefined;
+    readonly packages: readonly PackagePathConfig[];
+};
+
+type FileChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' | 'repository-file' }>;
+type PackageChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' }>;
+type PackageChangelogOutputWithExplicitPaths = PackageChangelogOutput & {
+    readonly paths: Readonly<Record<string, string>>;
+};
+
+function normalizeConfiguredPath(filePath: string): string {
+    return filePath.split(/[/\\]/u).join(path.sep);
+}
+
+function resolveRepositoryPath(repositoryFolder: string, filePath: string): string {
+    return path.resolve(repositoryFolder, normalizeConfiguredPath(filePath));
+}
+
+function resolvePackageSourcesFolder(packageConfig: PackagePathConfig, config: GeneratedAttributionPathConfig): string {
+    const sourcesFolder = packageConfig.sourcesFolder ?? config.commonPackageSettings?.sourcesFolder;
+    if (sourcesFolder === undefined) {
+        throw new Error(`Config for package "${packageConfig.name}" is missing the sources folder`);
+    }
+    return sourcesFolder;
+}
+
+function resolvePackageFilePath(
+    repositoryFolder: string,
+    config: GeneratedAttributionPathConfig,
+    packageConfig: PackagePathConfig,
+    outputPath: string
+): string {
+    return path.resolve(
+        repositoryFolder,
+        normalizeConfiguredPath(resolvePackageSourcesFolder(packageConfig, config)),
+        normalizeConfiguredPath(outputPath)
+    );
+}
+
+function hasExplicitPackagePaths(output: PackageChangelogOutput): output is PackageChangelogOutputWithExplicitPaths {
+    return 'paths' in output;
+}
+
+function resolveRepositoryRelativePath(repositoryFolder: string, filePath: string): string | undefined {
+    const relativePath = path.relative(repositoryFolder, filePath);
+    if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+        return undefined;
+    }
+    return relativePath.split(path.sep).join('/');
+}
+
+export function collectGeneratedAttributionPaths(
+    repositoryFolder: string,
+    config: GeneratedAttributionPathConfig
+): readonly string[] {
+    if (config.changelog?.outputs === undefined) {
+        return [];
+    }
+
+    const paths = config.changelog.outputs
+        .filter((output): output is FileChangelogOutput => {
+            return output.kind !== 'github-release';
+        })
+        .flatMap((output) => {
+            if (output.kind === 'repository-file') {
+                return [resolveRepositoryPath(repositoryFolder, output.path)];
+            }
+            if (hasExplicitPackagePaths(output)) {
+                return Object.values(output.paths).map((outputPath) => {
+                    return resolveRepositoryPath(repositoryFolder, outputPath);
+                });
+            }
+            return config.packages.map((packageConfig) => {
+                return resolvePackageFilePath(repositoryFolder, config, packageConfig, output.path);
+            });
+        });
+    return Array.from(
+        new Set(
+            paths.flatMap((filePath) => {
+                const relativePath = resolveRepositoryRelativePath(repositoryFolder, filePath);
+                return relativePath === undefined ? [] : [relativePath];
+            })
+        )
+    );
+}

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -47,12 +47,9 @@ function runMapConfig(
             : { commonPackageSettings: options.commonPackageSettings }),
         packages: [packageWithFallback, ...additionalPackages]
     } as unknown as PacktoryConfigInput;
-    return configToBuildAndPublishOptions(
-        packageName,
-        { [packageName]: packageWithFallback },
-        baseConfig,
-        options.bundleDependencies ?? []
-    );
+    return configToBuildAndPublishOptions(packageName, { [packageName]: packageWithFallback }, baseConfig, {
+        existingBundles: options.bundleDependencies ?? []
+    });
 }
 
 function runMapConfigExpectingError(
@@ -85,7 +82,7 @@ suite('map-config', function () {
                         }
                     ]
                 },
-                []
+                { existingBundles: [] }
             );
             assert.fail('Expected configToBuildAndPublishOptions() should fail but it did not');
         } catch (error: unknown) {
@@ -526,9 +523,53 @@ suite('map-config', function () {
         } as unknown as PackageConfigInput;
         const config = { packages: [packageConfig] } as unknown as PacktoryConfigInput;
 
-        const result = configToBuildAndPublishOptions('foo', { foo: packageConfig }, config, []);
+        const result = configToBuildAndPublishOptions('foo', { foo: packageConfig }, config, {
+            existingBundles: []
+        });
 
         assert.deepStrictEqual(result.registrySettings, {});
+    });
+
+    test('collects generated changelog outputs as ignored attribution paths', function () {
+        const packageConfig = {
+            ...fooPackageConfigFactory.build({ sourcesFolder: 'packages/foo' }),
+            publishSettings: { access: 'public' }
+        } as unknown as PackageConfigInput;
+        const config = {
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            changelog: {
+                outputs: [
+                    { kind: 'repository-file', path: 'CHANGELOG.md' },
+                    { kind: 'package-file', path: 'docs/CHANGELOG.md' }
+                ]
+            },
+            packages: [packageConfig]
+        } as const;
+
+        const result = configToBuildAndPublishOptions('foo', { foo: packageConfig }, config, {
+            existingBundles: [],
+            repositoryFolder: '/repo'
+        });
+
+        assert.deepStrictEqual(result.ignoredAttributionPaths, ['CHANGELOG.md', 'packages/foo/docs/CHANGELOG.md']);
+    });
+
+    test('collects ignored attribution paths against the repository root by default', function () {
+        const packageConfig = {
+            ...fooPackageConfigFactory.build({ sourcesFolder: '/src/pkg-a' }),
+            publishSettings: { access: 'public' }
+        } as unknown as PackageConfigInput;
+        const config = {
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            changelog: { outputs: [{ kind: 'package-file', path: 'CHANGELOG.md' }] },
+            packages: [packageConfig]
+        } as const;
+
+        const result = configToBuildAndPublishOptions('foo', { foo: packageConfig }, config, {
+            existingBundles: []
+        });
+
+        assert.deepStrictEqual(result.ignoredAttributionPaths, ['src/pkg-a/CHANGELOG.md']);
     });
 
     test('throws a "missing publish settings" error when neither commonPackageSettings nor the package supplies one', function () {
@@ -540,7 +581,9 @@ suite('map-config', function () {
 
         assert.throws(
             () => {
-                configToBuildAndPublishOptions('foo', { foo: packageWithoutPublishSettings }, config, []);
+                configToBuildAndPublishOptions('foo', { foo: packageWithoutPublishSettings }, config, {
+                    existingBundles: []
+                });
             },
             { message: 'Config for package "foo" is missing publish settings' }
         );

--- a/source/packtory/map-config.ts
+++ b/source/packtory/map-config.ts
@@ -6,6 +6,7 @@ import {
     type SharedPackageOptions,
     type VersioningSettings
 } from './options/prepare-package-options.ts';
+import { collectGeneratedAttributionPaths } from './generated-attribution-paths.ts';
 import { resolvePublishSettings, type PublishSettings } from './options/setting-resolvers.ts';
 
 export type BuildOptions = SharedPackageOptions<PublishedPackageWithManifest> & {
@@ -16,21 +17,27 @@ export type BuildAndPublishOptions = SharedPackageOptions<PublishedPackageWithMa
     readonly registrySettings: NonNullable<PacktoryConfig['registrySettings']>;
     readonly publishSettings: PublishSettings;
     readonly versioning: VersioningSettings;
+    readonly ignoredAttributionPaths: readonly string[];
 };
 
 export type ResolveAndLinkOptions = SharedPackageOptions<BundleSubstitutionSource>;
+
+export type BuildAndPublishMappingContext = {
+    readonly existingBundles: readonly PublishedPackageWithManifest[];
+    readonly repositoryFolder?: string | undefined;
+};
 
 export function configToBuildAndPublishOptions(
     packageName: string,
     packageConfigs: PackageConfigsByName,
     packtoryConfig: PacktoryConfig,
-    existingBundles: readonly PublishedPackageWithManifest[]
+    context: BuildAndPublishMappingContext
 ): BuildAndPublishOptions {
     const { packageConfig, sharedOptions, versioning } = preparePackageOptions(
         packageName,
         packageConfigs,
         packtoryConfig,
-        existingBundles
+        context.existingBundles
     );
     const publishSettings = resolvePublishSettings(packageConfig, packtoryConfig);
 
@@ -38,7 +45,8 @@ export function configToBuildAndPublishOptions(
         ...sharedOptions,
         versioning,
         registrySettings: packtoryConfig.registrySettings ?? {},
-        publishSettings
+        publishSettings,
+        ignoredAttributionPaths: collectGeneratedAttributionPaths(context.repositoryFolder ?? '/', packtoryConfig)
     };
 }
 

--- a/source/packtory/options/version-provider-context.test.ts
+++ b/source/packtory/options/version-provider-context.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { BuildAndPublishOptions } from '../map-config.ts';
+import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
+import { createVersionProviderContext } from './version-provider-context.ts';
+
+suite('version-provider-context', function () {
+    test('does not calculate targetSourceFiles when versioning has no provider', async function () {
+        const context = await createVersionProviderContext(
+            {
+                fileManager: {
+                    async checkReadability() {
+                        throw new Error('file manager should not be used');
+                    },
+                    async readFile() {
+                        throw new Error('file manager should not be used');
+                    }
+                },
+                repositoryFolder: '/'
+            },
+            analyzedBundle({ contents: [analyzedBundleResource('/source/index.js')] }),
+            {
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: {},
+                versioning: { automatic: true }
+            } as unknown as BuildAndPublishOptions,
+            false
+        );
+
+        assert.deepStrictEqual(context, {
+            ignoredAttributionPaths: ['CHANGELOG.md'],
+            registrySettings: {},
+            stage: false,
+            targetSourceFiles: []
+        });
+    });
+});

--- a/source/packtory/options/version-provider-context.ts
+++ b/source/packtory/options/version-provider-context.ts
@@ -1,0 +1,24 @@
+import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
+import { hasVersionProvider } from '../../config/versioning-settings.ts';
+import {
+    attributeChangelogSourceFiles,
+    type ChangelogSourceAttributionDependencies
+} from '../changelog-source-attribution.ts';
+import type { BuildAndPublishOptions } from '../map-config.ts';
+import type { VersionProviderContext } from './version-trigger.ts';
+
+export async function createVersionProviderContext(
+    dependencies: ChangelogSourceAttributionDependencies,
+    analyzedBundle: AnalyzedBundle,
+    options: BuildAndPublishOptions,
+    stage: boolean
+): Promise<VersionProviderContext> {
+    return {
+        ignoredAttributionPaths: options.ignoredAttributionPaths,
+        registrySettings: options.registrySettings,
+        stage,
+        targetSourceFiles: hasVersionProvider(options.versioning)
+            ? await attributeChangelogSourceFiles(dependencies, analyzedBundle)
+            : []
+    };
+}

--- a/source/packtory/options/version-trigger.test.ts
+++ b/source/packtory/options/version-trigger.test.ts
@@ -1,8 +1,16 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { Maybe } from 'true-myth';
+import type { VersionProviderInput } from '../../config/manual-versioning-settings.ts';
 import type { BuildAndPublishOptions } from '../map-config.ts';
-import { determineBuildVersion, inferVersionTrigger, shouldIncreaseVersion } from './version-trigger.ts';
+import {
+    determineBuildVersion,
+    inferVersionTrigger,
+    shouldIncreaseVersion,
+    type VersionProviderContext
+} from './version-trigger.ts';
+
+type ManualVersionProvider = (input: VersionProviderInput) => Promise<string> | string;
 
 function automaticOptions(minimumVersion?: string): BuildAndPublishOptions {
     return { versioning: { automatic: true, minimumVersion } } as unknown as BuildAndPublishOptions;
@@ -12,21 +20,86 @@ function pinnedOptions(version: string): BuildAndPublishOptions {
     return { versioning: { automatic: false, version } } as unknown as BuildAndPublishOptions;
 }
 
+function providerOptions(provideVersion: ManualVersionProvider): BuildAndPublishOptions {
+    return {
+        name: 'pkg-a',
+        versioning: { automatic: false, provideVersion }
+    } as unknown as BuildAndPublishOptions;
+}
+
+function providerContext(): VersionProviderContext {
+    return {
+        ignoredAttributionPaths: ['CHANGELOG.md'],
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        stage: false,
+        targetSourceFiles: ['source/index.ts']
+    };
+}
+
 suite('version-trigger', function () {
-    test('determineBuildVersion returns the current version when the registry already has one', function () {
-        assert.strictEqual(determineBuildVersion(Maybe.just('1.0.0'), automaticOptions()), '1.0.0');
+    test('determineBuildVersion returns the current version when the registry already has one', async function () {
+        assert.strictEqual(
+            await determineBuildVersion(Maybe.just('1.0.0'), automaticOptions(), providerContext()),
+            '1.0.0'
+        );
     });
 
-    test('determineBuildVersion returns the pinned version when automatic is disabled and no current version exists', function () {
-        assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), pinnedOptions('2.0.0')), '2.0.0');
+    test('determineBuildVersion returns the pinned version when automatic is disabled and no current version exists', async function () {
+        assert.strictEqual(
+            await determineBuildVersion(Maybe.nothing<string>(), pinnedOptions('2.0.0'), providerContext()),
+            '2.0.0'
+        );
     });
 
-    test('determineBuildVersion returns the minimum version when automatic is enabled and no current version exists', function () {
-        assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), automaticOptions('0.1.0')), '0.1.0');
+    test('determineBuildVersion returns the minimum version when automatic is enabled and no current version exists', async function () {
+        assert.strictEqual(
+            await determineBuildVersion(Maybe.nothing<string>(), automaticOptions('0.1.0'), providerContext()),
+            '0.1.0'
+        );
     });
 
-    test('determineBuildVersion defaults to "0.0.0" when automatic and no minimum version is set', function () {
-        assert.strictEqual(determineBuildVersion(Maybe.nothing<string>(), automaticOptions()), '0.0.0');
+    test('determineBuildVersion defaults to "0.0.0" when automatic and no minimum version is set', async function () {
+        assert.strictEqual(
+            await determineBuildVersion(Maybe.nothing<string>(), automaticOptions(), providerContext()),
+            '0.0.0'
+        );
+    });
+
+    test('determineBuildVersion calls async manual providers with package attribution context', async function () {
+        const providerInput: unknown[] = [];
+        const version = await determineBuildVersion(
+            Maybe.just('1.0.0'),
+            providerOptions(async (input) => {
+                providerInput.push(input);
+                return '1.0.1';
+            }),
+            providerContext()
+        );
+
+        assert.strictEqual(version, '1.0.1');
+        assert.deepStrictEqual(providerInput, [
+            {
+                packageName: 'pkg-a',
+                currentVersion: '1.0.0',
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                stage: false,
+                targetSourceFiles: ['source/index.ts']
+            }
+        ]);
+    });
+
+    test('determineBuildVersion rejects empty provider versions', async function () {
+        await assert.rejects(
+            async () => {
+                await determineBuildVersion(
+                    Maybe.just('1.0.0'),
+                    providerOptions(() => ''),
+                    providerContext()
+                );
+            },
+            { message: 'Manual version provider must return a non-empty string' }
+        );
     });
 
     test('shouldIncreaseVersion returns false when automatic versioning is disabled', function () {

--- a/source/packtory/options/version-trigger.ts
+++ b/source/packtory/options/version-trigger.ts
@@ -1,8 +1,28 @@
 import type { Maybe } from 'true-myth';
 import type { BuildAndPublishOptions } from '../map-config.ts';
 import type { VersionTrigger } from '../../progress/progress-broadcaster.ts';
+import { hasVersionProvider } from '../../config/versioning-settings.ts';
+import { validateManualVersion, type VersionProviderInput } from '../../config/manual-versioning-settings.ts';
 
-export function determineBuildVersion(currentVersion: Maybe<string>, options: BuildAndPublishOptions): string {
+export type VersionProviderContext = Pick<
+    VersionProviderInput,
+    'ignoredAttributionPaths' | 'registrySettings' | 'stage' | 'targetSourceFiles'
+>;
+
+export async function determineBuildVersion(
+    currentVersion: Maybe<string>,
+    options: BuildAndPublishOptions,
+    context: VersionProviderContext
+): Promise<string> {
+    if (hasVersionProvider(options.versioning)) {
+        return validateManualVersion(
+            await options.versioning.provideVersion({
+                ...context,
+                packageName: options.name,
+                currentVersion: currentVersion.isJust ? currentVersion.value : undefined
+            })
+        );
+    }
     if (currentVersion.isJust) {
         return currentVersion.value;
     }

--- a/source/packtory/package-processor-publish.test.ts
+++ b/source/packtory/package-processor-publish.test.ts
@@ -12,7 +12,16 @@ function stubDependencies() {
         bundleEmitter: {} as BundleEmitter,
         progressBroadcaster: {} as ProgressBroadcastProvider,
         sbomFileBuilder: {} as SbomFileBuilder,
-        versionManager: {} as VersionManager
+        versionManager: {} as VersionManager,
+        fileManager: {
+            async checkReadability() {
+                return { isReadable: true };
+            },
+            async readFile() {
+                return '';
+            }
+        },
+        repositoryFolder: '/'
     };
 }
 

--- a/source/packtory/package-processor-publish.ts
+++ b/source/packtory/package-processor-publish.ts
@@ -1,29 +1,35 @@
 import { isDefined, pickBy } from 'remeda';
 import { noPublication } from '../bundle-emitter/publication-outcome.ts';
-import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { BundleEmitter } from '../bundle-emitter/emitter.ts';
 import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
 import type { SbomFileBuilder } from '../sbom/sbom-file.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
 import type { BuildAndPublishOptions } from './map-config.ts';
+import { createVersionProviderContext } from './options/version-provider-context.ts';
 import { determineBuildVersion, inferVersionTrigger, shouldIncreaseVersion } from './options/version-trigger.ts';
 import { publishedReleaseStatus, type PublishedReleaseStatus, wasAlreadyPublished } from './published-release-state.ts';
 
-type VersionedBundleWithManifest = Awaited<ReturnType<VersionManager['addVersion']>>;
-type CurrentVersion = Awaited<ReturnType<BundleEmitter['determineCurrentVersion']>>;
-type PublicationOutcome = Awaited<ReturnType<BundleEmitter['publish']>>;
-type PreviousReleaseArtifacts = Awaited<
-    ReturnType<BundleEmitter['checkBundleAlreadyPublished']>
->['previousReleaseArtifacts'];
-type ExtraFiles = Exclude<Awaited<ReturnType<SbomFileBuilder['generate']>>, undefined>;
-type SiblingPackage = Parameters<SbomFileBuilder['generate']>[1][number];
-
 type PublishDependencies = {
     readonly bundleEmitter: BundleEmitter;
+    readonly fileManager: {
+        readonly checkReadability: (fileOrFolderPath: string) => Promise<{ readonly isReadable: boolean }>;
+        readonly readFile: (filePath: string) => Promise<string>;
+    };
     readonly progressBroadcaster: ProgressBroadcastProvider;
+    readonly repositoryFolder: string;
     readonly sbomFileBuilder: SbomFileBuilder;
     readonly versionManager: VersionManager;
 };
+
+type VersionedBundleWithManifest = Awaited<ReturnType<PublishDependencies['versionManager']['addVersion']>>;
+type CurrentVersion = Awaited<ReturnType<PublishDependencies['bundleEmitter']['determineCurrentVersion']>>;
+type PublicationOutcome = Awaited<ReturnType<PublishDependencies['bundleEmitter']['publish']>>;
+type PreviousReleaseArtifacts = Awaited<
+    ReturnType<PublishDependencies['bundleEmitter']['checkBundleAlreadyPublished']>
+>['previousReleaseArtifacts'];
+type ExtraFiles = Exclude<Awaited<ReturnType<PublishDependencies['sbomFileBuilder']['generate']>>, undefined>;
+type SiblingPackage = Parameters<PublishDependencies['sbomFileBuilder']['generate']>[1][number];
+type AnalyzedBundle = Parameters<typeof createVersionProviderContext>[1];
 
 export type BuildAndPublishResult = {
     readonly status: PublishedReleaseStatus;
@@ -73,7 +79,11 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
             stage,
             versioning: options.versioning
         });
-        const version = determineBuildVersion(currentVersion, options);
+        const version = await determineBuildVersion(
+            currentVersion,
+            options,
+            await createVersionProviderContext(dependencies, analyzedBundle, options, stage)
+        );
         dependencies.progressBroadcaster.emit('building', { packageName: options.name, version });
         const versionedBundle = dependencies.versionManager.addVersion({
             bundle: analyzedBundle,

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -48,6 +48,23 @@ function createAnalyzedBundle(name = 'package-a'): AnalyzedBundle {
     };
 }
 
+function createAnalyzedResource(
+    sourceFilePath: string,
+    targetFilePath = sourceFilePath.slice(1)
+): AnalyzedBundle['contents'][number] {
+    return {
+        fileDescription: createTransferableFile(sourceFilePath, targetFilePath),
+        directDependencies: new Set(),
+        isExplicitlyIncluded: false,
+        isSubstituted: false,
+        analysis: {
+            sideEffectImports: new Set(),
+            sideEffectStatements: [],
+            survivingBindings: new Set()
+        }
+    };
+}
+
 function createVersionedBundle(
     name = 'package-a',
     version = '1.2.3',
@@ -87,6 +104,7 @@ type Overrides = {
     readonly publish?: SinonSpy;
     readonly generateSbom?: SinonSpy;
     readonly eliminate?: SinonSpy;
+    readonly repositoryFolder?: string;
 };
 
 type ProcessorContext = {
@@ -149,7 +167,16 @@ function createProcessor(overrides: Overrides = {}): ProcessorContext {
         bundleEmitter: { determineCurrentVersion, checkBundleAlreadyPublished, publish },
         versionManager: { addVersion, increaseVersion },
         sbomFileBuilder: { generate: generateSbom },
-        deadCodeEliminator: { eliminate }
+        deadCodeEliminator: { eliminate },
+        fileManager: {
+            async checkReadability() {
+                return { isReadable: true };
+            },
+            async readFile() {
+                return '';
+            }
+        },
+        repositoryFolder: overrides.repositoryFolder ?? '/'
     } as const;
 
     return {
@@ -187,6 +214,7 @@ function createBuildAndPublishOptions(): BuildAndPublishOptions {
         versioning: { automatic: true } as const,
         registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         publishSettings: { access: 'public', sbom: { enabled: false } } as const,
+        ignoredAttributionPaths: [],
         bundleDependencies: [createVersionedBundle('bundle-dependency', '1.0.0')],
         bundlePeerDependencies: [createVersionedBundle('peer-dependency', '2.0.0')]
     };
@@ -531,6 +559,47 @@ suite('package-processor', function () {
                 substitutionPublicModuleSourcePaths: undefined
             }
         ]);
+    });
+
+    test('tryBuildAndPublish() passes calculated attribution files to manual version providers', async function () {
+        const providerInputs: unknown[] = [];
+        const { processor } = createProcessor({ repositoryFolder: '/repo' });
+        const analyzedBundle = createAnalyzedBundle();
+        const buildOptions: BuildAndPublishOptions = {
+            ...createBuildAndPublishOptions(),
+            ignoredAttributionPaths: ['CHANGELOG.md'],
+            versioning: {
+                automatic: false,
+                async provideVersion(input) {
+                    providerInputs.push(input);
+                    return '1.2.3';
+                }
+            }
+        };
+
+        const result = await processor.tryBuildAndPublish({
+            analyzedBundle: {
+                ...analyzedBundle,
+                contents: [
+                    createAnalyzedResource('/repo/source/index.js'),
+                    createAnalyzedResource('/repo/docs/readme.md', 'readme.md')
+                ]
+            },
+            buildOptions,
+            stage: true
+        });
+
+        assert.deepStrictEqual(providerInputs, [
+            {
+                packageName: 'package-a',
+                currentVersion: undefined,
+                targetSourceFiles: ['docs/readme.md', 'source/index.js'],
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                stage: true
+            }
+        ]);
+        assert.strictEqual(result.bundle.version, '1.2.3');
     });
 
     test('tryBuildAndPublish() keeps the configured manual version without rebuilding on a rerun', async function () {

--- a/source/packtory/package-processor.ts
+++ b/source/packtory/package-processor.ts
@@ -1,6 +1,6 @@
+import type { BundleLinker } from '../linker/linker.ts';
 import type { DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { BundleEmitter } from '../bundle-emitter/emitter.ts';
-import type { BundleLinker } from '../linker/linker.ts';
 import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
 import type { ResourceResolver } from '../resource-resolver/resource-resolver.ts';
 import type { SbomFileBuilder } from '../sbom/sbom-file.ts';
@@ -24,6 +24,11 @@ export type PackageProcessorDependencies = {
     readonly resourceResolver: ResourceResolver;
     readonly sbomFileBuilder: SbomFileBuilder;
     readonly deadCodeEliminator: DeadCodeEliminator;
+    readonly fileManager: {
+        readonly checkReadability: (fileOrFolderPath: string) => Promise<{ readonly isReadable: boolean }>;
+        readonly readFile: (filePath: string) => Promise<string>;
+    };
+    readonly repositoryFolder: string;
 };
 
 export type PackageProcessor = {

--- a/source/packtory/packtory-publish.test.ts
+++ b/source/packtory/packtory-publish.test.ts
@@ -13,7 +13,8 @@ function happyDependencies() {
     return {
         packageProcessor: stubPackageProcessor,
         scheduler: emptyScheduler,
-        progressBroadcaster: stubProgressBroadcaster
+        progressBroadcaster: stubProgressBroadcaster,
+        repositoryFolder: '/'
     };
 }
 

--- a/source/packtory/packtory-release-diff.test.ts
+++ b/source/packtory/packtory-release-diff.test.ts
@@ -55,7 +55,8 @@ function createDiff(
         artifactsBuilder,
         packageProcessor,
         progressBroadcaster: stubProgressBroadcaster,
-        scheduler
+        scheduler,
+        repositoryFolder: '/'
     };
     return createDiffAgainstLatestPublishedValidated(dependencies);
 }

--- a/source/packtory/stages/publish-stage.test.ts
+++ b/source/packtory/stages/publish-stage.test.ts
@@ -17,7 +17,8 @@ suite('publish-stage', function () {
             {
                 packageProcessor: stubPackageProcessor,
                 scheduler: emptyScheduler,
-                progressBroadcaster: stubProgressBroadcaster
+                progressBroadcaster: stubProgressBroadcaster,
+                repositoryFolder: '/'
             },
             { packageConfigs: {}, packtoryConfig: { packages: [] } } as never,
             [],
@@ -60,7 +61,8 @@ suite('publish-stage', function () {
             {
                 packageProcessor: stubPackageProcessor,
                 scheduler: iteratingScheduler(['pkg-orphan']),
-                progressBroadcaster: stubProgressBroadcaster
+                progressBroadcaster: stubProgressBroadcaster,
+                repositoryFolder: '/'
             },
             config as never,
             [],
@@ -100,7 +102,8 @@ suite('publish-stage', function () {
             {
                 packageProcessor: processor,
                 scheduler: iteratingScheduler(['pkg-a'], capture),
-                progressBroadcaster: stubProgressBroadcaster
+                progressBroadcaster: stubProgressBroadcaster,
+                repositoryFolder: '/'
             },
             config as never,
             [

--- a/source/packtory/stages/publish-stage.ts
+++ b/source/packtory/stages/publish-stage.ts
@@ -19,6 +19,7 @@ export type PublishStageDependencies = {
     readonly packageProcessor: PackageProcessor;
     readonly scheduler: PacktoryScheduler;
     readonly progressBroadcaster: ProgressBroadcaster;
+    readonly repositoryFolder: string;
 };
 
 export type PublishStageResult = Result<readonly BuildAndPublishResult[], PartialError<BuildAndPublishResult>>;
@@ -62,7 +63,7 @@ export async function determineVersionAndPublishAll(
                 packageName,
                 validatedConfig.packageConfigs,
                 validatedConfig.packtoryConfig,
-                existing
+                { existingBundles: existing, repositoryFolder: dependencies.repositoryFolder }
             );
         },
         execute: withFailureCapture(dependencies.progressBroadcaster.provider, 'publish', async (buildOptions) => {

--- a/source/test-libraries/orchestrator-stub-fixtures.ts
+++ b/source/test-libraries/orchestrator-stub-fixtures.ts
@@ -50,10 +50,12 @@ export function failingDependencies(message: string): {
     readonly packageProcessor: PackageProcessor;
     readonly scheduler: PackageScheduler;
     readonly progressBroadcaster: ProgressBroadcaster;
+    readonly repositoryFolder: string;
 } {
     return {
         packageProcessor: stubPackageProcessor,
         scheduler: failingScheduler({ succeeded: [], failures: [new Error(message)] }),
-        progressBroadcaster: stubProgressBroadcaster
+        progressBroadcaster: stubProgressBroadcaster,
+        repositoryFolder: '/'
     };
 }


### PR DESCRIPTION
Adds provider-based manual versioning so configs can choose a version after Packtory has calculated package attribution inputs. The provider receives current registry version, target source files, ignored attribution paths, registry settings, package name, and stage, while static manual and automatic versioning keep existing behavior.