### PR TITLE
Add release PR workflow commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,18 @@ npx packtory release --write-changelog --commit --publish --tag --push --github-
 
 `release` writes changelogs, commits them, recomputes the final plan, publishes directly to npm, creates annotated `{packageName}@{version}` tags, pushes with `git push --follow-tags`, and creates GitHub Releases. It requires a clean Git index and worktree before writing. Commit identity and push credentials come from normal Git config and environment, such as `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, and your configured Git credential helper or CI checkout credentials.
 
+For a reviewed release PR flow, use `release-pr`:
+
+```bash
+npx packtory release-pr maintain --no-dry-run
+npx packtory release-pr validate
+npx packtory release-pr authorize-publish
+```
+
+`release-pr maintain` prepares the changelog commit with the same release planning logic, pushes it to the configured release branch, and creates or updates the release PR. `release-pr validate` checks that release PRs only change configured changelog output files and are not batched with other PRs in a merge queue. `release-pr authorize-publish` lets a publish workflow proceed only when the current commit, or a manually supplied PR number, is a merged valid release PR.
+
+The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory dispatches the configured workflow on the release branch, waits for the run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch push already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human push, or another CI system.
+
 For more details about the CLI application have a look at the [full documentation](./source/packages/command-line-interface/readme.md).
 
 ## Concept

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -35,6 +35,10 @@ type FileChangelogDestination = {
     readonly filePath: string;
     readonly generatedMarkdown: string;
 };
+type ChangelogOutputFilePath = {
+    readonly filePath: string;
+    readonly packageName: string | undefined;
+};
 
 type PackageChangelogOutput = Extract<ChangelogOutput, { readonly kind: 'package-file' }>;
 type PackageChangelogOutputWithSharedPath = PackageChangelogOutput & { readonly path: string };
@@ -144,6 +148,18 @@ function collectRepositoryDestinations(
     });
 }
 
+function collectRepositoryOutputFilePaths(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    outputs: readonly ChangelogOutput[]
+): readonly ChangelogOutputFilePath[] {
+    return outputs.flatMap((output) => {
+        if (output.kind !== 'repository-file') {
+            return [];
+        }
+        return [{ filePath: resolveRepositoryPath(deps, output.path), packageName: undefined }];
+    });
+}
+
 function collectPackageDestinationsWithSharedPath(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     config: ChangelogConfig,
@@ -160,6 +176,19 @@ function collectPackageDestinationsWithSharedPath(
     });
 }
 
+function collectPackageOutputFilePathsWithSharedPath(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    output: PackageChangelogOutputWithSharedPath
+): readonly ChangelogOutputFilePath[] {
+    return config.packages.map((packageConfig) => {
+        return {
+            filePath: resolvePackageFilePath(deps, config, packageConfig, output.path),
+            packageName: packageConfig.name
+        };
+    });
+}
+
 function collectPackageDestinationsWithExplicitPaths(
     deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
     output: PackageChangelogOutputWithExplicitPaths,
@@ -167,6 +196,15 @@ function collectPackageDestinationsWithExplicitPaths(
 ): readonly FileChangelogDestination[] {
     return Array.from(changelog.packageMarkdownByName, ([packageName, generatedMarkdown]) => {
         return { filePath: resolveExplicitPackageFilePath(deps, output, packageName), generatedMarkdown };
+    });
+}
+
+function collectPackageOutputFilePathsWithExplicitPaths(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    output: PackageChangelogOutputWithExplicitPaths
+): readonly ChangelogOutputFilePath[] {
+    return Object.entries(output.paths).map(([packageName, outputPath]) => {
+        return { filePath: resolveRepositoryPath(deps, outputPath), packageName };
     });
 }
 
@@ -185,6 +223,36 @@ function collectPackageDestinations(
         }
         return collectPackageDestinationsWithExplicitPaths(deps, output, changelog);
     });
+}
+
+function collectPackageOutputFilePaths(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    outputs: readonly ChangelogOutput[]
+): readonly ChangelogOutputFilePath[] {
+    return outputs.flatMap((output) => {
+        if (output.kind !== 'package-file') {
+            return [];
+        }
+        if (hasSharedPackagePath(output)) {
+            return collectPackageOutputFilePathsWithSharedPath(deps, config, output);
+        }
+        return collectPackageOutputFilePathsWithExplicitPaths(deps, output);
+    });
+}
+
+export function collectChangelogOutputFilePaths(
+    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    config: ChangelogConfig
+): readonly ChangelogOutputFilePath[] {
+    const outputs = config.changelog?.outputs;
+    if (outputs === undefined) {
+        return [];
+    }
+    return [
+        ...collectRepositoryOutputFilePaths(deps, outputs),
+        ...collectPackageOutputFilePaths(deps, config, outputs)
+    ];
 }
 
 function isMissingFileError(error: unknown): boolean {

--- a/source/command-line-interface/runner/release-git-client.test.ts
+++ b/source/command-line-interface/runner/release-git-client.test.ts
@@ -29,6 +29,30 @@ function createGitClientWithRunner(run: ReleaseGitCommandRunner): {
     };
 }
 
+function expectedPushHeadToBranchCalls(leaseHead: string): readonly GitCall[] {
+    return [
+        {
+            command: 'git',
+            args: ['-C', '/repo', 'fetch', 'origin', 'refs/heads/release/packtory:refs/remotes/origin/release/packtory']
+        },
+        {
+            command: 'git',
+            args: ['-C', '/repo', 'rev-parse', '--verify', 'refs/remotes/origin/release/packtory']
+        },
+        {
+            command: 'git',
+            args: [
+                '-C',
+                '/repo',
+                'push',
+                `--force-with-lease=refs/heads/release/packtory:${leaseHead}`,
+                'origin',
+                'HEAD:refs/heads/release/packtory'
+            ]
+        }
+    ];
+}
+
 suite('release-git-client', function () {
     test('ensureClean succeeds when git status is empty', async function () {
         const { calls, client } = createGitClientWithRunner(async () => {
@@ -142,5 +166,44 @@ suite('release-git-client', function () {
             command: 'git',
             args: ['-C', '/repo', 'push', '--follow-tags']
         });
+    });
+
+    test('deleteRemoteBranch ignores missing remote branches', async function () {
+        const { calls, client } = createGitClientWithRunner(async () => {
+            throw new Error('missing branch');
+        });
+
+        await client.deleteRemoteBranch('release/packtory');
+
+        assert.deepStrictEqual(calls[0], {
+            command: 'git',
+            args: ['-C', '/repo', 'push', 'origin', '--delete', 'release/packtory']
+        });
+    });
+
+    test('pushHeadToBranch pushes with a lease for an existing remote branch', async function () {
+        const { calls, client } = createGitClientWithRunner(async (_command, args) => {
+            if (args.includes('rev-parse')) {
+                return { stdout: 'remote-head\n', stderr: '' };
+            }
+            return { stdout: '', stderr: '' };
+        });
+
+        await client.pushHeadToBranch('release/packtory');
+
+        assert.deepStrictEqual(calls, expectedPushHeadToBranchCalls('remote-head'));
+    });
+
+    test('pushHeadToBranch pushes with an empty lease for a new remote branch', async function () {
+        const { calls, client } = createGitClientWithRunner(async (_command, args) => {
+            if (args.includes('rev-parse')) {
+                throw new Error('missing branch');
+            }
+            return { stdout: '', stderr: '' };
+        });
+
+        await client.pushHeadToBranch('release/packtory');
+
+        assert.deepStrictEqual(calls, expectedPushHeadToBranchCalls(''));
     });
 });

--- a/source/command-line-interface/runner/release-git-client.ts
+++ b/source/command-line-interface/runner/release-git-client.ts
@@ -8,8 +8,10 @@ type ReleaseGitCommandRunner = (
 export type ReleaseGitClient = {
     readonly commit: (filePaths: readonly string[], message: string) => Promise<void>;
     readonly currentHead: () => Promise<string>;
+    readonly deleteRemoteBranch: (branch: string) => Promise<void>;
     readonly ensureClean: () => Promise<void>;
     readonly ensureTag: (tagName: string, message: string, targetHead: string) => Promise<void>;
+    readonly pushHeadToBranch: (branch: string) => Promise<void>;
     readonly pushFollowTags: () => Promise<void>;
 };
 
@@ -53,6 +55,10 @@ export function createReleaseGitClient(deps: ReleaseGitClientDependencies): Rele
             return head;
         },
 
+        async deleteRemoteBranch(branch) {
+            await readGitOutputResult(deps, ['push', 'origin', '--delete', branch]);
+        },
+
         async ensureClean() {
             const status = await runGit(deps, ['status', '--porcelain=v1']);
             if (status.length > 0) {
@@ -71,6 +77,20 @@ export function createReleaseGitClient(deps: ReleaseGitClientDependencies): Rele
                 return;
             }
             throw new Error(`Tag "${tagName}" already exists at ${existingTag.value}, expected ${targetHead}`);
+        },
+
+        async pushHeadToBranch(branch) {
+            await readGitOutputResult(deps, ['fetch', 'origin', `refs/heads/${branch}:refs/remotes/origin/${branch}`]);
+            const remoteBranch = await readGitOutputResult(deps, [
+                'rev-parse',
+                '--verify',
+                `refs/remotes/origin/${branch}`
+            ]);
+            const lease =
+                remoteBranch.kind === 'found'
+                    ? `--force-with-lease=refs/heads/${branch}:${remoteBranch.value}`
+                    : `--force-with-lease=refs/heads/${branch}:`;
+            await runGit(deps, ['push', lease, 'origin', `HEAD:refs/heads/${branch}`]);
         },
 
         async pushFollowTags() {

--- a/source/command-line-interface/runner/release-handler.test.ts
+++ b/source/command-line-interface/runner/release-handler.test.ts
@@ -235,11 +235,17 @@ function createReleaseHandlerDeps(scenario: Scenario = {}): ReleaseHandlerDeps {
                 order.push('head');
                 return 'new-head';
             },
+            async deleteRemoteBranch() {
+                order.push('delete-branch');
+            },
             async ensureClean() {
                 order.push('clean');
             },
             async ensureTag(tagName) {
                 order.push(`tag:${tagName}`);
+            },
+            async pushHeadToBranch() {
+                order.push('push-branch');
             },
             async pushFollowTags() {
                 order.push('push');

--- a/source/command-line-interface/runner/release-output-files.test.ts
+++ b/source/command-line-interface/runner/release-output-files.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { collectReleaseOutputFiles } from './release-output-files.ts';
+
+suite('release-output-files', function () {
+    test('returns no files when changelog outputs are not configured', function () {
+        assert.deepStrictEqual(
+            collectReleaseOutputFiles({
+                workingDirectory: '/repo',
+                config: { packages: [{ name: 'pkg-a' }] }
+            }),
+            []
+        );
+    });
+
+    test('collects repository and package changelog outputs as release files', function () {
+        assert.deepStrictEqual(
+            collectReleaseOutputFiles({
+                workingDirectory: '/repo',
+                config: {
+                    changelog: {
+                        outputs: [
+                            { kind: 'repository-file', path: 'CHANGELOG.md' },
+                            { kind: 'package-file', path: 'docs/CHANGELOG.md' },
+                            { kind: 'github-release' }
+                        ]
+                    },
+                    commonPackageSettings: { sourcesFolder: 'packages' },
+                    packages: [{ name: 'pkg-a' }, { name: 'pkg-b', sourcesFolder: 'other/pkg-b' }]
+                }
+            }),
+            ['CHANGELOG.md', 'packages/docs/CHANGELOG.md', 'other/pkg-b/docs/CHANGELOG.md']
+        );
+    });
+
+    test('collects explicit package changelog outputs', function () {
+        assert.deepStrictEqual(
+            collectReleaseOutputFiles({
+                workingDirectory: '/repo',
+                config: {
+                    changelog: {
+                        outputs: [
+                            {
+                                kind: 'package-file',
+                                paths: {
+                                    'pkg-a': 'source/pkg-a/CHANGELOG.md',
+                                    'pkg-b': 'source/pkg-b/CHANGELOG.md'
+                                }
+                            }
+                        ]
+                    },
+                    packages: [{ name: 'pkg-a' }, { name: 'pkg-b' }]
+                }
+            }),
+            ['source/pkg-a/CHANGELOG.md', 'source/pkg-b/CHANGELOG.md']
+        );
+    });
+});

--- a/source/command-line-interface/runner/release-output-files.ts
+++ b/source/command-line-interface/runner/release-output-files.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { collectChangelogOutputFilePaths, type ChangelogConfig } from './changelog-destinations.ts';
+
+function normalizeRepositoryPath(filePath: string): string {
+    return filePath.split(path.sep).join('/');
+}
+
+function toRepositoryRelativePath(workingDirectory: string, filePath: string): string {
+    return normalizeRepositoryPath(path.relative(workingDirectory, filePath));
+}
+
+export function collectReleaseOutputFiles(input: {
+    readonly config: ChangelogConfig;
+    readonly workingDirectory: string;
+}): readonly string[] {
+    return collectChangelogOutputFilePaths({ workingDirectory: input.workingDirectory }, input.config).map((output) => {
+        return toRepositoryRelativePath(input.workingDirectory, output.filePath);
+    });
+}

--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -1,0 +1,424 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { createReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+
+type RecordedRequest = {
+    readonly body: string;
+    readonly headers: HeadersInit | undefined;
+    readonly method: string;
+    readonly path: string;
+    readonly search: string;
+};
+
+function jsonResponse(data: unknown, status = 200): Response {
+    return Response.json(data, { status });
+}
+
+function emptyResponse(status = 204): Response {
+    return new Response(null, { status });
+}
+
+function createPullRequest(number: number, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        base: { ref: 'main' },
+        head: { ref: 'release/packtory', repo: { full_name: 'owner/repo' }, sha: 'release-head' },
+        labels: [{ name: 'release' }],
+        merge_commit_sha: 'merge-sha',
+        merged_at: '2026-06-01T00:00:00.000Z',
+        number,
+        title: 'Prepare release',
+        user: { login: 'github-actions[bot]' },
+        ...overrides
+    };
+}
+
+function createCommit(message = 'Release packages'): Record<string, unknown> {
+    return {
+        commit: { message },
+        parents: [{ sha: 'main-head' }]
+    };
+}
+
+function requestUrl(input: Parameters<typeof globalThis.fetch>[0]): URL {
+    if (typeof input === 'string') {
+        return new URL(input);
+    }
+    if (input instanceof URL) {
+        return input;
+    }
+    return new URL(input.url);
+}
+
+function requestBody(init: Parameters<typeof globalThis.fetch>[1]): string {
+    return typeof init?.body === 'string' ? init.body : '';
+}
+
+function readHeader(headers: HeadersInit | undefined, name: string): string | undefined {
+    if (headers instanceof Headers) {
+        return headers.get(name) ?? undefined;
+    }
+    if (headers === undefined || Array.isArray(headers)) {
+        return undefined;
+    }
+    const value: unknown = Reflect.get(headers, name);
+    return typeof value === 'string' ? value : undefined;
+}
+
+function recordRequest(
+    records: RecordedRequest[],
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: Parameters<typeof globalThis.fetch>[1]
+): { readonly method: string; readonly url: URL } {
+    const url = requestUrl(input);
+    const method = init?.method ?? 'GET';
+    records.push({ body: requestBody(init), headers: init?.headers, method, path: url.pathname, search: url.search });
+    return { method, url };
+}
+
+function requestHasSearchParameter(record: RecordedRequest, name: string, value: string): boolean {
+    return new URLSearchParams(record.search).get(name) === value;
+}
+
+function createClient(fetchImplementation: typeof globalThis.fetch) {
+    return createReleasePullRequestGitHubClient({
+        fetch: fetchImplementation,
+        owner: 'owner',
+        repo: 'repo',
+        token: 'token'
+    });
+}
+
+function hasRequestWithBody(
+    records: readonly RecordedRequest[],
+    method: string,
+    path: string,
+    bodyPart: string
+): boolean {
+    return records.some((record) => {
+        return record.method === method && record.path === path && record.body.includes(bodyPart);
+    });
+}
+
+function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
+    return async (input, init) => {
+        const { method, url } = recordRequest(records, input, init);
+
+        if (url.pathname === '/repos/owner/repo/pulls' && method === 'GET') {
+            return jsonResponse([createPullRequest(1)]);
+        }
+        if (url.pathname === '/repos/owner/repo/pulls' && method === 'POST') {
+            return jsonResponse(createPullRequest(2));
+        }
+        if (url.pathname === '/repos/owner/repo/pulls/1' && method === 'PATCH') {
+            return jsonResponse(createPullRequest(1));
+        }
+        if (url.pathname === '/repos/owner/repo/pulls/12') {
+            return jsonResponse(createPullRequest(12));
+        }
+        if (url.pathname === '/repos/owner/repo/pulls/12/files') {
+            return jsonResponse([{ filename: 'CHANGELOG.md' }]);
+        }
+        if (url.pathname === '/repos/owner/repo/pulls/1/files') {
+            return jsonResponse([{ filename: 'CHANGELOG.md' }]);
+        }
+        if (url.pathname === '/repos/owner/repo/commits/release-head') {
+            return jsonResponse(createCommit());
+        }
+        if (url.pathname === '/repos/owner/repo/commits/merge-sha/pulls') {
+            return jsonResponse([createPullRequest(12)]);
+        }
+        if (url.pathname === '/repos/owner/repo/issues/1/labels' && method === 'PUT') {
+            return jsonResponse([{ name: 'release' }]);
+        }
+        if (url.pathname === '/repos/owner/repo/statuses/release-head') {
+            return jsonResponse({});
+        }
+        if (url.pathname === '/repos/owner/repo/actions/runs') {
+            return jsonResponse({
+                workflow_runs: [
+                    { conclusion: 'action_required', database_id: 10, event: 'pull_request', head_sha: 'release-head' },
+                    { conclusion: 'action_required', event: 'pull_request', head_sha: 'release-head' },
+                    { conclusion: 'action_required', database_id: 12, event: 'pull_request', head_sha: 'other-head' },
+                    { conclusion: 'success', database_id: 13, event: 'pull_request', head_sha: 'release-head' },
+                    { conclusion: 'success', database_id: 11, event: 'workflow_dispatch', head_sha: 'release-head' }
+                ]
+            });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/runs/10' && method === 'DELETE') {
+            return emptyResponse();
+        }
+        if (url.pathname === '/repos/owner/repo/actions/runs/11') {
+            return jsonResponse({ conclusion: 'success' });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/runs/12') {
+            return jsonResponse({ conclusion: null });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/runs/11/jobs') {
+            return jsonResponse({
+                jobs: [{ conclusion: 'success', html_url: 'https://run/job', name: 'Node.js' }],
+                total_count: 1
+            });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/runs/12/jobs') {
+            return jsonResponse({
+                jobs: [{ conclusion: null, html_url: null, name: 'Node.js' }],
+                total_count: 1
+            });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/workflows/ci.yml/dispatches') {
+            return emptyResponse();
+        }
+        if (url.pathname === '/repos/owner/repo/actions/workflows/ci.yml/runs') {
+            return jsonResponse({
+                workflow_runs: [{ database_id: 11, event: 'workflow_dispatch', head_sha: 'release-head' }]
+            });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/workflows/ci-db.yml/runs') {
+            return jsonResponse({
+                workflow_runs: [{ databaseId: 12, event: 'workflow_dispatch', head_sha: 'release-head' }]
+            });
+        }
+        if (url.pathname === '/repos/owner/repo/branches/main') {
+            return jsonResponse({ commit: { sha: 'main-head' } });
+        }
+
+        return jsonResponse({ message: `Unhandled ${method} ${url.pathname}` }, 500);
+    };
+}
+
+suite('release-pr-github-client', function () {
+    test('maintains release pull requests and reads release metadata', async function () {
+        const records: RecordedRequest[] = [];
+        const client = createClient(createFetch(records));
+
+        await client.closeOpenReleasePullRequests({ baseBranch: 'main', releaseBranch: 'release/packtory' });
+        assert.strictEqual(
+            await client.createOrUpdateReleasePullRequest({
+                baseBranch: 'main',
+                body: 'Body',
+                label: 'release',
+                releaseBranch: 'release/packtory',
+                title: 'Prepare release'
+            }),
+            1
+        );
+        await client.createStatus({
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'pending',
+            state: 'pending',
+            targetUrl: undefined
+        });
+        await client.createStatus({
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'success',
+            state: 'success',
+            targetUrl: 'https://run/job'
+        });
+        await client.deleteActionRequiredPullRequestRuns({ branch: 'release/packtory', headSha: 'release-head' });
+        await client.dispatchWorkflow({ ref: 'release/packtory', workflowFile: 'ci.yml' });
+
+        assert.strictEqual(
+            await client.findDispatchedWorkflowRunId({
+                branch: 'release/packtory',
+                headSha: 'release-head',
+                workflowFile: 'ci.yml'
+            }),
+            11
+        );
+        assert.strictEqual(
+            await client.findDispatchedWorkflowRunId({
+                branch: 'release/packtory',
+                headSha: 'missing-head',
+                workflowFile: 'ci.yml'
+            }),
+            undefined
+        );
+        assert.strictEqual(
+            await client.findDispatchedWorkflowRunId({
+                branch: 'release/packtory',
+                headSha: 'release-head',
+                workflowFile: 'ci-db.yml'
+            }),
+            12
+        );
+        assert.strictEqual(await client.getBranchHeadSha('main'), 'main-head');
+        assert.deepStrictEqual(await client.getPullRequestHead(12), {
+            author: 'github-actions[bot]',
+            changedFiles: ['CHANGELOG.md'],
+            headRef: 'release/packtory',
+            labels: ['release'],
+            parentShas: ['main-head'],
+            subject: 'Release packages',
+            title: 'Prepare release'
+        });
+        const pullRequest = await client.getPullRequest(12);
+        const commitPullRequests = await client.listCommitPullRequests('merge-sha');
+        assert.strictEqual(pullRequest.number, 12);
+        assert.strictEqual(pullRequest.merged, true);
+        assert.strictEqual(commitPullRequests[0]?.number, 12);
+        assert.deepStrictEqual(await client.readWorkflowRunResult(11), {
+            conclusion: 'success',
+            databaseId: 11,
+            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+        });
+        assert.deepStrictEqual(await client.readWorkflowRunResult(12), {
+            conclusion: undefined,
+            databaseId: 12,
+            jobs: [{ conclusion: undefined, name: 'Node.js', url: undefined }]
+        });
+        assert.deepStrictEqual(
+            records.filter((record) => record.method === 'DELETE').map((record) => record.path),
+            ['/repos/owner/repo/actions/runs/10']
+        );
+        assert.strictEqual(
+            records.filter((record) => {
+                return (
+                    record.method === 'GET' &&
+                    record.path === '/repos/owner/repo/pulls' &&
+                    requestHasSearchParameter(record, 'head', 'owner:release/packtory') &&
+                    requestHasSearchParameter(record, 'state', 'open')
+                );
+            }).length,
+            2
+        );
+        assert.strictEqual(hasRequestWithBody(records, 'PATCH', '/repos/owner/repo/pulls/1', '"state":"closed"'), true);
+        assert.strictEqual(hasRequestWithBody(records, 'PUT', '/repos/owner/repo/issues/1/labels', '"release"'), true);
+        assert.strictEqual(
+            hasRequestWithBody(records, 'POST', '/repos/owner/repo/statuses/release-head', '"target_url":null'),
+            true
+        );
+        assert.strictEqual(
+            hasRequestWithBody(
+                records,
+                'POST',
+                '/repos/owner/repo/statuses/release-head',
+                '"target_url":"https://run/job"'
+            ),
+            true
+        );
+        assert.strictEqual(
+            hasRequestWithBody(
+                records,
+                'POST',
+                '/repos/owner/repo/actions/workflows/ci.yml/dispatches',
+                '"ref":"release/packtory"'
+            ),
+            true
+        );
+        assert.ok(records.some((record) => record.search.includes('event=pull_request')));
+        assert.ok(records.some((record) => record.search.includes('event=workflow_dispatch')));
+        assert.strictEqual(readHeader(records[0]?.headers, 'user-agent'), 'packtory-release-pr');
+    });
+
+    test('creates a release pull request when no open release pull request exists', async function () {
+        const records: RecordedRequest[] = [];
+        const fetchMock: typeof globalThis.fetch = async (input, init) => {
+            const { method, url } = recordRequest(records, input, init);
+
+            if (url.pathname === '/repos/owner/repo/pulls' && method === 'GET') {
+                return jsonResponse([]);
+            }
+            if (url.pathname === '/repos/owner/repo/pulls' && method === 'POST') {
+                return jsonResponse(createPullRequest(2));
+            }
+            if (url.pathname === '/repos/owner/repo/issues/2/labels' && method === 'PUT') {
+                return jsonResponse([{ name: 'release' }]);
+            }
+
+            return jsonResponse({ message: `Unhandled ${method} ${url.pathname}` }, 500);
+        };
+        const client = createClient(fetchMock);
+
+        assert.strictEqual(
+            await client.createOrUpdateReleasePullRequest({
+                baseBranch: 'main',
+                body: 'Body',
+                label: 'release',
+                releaseBranch: 'release/packtory',
+                title: 'Prepare release'
+            }),
+            2
+        );
+        assert.strictEqual(
+            records.some((record) => record.method === 'POST' && record.path === '/repos/owner/repo/pulls'),
+            true
+        );
+    });
+
+    test('normalizes nullable GitHub response fields', async function () {
+        const fetchMock: typeof globalThis.fetch = async (input) => {
+            const url = requestUrl(input);
+
+            if (url.pathname === '/repos/owner/repo/pulls/12') {
+                return jsonResponse(
+                    createPullRequest(12, {
+                        head: { ref: 'release/packtory', repo: null, sha: 'release-head' },
+                        labels: [{ name: null }, {}],
+                        merge_commit_sha: null,
+                        merged_at: null,
+                        user: null
+                    })
+                );
+            }
+            if (url.pathname === '/repos/owner/repo/pulls/13') {
+                return jsonResponse(
+                    createPullRequest(13, {
+                        merge_commit_sha: null,
+                        merged_at: undefined
+                    })
+                );
+            }
+            if (url.pathname === '/repos/owner/repo/pulls/12/files') {
+                return jsonResponse([]);
+            }
+            if (url.pathname === '/repos/owner/repo/pulls/13/files') {
+                return jsonResponse([]);
+            }
+            if (url.pathname === '/repos/owner/repo/commits/release-head') {
+                return jsonResponse(createCommit('Release packages\n\nDetails'));
+            }
+
+            return jsonResponse({ message: `Unhandled ${url.pathname}` }, 500);
+        };
+        const client = createClient(fetchMock);
+
+        assert.deepStrictEqual(await client.getPullRequest(12), {
+            author: '',
+            baseRef: 'main',
+            changedFiles: [],
+            headRef: 'release/packtory',
+            headRepository: '',
+            labels: [],
+            mergeCommitSha: undefined,
+            merged: false,
+            number: 12,
+            subject: 'Release packages',
+            title: 'Prepare release'
+        });
+        const pullRequestWithOmittedMergeTimestamp = await client.getPullRequest(13);
+        assert.strictEqual(pullRequestWithOmittedMergeTimestamp.merged, false);
+    });
+
+    test('formats failed GitHub API requests with the endpoint path', async function () {
+        const client = createClient(async () => {
+            return jsonResponse({ message: 'Bad credentials' }, 401);
+        });
+
+        await assert.rejects(
+            async () => {
+                await client.getBranchHeadSha('main');
+            },
+            (error: unknown) => {
+                assert.ok(error instanceof Error);
+                assert.strictEqual(
+                    error.message,
+                    'GitHub API request failed (401) for /repos/owner/repo/branches/main'
+                );
+                assert.ok(error.cause instanceof Error);
+                return true;
+            }
+        );
+    });
+});

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -1,0 +1,443 @@
+import { isDefined } from 'remeda';
+import { Octokit } from '@octokit/core';
+import { paginateRest } from '@octokit/plugin-paginate-rest';
+import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
+import { createGitHubJsonRequestHeaders } from './github-api-request.ts';
+
+export type PullRequestDetails = {
+    readonly author: string;
+    readonly baseRef: string;
+    readonly changedFiles: readonly string[];
+    readonly headRef: string;
+    readonly headRepository: string;
+    readonly labels: readonly string[];
+    readonly mergeCommitSha: string | undefined;
+    readonly merged: boolean;
+    readonly number: number;
+    readonly subject: string;
+    readonly title: string;
+};
+
+type PullRequestHeadDetails = {
+    readonly author: string;
+    readonly changedFiles: readonly string[];
+    readonly headRef: string;
+    readonly labels: readonly string[];
+    readonly parentShas: readonly string[];
+    readonly subject: string;
+    readonly title: string;
+};
+
+type WorkflowJobResult = {
+    readonly conclusion: string | undefined;
+    readonly name: string;
+    readonly url: string | undefined;
+};
+
+type WorkflowRunResult = {
+    readonly conclusion: string | undefined;
+    readonly databaseId: number;
+    readonly jobs: readonly WorkflowJobResult[];
+};
+
+export type ReleasePullRequestGitHubClient = {
+    readonly closeOpenReleasePullRequests: (input: {
+        readonly baseBranch: string;
+        readonly releaseBranch: string;
+    }) => Promise<void>;
+    readonly createOrUpdateReleasePullRequest: (input: {
+        readonly baseBranch: string;
+        readonly body: string;
+        readonly label: string;
+        readonly releaseBranch: string;
+        readonly title: string;
+    }) => Promise<number>;
+    readonly createStatus: (input: {
+        readonly commitSha: string;
+        readonly context: string;
+        readonly description: string;
+        readonly state: 'error' | 'failure' | 'pending' | 'success';
+        readonly targetUrl: string | undefined;
+    }) => Promise<void>;
+    readonly deleteActionRequiredPullRequestRuns: (input: {
+        readonly branch: string;
+        readonly headSha: string;
+    }) => Promise<void>;
+    readonly dispatchWorkflow: (input: { readonly ref: string; readonly workflowFile: string }) => Promise<void>;
+    readonly findDispatchedWorkflowRunId: (input: {
+        readonly branch: string;
+        readonly headSha: string;
+        readonly workflowFile: string;
+    }) => Promise<number | undefined>;
+    readonly getBranchHeadSha: (branch: string) => Promise<string>;
+    readonly getPullRequest: (pullRequestNumber: number) => Promise<PullRequestDetails>;
+    readonly getPullRequestHead: (pullRequestNumber: number) => Promise<PullRequestHeadDetails>;
+    readonly listCommitPullRequests: (commitSha: string) => Promise<readonly PullRequestDetails[]>;
+    readonly readWorkflowRunResult: (runId: number) => Promise<WorkflowRunResult>;
+};
+
+type GitHubClientContext = {
+    readonly fetch: typeof globalThis.fetch;
+    readonly owner: string;
+    readonly repo: string;
+    readonly token: string;
+};
+
+type RawLabel = { readonly name?: string | null | undefined };
+type RawPullRequest = {
+    readonly base: { readonly ref: string };
+    readonly head: {
+        readonly ref: string;
+        readonly repo: { readonly full_name: string | null } | null;
+        readonly sha: string;
+    };
+    readonly labels: readonly RawLabel[];
+    readonly merge_commit_sha: string | null;
+    readonly merged_at?: string | null | undefined;
+    readonly number: number;
+    readonly title: string;
+    readonly user: { readonly login: string } | null;
+};
+type RawCommit = {
+    readonly commit: { readonly message: string };
+    readonly parents: readonly { readonly sha: string }[];
+};
+type RawWorkflowRun = {
+    readonly conclusion: string | null;
+    readonly databaseId?: number | undefined;
+    readonly database_id?: number | undefined;
+    readonly event: string;
+    readonly head_sha: string;
+    readonly status: string | null;
+};
+type RawWorkflowJob = {
+    readonly conclusion: string | null;
+    readonly html_url?: string | null | undefined;
+    readonly name: string;
+};
+
+type RequestContext = {
+    readonly headers: Readonly<Record<string, string>>;
+    readonly owner: string;
+    readonly repo: string;
+};
+
+function labelNames(labels: readonly RawLabel[]): readonly string[] {
+    return labels
+        .map((label) => {
+            return label.name ?? undefined;
+        })
+        .filter(isDefined);
+}
+
+function commitSubject(commit: RawCommit): string {
+    const firstLineBreak = commit.commit.message.indexOf('\n');
+    if (firstLineBreak === -1) {
+        return commit.commit.message;
+    }
+    return commit.commit.message.slice(0, firstLineBreak);
+}
+
+function runDatabaseId(run: RawWorkflowRun): number | undefined {
+    return run.database_id ?? run.databaseId;
+}
+
+function pullRequestIsMerged(pullRequest: RawPullRequest): boolean {
+    return pullRequest.merged_at !== undefined && pullRequest.merged_at !== null;
+}
+
+function readReflectedProperty(value: unknown, property: string): unknown {
+    return Reflect.get(new Object(value), property) as unknown;
+}
+
+function createRequestError(error: unknown): Error {
+    const status = String(readReflectedProperty(error, 'status'));
+    const requestUrl = String(readReflectedProperty(readReflectedProperty(error, 'request'), 'url'));
+    const parsedUrl = new URL(requestUrl);
+    return new Error(`GitHub API request failed (${status}) for ${parsedUrl.pathname}${parsedUrl.search}`, {
+        cause: error
+    });
+}
+
+async function resolveGitHubResponse<T>(request: Promise<T>): Promise<T> {
+    try {
+        return await request;
+    } catch (error) {
+        throw createRequestError(error);
+    }
+}
+
+export function createReleasePullRequestGitHubClient(context: GitHubClientContext): ReleasePullRequestGitHubClient {
+    const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
+    const requestContext: RequestContext = {
+        headers: createGitHubJsonRequestHeaders(context.token, 'packtory-release-pr'),
+        owner: context.owner,
+        repo: context.repo
+    };
+    const octokit = new GitHubRestClient({
+        request: {
+            fetch: context.fetch,
+            headers: requestContext.headers
+        }
+    });
+
+    async function readPullRequestFiles(pullRequestNumber: number): Promise<readonly string[]> {
+        const files = await resolveGitHubResponse(
+            octokit.paginate(octokit.rest.pulls.listFiles, {
+                ...requestContext,
+                pull_number: pullRequestNumber,
+                per_page: 100
+            })
+        );
+        return files.map((file) => {
+            return file.filename;
+        });
+    }
+
+    async function readCommit(commitSha: string): Promise<RawCommit> {
+        const response = await resolveGitHubResponse(
+            octokit.rest.repos.getCommit({
+                ...requestContext,
+                ref: commitSha
+            })
+        );
+        return response.data;
+    }
+
+    async function toPullRequestDetails(pullRequest: RawPullRequest): Promise<PullRequestDetails> {
+        const commit = await readCommit(pullRequest.head.sha);
+        return {
+            author: pullRequest.user?.login ?? '',
+            baseRef: pullRequest.base.ref,
+            changedFiles: await readPullRequestFiles(pullRequest.number),
+            headRef: pullRequest.head.ref,
+            headRepository: pullRequest.head.repo?.full_name ?? '',
+            labels: labelNames(pullRequest.labels),
+            mergeCommitSha: pullRequest.merge_commit_sha ?? undefined,
+            merged: pullRequestIsMerged(pullRequest),
+            number: pullRequest.number,
+            subject: commitSubject(commit),
+            title: pullRequest.title
+        };
+    }
+
+    async function createReleasePullRequest(input: {
+        readonly baseBranch: string;
+        readonly body: string;
+        readonly releaseBranch: string;
+        readonly title: string;
+    }): Promise<number> {
+        const response = await resolveGitHubResponse(
+            octokit.rest.pulls.create({
+                ...requestContext,
+                base: input.baseBranch,
+                body: input.body,
+                head: input.releaseBranch,
+                title: input.title
+            })
+        );
+        return response.data.number;
+    }
+
+    async function updateReleasePullRequest(
+        input: { readonly body: string; readonly title: string },
+        pullRequestNumber: number
+    ): Promise<number> {
+        const response = await resolveGitHubResponse(
+            octokit.rest.pulls.update({
+                ...requestContext,
+                body: input.body,
+                pull_number: pullRequestNumber,
+                title: input.title
+            })
+        );
+        return response.data.number;
+    }
+
+    return {
+        async closeOpenReleasePullRequests(input) {
+            const pullRequests = await resolveGitHubResponse(
+                octokit.rest.pulls.list({
+                    ...requestContext,
+                    base: input.baseBranch,
+                    head: `${context.owner}:${input.releaseBranch}`,
+                    state: 'open'
+                })
+            );
+            for (const pullRequest of pullRequests.data) {
+                await resolveGitHubResponse(
+                    octokit.rest.pulls.update({
+                        ...requestContext,
+                        pull_number: pullRequest.number,
+                        state: 'closed'
+                    })
+                );
+            }
+        },
+
+        async createOrUpdateReleasePullRequest(input) {
+            const existingPullRequests = await resolveGitHubResponse(
+                octokit.rest.pulls.list({
+                    ...requestContext,
+                    base: input.baseBranch,
+                    head: `${context.owner}:${input.releaseBranch}`,
+                    state: 'open'
+                })
+            );
+            const existingPullRequest = existingPullRequests.data[0];
+            const pullRequestNumber =
+                existingPullRequest === undefined
+                    ? await createReleasePullRequest(input)
+                    : await updateReleasePullRequest(input, existingPullRequest.number);
+
+            await resolveGitHubResponse(
+                octokit.rest.issues.setLabels({
+                    ...requestContext,
+                    issue_number: pullRequestNumber,
+                    labels: [input.label]
+                })
+            );
+            return pullRequestNumber;
+        },
+
+        async createStatus(input) {
+            await resolveGitHubResponse(
+                octokit.rest.repos.createCommitStatus({
+                    ...requestContext,
+                    context: input.context,
+                    description: input.description,
+                    sha: input.commitSha,
+                    state: input.state,
+                    target_url: input.targetUrl ?? null
+                })
+            );
+        },
+
+        async deleteActionRequiredPullRequestRuns(input) {
+            const response = await resolveGitHubResponse(
+                octokit.rest.actions.listWorkflowRunsForRepo({
+                    ...requestContext,
+                    branch: input.branch,
+                    event: 'pull_request',
+                    per_page: 100
+                })
+            );
+            const blockedRuns = response.data.workflow_runs.filter((run) => {
+                return run.head_sha === input.headSha && run.conclusion === 'action_required';
+            });
+            const blockedRunIds = blockedRuns
+                .map((run) => {
+                    return runDatabaseId(run as RawWorkflowRun);
+                })
+                .filter(isDefined);
+            for (const databaseId of blockedRunIds) {
+                await resolveGitHubResponse(
+                    octokit.rest.actions.deleteWorkflowRun({ ...requestContext, run_id: databaseId })
+                );
+            }
+        },
+
+        async dispatchWorkflow(input) {
+            await resolveGitHubResponse(
+                octokit.rest.actions.createWorkflowDispatch({
+                    ...requestContext,
+                    ref: input.ref,
+                    workflow_id: input.workflowFile
+                })
+            );
+        },
+
+        async findDispatchedWorkflowRunId(input) {
+            const response = await resolveGitHubResponse(
+                octokit.rest.actions.listWorkflowRuns({
+                    ...requestContext,
+                    branch: input.branch,
+                    event: 'workflow_dispatch',
+                    workflow_id: input.workflowFile,
+                    per_page: 100
+                })
+            );
+            const run = response.data.workflow_runs.find((workflowRun) => {
+                return workflowRun.head_sha === input.headSha;
+            });
+            return run === undefined ? undefined : runDatabaseId(run as RawWorkflowRun);
+        },
+
+        async getBranchHeadSha(branch) {
+            const response = await resolveGitHubResponse(
+                octokit.rest.repos.getBranch({
+                    ...requestContext,
+                    branch
+                })
+            );
+            return response.data.commit.sha;
+        },
+
+        async getPullRequest(pullRequestNumber) {
+            const response = await resolveGitHubResponse(
+                octokit.rest.pulls.get({
+                    ...requestContext,
+                    pull_number: pullRequestNumber
+                })
+            );
+            return toPullRequestDetails(response.data);
+        },
+
+        async getPullRequestHead(pullRequestNumber) {
+            const response = await resolveGitHubResponse(
+                octokit.rest.pulls.get({
+                    ...requestContext,
+                    pull_number: pullRequestNumber
+                })
+            );
+            const pullRequest = response.data;
+            const commit = await readCommit(pullRequest.head.sha);
+            return {
+                author: pullRequest.user.login,
+                changedFiles: await readPullRequestFiles(pullRequest.number),
+                headRef: pullRequest.head.ref,
+                labels: labelNames(pullRequest.labels),
+                parentShas: commit.parents.map((parent) => {
+                    return parent.sha;
+                }),
+                subject: commitSubject(commit),
+                title: pullRequest.title
+            };
+        },
+
+        async listCommitPullRequests(commitSha) {
+            const pullRequests = await resolveGitHubResponse(
+                octokit.paginate(octokit.rest.repos.listPullRequestsAssociatedWithCommit, {
+                    ...requestContext,
+                    commit_sha: commitSha,
+                    per_page: 100
+                })
+            );
+            return Promise.all(pullRequests.map(toPullRequestDetails));
+        },
+
+        async readWorkflowRunResult(runId) {
+            const [runResponse, jobResponse] = await Promise.all([
+                resolveGitHubResponse(octokit.rest.actions.getWorkflowRun({ ...requestContext, run_id: runId })),
+                resolveGitHubResponse(
+                    octokit.rest.actions.listJobsForWorkflowRun({
+                        ...requestContext,
+                        run_id: runId,
+                        per_page: 100
+                    })
+                )
+            ]);
+            return {
+                conclusion: runResponse.data.conclusion ?? undefined,
+                databaseId: runId,
+                jobs: jobResponse.data.jobs.map((job: RawWorkflowJob) => {
+                    return {
+                        conclusion: job.conclusion ?? undefined,
+                        name: job.name,
+                        url: job.html_url ?? undefined
+                    };
+                })
+            };
+        }
+    };
+}

--- a/source/command-line-interface/runner/release-publish-authorization.test.ts
+++ b/source/command-line-interface/runner/release-publish-authorization.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { PullRequestDetails } from './release-pr-github-client.ts';
+import {
+    authorizeReleasePublishFromCommit,
+    authorizeReleasePublishFromPullRequest
+} from './release-publish-authorization.ts';
+import type { ReleasePullRequestPolicyConfig } from './release-pull-request-policy.ts';
+
+const policyConfig: ReleasePullRequestPolicyConfig = {
+    allowedFiles: new Set(['CHANGELOG.md']),
+    automationAuthor: 'github-actions[bot]',
+    branch: 'release/packtory',
+    commitSubject: 'Release packages',
+    defaultBranch: 'main',
+    label: 'release',
+    title: 'Prepare release'
+};
+
+const releasePullRequest: PullRequestDetails = {
+    author: 'github-actions[bot]',
+    baseRef: 'main',
+    changedFiles: ['CHANGELOG.md'],
+    headRef: 'release/packtory',
+    headRepository: 'owner/repo',
+    labels: ['release'],
+    mergeCommitSha: 'merge-sha',
+    merged: true,
+    number: 12,
+    subject: 'Release packages',
+    title: 'Prepare release'
+};
+
+suite('release-publish-authorization', function () {
+    test('skips normal commits without a release PR', function () {
+        assert.deepStrictEqual(
+            authorizeReleasePublishFromCommit({
+                commitSha: 'commit-sha',
+                config: policyConfig,
+                pullRequests: [
+                    {
+                        ...releasePullRequest,
+                        labels: ['bug'],
+                        mergeCommitSha: 'commit-sha'
+                    }
+                ],
+                repository: 'owner/repo'
+            }),
+            { shouldPublish: false }
+        );
+    });
+
+    test('authorizes a commit associated with exactly one merged release PR', function () {
+        assert.deepStrictEqual(
+            authorizeReleasePublishFromCommit({
+                commitSha: 'merge-sha',
+                config: policyConfig,
+                pullRequests: [releasePullRequest],
+                repository: 'owner/repo'
+            }),
+            {
+                publishCommitSha: 'merge-sha',
+                releaseCommitSha: 'merge-sha',
+                releasePullRequestNumber: 12,
+                shouldPublish: true
+            }
+        );
+    });
+
+    test('rejects commits associated with multiple release PRs', function () {
+        assert.throws(
+            () => {
+                authorizeReleasePublishFromCommit({
+                    commitSha: 'merge-sha',
+                    config: policyConfig,
+                    pullRequests: [releasePullRequest, { ...releasePullRequest, number: 13 }],
+                    repository: 'owner/repo'
+                });
+            },
+            { message: 'Commit merge-sha is associated with multiple release PRs' }
+        );
+    });
+
+    test('rejects manual retries for unmerged release PRs', function () {
+        assert.throws(
+            () => {
+                authorizeReleasePublishFromPullRequest({
+                    config: policyConfig,
+                    pullRequest: {
+                        ...releasePullRequest,
+                        mergeCommitSha: undefined,
+                        merged: false
+                    },
+                    repository: 'owner/repo'
+                });
+            },
+            { message: 'Pull request #12 is not a merged release PR' }
+        );
+    });
+});

--- a/source/command-line-interface/runner/release-publish-authorization.ts
+++ b/source/command-line-interface/runner/release-publish-authorization.ts
@@ -1,0 +1,113 @@
+import type { PullRequestDetails } from './release-pr-github-client.ts';
+import {
+    validateReleasePullRequestPublishPolicy,
+    type ReleasePullRequestPolicyConfig,
+    type ReleasePullRequestPublishInput
+} from './release-pull-request-policy.ts';
+
+type AuthorizedReleasePublish = {
+    readonly publishCommitSha: string;
+    readonly releaseCommitSha: string;
+    readonly releasePullRequestNumber: number;
+    readonly shouldPublish: true;
+};
+
+export type ReleasePublishAuthorization = AuthorizedReleasePublish | { readonly shouldPublish: false };
+
+function selectSingleReleasePullRequest(
+    pullRequests: readonly PullRequestDetails[],
+    commitSha: string
+): PullRequestDetails | undefined {
+    const pullRequest = pullRequests.at(0);
+    const secondPullRequest = pullRequests.at(1);
+    if (secondPullRequest !== undefined) {
+        throw new Error(`Commit ${commitSha} is associated with multiple release PRs`);
+    }
+    return pullRequest;
+}
+
+function toPublishInput(pullRequest: PullRequestDetails, repository: string): ReleasePullRequestPublishInput {
+    return {
+        author: pullRequest.author,
+        baseRef: pullRequest.baseRef,
+        changedFiles: pullRequest.changedFiles,
+        headRef: pullRequest.headRef,
+        headRepository: pullRequest.headRepository,
+        labels: pullRequest.labels,
+        mergeCommitSha: pullRequest.mergeCommitSha,
+        merged: pullRequest.merged,
+        repository,
+        subject: pullRequest.subject,
+        title: pullRequest.title
+    };
+}
+
+function isAuthorizedPullRequest(input: {
+    readonly config: ReleasePullRequestPolicyConfig;
+    readonly expectedMergeCommitSha: string;
+    readonly pullRequest: PullRequestDetails;
+    readonly repository: string;
+}): boolean {
+    let authorized = true;
+    try {
+        validateReleasePullRequestPublishPolicy(
+            toPublishInput(input.pullRequest, input.repository),
+            input.config,
+            input.expectedMergeCommitSha
+        );
+    } catch {
+        authorized = false;
+    }
+    return authorized;
+}
+
+export function authorizeReleasePublishFromCommit(input: {
+    readonly config: ReleasePullRequestPolicyConfig;
+    readonly commitSha: string;
+    readonly pullRequests: readonly PullRequestDetails[];
+    readonly repository: string;
+}): ReleasePublishAuthorization {
+    const releasePullRequests = input.pullRequests.filter((pullRequest) => {
+        return isAuthorizedPullRequest({
+            config: input.config,
+            expectedMergeCommitSha: input.commitSha,
+            pullRequest,
+            repository: input.repository
+        });
+    });
+
+    const releasePullRequest = selectSingleReleasePullRequest(releasePullRequests, input.commitSha);
+    if (releasePullRequest === undefined) {
+        return { shouldPublish: false };
+    }
+
+    return {
+        publishCommitSha: input.commitSha,
+        releaseCommitSha: input.commitSha,
+        releasePullRequestNumber: releasePullRequest.number,
+        shouldPublish: true
+    };
+}
+
+export function authorizeReleasePublishFromPullRequest(input: {
+    readonly config: ReleasePullRequestPolicyConfig;
+    readonly pullRequest: PullRequestDetails;
+    readonly repository: string;
+}): ReleasePublishAuthorization {
+    if (input.pullRequest.mergeCommitSha === undefined) {
+        throw new Error(`Pull request #${input.pullRequest.number} is not a merged release PR`);
+    }
+
+    validateReleasePullRequestPublishPolicy(
+        toPublishInput(input.pullRequest, input.repository),
+        input.config,
+        input.pullRequest.mergeCommitSha
+    );
+
+    return {
+        publishCommitSha: input.pullRequest.mergeCommitSha,
+        releaseCommitSha: input.pullRequest.mergeCommitSha,
+        releasePullRequestNumber: input.pullRequest.number,
+        shouldPublish: true
+    };
+}

--- a/source/command-line-interface/runner/release-pull-request-ci.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.test.ts
@@ -1,0 +1,251 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import { runConfiguredGitHubActionsCi } from './release-pull-request-ci.ts';
+import type { ReleasePullRequestConfig } from './release-pull-request-config.ts';
+import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+
+function createConfig(requiredStatusContexts: readonly string[] = ['Node.js']): ReleasePullRequestConfig {
+    return {
+        automationAuthor: 'github-actions[bot]',
+        body: 'Body',
+        branch: 'release/packtory',
+        commitSubject: 'Release packages',
+        defaultBranch: 'main',
+        githubActionsCi: {
+            deleteActionRequiredPullRequestRuns: true,
+            requiredStatusContexts,
+            workflowFile: 'ci.yml'
+        },
+        label: 'release',
+        title: 'Prepare release'
+    };
+}
+
+function createClient(overrides: Partial<ReleasePullRequestGitHubClient> = {}): ReleasePullRequestGitHubClient {
+    return {
+        closeOpenReleasePullRequests: fake.resolves(undefined),
+        createOrUpdateReleasePullRequest: fake.resolves(1),
+        createStatus: fake.resolves(undefined),
+        deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
+        dispatchWorkflow: fake.resolves(undefined),
+        findDispatchedWorkflowRunId: fake.resolves(1),
+        getBranchHeadSha: fake.resolves('main-head'),
+        getPullRequest: fake.resolves(undefined as never),
+        getPullRequestHead: fake.resolves(undefined as never),
+        listCommitPullRequests: fake.resolves([]),
+        readWorkflowRunResult: fake.resolves({
+            conclusion: 'success',
+            databaseId: 1,
+            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+        }),
+        ...overrides
+    };
+}
+
+suite('release-pull-request-ci', function () {
+    test('returns true without dispatch when GitHub Actions CI is not configured', async function () {
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: createClient(),
+                config: { ...createConfig(), githubActionsCi: undefined },
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+    });
+
+    test('dispatches the configured workflow and mirrors successful statuses', async function () {
+        const createStatus = fake.resolves(undefined);
+        const deleteActionRequiredPullRequestRuns = fake.resolves(undefined);
+        const dispatchWorkflow = fake.resolves(undefined);
+        const findDispatchedWorkflowRunId = fake.resolves(1);
+        const client = createClient({
+            createStatus,
+            deleteActionRequiredPullRequestRuns,
+            dispatchWorkflow,
+            findDispatchedWorkflowRunId
+        });
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client,
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Waiting for dispatched release CI.',
+            state: 'pending',
+            targetUrl: undefined
+        });
+        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/job'
+        });
+        assert.deepStrictEqual(dispatchWorkflow.firstCall.args[0], {
+            ref: 'release/packtory',
+            workflowFile: 'ci.yml'
+        });
+        assert.deepStrictEqual(findDispatchedWorkflowRunId.firstCall.args[0], {
+            branch: 'release/packtory',
+            headSha: 'release-head',
+            workflowFile: 'ci.yml'
+        });
+        assert.deepStrictEqual(deleteActionRequiredPullRequestRuns.firstCall.args[0], {
+            branch: 'release/packtory',
+            headSha: 'release-head'
+        });
+    });
+
+    test('requires all mirrored statuses to pass', async function () {
+        const createStatus = fake.resolves(undefined);
+        const client = createClient({ createStatus });
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client,
+                config: createConfig(['Node.js', 'Missing job']),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            false
+        );
+
+        assert.deepStrictEqual(createStatus.thirdCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/job'
+        });
+        assert.deepStrictEqual(createStatus.getCall(3).args[0], {
+            commitSha: 'release-head',
+            context: 'Missing job',
+            description: 'Missing dispatched release CI job: Missing job.',
+            state: 'failure',
+            targetUrl: undefined
+        });
+    });
+
+    test('returns false and mirrors a failure when a required job is missing', async function () {
+        const createStatus = fake.resolves(undefined);
+        const client = createClient({ createStatus });
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client,
+                config: createConfig(['Missing job']),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            false
+        );
+
+        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Missing job',
+            description: 'Missing dispatched release CI job: Missing job.',
+            state: 'failure',
+            targetUrl: undefined
+        });
+    });
+
+    test('returns false and mirrors a failed required job', async function () {
+        const createStatus = fake.resolves(undefined);
+        const client = createClient({
+            createStatus,
+            readWorkflowRunResult: fake.resolves({
+                conclusion: 'failure',
+                databaseId: 1,
+                jobs: [{ conclusion: 'failure', name: 'Node.js', url: 'https://run/job' }]
+            })
+        });
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client,
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            false
+        );
+
+        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI job failure.',
+            state: 'failure',
+            targetUrl: 'https://run/job'
+        });
+    });
+
+    test('does not delete blocked pull request runs when cleanup is disabled', async function () {
+        const deleteActionRequiredPullRequestRuns = fake.resolves(undefined);
+        const client = createClient({ deleteActionRequiredPullRequestRuns });
+        const config = createConfig();
+        if (config.githubActionsCi === undefined) {
+            assert.fail('Expected test config to include GitHub Actions CI');
+        }
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client,
+                config: {
+                    ...config,
+                    githubActionsCi: {
+                        deleteActionRequiredPullRequestRuns: false,
+                        requiredStatusContexts: config.githubActionsCi.requiredStatusContexts,
+                        workflowFile: config.githubActionsCi.workflowFile
+                    }
+                },
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+        assert.strictEqual(deleteActionRequiredPullRequestRuns.callCount, 0);
+    });
+
+    test('fails when the dispatched workflow run is not created', async function () {
+        const findDispatchedWorkflowRunId = fake.resolves(undefined);
+        const sleep = fake.resolves(undefined);
+        await assert.rejects(
+            runConfiguredGitHubActionsCi({
+                client: createClient({ findDispatchedWorkflowRunId }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep
+            }),
+            { message: 'Release workflow run was not created for release-head' }
+        );
+        assert.strictEqual(findDispatchedWorkflowRunId.callCount, 30);
+        assert.strictEqual(sleep.callCount, 29);
+    });
+
+    test('fails when the dispatched workflow run does not complete', async function () {
+        const readWorkflowRunResult = fake.resolves({ conclusion: undefined, databaseId: 1, jobs: [] });
+        const sleep = fake.resolves(undefined);
+        await assert.rejects(
+            runConfiguredGitHubActionsCi({
+                client: createClient({ readWorkflowRunResult }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep
+            }),
+            { message: 'Release workflow run 1 did not complete' }
+        );
+        assert.strictEqual(readWorkflowRunResult.callCount, 120);
+        assert.strictEqual(sleep.callCount, 119);
+    });
+});

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -1,0 +1,149 @@
+import type { ReleasePullRequestConfig } from './release-pull-request-config.ts';
+import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+
+type GitHubActionsCiConfig = NonNullable<ReleasePullRequestConfig['githubActionsCi']>;
+
+const workflowRunLookupAttempts = 30;
+const workflowRunCompletionAttempts = 120;
+const workflowPollIntervalMilliseconds = 10_000;
+
+function createRetryAttempts(count: number): readonly number[] {
+    return Array.from({ length: count }, (_value, index) => {
+        return index;
+    });
+}
+
+function isLastAttempt(attempt: number, count: number): boolean {
+    return attempt === count - 1;
+}
+
+async function waitForDispatchedWorkflowRun(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly headSha: string;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+}): Promise<number> {
+    for (const attempt of createRetryAttempts(workflowRunLookupAttempts)) {
+        const runId = await input.client.findDispatchedWorkflowRunId({
+            branch: input.config.branch,
+            headSha: input.headSha,
+            workflowFile: input.ciConfig.workflowFile
+        });
+        if (runId !== undefined) {
+            return runId;
+        }
+        if (!isLastAttempt(attempt, workflowRunLookupAttempts)) {
+            await input.sleep(workflowPollIntervalMilliseconds);
+        }
+    }
+    throw new Error(`Release workflow run was not created for ${input.headSha}`);
+}
+
+async function waitForWorkflowCompletion(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly runId: number;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+}): Promise<Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>> {
+    for (const attempt of createRetryAttempts(workflowRunCompletionAttempts)) {
+        const result = await input.client.readWorkflowRunResult(input.runId);
+        if (result.conclusion !== undefined) {
+            return result;
+        }
+        if (!isLastAttempt(attempt, workflowRunCompletionAttempts)) {
+            await input.sleep(workflowPollIntervalMilliseconds);
+        }
+    }
+    throw new Error(`Release workflow run ${input.runId} did not complete`);
+}
+
+function formatWorkflowStatusFailure(context: string, conclusion: string | undefined): string {
+    if (conclusion === undefined) {
+        return `Missing dispatched release CI job: ${context}.`;
+    }
+    return `Dispatched release CI job ${conclusion}.`;
+}
+
+async function mirrorWorkflowStatus(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly context: string;
+    readonly headSha: string;
+    readonly runResult: Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
+}): Promise<boolean> {
+    const job = input.runResult.jobs.find((candidate) => {
+        return candidate.name === input.context;
+    });
+    if (job?.conclusion === 'success') {
+        await input.client.createStatus({
+            commitSha: input.headSha,
+            context: input.context,
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: job.url
+        });
+        return true;
+    }
+    await input.client.createStatus({
+        commitSha: input.headSha,
+        context: input.context,
+        description: formatWorkflowStatusFailure(input.context, job?.conclusion),
+        state: 'failure',
+        targetUrl: job?.url
+    });
+    return false;
+}
+
+async function mirrorWorkflowStatuses(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly headSha: string;
+    readonly runResult: Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
+}): Promise<boolean> {
+    const statuses = await Promise.all(
+        input.ciConfig.requiredStatusContexts.map(async (context) => {
+            return mirrorWorkflowStatus({ ...input, context });
+        })
+    );
+    return statuses.every(Boolean);
+}
+
+async function createPendingWorkflowStatuses(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly headSha: string;
+}): Promise<void> {
+    for (const context of input.ciConfig.requiredStatusContexts) {
+        await input.client.createStatus({
+            commitSha: input.headSha,
+            context,
+            description: 'Waiting for dispatched release CI.',
+            state: 'pending',
+            targetUrl: undefined
+        });
+    }
+}
+
+export async function runConfiguredGitHubActionsCi(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly headSha: string;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+}): Promise<boolean> {
+    const { githubActionsCi } = input.config;
+    if (githubActionsCi === undefined) {
+        return true;
+    }
+    await createPendingWorkflowStatuses({ ...input, ciConfig: githubActionsCi });
+    await input.client.dispatchWorkflow({ ref: input.config.branch, workflowFile: githubActionsCi.workflowFile });
+    const runId = await waitForDispatchedWorkflowRun({ ...input, ciConfig: githubActionsCi });
+    const runResult = await waitForWorkflowCompletion({ client: input.client, runId, sleep: input.sleep });
+    if (githubActionsCi.deleteActionRequiredPullRequestRuns) {
+        await input.client.deleteActionRequiredPullRequestRuns({ branch: input.config.branch, headSha: input.headSha });
+    }
+    return mirrorWorkflowStatuses({
+        ciConfig: githubActionsCi,
+        client: input.client,
+        headSha: input.headSha,
+        runResult
+    });
+}

--- a/source/command-line-interface/runner/release-pull-request-config.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-config.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import {
+    parseReleasePullRequestConfigContainer,
+    resolveReleasePullRequestConfig
+} from './release-pull-request-config.ts';
+
+suite('release-pull-request-config', function () {
+    test('uses defaults when release pull request settings are absent', function () {
+        assert.deepStrictEqual(resolveReleasePullRequestConfig({}), {
+            automationAuthor: 'github-actions[bot]',
+            body: 'Updates changelogs for the next release.',
+            branch: 'release/packtory',
+            commitSubject: 'Release packages',
+            defaultBranch: 'main',
+            githubActionsCi: undefined,
+            label: 'release',
+            title: 'Prepare release'
+        });
+    });
+
+    test('defaults pull request run cleanup for configured GitHub Actions CI', function () {
+        assert.deepStrictEqual(
+            resolveReleasePullRequestConfig({
+                releasePullRequest: {
+                    githubActionsCi: {
+                        trigger: 'workflow-dispatch',
+                        workflowFile: 'ci.yml',
+                        requiredStatusContexts: ['Node.js']
+                    }
+                }
+            }).githubActionsCi,
+            {
+                deleteActionRequiredPullRequestRuns: true,
+                requiredStatusContexts: ['Node.js'],
+                workflowFile: 'ci.yml'
+            }
+        );
+    });
+
+    test('parses release pull request settings from CLI config', function () {
+        assert.deepStrictEqual(
+            parseReleasePullRequestConfigContainer({
+                releasePullRequest: {
+                    branch: 'release/pkg',
+                    githubActionsCi: {
+                        trigger: 'workflow-dispatch',
+                        workflowFile: 'ci.yml',
+                        requiredStatusContexts: ['Node.js v24.x']
+                    }
+                },
+                packages: []
+            }),
+            {
+                releasePullRequest: {
+                    branch: 'release/pkg',
+                    githubActionsCi: {
+                        trigger: 'workflow-dispatch',
+                        workflowFile: 'ci.yml',
+                        requiredStatusContexts: ['Node.js v24.x']
+                    }
+                }
+            }
+        );
+    });
+
+    test('rejects release CI without status contexts', function () {
+        assert.strictEqual(
+            parseReleasePullRequestConfigContainer({
+                releasePullRequest: {
+                    githubActionsCi: {
+                        trigger: 'workflow-dispatch',
+                        workflowFile: 'ci.yml',
+                        requiredStatusContexts: []
+                    }
+                }
+            }),
+            undefined
+        );
+    });
+});

--- a/source/command-line-interface/runner/release-pull-request-config.ts
+++ b/source/command-line-interface/runner/release-pull-request-config.ts
@@ -1,0 +1,79 @@
+import { safeParse } from '@schema-hub/zod-error-formatter';
+import { z } from 'zod/mini';
+import { releasePullRequestSettingsSchema, type ReleasePullRequestSettings } from './release-pull-request-settings.ts';
+
+type GitHubActionsCiConfig = {
+    readonly deleteActionRequiredPullRequestRuns: boolean;
+    readonly requiredStatusContexts: readonly string[];
+    readonly workflowFile: string;
+};
+
+export type ReleasePullRequestConfig = {
+    readonly automationAuthor: string;
+    readonly body: string;
+    readonly branch: string;
+    readonly commitSubject: string;
+    readonly defaultBranch: string;
+    readonly githubActionsCi: GitHubActionsCiConfig | undefined;
+    readonly label: string;
+    readonly title: string;
+};
+
+type ReleasePullRequestConfigContainer = {
+    readonly releasePullRequest?: ReleasePullRequestSettings | undefined;
+};
+type StringReleasePullRequestSetting = Exclude<keyof ReleasePullRequestConfig, 'githubActionsCi'>;
+
+const releasePullRequestConfigContainerSchema = z.readonly(
+    z.object({ releasePullRequest: z.optional(releasePullRequestSettingsSchema) })
+);
+
+const defaultReleasePullRequestConfig: ReleasePullRequestConfig = {
+    automationAuthor: 'github-actions[bot]',
+    body: 'Updates changelogs for the next release.',
+    branch: 'release/packtory',
+    commitSubject: 'Release packages',
+    defaultBranch: 'main',
+    githubActionsCi: undefined,
+    label: 'release',
+    title: 'Prepare release'
+};
+
+function resolveGitHubActionsCiConfig(
+    settings: ReleasePullRequestSettings['githubActionsCi']
+): GitHubActionsCiConfig | undefined {
+    if (settings === undefined) {
+        return undefined;
+    }
+    return {
+        deleteActionRequiredPullRequestRuns: settings.deleteActionRequiredPullRequestRuns ?? true,
+        requiredStatusContexts: settings.requiredStatusContexts,
+        workflowFile: settings.workflowFile
+    };
+}
+
+function resolveStringSetting(
+    settings: ReleasePullRequestSettings | undefined,
+    setting: StringReleasePullRequestSetting
+): string {
+    return settings?.[setting] ?? defaultReleasePullRequestConfig[setting];
+}
+
+export function resolveReleasePullRequestConfig(config: ReleasePullRequestConfigContainer): ReleasePullRequestConfig {
+    const { releasePullRequest } = config;
+    return {
+        automationAuthor: resolveStringSetting(releasePullRequest, 'automationAuthor'),
+        body: resolveStringSetting(releasePullRequest, 'body'),
+        branch: resolveStringSetting(releasePullRequest, 'branch'),
+        commitSubject: resolveStringSetting(releasePullRequest, 'commitSubject'),
+        defaultBranch: resolveStringSetting(releasePullRequest, 'defaultBranch'),
+        githubActionsCi: resolveGitHubActionsCiConfig(releasePullRequest?.githubActionsCi),
+        label: resolveStringSetting(releasePullRequest, 'label'),
+        title: resolveStringSetting(releasePullRequest, 'title')
+    };
+}
+
+export function parseReleasePullRequestConfigContainer(config: unknown): ReleasePullRequestConfigContainer | undefined {
+    const result = safeParse(releasePullRequestConfigContainerSchema, config);
+    return result.success ? result.data : undefined;
+}

--- a/source/command-line-interface/runner/release-pull-request-handler.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.test.ts
@@ -1,0 +1,715 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import { Result } from 'true-myth';
+import { createBuildReportFixture } from '../../test-libraries/preview-fixtures.ts';
+import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
+import type { Packtory } from '../../packtory/packtory.ts';
+import type { PullRequestDetails, ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+import {
+    runReleasePullRequestHandler,
+    type ReleasePullRequestHandlerDependencies
+} from './release-pull-request-handler.ts';
+
+function createReleasePackage() {
+    return {
+        name: 'pkg',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed' as const,
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'current-head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: ['dist/index.js'],
+        changedArtifactFiles: ['dist/index.js'],
+        sourceFiles: ['src/index.ts'],
+        changelogSourceFiles: ['src/index.ts']
+    };
+}
+
+function createConfig() {
+    return {
+        changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] },
+        packages: [
+            {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } },
+                publishSettings: { access: 'public' }
+            }
+        ]
+    };
+}
+
+async function unusedPacktoryMethod(): Promise<never> {
+    throw new Error('unused packtory method');
+}
+
+async function rejectWithUnknown(reason: unknown): Promise<never> {
+    return new Promise((_resolve, reject) => {
+        Reflect.apply(reject, undefined, [reason]);
+    });
+}
+
+function createPacktoryWithPlan(
+    planReleaseAgainstLatestPublished: Packtory['planReleaseAgainstLatestPublished']
+): Packtory {
+    return {
+        analyzeReleaseAgainstLatestPublished: unusedPacktoryMethod,
+        buildAndPublishAll: unusedPacktoryMethod,
+        diffAgainstLatestPublished: unusedPacktoryMethod,
+        packPackage: unusedPacktoryMethod,
+        planReleaseAgainstLatestPublished,
+        resolveAndLinkAll: unusedPacktoryMethod
+    };
+}
+
+function createReleasePullRequestClient(
+    overrides: Partial<ReleasePullRequestGitHubClient> = {}
+): ReleasePullRequestGitHubClient {
+    return {
+        closeOpenReleasePullRequests: fake.resolves(undefined),
+        createOrUpdateReleasePullRequest: fake.resolves(12),
+        createStatus: fake.resolves(undefined),
+        deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
+        dispatchWorkflow: fake.resolves(undefined),
+        findDispatchedWorkflowRunId: fake.resolves(1),
+        getBranchHeadSha: fake.resolves('main-head'),
+        getPullRequest: fake.resolves({
+            author: 'github-actions[bot]',
+            baseRef: 'main',
+            changedFiles: ['CHANGELOG.md'],
+            headRef: 'release/packtory',
+            headRepository: 'owner/repo',
+            labels: ['release'],
+            mergeCommitSha: 'merge-sha',
+            merged: true,
+            number: 12,
+            subject: 'Release packages',
+            title: 'Prepare release'
+        }),
+        getPullRequestHead: fake.resolves({
+            author: 'github-actions[bot]',
+            changedFiles: ['CHANGELOG.md'],
+            headRef: 'release/packtory',
+            labels: ['release'],
+            parentShas: ['main-head'],
+            subject: 'Release packages',
+            title: 'Prepare release'
+        }),
+        listCommitPullRequests: fake.resolves([]),
+        readWorkflowRunResult: fake.resolves({
+            conclusion: 'success',
+            databaseId: 1,
+            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+        }),
+        ...overrides
+    };
+}
+
+function createDependencies(overrides: Partial<ReleasePullRequestHandlerDependencies> = {}): {
+    readonly dependencies: ReleasePullRequestHandlerDependencies;
+    readonly log: ReturnType<typeof fake>;
+} {
+    const log = fake();
+    const fileManager = createFakeFileManager();
+    const releasePullRequestClient = createReleasePullRequestClient();
+    const dependencies: ReleasePullRequestHandlerDependencies = {
+        createGitHubReleaseClient: fake.returns({ createReleaseIfMissing: fake.resolves('created') }),
+        createPrLogEngine: fake.returns({
+            collectMergedPullRequests: fake.resolves([{ id: 1, title: 'Fix package' }]),
+            filterPullRequestsByTargetFiles: fake.returns([{ id: 1, title: 'Fix package' }]),
+            readPullRequestLabels: fake.resolves(new Map([[1, ['bug']]])),
+            readPullRequestChangedFiles: fake.resolves(new Map([[1, ['src/index.ts']]])),
+            renderChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),
+            renderGroupedTargetChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),
+            renderTargetChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),
+            resolveChangelogBaseRef: fake.resolves({ ref: 'pkg@1.0.0' }),
+            resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: '1.0.0' }),
+            resolvePullRequestLabels: fake.resolves([{ id: 1, label: 'bug', title: 'Fix package' }]),
+            updateChangelog: fake.returns('updated changelog')
+        }),
+        createReleasePullRequestGitHubClient: fake.returns(releasePullRequestClient),
+        currentDate: () => {
+            return new Date('2026-06-13T00:00:00.000Z');
+        },
+        fileManager,
+        flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
+        gitClient: {
+            commit: fake.resolves(undefined),
+            currentHead: fake.resolves('head'),
+            deleteRemoteBranch: fake.resolves(undefined),
+            ensureClean: fake.resolves(undefined),
+            ensureTag: fake.resolves(undefined),
+            pushHeadToBranch: fake.resolves(undefined),
+            pushFollowTags: fake.resolves(undefined)
+        },
+        log(message) {
+            log(message);
+        },
+        packtory: createPacktoryWithPlan(
+            fake.resolves({
+                result: Result.ok({ packages: [] }),
+                getReport() {
+                    return createBuildReportFixture();
+                }
+            })
+        ),
+        readEnvironmentVariable(name) {
+            return { GH_TOKEN: 'token', GITHUB_REPOSITORY: 'owner/repo', GITHUB_SHA: 'merge-sha' }[name];
+        },
+        readPackageInfo: async () => {
+            return { repository: { url: 'https://github.com/owner/repo' } };
+        },
+        sleep: fake.resolves(undefined),
+        spinnerRenderer: { stopAll: fake() },
+        configLoader: { load: fake.resolves(createConfig()) },
+        workingDirectory: '/repo',
+        ...overrides
+    };
+    return { dependencies, log };
+}
+
+function createGitHubEnvironment(overrides: Record<string, string>) {
+    return (name: string) => {
+        return { GH_TOKEN: 'token', GITHUB_REPOSITORY: 'owner/repo', ...overrides }[name];
+    };
+}
+
+function createReleasePullRequestDetails(overrides: Partial<PullRequestDetails> = {}): PullRequestDetails {
+    return {
+        author: 'github-actions[bot]',
+        baseRef: 'main',
+        changedFiles: ['CHANGELOG.md'],
+        headRef: 'release/packtory',
+        headRepository: 'owner/repo',
+        labels: ['release'],
+        mergeCommitSha: 'merge-sha',
+        merged: true,
+        number: 12,
+        subject: 'Release packages',
+        title: 'Prepare release',
+        ...overrides
+    };
+}
+
+function createValidateDependencies(input: {
+    readonly client: ReleasePullRequestGitHubClient | undefined;
+    readonly eventName: string;
+    readonly eventPayload: unknown;
+}) {
+    const commonDependencies = {
+        fileManager: createFakeFileManager({
+            simulatedReadFileResponses: [{ value: JSON.stringify(input.eventPayload) }]
+        }),
+        flags: { command: 'validate', releasePullRequestNumber: undefined },
+        readEnvironmentVariable: createGitHubEnvironment({
+            GITHUB_EVENT_NAME: input.eventName,
+            GITHUB_EVENT_PATH: '/event.json'
+        })
+    } satisfies Partial<ReleasePullRequestHandlerDependencies>;
+    if (input.client === undefined) {
+        return createDependencies(commonDependencies);
+    }
+    return createDependencies({
+        ...commonDependencies,
+        createReleasePullRequestGitHubClient: fake.returns(input.client)
+    });
+}
+
+function createManualAuthorizationDependencies(fileManager = createFakeFileManager()) {
+    return createDependencies({
+        fileManager,
+        flags: { command: 'authorize-publish', releasePullRequestNumber: '12' },
+        readEnvironmentVariable: createGitHubEnvironment({
+            GITHUB_OUTPUT: '/github-output',
+            GITHUB_REF_NAME: 'main'
+        })
+    });
+}
+
+function createChangingReleaseGitClient(
+    overrides: Partial<ReleasePullRequestHandlerDependencies['gitClient']> = {}
+): ReleasePullRequestHandlerDependencies['gitClient'] {
+    const heads = ['main-head', 'release-head'];
+    return {
+        commit: fake.resolves(undefined),
+        async currentHead() {
+            return heads.shift() ?? 'release-head';
+        },
+        deleteRemoteBranch: fake.resolves(undefined),
+        ensureClean: fake.resolves(undefined),
+        ensureTag: fake.resolves(undefined),
+        pushHeadToBranch: fake.resolves(undefined),
+        pushFollowTags: fake.resolves(undefined),
+        ...overrides
+    };
+}
+
+function createReleaseContentDependencies(overrides: Partial<ReleasePullRequestHandlerDependencies> = {}) {
+    return createDependencies({
+        flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined },
+        gitClient: createChangingReleaseGitClient(),
+        packtory: createPacktoryWithPlan(
+            fake.resolves({
+                result: Result.ok({ packages: [createReleasePackage()] }),
+                getReport() {
+                    return createBuildReportFixture();
+                }
+            })
+        ),
+        ...overrides
+    });
+}
+
+async function assertHandlerFailure(
+    setup: ReturnType<typeof createDependencies>,
+    expectedMessage: string
+): Promise<void> {
+    assert.strictEqual(await runReleasePullRequestHandler(setup.dependencies), 1);
+    assert.strictEqual(setup.log.lastCall.args[0], expectedMessage);
+}
+
+type AuthorizePublishEnvironment = Readonly<
+    Record<'GH_TOKEN' | 'GITHUB_REPOSITORY' | 'GITHUB_SHA', string | undefined>
+>;
+
+function createAuthorizePublishEnvironment(input: AuthorizePublishEnvironment) {
+    return (name: string) => {
+        return input[name as keyof AuthorizePublishEnvironment];
+    };
+}
+
+suite('release-pull-request-handler', function () {
+    test('maintain requires no-dry-run', async function () {
+        const { dependencies, log } = createDependencies({
+            flags: { command: 'maintain', noDryRun: false, releasePullRequestNumber: undefined }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.firstCall.args[0], 'Release PR writes require --no-dry-run');
+    });
+
+    test('maintain closes release state when no release content remains', async function () {
+        const deleteRemoteBranch = fake.resolves(undefined);
+        const closeOpenReleasePullRequests = fake.resolves(undefined);
+        const { dependencies, log } = createDependencies({
+            createReleasePullRequestGitHubClient: fake.returns(
+                createReleasePullRequestClient({
+                    closeOpenReleasePullRequests
+                })
+            ),
+            flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined },
+            gitClient: {
+                commit: fake.resolves(undefined),
+                currentHead: fake.resolves('head'),
+                deleteRemoteBranch,
+                ensureClean: fake.resolves(undefined),
+                ensureTag: fake.resolves(undefined),
+                pushHeadToBranch: fake.resolves(undefined),
+                pushFollowTags: fake.resolves(undefined)
+            }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(deleteRemoteBranch.callCount, 1);
+        assert.deepStrictEqual(closeOpenReleasePullRequests.firstCall.args[0], {
+            baseBranch: 'main',
+            releaseBranch: 'release/packtory'
+        });
+        assert.strictEqual(log.lastCall.args[0], 'No release content remains');
+    });
+
+    test('maintain updates the release PR when changelog content is committed', async function () {
+        const commit = fake.resolves(undefined);
+        const createOrUpdateReleasePullRequest = fake.resolves(12);
+        const pushHeadToBranch = fake.resolves(undefined);
+        const pushFollowTags = fake.resolves(undefined);
+        const { dependencies, log } = createReleaseContentDependencies({
+            createReleasePullRequestGitHubClient: fake.returns(
+                createReleasePullRequestClient({
+                    createOrUpdateReleasePullRequest
+                })
+            ),
+            gitClient: createChangingReleaseGitClient({ commit, pushFollowTags, pushHeadToBranch })
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(commit.callCount, 1);
+        assert.deepStrictEqual(pushHeadToBranch.firstCall.args, ['release/packtory']);
+        assert.strictEqual(pushFollowTags.callCount, 0);
+        assert.deepStrictEqual(createOrUpdateReleasePullRequest.firstCall.args[0], {
+            baseBranch: 'main',
+            body: 'Updates changelogs for the next release.',
+            label: 'release',
+            releaseBranch: 'release/packtory',
+            title: 'Prepare release'
+        });
+        assert.strictEqual(log.lastCall.args[0], 'Release PR #12 points at release-head');
+    });
+
+    test('maintain returns failure when configured release PR CI fails', async function () {
+        const { dependencies, log } = createReleaseContentDependencies({
+            configLoader: {
+                load: fake.resolves({
+                    ...createConfig(),
+                    releasePullRequest: {
+                        githubActionsCi: {
+                            trigger: 'workflow-dispatch',
+                            workflowFile: 'ci.yml',
+                            requiredStatusContexts: ['Missing job']
+                        }
+                    }
+                })
+            }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'Release PR #12 points at release-head');
+    });
+
+    test('maintain reports release preparation failures', async function () {
+        const { dependencies, log } = createDependencies({
+            flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined },
+            packtory: createPacktoryWithPlan(
+                fake.resolves({
+                    result: Result.err({ type: 'config', issues: ['Registry failed'] }),
+                    getReport() {
+                        return createBuildReportFixture();
+                    }
+                })
+            )
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'Release preparation failed');
+    });
+
+    test('maintain rejects configs without valid packages', async function () {
+        const { dependencies, log } = createDependencies({
+            configLoader: { load: fake.resolves({}) },
+            flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'The loaded config is invalid for release PR management');
+    });
+
+    test('maintain rejects invalid release pull request settings', async function () {
+        const { dependencies, log } = createDependencies({
+            configLoader: {
+                load: fake.resolves({
+                    ...createConfig(),
+                    releasePullRequest: {
+                        githubActionsCi: {
+                            trigger: 'workflow-dispatch',
+                            workflowFile: 'ci.yml',
+                            requiredStatusContexts: []
+                        }
+                    }
+                })
+            },
+            flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'The loaded config is invalid for release PR management');
+    });
+
+    test('formats non-error command failures', async function () {
+        const { dependencies, log } = createDependencies({
+            configLoader: {
+                async load() {
+                    return rejectWithUnknown('plain failure');
+                }
+            },
+            flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'plain failure');
+    });
+
+    test('validate accepts a normal pull request without the release label', async function () {
+        const { dependencies, log } = createValidateDependencies({
+            eventName: 'pull_request',
+            eventPayload: { pull_request: { number: 12 } },
+            client: createReleasePullRequestClient({
+                getPullRequestHead: fake.resolves({
+                    author: 'maintainer',
+                    changedFiles: ['src/index.ts'],
+                    headRef: 'feature',
+                    labels: ['bug'],
+                    parentShas: ['branch-head'],
+                    subject: 'Fix bug',
+                    title: 'Fix bug'
+                })
+            })
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(log.lastCall.args[0], 'Release PR policy passed.');
+    });
+
+    test('validate accepts a release pull request that follows the policy', async function () {
+        const { dependencies, log } = createValidateDependencies({
+            client: undefined,
+            eventName: 'pull_request',
+            eventPayload: { pull_request: { number: 12 } }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(log.lastCall.args[0], 'Release PR policy passed.');
+    });
+
+    test('validate rejects release pull requests that violate the policy', async function () {
+        const { dependencies, log } = createValidateDependencies({
+            eventName: 'pull_request',
+            eventPayload: { pull_request: { number: 12 } },
+            client: createReleasePullRequestClient({
+                getPullRequestHead: fake.resolves({
+                    author: 'github-actions[bot]',
+                    changedFiles: ['src/index.ts'],
+                    headRef: 'release/packtory',
+                    labels: ['release'],
+                    parentShas: ['main-head'],
+                    subject: 'Release packages',
+                    title: 'Prepare release'
+                })
+            })
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'Unexpected release PR file change: src/index.ts');
+    });
+
+    test('validate rejects pull request events without a pull request number', async function () {
+        for (const eventPayload of [{}, { pull_request: {} }]) {
+            await assertHandlerFailure(
+                createValidateDependencies({
+                    client: undefined,
+                    eventName: 'pull_request',
+                    eventPayload
+                }),
+                'GitHub pull_request event payload is missing pull_request.number'
+            );
+        }
+    });
+
+    test('validate accepts a merge group that contains only the release pull request', async function () {
+        const { dependencies, log } = createValidateDependencies({
+            eventName: 'merge_group',
+            eventPayload: { merge_group: { base_sha: 'main-head', head_sha: 'merge-group-head' } },
+            client: createReleasePullRequestClient({
+                listCommitPullRequests: fake.resolves([createReleasePullRequestDetails()])
+            })
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(log.lastCall.args[0], 'Release PR policy passed.');
+    });
+
+    test('validate rejects merge group events without merge group SHAs', async function () {
+        for (const eventPayload of [
+            {},
+            { merge_group: {} },
+            { merge_group: { base_sha: 'main-head' } },
+            { merge_group: { head_sha: 'merge-group-head' } }
+        ]) {
+            await assertHandlerFailure(
+                createValidateDependencies({
+                    client: undefined,
+                    eventName: 'merge_group',
+                    eventPayload
+                }),
+                'GitHub merge_group event payload is missing merge group SHAs'
+            );
+        }
+    });
+
+    test('validate rejects unsupported GitHub events', async function () {
+        const { dependencies, log } = createValidateDependencies({
+            client: undefined,
+            eventName: 'push',
+            eventPayload: {}
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(
+            log.lastCall.args[0],
+            'release-pr validate only supports pull_request and merge_group events'
+        );
+    });
+
+    test('validate rejects non-object GitHub event payloads', async function () {
+        for (const eventPayload of [null, 'not an event']) {
+            await assertHandlerFailure(
+                createValidateDependencies({
+                    client: undefined,
+                    eventName: 'pull_request',
+                    eventPayload
+                }),
+                'GitHub event payload must be an object'
+            );
+        }
+    });
+
+    test('authorize-publish writes GitHub output for manual retries', async function () {
+        const fileManager = createFakeFileManager();
+        const { dependencies } = createManualAuthorizationDependencies(fileManager);
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(
+            fileManager.getWriteFileCall(0).content,
+            [
+                'should_publish=true',
+                'publish_commit_sha=merge-sha',
+                'release_commit_sha=merge-sha',
+                'release_pull_request_number=12',
+                ''
+            ].join('\n')
+        );
+    });
+
+    test('authorize-publish writes GitHub output when no previous output file is readable', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ error: new Error('missing output') }]
+        });
+        const { dependencies } = createManualAuthorizationDependencies(fileManager);
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(fileManager.getWriteFileCall(0).content.startsWith('should_publish=true\n'), true);
+    });
+
+    test('authorize-publish appends to existing GitHub output', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: 'existing=true\n' }]
+        });
+        const { dependencies } = createManualAuthorizationDependencies(fileManager);
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(
+            fileManager.getWriteFileCall(0).content.startsWith('existing=true\nshould_publish=true\n'),
+            true
+        );
+    });
+
+    test('authorize-publish rejects manual retries from non-default branches', async function () {
+        const { dependencies, log } = createDependencies({
+            flags: { command: 'authorize-publish', releasePullRequestNumber: '12' },
+            readEnvironmentVariable(name) {
+                return {
+                    GH_TOKEN: 'token',
+                    GITHUB_REF_NAME: 'feature',
+                    GITHUB_REPOSITORY: 'owner/repo'
+                }[name];
+            }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'Manual release publish retries must run from main');
+    });
+
+    test('authorize-publish logs push authorization when the commit belongs to one release PR', async function () {
+        const { dependencies, log } = createDependencies({
+            createReleasePullRequestGitHubClient: fake.returns(
+                createReleasePullRequestClient({
+                    listCommitPullRequests: fake.resolves([createReleasePullRequestDetails()])
+                })
+            )
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.strictEqual(
+            log.lastCall.args[0],
+            [
+                'should_publish=true',
+                'publish_commit_sha=merge-sha',
+                'release_commit_sha=merge-sha',
+                'release_pull_request_number=12'
+            ].join('\n')
+        );
+    });
+
+    test('rejects malformed GitHub repository environment values', async function () {
+        for (const repository of ['owner', '', '/repo', 'owner/', 'owner/repo/extra']) {
+            await assertHandlerFailure(
+                createDependencies({
+                    flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
+                    readEnvironmentVariable: createAuthorizePublishEnvironment({
+                        GH_TOKEN: 'token',
+                        GITHUB_REPOSITORY: repository,
+                        GITHUB_SHA: 'merge-sha'
+                    })
+                }),
+                'GITHUB_REPOSITORY must use owner/repo format'
+            );
+        }
+    });
+
+    test('uses package repository metadata when GitHub repository environment is absent', async function () {
+        const createReleasePullRequestGitHubClient = fake.returns(createReleasePullRequestClient());
+        const { dependencies } = createDependencies({
+            createReleasePullRequestGitHubClient,
+            flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
+            readEnvironmentVariable(name) {
+                return { GH_TOKEN: 'token', GITHUB_SHA: 'merge-sha' }[name];
+            }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+            owner: 'owner',
+            repo: 'repo',
+            token: 'token'
+        });
+    });
+
+    test('requires a GitHub token', async function () {
+        const { dependencies, log } = createDependencies({
+            flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
+            readEnvironmentVariable(name) {
+                return { GITHUB_REPOSITORY: 'owner/repo', GITHUB_SHA: 'merge-sha' }[name];
+            }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
+        assert.strictEqual(log.lastCall.args[0], 'GH_TOKEN or GITHUB_TOKEN must be set');
+    });
+
+    test('uses GITHUB_TOKEN when GH_TOKEN is absent', async function () {
+        const createReleasePullRequestGitHubClient = fake.returns(createReleasePullRequestClient());
+        const { dependencies } = createDependencies({
+            createReleasePullRequestGitHubClient,
+            flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
+            readEnvironmentVariable(name) {
+                return { GITHUB_REPOSITORY: 'owner/repo', GITHUB_SHA: 'merge-sha', GITHUB_TOKEN: 'github-token' }[name];
+            }
+        });
+
+        assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+        assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+            owner: 'owner',
+            repo: 'repo',
+            token: 'github-token'
+        });
+    });
+
+    test('requires a commit SHA for push publish authorization', async function () {
+        for (const commitSha of [undefined, '']) {
+            await assertHandlerFailure(
+                createDependencies({
+                    flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
+                    readEnvironmentVariable: createAuthorizePublishEnvironment({
+                        GH_TOKEN: 'token',
+                        GITHUB_REPOSITORY: 'owner/repo',
+                        GITHUB_SHA: commitSha
+                    })
+                }),
+                'GITHUB_SHA must be set'
+            );
+        }
+    });
+});

--- a/source/command-line-interface/runner/release-pull-request-handler.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.ts
@@ -1,0 +1,499 @@
+import { parseValidConfig } from './changelog-destinations.ts';
+import { formatGitHubRepositoryName, parseGitHubRepositoryParts } from './github-repository.ts';
+import type { ReleaseGitClient } from './release-git-client.ts';
+import { runReleaseHandler } from './release-handler.ts';
+import {
+    authorizeReleasePublishFromCommit,
+    authorizeReleasePublishFromPullRequest,
+    type ReleasePublishAuthorization
+} from './release-publish-authorization.ts';
+import { collectReleaseOutputFiles } from './release-output-files.ts';
+import { runConfiguredGitHubActionsCi } from './release-pull-request-ci.ts';
+import {
+    parseReleasePullRequestConfigContainer,
+    resolveReleasePullRequestConfig,
+    type ReleasePullRequestConfig
+} from './release-pull-request-config.ts';
+import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+import {
+    validateReleaseMergeGroupPolicy,
+    validateReleasePullRequestPolicy,
+    type ReleasePullRequestPolicyConfig,
+    type ReleasePullRequestPolicyInput
+} from './release-pull-request-policy.ts';
+
+type Logger = (message: string) => void;
+type EnvironmentReader = (name: string) => string | undefined;
+type ReleaseHandlerDependencies = Parameters<typeof runReleaseHandler>[0];
+
+type AuthorizePublishReleasePullRequestFlags = {
+    readonly command: 'authorize-publish';
+    readonly releasePullRequestNumber: string | undefined;
+};
+
+type MaintainReleasePullRequestFlags = {
+    readonly command: 'maintain';
+    readonly noDryRun: boolean;
+    readonly releasePullRequestNumber: undefined;
+};
+
+type ValidateReleasePullRequestFlags = {
+    readonly command: 'validate';
+    readonly releasePullRequestNumber: undefined;
+};
+
+type ReleasePullRequestFlags =
+    | AuthorizePublishReleasePullRequestFlags
+    | MaintainReleasePullRequestFlags
+    | ValidateReleasePullRequestFlags;
+
+export type ReleasePullRequestHandlerDependencies = {
+    readonly createGitHubReleaseClient: ReleaseHandlerDependencies['createGitHubReleaseClient'];
+    readonly createPrLogEngine: ReleaseHandlerDependencies['createPrLogEngine'];
+    readonly createReleasePullRequestGitHubClient: (context: {
+        readonly owner: string;
+        readonly repo: string;
+        readonly token: string;
+    }) => ReleasePullRequestGitHubClient;
+    readonly currentDate: () => Date;
+    readonly fileManager: {
+        readonly readFile: (filePath: string) => Promise<string>;
+        readonly writeFile: (filePath: string, content: string) => Promise<void>;
+    };
+    readonly flags: ReleasePullRequestFlags;
+    readonly gitClient: ReleaseGitClient;
+    readonly log: Logger;
+    readonly packtory: ReleaseHandlerDependencies['packtory'];
+    readonly readEnvironmentVariable: EnvironmentReader;
+    readonly readPackageInfo: () => Promise<Record<string, unknown>>;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+    readonly spinnerRenderer: { readonly stopAll: () => void };
+    readonly configLoader: { readonly load: () => Promise<unknown> };
+    readonly workingDirectory: string;
+};
+
+type LoadedReleasePullRequestConfig = {
+    readonly config: ReleasePullRequestConfig;
+    readonly policyConfig: ReleasePullRequestPolicyConfig;
+};
+
+type GitHubEvent = {
+    readonly merge_group?: { readonly base_sha?: string | undefined; readonly head_sha?: string | undefined };
+    readonly pull_request?: { readonly number?: number | undefined };
+};
+type GitHubContext = {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly repository: string;
+};
+
+function formatHandlerError(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function readGitHubToken(dependencies: Pick<ReleasePullRequestHandlerDependencies, 'readEnvironmentVariable'>): string {
+    const token =
+        dependencies.readEnvironmentVariable('GH_TOKEN') ?? dependencies.readEnvironmentVariable('GITHUB_TOKEN');
+    if (token === undefined) {
+        throw new Error('GH_TOKEN or GITHUB_TOKEN must be set');
+    }
+    return token;
+}
+
+function parseGitHubRepositoryName(repositoryName: string): { readonly owner: string; readonly repo: string } {
+    const ownerSeparatorIndex = repositoryName.indexOf('/');
+    const owner = repositoryName.slice(0, ownerSeparatorIndex);
+    const repo = repositoryName.slice(ownerSeparatorIndex + 1);
+    if (!repositoryName.includes('/') || owner.length === 0 || repo.length === 0 || repo.includes('/')) {
+        throw new Error('GITHUB_REPOSITORY must use owner/repo format');
+    }
+    return { owner, repo };
+}
+
+async function readGitHubRepository(
+    dependencies: Pick<ReleasePullRequestHandlerDependencies, 'readEnvironmentVariable' | 'readPackageInfo'>
+): Promise<{ readonly name: string; readonly owner: string; readonly repo: string }> {
+    const repositoryName = dependencies.readEnvironmentVariable('GITHUB_REPOSITORY');
+    if (repositoryName !== undefined) {
+        const { owner, repo } = parseGitHubRepositoryName(repositoryName);
+        return { name: repositoryName, owner, repo };
+    }
+    const packageInfo = await dependencies.readPackageInfo();
+    const repository = parseGitHubRepositoryParts(packageInfo);
+    return { ...repository, name: formatGitHubRepositoryName(packageInfo) };
+}
+
+async function createGitHubClient(dependencies: ReleasePullRequestHandlerDependencies): Promise<{
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly repository: string;
+}> {
+    const repository = await readGitHubRepository(dependencies);
+    return {
+        client: dependencies.createReleasePullRequestGitHubClient({
+            owner: repository.owner,
+            repo: repository.repo,
+            token: readGitHubToken(dependencies)
+        }),
+        repository: repository.name
+    };
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+    return typeof value === 'object' && value !== null;
+}
+
+const isGitHubEvent: (value: unknown) => value is GitHubEvent = isRecord;
+
+function parseReleasePullRequestConfig(
+    dependencies: Pick<ReleasePullRequestHandlerDependencies, 'workingDirectory'>,
+    rawConfig: unknown
+): LoadedReleasePullRequestConfig {
+    const parsedConfig = parseValidConfig(rawConfig);
+    if (parsedConfig === undefined) {
+        throw new Error('The loaded config is invalid for release PR management');
+    }
+    const releasePullRequestConfigContainer = parseReleasePullRequestConfigContainer(rawConfig);
+    if (releasePullRequestConfigContainer === undefined) {
+        throw new Error('The loaded config is invalid for release PR management');
+    }
+    const config = resolveReleasePullRequestConfig(releasePullRequestConfigContainer);
+    return {
+        config,
+        policyConfig: {
+            allowedFiles: new Set(
+                collectReleaseOutputFiles({ config: parsedConfig, workingDirectory: dependencies.workingDirectory })
+            ),
+            automationAuthor: config.automationAuthor,
+            branch: config.branch,
+            commitSubject: config.commitSubject,
+            defaultBranch: config.defaultBranch,
+            label: config.label,
+            title: config.title
+        }
+    };
+}
+
+async function loadReleasePullRequestConfig(
+    dependencies: Pick<ReleasePullRequestHandlerDependencies, 'configLoader' | 'workingDirectory'>
+): Promise<LoadedReleasePullRequestConfig> {
+    return parseReleasePullRequestConfig(dependencies, await dependencies.configLoader.load());
+}
+
+async function runPrepareRelease(dependencies: ReleasePullRequestHandlerDependencies): Promise<number> {
+    return runReleaseHandler({
+        createGitHubReleaseClient: dependencies.createGitHubReleaseClient,
+        createPrLogEngine: dependencies.createPrLogEngine,
+        currentDate: dependencies.currentDate,
+        fileManager: dependencies.fileManager,
+        flags: {
+            commit: true,
+            githubRelease: false,
+            noDryRun: true,
+            publish: false,
+            push: false,
+            tag: false,
+            writeChangelog: true
+        },
+        gitClient: dependencies.gitClient,
+        log: dependencies.log,
+        packtory: dependencies.packtory,
+        readEnvironmentVariable: dependencies.readEnvironmentVariable,
+        readPackageInfo: dependencies.readPackageInfo,
+        spinnerRenderer: dependencies.spinnerRenderer,
+        configLoader: dependencies.configLoader,
+        workingDirectory: dependencies.workingDirectory
+    });
+}
+
+async function closeReleaseState(
+    dependencies: ReleasePullRequestHandlerDependencies,
+    client: ReleasePullRequestGitHubClient,
+    config: ReleasePullRequestConfig
+): Promise<void> {
+    await client.closeOpenReleasePullRequests({ baseBranch: config.defaultBranch, releaseBranch: config.branch });
+    await dependencies.gitClient.deleteRemoteBranch(config.branch);
+}
+
+async function prepareReleasePullRequest(
+    dependencies: ReleasePullRequestHandlerDependencies
+): Promise<string | undefined> {
+    const originalHead = await dependencies.gitClient.currentHead();
+    const releaseExitCode = await runPrepareRelease(dependencies);
+    if (releaseExitCode !== 0) {
+        throw new Error('Release preparation failed');
+    }
+    const releaseHead = await dependencies.gitClient.currentHead();
+    return releaseHead === originalHead ? undefined : releaseHead;
+}
+
+async function updateReleasePullRequest(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly dependencies: ReleasePullRequestHandlerDependencies;
+    readonly releaseHead: string;
+}): Promise<number> {
+    const { client, config, dependencies, releaseHead } = input;
+    await dependencies.gitClient.pushHeadToBranch(config.branch);
+    const pullRequestNumber = await client.createOrUpdateReleasePullRequest({
+        baseBranch: config.defaultBranch,
+        body: config.body,
+        label: config.label,
+        releaseBranch: config.branch,
+        title: config.title
+    });
+    const ciSucceeded = await runConfiguredGitHubActionsCi({
+        client,
+        config,
+        headSha: releaseHead,
+        sleep: dependencies.sleep
+    });
+    dependencies.log(`Release PR #${pullRequestNumber} points at ${releaseHead}`);
+    return ciSucceeded ? 0 : 1;
+}
+
+async function finishReleasePullRequestMaintenance(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly dependencies: ReleasePullRequestHandlerDependencies;
+    readonly releaseHead: string | undefined;
+}): Promise<number> {
+    if (input.releaseHead === undefined) {
+        await closeReleaseState(input.dependencies, input.client, input.config);
+        input.dependencies.log('No release content remains');
+        return 0;
+    }
+    return updateReleasePullRequest({
+        client: input.client,
+        config: input.config,
+        dependencies: input.dependencies,
+        releaseHead: input.releaseHead
+    });
+}
+
+type MaintainReleasePullRequestHandlerDependencies = ReleasePullRequestHandlerDependencies & {
+    readonly flags: Extract<ReleasePullRequestFlags, { readonly command: 'maintain' }>;
+};
+
+async function runMaintain(dependencies: MaintainReleasePullRequestHandlerDependencies): Promise<number> {
+    if (!dependencies.flags.noDryRun) {
+        dependencies.log('Release PR writes require --no-dry-run');
+        return 1;
+    }
+    const loadedConfig = await loadReleasePullRequestConfig(dependencies);
+    const { client } = await createGitHubClient(dependencies);
+    const releaseHead = await prepareReleasePullRequest(dependencies);
+    return finishReleasePullRequestMaintenance({ client, config: loadedConfig.config, dependencies, releaseHead });
+}
+
+function readRequiredEnvironmentVariable(dependencies: ReleasePullRequestHandlerDependencies, name: string): string {
+    const value = dependencies.readEnvironmentVariable(name);
+    if (value === undefined || value.length === 0) {
+        throw new Error(`${name} must be set`);
+    }
+    return value;
+}
+
+async function readGitHubEvent(dependencies: ReleasePullRequestHandlerDependencies): Promise<GitHubEvent> {
+    const eventPath = readRequiredEnvironmentVariable(dependencies, 'GITHUB_EVENT_PATH');
+    const parsedEvent: unknown = JSON.parse(await dependencies.fileManager.readFile(eventPath));
+    if (!isGitHubEvent(parsedEvent)) {
+        throw new Error('GitHub event payload must be an object');
+    }
+    return parsedEvent;
+}
+
+async function toPolicyInput(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly expectedBaseSha: string;
+    readonly pullRequestNumber: number;
+}): Promise<ReleasePullRequestPolicyInput> {
+    const pullRequest = await input.client.getPullRequestHead(input.pullRequestNumber);
+    return {
+        author: pullRequest.author,
+        changedFiles: pullRequest.changedFiles,
+        expectedBaseSha: input.expectedBaseSha,
+        headRef: pullRequest.headRef,
+        labels: pullRequest.labels,
+        parentShas: pullRequest.parentShas,
+        subject: pullRequest.subject,
+        title: pullRequest.title
+    };
+}
+
+async function runPullRequestValidation(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: LoadedReleasePullRequestConfig;
+    readonly event: GitHubEvent;
+}): Promise<void> {
+    const pullRequestNumber = input.event.pull_request?.number;
+    if (pullRequestNumber === undefined) {
+        throw new Error('GitHub pull_request event payload is missing pull_request.number');
+    }
+    const expectedBaseSha = await input.client.getBranchHeadSha(input.config.config.defaultBranch);
+    const policyInput = await toPolicyInput({ client: input.client, expectedBaseSha, pullRequestNumber });
+    if (policyInput.labels.includes(input.config.config.label)) {
+        validateReleasePullRequestPolicy(policyInput, input.config.policyConfig);
+    }
+}
+
+async function runMergeGroupValidation(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: LoadedReleasePullRequestConfig;
+    readonly event: GitHubEvent;
+}): Promise<void> {
+    const headSha = input.event.merge_group?.head_sha;
+    const expectedBaseSha = input.event.merge_group?.base_sha;
+    if (headSha === undefined || expectedBaseSha === undefined) {
+        throw new Error('GitHub merge_group event payload is missing merge group SHAs');
+    }
+    const pullRequests = await input.client.listCommitPullRequests(headSha);
+    const policyInputs = await Promise.all(
+        pullRequests.map(async (pullRequest) => {
+            return toPolicyInput({ client: input.client, expectedBaseSha, pullRequestNumber: pullRequest.number });
+        })
+    );
+    validateReleaseMergeGroupPolicy({ pullRequests: policyInputs }, input.config.policyConfig);
+}
+
+async function validateGitHubEvent(input: {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: LoadedReleasePullRequestConfig;
+    readonly event: GitHubEvent;
+    readonly eventName: string;
+}): Promise<void> {
+    if (input.eventName === 'pull_request') {
+        await runPullRequestValidation(input);
+        return;
+    }
+    if (input.eventName === 'merge_group') {
+        await runMergeGroupValidation(input);
+        return;
+    }
+    throw new Error('release-pr validate only supports pull_request and merge_group events');
+}
+
+async function runValidate(dependencies: ReleasePullRequestHandlerDependencies): Promise<number> {
+    const loadedConfig = await loadReleasePullRequestConfig(dependencies);
+    const { client } = await createGitHubClient(dependencies);
+    const eventName = readRequiredEnvironmentVariable(dependencies, 'GITHUB_EVENT_NAME');
+    const event = await readGitHubEvent(dependencies);
+    await validateGitHubEvent({ client, config: loadedConfig, event, eventName });
+    dependencies.log('Release PR policy passed.');
+    return 0;
+}
+
+function formatAuthorizationOutput(authorization: ReleasePublishAuthorization): readonly string[] {
+    if (!authorization.shouldPublish) {
+        return ['should_publish=false'];
+    }
+    return [
+        'should_publish=true',
+        `publish_commit_sha=${authorization.publishCommitSha}`,
+        `release_commit_sha=${authorization.releaseCommitSha}`,
+        `release_pull_request_number=${authorization.releasePullRequestNumber}`
+    ];
+}
+
+async function readExistingOutput(
+    dependencies: ReleasePullRequestHandlerDependencies,
+    githubOutputPath: string
+): Promise<string> {
+    try {
+        return await dependencies.fileManager.readFile(githubOutputPath);
+    } catch {
+        return '';
+    }
+}
+
+async function writeAuthorizationOutput(
+    dependencies: ReleasePullRequestHandlerDependencies,
+    authorization: ReleasePublishAuthorization
+): Promise<void> {
+    const output = `${formatAuthorizationOutput(authorization).join('\n')}\n`;
+    const githubOutputPath = dependencies.readEnvironmentVariable('GITHUB_OUTPUT');
+    if (githubOutputPath === undefined) {
+        dependencies.log(output.trimEnd());
+        return;
+    }
+    await dependencies.fileManager.writeFile(
+        githubOutputPath,
+        `${await readExistingOutput(dependencies, githubOutputPath)}${output}`
+    );
+}
+
+async function authorizeManualPublish(
+    input: {
+        readonly config: LoadedReleasePullRequestConfig;
+        readonly dependencies: ReleasePullRequestHandlerDependencies;
+        readonly github: GitHubContext;
+    },
+    releasePullRequestNumber: string
+): Promise<ReleasePublishAuthorization> {
+    const refName = readRequiredEnvironmentVariable(input.dependencies, 'GITHUB_REF_NAME');
+    if (refName !== input.config.config.defaultBranch) {
+        throw new Error(`Manual release publish retries must run from ${input.config.config.defaultBranch}`);
+    }
+    return authorizeReleasePublishFromPullRequest({
+        config: input.config.policyConfig,
+        pullRequest: await input.github.client.getPullRequest(Number(releasePullRequestNumber)),
+        repository: input.github.repository
+    });
+}
+
+async function authorizePushPublish(input: {
+    readonly config: LoadedReleasePullRequestConfig;
+    readonly dependencies: ReleasePullRequestHandlerDependencies;
+    readonly github: GitHubContext;
+}): Promise<ReleasePublishAuthorization> {
+    const commitSha = readRequiredEnvironmentVariable(input.dependencies, 'GITHUB_SHA');
+    return authorizeReleasePublishFromCommit({
+        commitSha,
+        config: input.config.policyConfig,
+        pullRequests: await input.github.client.listCommitPullRequests(commitSha),
+        repository: input.github.repository
+    });
+}
+
+async function authorizePublish(input: {
+    readonly config: LoadedReleasePullRequestConfig;
+    readonly dependencies: ReleasePullRequestHandlerDependencies;
+    readonly github: GitHubContext;
+}): Promise<ReleasePublishAuthorization> {
+    const { releasePullRequestNumber } = input.dependencies.flags;
+    if (releasePullRequestNumber !== undefined) {
+        return authorizeManualPublish(input, releasePullRequestNumber);
+    }
+    return authorizePushPublish(input);
+}
+
+async function runAuthorizePublish(dependencies: ReleasePullRequestHandlerDependencies): Promise<number> {
+    const config = await loadReleasePullRequestConfig(dependencies);
+    const github = await createGitHubClient(dependencies);
+    await writeAuthorizationOutput(dependencies, await authorizePublish({ config, dependencies, github }));
+    return 0;
+}
+
+async function runReleasePullRequestCommand(dependencies: ReleasePullRequestHandlerDependencies): Promise<number> {
+    if (dependencies.flags.command === 'maintain') {
+        return runMaintain({ ...dependencies, flags: dependencies.flags });
+    }
+    if (dependencies.flags.command === 'validate') {
+        return runValidate(dependencies);
+    }
+    return runAuthorizePublish(dependencies);
+}
+
+function stopSpinnersAndReturn(dependencies: ReleasePullRequestHandlerDependencies, exitCode: number): number {
+    dependencies.spinnerRenderer.stopAll();
+    return exitCode;
+}
+
+export async function runReleasePullRequestHandler(
+    dependencies: ReleasePullRequestHandlerDependencies
+): Promise<number> {
+    try {
+        return stopSpinnersAndReturn(dependencies, await runReleasePullRequestCommand(dependencies));
+    } catch (error: unknown) {
+        dependencies.log(formatHandlerError(error));
+        return stopSpinnersAndReturn(dependencies, 1);
+    }
+}

--- a/source/command-line-interface/runner/release-pull-request-policy.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-policy.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import {
+    validateReleaseMergeGroupPolicy,
+    validateReleasePullRequestPolicy,
+    validateReleasePullRequestPublishPolicy,
+    type ReleasePullRequestPolicyConfig,
+    type ReleasePullRequestPolicyInput,
+    type ReleasePullRequestPublishInput
+} from './release-pull-request-policy.ts';
+
+const policyConfig: ReleasePullRequestPolicyConfig = {
+    allowedFiles: new Set(['CHANGELOG.md']),
+    automationAuthor: 'github-actions[bot]',
+    branch: 'release/packtory',
+    commitSubject: 'Release packages',
+    defaultBranch: 'main',
+    label: 'release',
+    title: 'Prepare release'
+};
+
+const validPullRequest: ReleasePullRequestPolicyInput = {
+    author: 'github-actions[bot]',
+    changedFiles: ['CHANGELOG.md'],
+    expectedBaseSha: 'main-head',
+    headRef: 'release/packtory',
+    labels: ['release'],
+    parentShas: ['main-head'],
+    subject: 'Release packages',
+    title: 'Prepare release'
+};
+
+const validPublishInput: ReleasePullRequestPublishInput = {
+    author: 'github-actions[bot]',
+    baseRef: 'main',
+    changedFiles: ['CHANGELOG.md'],
+    headRef: 'release/packtory',
+    headRepository: 'owner/repo',
+    labels: ['release'],
+    mergeCommitSha: 'merge-sha',
+    merged: true,
+    repository: 'owner/repo',
+    subject: 'Release packages',
+    title: 'Prepare release'
+};
+
+function assertPolicyError(validate: () => void, expectedMessage: string): void {
+    assert.throws(validate, { message: expectedMessage });
+}
+
+suite('release-pull-request-policy', function () {
+    test('accepts a valid release pull request', function () {
+        assert.doesNotThrow(() => {
+            validateReleasePullRequestPolicy(validPullRequest, policyConfig);
+        });
+    });
+
+    test('rejects release pull requests that violate the policy', function () {
+        for (const [pullRequest, expectedMessage] of [
+            [
+                { ...validPullRequest, changedFiles: ['source/index.ts'] },
+                'Unexpected release PR file change: source/index.ts'
+            ],
+            [{ ...validPullRequest, changedFiles: [] }, 'Release PRs must change release output files'],
+            [{ ...validPullRequest, author: 'maintainer' }, 'Release PRs must be authored by github-actions[bot]'],
+            [{ ...validPullRequest, headRef: 'feature' }, 'Release PRs must use release/packtory'],
+            [{ ...validPullRequest, title: 'Release' }, 'Release PR title must be Prepare release'],
+            [
+                { ...validPullRequest, subject: 'Update changelogs' },
+                'Release PR commit subject must be Release packages'
+            ],
+            [{ ...validPullRequest, parentShas: ['old-head'] }, 'Release PR head must be based on expected main'],
+            [
+                { ...validPullRequest, parentShas: ['main-head', 'other-head'] },
+                'Release PR head must have exactly one parent'
+            ],
+            [{ ...validPullRequest, labels: ['release', 'bug'] }, 'Release PRs must only have the release label']
+        ] as const) {
+            assertPolicyError(() => {
+                validateReleasePullRequestPolicy(pullRequest, policyConfig);
+            }, expectedMessage);
+        }
+    });
+
+    test('rejects merge groups that batch release PRs with other pull requests', function () {
+        assertPolicyError(() => {
+            validateReleaseMergeGroupPolicy(
+                {
+                    pullRequests: [
+                        validPullRequest,
+                        {
+                            ...validPullRequest,
+                            labels: ['bug']
+                        }
+                    ]
+                },
+                policyConfig
+            );
+        }, 'Release PRs must not be grouped with other pull requests');
+    });
+
+    test('accepts merge groups that contain only the release pull request', function () {
+        assert.doesNotThrow(() => {
+            validateReleaseMergeGroupPolicy({ pullRequests: [validPullRequest] }, policyConfig);
+        });
+    });
+
+    test('rejects merge groups with invalid release pull requests', function () {
+        assertPolicyError(() => {
+            validateReleaseMergeGroupPolicy(
+                {
+                    pullRequests: [
+                        {
+                            ...validPullRequest,
+                            changedFiles: ['src/index.ts']
+                        }
+                    ]
+                },
+                policyConfig
+            );
+        }, 'Unexpected release PR file change: src/index.ts');
+    });
+
+    test('accepts a merged release PR publish target', function () {
+        assert.doesNotThrow(() => {
+            validateReleasePullRequestPublishPolicy(validPublishInput, policyConfig, 'merge-sha');
+        });
+    });
+
+    test('rejects publish targets that violate the policy', function () {
+        for (const [publishInput, mergeCommitSha, expectedMessage] of [
+            [
+                { ...validPublishInput, headRepository: 'other/repo' },
+                'merge-sha',
+                'Release PRs must come from the release repository'
+            ],
+            [{ ...validPublishInput, baseRef: 'next' }, 'merge-sha', 'Release PR base must be main'],
+            [{ ...validPublishInput, merged: false }, 'merge-sha', 'Release PR must be merged'],
+            [validPublishInput, 'other-sha', 'Release PR merge commit must be other-sha']
+        ] as const) {
+            assertPolicyError(() => {
+                validateReleasePullRequestPublishPolicy(publishInput, policyConfig, mergeCommitSha);
+            }, expectedMessage);
+        }
+    });
+
+    test('accepts merge groups without release pull requests', function () {
+        assert.doesNotThrow(() => {
+            validateReleaseMergeGroupPolicy(
+                {
+                    pullRequests: [
+                        { ...validPullRequest, labels: ['bug'] },
+                        { ...validPullRequest, labels: ['feature'] }
+                    ]
+                },
+                policyConfig
+            );
+        });
+    });
+});

--- a/source/command-line-interface/runner/release-pull-request-policy.ts
+++ b/source/command-line-interface/runner/release-pull-request-policy.ts
@@ -1,0 +1,114 @@
+import type { ReleasePullRequestConfig } from './release-pull-request-config.ts';
+
+export type ReleasePullRequestPolicyInput = {
+    readonly author: string;
+    readonly changedFiles: readonly string[];
+    readonly expectedBaseSha: string;
+    readonly headRef: string;
+    readonly labels: readonly string[];
+    readonly parentShas: readonly string[];
+    readonly subject: string;
+    readonly title: string;
+};
+
+type ReleasePullRequestShape = Pick<
+    ReleasePullRequestPolicyInput,
+    'author' | 'changedFiles' | 'headRef' | 'labels' | 'subject' | 'title'
+>;
+
+export type ReleasePullRequestPublishInput = ReleasePullRequestShape & {
+    readonly baseRef: string;
+    readonly headRepository: string;
+    readonly mergeCommitSha: string | undefined;
+    readonly merged: boolean;
+    readonly repository: string;
+};
+
+export type ReleasePullRequestPolicyConfig = Pick<
+    ReleasePullRequestConfig,
+    'automationAuthor' | 'branch' | 'commitSubject' | 'defaultBranch' | 'label' | 'title'
+> & {
+    readonly allowedFiles: ReadonlySet<string>;
+};
+
+type MergeGroupPolicyInput = {
+    readonly pullRequests: readonly ReleasePullRequestPolicyInput[];
+};
+
+function requirePolicy(condition: boolean, message: string): void {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function validateReleaseLabelSet(labels: readonly string[], config: ReleasePullRequestPolicyConfig): void {
+    requirePolicy(
+        labels.length === 1 && labels[0] === config.label,
+        `Release PRs must only have the ${config.label} label`
+    );
+}
+
+function validateReleaseChangedFiles(changedFiles: readonly string[], config: ReleasePullRequestPolicyConfig): void {
+    requirePolicy(changedFiles.length > 0, 'Release PRs must change release output files');
+
+    for (const changedFile of changedFiles) {
+        requirePolicy(config.allowedFiles.has(changedFile), `Unexpected release PR file change: ${changedFile}`);
+    }
+}
+
+function validateReleaseIdentity(
+    input: Pick<ReleasePullRequestPolicyInput, 'author' | 'headRef' | 'labels' | 'subject' | 'title'>,
+    config: ReleasePullRequestPolicyConfig
+): void {
+    validateReleaseLabelSet(input.labels, config);
+    requirePolicy(
+        input.author === config.automationAuthor,
+        `Release PRs must be authored by ${config.automationAuthor}`
+    );
+    requirePolicy(input.headRef === config.branch, `Release PRs must use ${config.branch}`);
+    requirePolicy(input.title === config.title, `Release PR title must be ${config.title}`);
+    requirePolicy(input.subject === config.commitSubject, `Release PR commit subject must be ${config.commitSubject}`);
+}
+
+export function validateReleasePullRequestPolicy(
+    input: ReleasePullRequestPolicyInput,
+    config: ReleasePullRequestPolicyConfig
+): void {
+    validateReleaseIdentity(input, config);
+    requirePolicy(input.parentShas.length === 1, 'Release PR head must have exactly one parent');
+    requirePolicy(input.parentShas[0] === input.expectedBaseSha, 'Release PR head must be based on expected main');
+    validateReleaseChangedFiles(input.changedFiles, config);
+}
+
+export function validateReleasePullRequestPublishPolicy(
+    input: ReleasePullRequestPublishInput,
+    config: ReleasePullRequestPolicyConfig,
+    expectedMergeCommitSha: string
+): void {
+    validateReleaseIdentity(input, config);
+    requirePolicy(input.baseRef === config.defaultBranch, `Release PR base must be ${config.defaultBranch}`);
+    requirePolicy(input.headRepository === input.repository, 'Release PRs must come from the release repository');
+    requirePolicy(input.merged, 'Release PR must be merged');
+    requirePolicy(
+        input.mergeCommitSha === expectedMergeCommitSha,
+        `Release PR merge commit must be ${expectedMergeCommitSha}`
+    );
+    validateReleaseChangedFiles(input.changedFiles, config);
+}
+
+export function validateReleaseMergeGroupPolicy(
+    input: MergeGroupPolicyInput,
+    config: ReleasePullRequestPolicyConfig
+): void {
+    const releasePullRequests = input.pullRequests.filter((pullRequest) => {
+        return pullRequest.labels.includes(config.label);
+    });
+
+    if (releasePullRequests.length > 0 && input.pullRequests.length !== 1) {
+        throw new Error('Release PRs must not be grouped with other pull requests');
+    }
+
+    for (const pullRequest of releasePullRequests) {
+        validateReleasePullRequestPolicy(pullRequest, config);
+    }
+}

--- a/source/command-line-interface/runner/release-pull-request-settings.ts
+++ b/source/command-line-interface/runner/release-pull-request-settings.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod/mini';
+import { nonEmptyStringSchema } from '../../config/base-validations.ts';
+
+const githubActionsWorkflowDispatchSchema = z.readonly(
+    z.strictObject({
+        trigger: z.literal('workflow-dispatch'),
+        workflowFile: nonEmptyStringSchema,
+        requiredStatusContexts: z.readonly(z.tuple([nonEmptyStringSchema], nonEmptyStringSchema)),
+        deleteActionRequiredPullRequestRuns: z.optional(z.boolean())
+    })
+);
+
+export const releasePullRequestSettingsSchema = z.readonly(
+    z.strictObject({
+        automationAuthor: z.optional(nonEmptyStringSchema),
+        body: z.optional(nonEmptyStringSchema),
+        branch: z.optional(nonEmptyStringSchema),
+        commitSubject: z.optional(nonEmptyStringSchema),
+        defaultBranch: z.optional(nonEmptyStringSchema),
+        githubActionsCi: z.optional(githubActionsWorkflowDispatchSchema),
+        label: z.optional(nonEmptyStringSchema),
+        title: z.optional(nonEmptyStringSchema)
+    })
+);
+
+export type ReleasePullRequestSettings = z.infer<typeof releasePullRequestSettingsSchema>;

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -34,7 +34,8 @@ type Overrides = {
     readonly createTemporaryFilePath?: () => string;
     readonly createPrLogEngine?: SinonSpy;
     readonly createGitHubReleaseClient?: SinonSpy;
-    readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+    readonly createReleasePullRequestGitHubClient?: SinonSpy;
+    readonly readEnvironmentVariable?: (name: string) => string | undefined;
     readonly readPackageInfo?: () => Promise<Record<string, unknown>>;
     readonly releaseGitClient?: CommandLineInterfaceRunnerDependencies['releaseGitClient'];
     progressBroadcaster?: ProgressBroadcaster;
@@ -96,6 +97,21 @@ function createRunner(overrides: Overrides = {}): CommandLineInterfaceRunner {
         createGitHubReleaseClient: createSpy(overrides.createGitHubReleaseClient, () => {
             return fake.returns({
                 createReleaseIfMissing: fake.resolves('created')
+            });
+        }),
+        createReleasePullRequestGitHubClient: createSpy(overrides.createReleasePullRequestGitHubClient, () => {
+            return fake.returns({
+                closeOpenReleasePullRequests: fake.resolves(undefined),
+                createOrUpdateReleasePullRequest: fake.resolves(1),
+                createStatus: fake.resolves(undefined),
+                deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
+                dispatchWorkflow: fake.resolves(undefined),
+                findDispatchedWorkflowRunId: fake.resolves(undefined),
+                getBranchHeadSha: fake.resolves('main-head'),
+                getPullRequest: fake.resolves(undefined),
+                getPullRequestHead: fake.resolves(undefined),
+                listCommitPullRequests: fake.resolves([]),
+                readWorkflowRunResult: fake.resolves({ conclusion: 'success', databaseId: 1, jobs: [] })
             });
         }),
         currentDate() {
@@ -161,10 +177,13 @@ function createRunner(overrides: Overrides = {}): CommandLineInterfaceRunner {
         releaseGitClient: overrides.releaseGitClient ?? {
             commit: fake.resolves(undefined),
             currentHead: fake.resolves('new-head'),
+            deleteRemoteBranch: fake.resolves(undefined),
             ensureClean: fake.resolves(undefined),
             ensureTag: fake.resolves(undefined),
+            pushHeadToBranch: fake.resolves(undefined),
             pushFollowTags: fake.resolves(undefined)
         },
+        sleep: fake.resolves(undefined),
         workingDirectory: '/workspace'
     };
 
@@ -196,6 +215,38 @@ async function expectHelp(args: readonly string[]): Promise<string> {
 
 async function expectSubcommandHelp(command: 'preview' | 'publish' | 'release'): Promise<string> {
     return expectHelp([command, '--help']);
+}
+
+function createReleasePullRequestConfig() {
+    return {
+        changelog: { outputs: [{ kind: 'repository-file', path: 'CHANGELOG.md' }] },
+        packages: [
+            {
+                sourcesFolder: 'src',
+                mainPackageJson: { type: 'module' },
+                name: 'pkg',
+                roots: { main: { js: 'index.js' } },
+                publishSettings: { access: 'public' }
+            }
+        ]
+    };
+}
+
+function createReleasePullRequestClient(overrides: Record<string, unknown>) {
+    return {
+        closeOpenReleasePullRequests: fake.resolves(undefined),
+        createOrUpdateReleasePullRequest: fake.resolves(1),
+        createStatus: fake.resolves(undefined),
+        deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
+        dispatchWorkflow: fake.resolves(undefined),
+        findDispatchedWorkflowRunId: fake.resolves(undefined),
+        getBranchHeadSha: fake.resolves('main-head'),
+        getPullRequest: fake.resolves(undefined),
+        getPullRequestHead: fake.resolves(undefined),
+        listCommitPullRequests: fake.resolves([]),
+        readWorkflowRunResult: fake.resolves({ conclusion: 'success', databaseId: 1, jobs: [] }),
+        ...overrides
+    };
 }
 
 async function expectCollectReportFlag(flag: '--report-html' | '--report-json'): Promise<void> {
@@ -322,8 +373,10 @@ suite('runner', function () {
             releaseGitClient: {
                 commit: fake.resolves(undefined),
                 currentHead: fake.resolves('new-head'),
+                deleteRemoteBranch: fake.resolves(undefined),
                 ensureClean: fake.resolves(undefined),
                 ensureTag,
+                pushHeadToBranch: fake.resolves(undefined),
                 pushFollowTags
             }
         });
@@ -988,6 +1041,144 @@ suite('runner', function () {
 
         const helpText = String(log.firstCall.args[0]);
         assert.match(helpText, /Generates grouped Markdown changelog output for the next release\./u);
+    });
+
+    test('release-pr authorize-publish writes a skipped publish decision for normal commits', async function () {
+        const log = fake();
+        const environment: Record<string, string> = {
+            GH_TOKEN: 'gh-token',
+            GITHUB_REPOSITORY: 'owner/repo',
+            GITHUB_SHA: 'commit-sha'
+        };
+        const runner = createRunner({
+            log,
+            loadConfig: fake.resolves(createReleasePullRequestConfig()),
+            readEnvironmentVariable(name) {
+                return environment[name];
+            }
+        });
+
+        const exitCode = await runner.run(['foo', 'bar', 'release-pr', 'authorize-publish']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(log.firstCall.args[0], 'should_publish=false');
+    });
+
+    test('release-pr authorize-publish forwards the manual release PR number', async function () {
+        const fileManager = createFakeFileManager();
+        const runner = createRunner({
+            fileManager,
+            loadConfig: fake.resolves(createReleasePullRequestConfig()),
+            createReleasePullRequestGitHubClient: fake.returns(
+                createReleasePullRequestClient({
+                    getPullRequest: fake.resolves({
+                        author: 'github-actions[bot]',
+                        baseRef: 'main',
+                        changedFiles: ['CHANGELOG.md'],
+                        headRef: 'release/packtory',
+                        headRepository: 'enormora/packtory',
+                        labels: ['release'],
+                        mergeCommitSha: 'merge-sha',
+                        merged: true,
+                        number: 12,
+                        subject: 'Release packages',
+                        title: 'Prepare release'
+                    })
+                })
+            ),
+            readEnvironmentVariable(name) {
+                return { GH_TOKEN: 'gh-token', GITHUB_OUTPUT: '/github-output', GITHUB_REF_NAME: 'main' }[name];
+            }
+        });
+
+        const exitCode = await runner.run([
+            'foo',
+            'bar',
+            'release-pr',
+            'authorize-publish',
+            '--release-pull-request',
+            '12'
+        ]);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(fileManager.getWriteFileCall(0).content.includes('release_pull_request_number=12'), true);
+    });
+
+    test('release-pr maintain routes through the release PR handler', async function () {
+        const log = fake();
+        const runner = createRunner({ log });
+
+        const exitCode = await runner.run(['foo', 'bar', 'release-pr', 'maintain']);
+
+        assert.strictEqual(exitCode, 1);
+        assert.strictEqual(log.firstCall.args[0], 'Release PR writes require --no-dry-run');
+    });
+
+    test('release-pr validate routes the GitHub event through the release PR handler', async function () {
+        const log = fake();
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: JSON.stringify({ pull_request: { number: 12 } }) }]
+        });
+        const environment: Record<string, string> = {
+            GH_TOKEN: 'gh-token',
+            GITHUB_EVENT_NAME: 'pull_request',
+            GITHUB_EVENT_PATH: '/event.json',
+            GITHUB_REPOSITORY: 'owner/repo'
+        };
+        const runner = createRunner({
+            fileManager,
+            loadConfig: fake.resolves(createReleasePullRequestConfig()),
+            log,
+            createReleasePullRequestGitHubClient: fake.returns(
+                createReleasePullRequestClient({
+                    getPullRequestHead: fake.resolves({
+                        author: 'maintainer',
+                        changedFiles: ['src/index.ts'],
+                        headRef: 'feature',
+                        labels: ['bug'],
+                        parentShas: ['main-head'],
+                        subject: 'Fix bug',
+                        title: 'Fix bug'
+                    })
+                })
+            ),
+            readEnvironmentVariable(name) {
+                return environment[name];
+            }
+        });
+
+        const exitCode = await runner.run(['foo', 'bar', 'release-pr', 'validate']);
+
+        assert.strictEqual(exitCode, 0);
+        assert.strictEqual(log.firstCall.args[0], 'Release PR policy passed.');
+    });
+
+    test('release-pr help advertises release PR subcommands', async function () {
+        const help = await expectHelp(['release-pr', '--help']);
+
+        assert.match(help, /maintain/);
+        assert.match(help, /validate/);
+        assert.match(help, /authorize-publish/);
+    });
+
+    test('release-pr maintain help advertises writes and dry-run opt-in', async function () {
+        const help = await expectHelp(['release-pr', 'maintain', '--help']);
+
+        assert.match(help, /Creates or updates the generated release PR\./);
+        assert.match(help, /--no-dry-run/);
+    });
+
+    test('release-pr validate help advertises GitHub event validation', async function () {
+        const help = await expectHelp(['release-pr', 'validate', '--help']);
+
+        assert.match(help, /Validates the release PR policy for the current GitHub event\./);
+    });
+
+    test('release-pr authorize-publish help advertises manual retry input', async function () {
+        const help = await expectHelp(['release-pr', 'authorize-publish', '--help']);
+
+        assert.match(help, /Authorizes publishing from a merged release PR\./);
+        assert.match(help, /--release-pull-request/);
     });
 
     test('pack command loads the config and forwards the flags into packPackage', async function () {

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -1,5 +1,16 @@
-/* eslint-disable import/max-dependencies -- the CLI runner wires six subcommands plus shared dependencies */
-import { binary, command, flag, oneOf, option, positional, runSafely, string, subcommands } from 'cmd-ts';
+/* eslint-disable import/max-dependencies -- the CLI runner wires seven subcommands plus shared dependencies */
+import {
+    binary,
+    command,
+    flag,
+    oneOf,
+    option,
+    optional as optionalType,
+    positional,
+    runSafely,
+    string,
+    subcommands
+} from 'cmd-ts';
 import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { FileManager } from '../../file-manager/file-manager.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
@@ -16,6 +27,8 @@ import { runPublishHandler } from './publish-handler.ts';
 import type { GitHubReleaseClient } from './github-release-client.ts';
 import type { ReleaseGitClient } from './release-git-client.ts';
 import { runReleaseHandler } from './release-handler.ts';
+import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+import { runReleasePullRequestHandler } from './release-pull-request-handler.ts';
 
 export type CommandLineInterfaceRunnerDependencies = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
@@ -24,6 +37,11 @@ export type CommandLineInterfaceRunnerDependencies = {
         readonly repo: string;
         readonly token: string;
     }) => GitHubReleaseClient;
+    readonly createReleasePullRequestGitHubClient: (context: {
+        readonly owner: string;
+        readonly repo: string;
+        readonly token: string;
+    }) => ReleasePullRequestGitHubClient;
     readonly currentDate: () => Date;
     readonly packtory: Packtory;
     readonly progressBroadcaster: ProgressBroadcastConsumer;
@@ -33,9 +51,10 @@ export type CommandLineInterfaceRunnerDependencies = {
     readonly pageOutput: (content: string) => Promise<void>;
     readonly openFile: (filePath: string) => Promise<boolean>;
     readonly createTemporaryFilePath: () => string;
-    readonly readEnvironmentVariable: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+    readonly readEnvironmentVariable: (name: string) => string | undefined;
     readonly readPackageInfo: () => Promise<Record<string, unknown>>;
     readonly releaseGitClient: ReleaseGitClient;
+    readonly sleep: (milliseconds: number) => Promise<void>;
     readonly workingDirectory: string;
     log: (message: string) => void;
 };
@@ -48,8 +67,12 @@ const publishCommandName = 'publish';
 const previewCommandName = 'preview';
 const releaseDiffCommandName = 'release-diff';
 const releaseCommandName = 'release';
+const releasePullRequestCommandName = 'release-pr';
+const authorizePublishReleasePullRequestCommandName = 'authorize-publish';
 const changelogCommandName = 'changelog';
+const maintainReleasePullRequestCommandName = 'maintain';
 const packCommandName = 'pack';
+const validateReleasePullRequestCommandName = 'validate';
 const defaultPackVersion = '0.0.0';
 
 export function createCommandLineInterfaceRunner(
@@ -66,11 +89,13 @@ export function createCommandLineInterfaceRunner(
         openFile,
         createTemporaryFilePath,
         createGitHubReleaseClient,
+        createReleasePullRequestGitHubClient,
         createPrLogEngine,
         currentDate,
         readEnvironmentVariable,
         readPackageInfo,
         releaseGitClient,
+        sleep,
         workingDirectory
     } = dependencies;
     let exitCode = 0;
@@ -157,6 +182,100 @@ export function createCommandLineInterfaceRunner(
                         gitClient: releaseGitClient,
                         flags: { writeChangelog, commit, publish, tag, push, githubRelease, noDryRun }
                     });
+                }
+            }),
+            [releasePullRequestCommandName]: subcommands({
+                name: releasePullRequestCommandName,
+                cmds: {
+                    [maintainReleasePullRequestCommandName]: command({
+                        name: maintainReleasePullRequestCommandName,
+                        description: 'Creates or updates the generated release PR.',
+                        args: {
+                            noDryRun: flag({ long: 'no-dry-run' })
+                        },
+                        async handler({ noDryRun }) {
+                            exitCode = await runReleasePullRequestHandler({
+                                log,
+                                packtory,
+                                spinnerRenderer,
+                                configLoader,
+                                fileManager,
+                                createPrLogEngine,
+                                createGitHubReleaseClient,
+                                createReleasePullRequestGitHubClient,
+                                currentDate,
+                                readEnvironmentVariable,
+                                readPackageInfo,
+                                workingDirectory,
+                                gitClient: releaseGitClient,
+                                sleep,
+                                flags: {
+                                    command: maintainReleasePullRequestCommandName,
+                                    noDryRun,
+                                    releasePullRequestNumber: undefined
+                                }
+                            });
+                        }
+                    }),
+                    [validateReleasePullRequestCommandName]: command({
+                        name: validateReleasePullRequestCommandName,
+                        description: 'Validates the release PR policy for the current GitHub event.',
+                        args: {},
+                        async handler() {
+                            exitCode = await runReleasePullRequestHandler({
+                                log,
+                                packtory,
+                                spinnerRenderer,
+                                configLoader,
+                                fileManager,
+                                createPrLogEngine,
+                                createGitHubReleaseClient,
+                                createReleasePullRequestGitHubClient,
+                                currentDate,
+                                readEnvironmentVariable,
+                                readPackageInfo,
+                                workingDirectory,
+                                gitClient: releaseGitClient,
+                                sleep,
+                                flags: {
+                                    command: validateReleasePullRequestCommandName,
+                                    releasePullRequestNumber: undefined
+                                }
+                            });
+                        }
+                    }),
+                    [authorizePublishReleasePullRequestCommandName]: command({
+                        name: authorizePublishReleasePullRequestCommandName,
+                        description: 'Authorizes publishing from a merged release PR.',
+                        args: {
+                            releasePullRequestNumber: option({
+                                long: 'release-pull-request',
+                                type: optionalType(string)
+                            })
+                        },
+                        async handler({ releasePullRequestNumber }) {
+                            exitCode = await runReleasePullRequestHandler({
+                                log,
+                                packtory,
+                                spinnerRenderer,
+                                configLoader,
+                                fileManager,
+                                createPrLogEngine,
+                                createGitHubReleaseClient,
+                                createReleasePullRequestGitHubClient,
+                                currentDate,
+                                readEnvironmentVariable,
+                                readPackageInfo,
+                                workingDirectory,
+                                gitClient: releaseGitClient,
+                                sleep,
+                                flags: {
+                                    command: authorizePublishReleasePullRequestCommandName,
+                                    releasePullRequestNumber
+                                }
+                            });
+                        }
+                    })
                 }
             }),
             [changelogCommandName]: command({

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline/promises';
 import { execFile } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
 import { createPrLogEngine } from '@pr-log/core';
 import { createClock } from '../../common/clock.ts';
 import { createLineSpinnerRenderer } from '../../command-line-interface/spinner/line-spinner-renderer.ts';
@@ -19,6 +20,7 @@ import { createWorkerSpinnerBackend } from '../../command-line-interface/spinner
 import { createConfigLoader } from '../../command-line-interface/config-loader.ts';
 import { createDefaultPreviewIo } from '../../command-line-interface/preview-io/preview-io.ts';
 import { createGitHubReleaseClient } from '../../command-line-interface/runner/github-release-client.ts';
+import { createReleasePullRequestGitHubClient } from '../../command-line-interface/runner/release-pr-github-client.ts';
 import { createReleaseGitClient } from '../../command-line-interface/runner/release-git-client.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPacktoryComposition } from '../packtory.composition.ts';
@@ -108,6 +110,9 @@ const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     createGitHubReleaseClient: (context) => {
         return createGitHubReleaseClient({ ...context, fetch: globalThis.fetch });
     },
+    createReleasePullRequestGitHubClient: (context) => {
+        return createReleasePullRequestGitHubClient({ ...context, fetch: globalThis.fetch });
+    },
     currentDate() {
         return new Date(clock.getCurrentTimeInMilliseconds());
     },
@@ -131,6 +136,9 @@ const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
         return parsePackageInfo(await fileManager.readFile(path.join(workingDirectory, 'package.json')));
     },
     releaseGitClient: createReleaseGitClient({ repositoryFolder: workingDirectory, runGitCommand }),
+    async sleep(milliseconds) {
+        await delay(milliseconds);
+    },
     workingDirectory,
     log: console.log
 });

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -22,6 +22,7 @@ packtory <command> [options]
 - **release-diff:** Runs the same dry-run build as `preview` and shows, per package, the changes between the latest version currently published on the configured registry and the bundle the next run would publish.
 - **changelog:** Builds the next release plan, attributes merged GitHub pull requests to changed packages, and prints grouped Markdown changelog output.
 - **release:** Prints the next release plan by default, or runs one explicit release workflow when action flags and `--no-dry-run` are set.
+- **release-pr:** Maintains, validates, and authorizes a reviewed release PR flow for generated changelog releases.
 - **publish:** Bundles and publishes npm packages based on the configuration in `packtory.config.js`.
 - **pack:** Builds a single configured package and writes it to disk as a zip archive, tarball, or expanded folder. Intended for ad-hoc artifact use cases such as AWS Lambda deployments, container builds, or local inspection — `pack` never talks to a registry.
 
@@ -38,6 +39,10 @@ packtory <command> [options]
 - **release --tag:** Creates one annotated tag per released package, named `{packageName}@{version}`.
 - **release --push:** Runs `git push --follow-tags`. Requires `--commit` or `--tag`.
 - **release --github-release:** Creates one GitHub Release per package tag. Requires `--tag --push`.
+- **release-pr maintain --no-dry-run:** Writes and commits configured changelogs, pushes the configured release branch, and creates or updates the release PR.
+- **release-pr validate:** Validates the current GitHub `pull_request` or `merge_group` event against the release PR policy.
+- **release-pr authorize-publish:** Writes `should_publish` and publish target outputs for a workflow that should publish only after a valid release PR merge.
+- **release-pr authorize-publish --release-pull-request &lt;number&gt;:** Authorizes a manual retry from a merged release PR.
 - **pack &lt;package&gt; --format &lt;zip|tar|folder&gt; --out &lt;path&gt;:** Selects which package from the configuration to build and where to write it. `--format` and `--out` are required.
 - **pack --version &lt;version&gt;:** Stamps the produced manifest with the given version. Defaults to `0.0.0` when omitted, since `pack` is decoupled from the registry-driven automatic versioning used by `publish`.
 - **pack --vendor-dependencies:** Resolves every external (and bundle) dependency from the local `node_modules` and materializes them next to the package files inside the artifact. Use this for self-contained deployments where the runtime cannot run `npm install` (e.g. AWS Lambda zips). Without the flag, dependencies are recorded in the generated `package.json` only.
@@ -94,6 +99,17 @@ packtory <command> [options]
 - Existing GitHub Releases for verified package tags are accepted and their notes are not rewritten.
 - Packtory uses inherited Git configuration, environment, and credentials. In CI, configure commit identity with standard variables such as `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL`, and configure push credentials outside Packtory.
 - GitHub Release creation reads `GH_TOKEN` first, then `GITHUB_TOKEN`.
+
+**Release PR behavior:**
+
+- `release-pr maintain --no-dry-run` runs the changelog commit part of `packtory release`, pushes the result to `releasePullRequest.branch`, creates or updates the release PR, and replaces its labels with `releasePullRequest.label`.
+- If release planning produces no changelog commit, `maintain` closes the open release PR for that branch and deletes the remote release branch.
+- Release PR settings live in top-level `releasePullRequest`. Defaults are `branch: 'release/packtory'`, `label: 'release'`, `title: 'Prepare release'`, `commitSubject: 'Release packages'`, `defaultBranch: 'main'`, and `automationAuthor: 'github-actions[bot]'`.
+- The release PR policy derives allowed files from `changelog.outputs`. Repository and package changelog files are allowed. GitHub Release outputs are ignored because they do not write repository files.
+- `release-pr validate` accepts normal PRs without a release label. Release-labeled PRs must match the configured branch, title, author, commit subject, base head, and allowed files. Merge groups must not batch release PRs with other PRs.
+- `release-pr authorize-publish` writes GitHub step outputs when `$GITHUB_OUTPUT` exists, otherwise it prints them. Normal commits get `should_publish=false`. A merged valid release PR gets `should_publish=true`, `publish_commit_sha`, `release_commit_sha`, and `release_pull_request_number`.
+- Set `releasePullRequest.githubActionsCi` only for the GitHub Actions `GITHUB_TOKEN` workaround. With `trigger: 'workflow-dispatch'`, `workflowFile`, and `requiredStatusContexts`, `maintain` dispatches CI for the release branch, waits for the exact release commit run, and mirrors the configured job names as commit statuses.
+- Leave `githubActionsCi` unset when the release branch push already triggers normal CI, such as with a GitHub App token, PAT, human push, external automation, or non-GitHub CI.
 
 **Pack behavior:**
 


### PR DESCRIPTION
Adds a configurable release PR flow around Packtory release changelog commits. The new `release-pr` commands maintain generated release PRs, validate their shape against configured changelog outputs, and authorize publishing only from merged release PRs. Optional GitHub Actions workflow-dispatch status mirroring supports projects that need a second token-triggered run after `GITHUB_TOKEN` branch pushes.