### PR TITLE
Add `pull-request-labels` version source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,8 +154,10 @@ Packtory supports two versioning modes:
 2. **Manual Versioning:**
     - Provide the exact version number in the configuration with `{ automatic: false, version: '1.2.3' }`.
     - Or provide an async callback with `{ automatic: false, provideVersion }`.
+    - Or derive the exact version with a named source, such as `{ automatic: false, source: 'pull-request-labels' }`.
     - `provideVersion(input)` runs after Packtory has calculated the package attribution files. The input contains `packageName`, `currentVersion`, `targetSourceFiles`, `ignoredAttributionPaths`, `registrySettings`, and `stage`.
     - The returned version is validated like a static manual version. Returning `currentVersion` keeps the package on the current registry version when no release is needed.
+    - Version sources are still manual versioning from Packtory's perspective because the source chooses the exact version. Packtory's automatic mode is reserved for artifact comparison plus patch bumps.
 
 ```javascript
 versioning: {
@@ -168,6 +170,17 @@ versioning: {
     }
 }
 ```
+
+For pull request label based numbering, use the built-in source:
+
+```javascript
+versioning: {
+    automatic: false,
+    source: 'pull-request-labels'
+}
+```
+
+This source uses the same pull request attribution files as changelog generation. It inspects merged pull request labels since the package's current version tag, bumps `major` for `breaking`, `minor` for `feature`, and `patch` for other configured changelog labels. If no attributed pull request has a matching label, it returns the current version.
 
 ### Pack (on-disk artifacts)
 

--- a/source/config/manual-versioning-settings.test.ts
+++ b/source/config/manual-versioning-settings.test.ts
@@ -21,6 +21,13 @@ suite('manual-versioning-settings', function () {
         );
     });
 
+    test('manual versioning schema accepts source versioning', function () {
+        assert.strictEqual(
+            safeParse(manualVersioningSettingsSchema, { automatic: false, source: 'pull-request-labels' }).success,
+            true
+        );
+    });
+
     test('manual versioning schema rejects automatic true', function () {
         assert.strictEqual(
             safeParse(manualVersioningSettingsSchema, { automatic: true, version: '1.0.0' }).success,
@@ -47,6 +54,15 @@ suite('manual-versioning-settings', function () {
     );
 
     test(
+        'manual versioning: validation succeeds with source versioning',
+        checkValidationSuccess({
+            schema: manualVersioningSettingsSchema,
+            data: { automatic: false, source: 'pull-request-labels' },
+            expectedData: { automatic: false, source: 'pull-request-labels' }
+        })
+    );
+
+    test(
         'manual versioning: validation fails when provideVersion is not a function',
         checkValidationFailure({
             schema: manualVersioningSettingsSchema,
@@ -65,10 +81,10 @@ suite('manual-versioning-settings', function () {
     );
 
     test(
-        'manual versioning: validation fails when both version and provideVersion are given',
+        'manual versioning: validation fails when multiple manual version choices are given',
         checkValidationFailure({
             schema: manualVersioningSettingsSchema,
-            data: { automatic: false, version: '1.0.0', provideVersion },
+            data: { automatic: false, version: '1.0.0', provideVersion, source: 'pull-request-labels' },
             expectedMessages: ['invalid value doesn’t match expected union']
         })
     );

--- a/source/config/manual-versioning-settings.ts
+++ b/source/config/manual-versioning-settings.ts
@@ -11,7 +11,10 @@ export type VersionProviderInput = {
     readonly stage: boolean;
 };
 
-type VersionProvider = (input: VersionProviderInput) => Promise<string> | string;
+export type VersionProvider = (input: VersionProviderInput) => Promise<string> | string;
+const pullRequestLabelsVersionSource = 'pull-request-labels';
+
+type VersionSource = typeof pullRequestLabelsVersionSource;
 
 type StaticManualVersioningSettings = {
     readonly automatic: false;
@@ -21,6 +24,11 @@ type StaticManualVersioningSettings = {
 type ProviderManualVersioningSettings = {
     readonly automatic: false;
     readonly provideVersion: VersionProvider;
+};
+
+export type SourceManualVersioningSettings = {
+    readonly automatic: false;
+    readonly source: VersionSource;
 };
 
 const staticManualVersioningSettingsSchema = z.readonly(
@@ -39,11 +47,25 @@ const providerManualVersioningSettingsSchema = z.readonly(
     })
 );
 
-export const manualVersioningSettingsSchema = z.readonly(
-    z.union([staticManualVersioningSettingsSchema, providerManualVersioningSettingsSchema])
+const sourceManualVersioningSettingsSchema = z.readonly(
+    z.strictObject({
+        automatic: z.literal(false),
+        source: z.literal(pullRequestLabelsVersionSource)
+    })
 );
 
-export type ManualVersioningSettings = ProviderManualVersioningSettings | StaticManualVersioningSettings;
+export const manualVersioningSettingsSchema = z.readonly(
+    z.union([
+        staticManualVersioningSettingsSchema,
+        providerManualVersioningSettingsSchema,
+        sourceManualVersioningSettingsSchema
+    ])
+);
+
+export type ManualVersioningSettings =
+    | ProviderManualVersioningSettings
+    | SourceManualVersioningSettings
+    | StaticManualVersioningSettings;
 
 export function validateManualVersion(version: unknown): string {
     const result = z.safeParse(nonEmptyStringSchema, version);

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -34,7 +34,7 @@ suite('schema-contracts', function () {
         });
     }).timeout(probeTestTimeoutMs);
 
-    test('versioning schema keeps the automatic, static manual, and provider manual branches', async function () {
+    test('versioning schema keeps the automatic and manual branches', async function () {
         const result = await runNodeProbe(`
             import { safeParse } from '@schema-hub/zod-error-formatter';
             import { versioningSettingsSchema } from './source/config/versioning-settings.ts';
@@ -62,6 +62,10 @@ suite('schema-contracts', function () {
                         return '1.0.0';
                     }
                 }).success,
+                sourceSuccess: safeParse(versioningSettingsSchema, {
+                    automatic: false,
+                    source: 'pull-request-labels'
+                }).success,
                 invalidAutomaticBranchSuccess: safeParse(versioningSettingsSchema, {
                     automatic: true,
                     version: '1.0.0'
@@ -79,12 +83,14 @@ suite('schema-contracts', function () {
                 ['automatic', 'minimumVersion'],
                 [
                     ['automatic', 'version'],
-                    ['automatic', 'provideVersion']
+                    ['automatic', 'provideVersion'],
+                    ['automatic', 'source']
                 ]
             ],
             automaticSuccess: true,
             manualSuccess: true,
             providerSuccess: true,
+            sourceSuccess: true,
             invalidAutomaticBranchSuccess: false,
             invalidManualBranchSuccess: false
         });

--- a/source/config/versioning-settings.test.ts
+++ b/source/config/versioning-settings.test.ts
@@ -23,6 +23,13 @@ suite('versioning-settings', function () {
         );
     });
 
+    test('schema accepts the source manual versioning branch', function () {
+        assert.strictEqual(
+            safeParse(versioningSettingsSchema, { automatic: false, source: 'pull-request-labels' }).success,
+            true
+        );
+    });
+
     test('schema rejects mixing automatic with manual-only fields', function () {
         assert.strictEqual(safeParse(versioningSettingsSchema, { automatic: true, version: '1' }).success, false);
     });
@@ -63,6 +70,15 @@ suite('versioning-settings', function () {
         }
         assert.deepStrictEqual(result.data, { automatic: false, provideVersion });
     });
+
+    test(
+        'validation succeeds when valid source manual versioning settings are given',
+        checkValidationSuccess({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, source: 'pull-request-labels' },
+            expectedData: { automatic: false, source: 'pull-request-labels' }
+        })
+    );
 
     test(
         'validation fails when a non-object is given',
@@ -176,7 +192,16 @@ suite('versioning-settings', function () {
         'validation fails when automatic is false and both manual version sources are given',
         checkValidationFailure({
             schema: versioningSettingsSchema,
-            data: { automatic: false, version: '1', provideVersion: () => '2' },
+            data: { automatic: false, version: '1', provideVersion: () => '2', source: 'pull-request-labels' },
+            expectedMessages: ['invalid value doesn’t match expected union']
+        })
+    );
+
+    test(
+        'validation fails when automatic is false and source is unknown',
+        checkValidationFailure({
+            schema: versioningSettingsSchema,
+            data: { automatic: false, source: 'unknown' },
             expectedMessages: ['invalid value doesn’t match expected union']
         })
     );

--- a/source/config/versioning-settings.ts
+++ b/source/config/versioning-settings.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod/mini';
 import { automaticVersioningSettingsSchema } from './automatic-versioning-settings.ts';
-import { manualVersioningSettingsSchema, type ManualVersioningSettings } from './manual-versioning-settings.ts';
+import {
+    manualVersioningSettingsSchema,
+    type ManualVersioningSettings,
+    type SourceManualVersioningSettings
+} from './manual-versioning-settings.ts';
 
 export const versioningSettingsSchema = z.readonly(
     z.union([automaticVersioningSettingsSchema, manualVersioningSettingsSchema])
@@ -14,4 +18,8 @@ export function hasVersionProvider(
     versioning: VersioningSettings
 ): versioning is Extract<VersioningSettings, { readonly provideVersion: unknown }> {
     return 'provideVersion' in versioning;
+}
+
+export function hasVersionSource(versioning: VersioningSettings): versioning is SourceManualVersioningSettings {
+    return 'source' in versioning;
 }

--- a/source/packages/command-line-interface/command-line-interface.entry-point.ts
+++ b/source/packages/command-line-interface/command-line-interface.entry-point.ts
@@ -24,6 +24,7 @@ import { createReleasePullRequestGitHubClient } from '../../command-line-interfa
 import { createReleaseGitClient } from '../../command-line-interface/runner/release-git-client.ts';
 import { readCiEnvironment } from '../../bundle-emitter/repository-coherence.ts';
 import { buildPacktoryComposition } from '../packtory.composition.ts';
+import { createPullRequestLabelVersionSourceResolver } from './pull-request-label-versioning.ts';
 import { awaitSpinnerWorkerTermination, createBootedSpinnerRuntime } from './spinner-boot.entry-point.ts';
 
 async function importModule(modulePath: string): Promise<unknown> {
@@ -73,6 +74,7 @@ async function runGitCommand(
 const spinnerRenderer = createSpinnerRenderer();
 const clock = createClock();
 const fileManager = createFileManager({ hostFileSystem: fs.promises });
+const workingDirectory = process.cwd();
 const previewIo = createDefaultPreviewIo({
     async openFile(filePath) {
         const { default: open } = await import('open');
@@ -99,11 +101,22 @@ const promptForOneTimePassword = createOneTimePasswordPrompt({
     }
 });
 
+async function readPackageInfo(): Promise<Record<string, unknown>> {
+    return parsePackageInfo(await fileManager.readFile(path.join(workingDirectory, 'package.json')));
+}
+
 const { packtory, progressBroadcaster } = buildPacktoryComposition({
     promptForOneTimePassword,
-    ciEnvironment: readCiEnvironment(process.env)
+    ciEnvironment: readCiEnvironment(process.env),
+    resolveVersionSource: createPullRequestLabelVersionSourceResolver({
+        createPrLogEngine,
+        readEnvironmentVariable(name) {
+            return process.env[name];
+        },
+        readPackageInfo,
+        workingDirectory
+    })
 });
-const workingDirectory = process.cwd();
 
 const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     createPrLogEngine,
@@ -132,9 +145,7 @@ const commandLinerInterfaceRunner = createCommandLineInterfaceRunner({
     readEnvironmentVariable(name) {
         return process.env[name];
     },
-    async readPackageInfo() {
-        return parsePackageInfo(await fileManager.readFile(path.join(workingDirectory, 'package.json')));
-    },
+    readPackageInfo,
     releaseGitClient: createReleaseGitClient({ repositoryFolder: workingDirectory, runGitCommand }),
     async sleep(milliseconds) {
         await delay(milliseconds);

--- a/source/packages/command-line-interface/pull-request-label-versioning.test.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.test.ts
@@ -1,0 +1,285 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
+import type { PacktoryConfig } from '../../config/config.ts';
+import { createPullRequestLabelVersionSourceResolver } from './pull-request-label-versioning.ts';
+
+type ResolveBaseRefInput = Parameters<PrLogEngine['resolveChangelogBaseRef']>[0];
+type CollectPullRequestsInput = Parameters<PrLogEngine['collectMergedPullRequests']>[0];
+type ReadChangedFilesInput = Parameters<PrLogEngine['readPullRequestChangedFiles']>[0];
+type FilterPullRequestsInput = Parameters<PrLogEngine['filterPullRequestsByTargetFiles']>[0];
+type ResolveLabelsInput = Parameters<PrLogEngine['resolvePullRequestLabels']>[0];
+
+const source = { automatic: false, source: 'pull-request-labels' } as const;
+const packtoryConfig: PacktoryConfig = {
+    changelog: { labels: { bug: 'Bug fixes', feature: 'Features' } },
+    packages: []
+};
+
+function createEngine(overrides: Partial<PrLogEngine> = {}): PrLogEngine {
+    return {
+        async resolveChangelogBaseRef(input: ResolveBaseRefInput) {
+            assert.deepStrictEqual(input, {
+                packageName: 'pkg',
+                previousVersion: '1.0.0',
+                previousGitHead: undefined,
+                packageTagFormat: undefined,
+                explicitBaseRef: undefined
+            });
+            return { ref: 'pkg@1.0.0' };
+        },
+        async collectMergedPullRequests(input: CollectPullRequestsInput) {
+            assert.deepStrictEqual(input, { githubRepo: 'owner/repo', baseRef: 'pkg@1.0.0' });
+            return [
+                { id: 1, title: 'Fix bug' },
+                { id: 2, title: 'Add feature' }
+            ];
+        },
+        async readPullRequestChangedFiles(input: ReadChangedFilesInput) {
+            assert.deepStrictEqual(
+                input.pullRequests.map((pullRequest) => {
+                    return pullRequest.id;
+                }),
+                [1, 2]
+            );
+            return new Map([
+                [1, ['source/index.ts']],
+                [2, ['source/index.ts']]
+            ]);
+        },
+        filterPullRequestsByTargetFiles(input: FilterPullRequestsInput) {
+            assert.strictEqual(input.targetName, 'pkg');
+            assert.deepStrictEqual(input.targetSourceFiles, ['source/index.ts']);
+            assert.deepStrictEqual(input.ignoredAttributionPaths, ['CHANGELOG.md']);
+            return input.pullRequests;
+        },
+        async resolvePullRequestLabels(input: ResolveLabelsInput) {
+            assert.strictEqual(input.githubRepo, 'owner/repo');
+            assert.strictEqual(input.targetName, 'pkg');
+            assert.strictEqual(input.targetScopedLabelPattern, undefined);
+            assert.deepStrictEqual(input.ignoredLabels, []);
+            return [
+                { id: 1, title: 'Fix bug', label: 'bug' },
+                { id: 2, title: 'Add feature', label: 'feature' }
+            ];
+        },
+        ...overrides
+    } as unknown as PrLogEngine;
+}
+
+function createVersionProvider(engine: PrLogEngine = createEngine(), config: PacktoryConfig = packtoryConfig) {
+    const resolver = createPullRequestLabelVersionSourceResolver({
+        createPrLogEngine() {
+            return engine;
+        },
+        readEnvironmentVariable() {
+            return undefined;
+        },
+        async readPackageInfo() {
+            return { repository: 'https://github.com/owner/repo.git' };
+        },
+        workingDirectory: '/repo'
+    });
+    return resolver({ packageName: 'pkg', source, packtoryConfig: config });
+}
+
+async function resolveVersionWithTokenSource(input: {
+    readonly assertEngineOptions: (options: Readonly<PrLogEngineOptions>) => void;
+    readonly readEnvironmentVariable: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
+}): Promise<string> {
+    const resolver = createPullRequestLabelVersionSourceResolver({
+        createPrLogEngine(options) {
+            input.assertEngineOptions(options);
+            return createEngine();
+        },
+        readEnvironmentVariable: input.readEnvironmentVariable,
+        async readPackageInfo() {
+            return { repository: 'https://github.com/owner/repo.git' };
+        },
+        workingDirectory: '/repo'
+    });
+    const provideVersion = resolver({ packageName: 'pkg', source, packtoryConfig });
+
+    return provideVersion({
+        packageName: 'pkg',
+        currentVersion: '1.0.0',
+        targetSourceFiles: ['source/index.ts'],
+        ignoredAttributionPaths: ['CHANGELOG.md'],
+        registrySettings: {},
+        stage: false
+    });
+}
+
+suite('pull-request-label-version-source', function () {
+    test('creates pr-log with GitHub token and retry settings', async function () {
+        const result = await resolveVersionWithTokenSource({
+            assertEngineOptions(options) {
+                assert.deepStrictEqual(options, {
+                    githubToken: 'gh-token',
+                    workingDirectory: '/repo',
+                    labelLookupIntervalMilliseconds: 250,
+                    maximumRateLimitRetryCount: 3
+                });
+            },
+            readEnvironmentVariable(name) {
+                return name === 'GH_TOKEN' ? 'gh-token' : undefined;
+            }
+        });
+
+        assert.strictEqual(result, '1.1.0');
+    });
+
+    test('uses GITHUB_TOKEN when GH_TOKEN is missing', async function () {
+        const result = await resolveVersionWithTokenSource({
+            assertEngineOptions(options) {
+                assert.strictEqual(options.githubToken, 'github-token');
+            },
+            readEnvironmentVariable(name) {
+                return name === 'GITHUB_TOKEN' ? 'github-token' : undefined;
+            }
+        });
+
+        assert.strictEqual(result, '1.1.0');
+    });
+
+    test('selects the highest pull request label bump', async function () {
+        const provideVersion = createVersionProvider();
+
+        assert.strictEqual(
+            await provideVersion({
+                packageName: 'pkg',
+                currentVersion: '1.0.0',
+                targetSourceFiles: ['source/index.ts'],
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: {},
+                stage: false
+            }),
+            '1.1.0'
+        );
+    });
+
+    test('uses breaking labels for major bumps', async function () {
+        const provideVersion = createVersionProvider(
+            createEngine({
+                async resolvePullRequestLabels() {
+                    return [{ id: 1, title: 'Break API', label: 'breaking' }];
+                }
+            })
+        );
+
+        assert.strictEqual(
+            await provideVersion({
+                packageName: 'pkg',
+                currentVersion: '1.0.0',
+                targetSourceFiles: ['source/index.ts'],
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: {},
+                stage: false
+            }),
+            '2.0.0'
+        );
+    });
+
+    test('uses default labels when changelog labels are not configured', async function () {
+        const provideVersion = createVersionProvider(
+            createEngine({
+                async resolvePullRequestLabels() {
+                    return [{ id: 1, title: 'Fix bug', label: 'bug' }];
+                }
+            }),
+            { packages: [] }
+        );
+
+        assert.strictEqual(
+            await provideVersion({
+                packageName: 'pkg',
+                currentVersion: '1.0.0',
+                targetSourceFiles: ['source/index.ts'],
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: {},
+                stage: false
+            }),
+            '1.0.1'
+        );
+    });
+
+    test('keeps the current version when no attributed pull request has a bump label', async function () {
+        const provideVersion = createVersionProvider(
+            createEngine({
+                async resolvePullRequestLabels() {
+                    return [];
+                }
+            })
+        );
+
+        assert.strictEqual(
+            await provideVersion({
+                packageName: 'pkg',
+                currentVersion: '1.0.0',
+                targetSourceFiles: ['source/index.ts'],
+                ignoredAttributionPaths: ['CHANGELOG.md'],
+                registrySettings: {},
+                stage: false
+            }),
+            '1.0.0'
+        );
+    });
+
+    test('throws when the current version cannot be incremented', async function () {
+        const provideVersion = createVersionProvider(
+            createEngine({
+                async resolveChangelogBaseRef() {
+                    return { ref: 'pkg@invalid' };
+                },
+                async collectMergedPullRequests() {
+                    return [{ id: 1, title: 'Fix bug' }];
+                },
+                async readPullRequestChangedFiles() {
+                    return new Map([[1, ['source/index.ts']]]);
+                },
+                filterPullRequestsByTargetFiles(input) {
+                    return input.pullRequests;
+                },
+                async resolvePullRequestLabels() {
+                    return [{ id: 1, title: 'Fix bug', label: 'bug' }];
+                }
+            })
+        );
+
+        await assert.rejects(
+            async () => {
+                await provideVersion({
+                    packageName: 'pkg',
+                    currentVersion: 'invalid',
+                    targetSourceFiles: ['source/index.ts'],
+                    ignoredAttributionPaths: ['CHANGELOG.md'],
+                    registrySettings: {},
+                    stage: false
+                });
+            },
+            { message: 'Failed to increment version "invalid"' }
+        );
+    });
+
+    test('returns the initial version when the package is unpublished', async function () {
+        const provideVersion = createVersionProvider(
+            createEngine({
+                async resolveChangelogBaseRef() {
+                    throw new Error('must not resolve a base ref');
+                }
+            })
+        );
+
+        assert.strictEqual(
+            await provideVersion({
+                packageName: 'pkg',
+                currentVersion: undefined,
+                targetSourceFiles: ['source/index.ts'],
+                ignoredAttributionPaths: [],
+                registrySettings: {},
+                stage: false
+            }),
+            '0.0.1'
+        );
+    });
+});

--- a/source/packages/command-line-interface/pull-request-label-versioning.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.ts
@@ -1,0 +1,137 @@
+import semver from 'semver';
+import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions, type PullRequestWithLabel } from '@pr-log/core';
+import type { VersionProvider } from '../../config/manual-versioning-settings.ts';
+import type { PacktoryConfig } from '../../config/config.ts';
+import type { VersionSourceResolver } from '../../packtory/map-config.ts';
+import { formatGitHubRepositoryName } from '../../command-line-interface/runner/github-repository.ts';
+
+type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
+
+export type PullRequestLabelVersionSourceDeps = {
+    readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
+    readonly readEnvironmentVariable: (name: EnvironmentVariableName) => string | undefined;
+    readonly readPackageInfo: () => Promise<Record<string, unknown>>;
+    readonly workingDirectory: string;
+};
+
+type VersionBumpLevel = 'major' | 'minor' | 'patch';
+
+const orderedVersionBumpLevels: readonly VersionBumpLevel[] = ['major', 'minor', 'patch'];
+const labelLookupIntervalMilliseconds = 250;
+const maximumRateLimitRetryCount = 3;
+
+function readGitHubToken(deps: Pick<PullRequestLabelVersionSourceDeps, 'readEnvironmentVariable'>): string | undefined {
+    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+}
+
+function createEngine(deps: PullRequestLabelVersionSourceDeps): PrLogEngine {
+    return deps.createPrLogEngine({
+        githubToken: readGitHubToken(deps),
+        workingDirectory: deps.workingDirectory,
+        labelLookupIntervalMilliseconds,
+        maximumRateLimitRetryCount
+    });
+}
+
+function createValidLabels(config: PacktoryConfig): ReadonlyMap<string, string> {
+    return new Map([...defaultValidLabels, ...Object.entries(config.changelog?.labels ?? {})]);
+}
+
+function createVersionBumpLabels(
+    validLabels: ReadonlyMap<string, string>
+): Readonly<Record<VersionBumpLevel, readonly string[]>> {
+    const allLabels = Array.from(validLabels.keys());
+    return {
+        major: ['breaking'],
+        minor: ['feature'],
+        patch: allLabels
+    };
+}
+
+function selectVersionBumpLevel(
+    pullRequests: readonly PullRequestWithLabel[],
+    validLabels: ReadonlyMap<string, string>
+): VersionBumpLevel | undefined {
+    const labels = new Set(
+        pullRequests.map((pullRequest) => {
+            return pullRequest.label;
+        })
+    );
+    const versionBumpLabels = createVersionBumpLabels(validLabels);
+    return orderedVersionBumpLevels.find((level) => {
+        return versionBumpLabels[level].some((label) => {
+            return labels.has(label);
+        });
+    });
+}
+
+function incrementVersion(version: string, level: VersionBumpLevel): string {
+    const nextVersion = semver.inc(version, level);
+    if (nextVersion === null) {
+        throw new Error(`Failed to increment version "${version}"`);
+    }
+    return nextVersion;
+}
+
+function selectNextVersion(
+    currentVersion: string,
+    pullRequests: readonly PullRequestWithLabel[],
+    validLabels: ReadonlyMap<string, string>
+): string {
+    const versionBumpLevel = selectVersionBumpLevel(pullRequests, validLabels);
+    return versionBumpLevel === undefined ? currentVersion : incrementVersion(currentVersion, versionBumpLevel);
+}
+
+export function createPullRequestLabelVersionSourceResolver(
+    deps: PullRequestLabelVersionSourceDeps
+): VersionSourceResolver {
+    async function collectLabeledPullRequests(
+        input: Parameters<VersionProvider>[0],
+        packtoryConfig: PacktoryConfig
+    ): Promise<readonly PullRequestWithLabel[]> {
+        const packageInfo = await deps.readPackageInfo();
+        const githubRepo = formatGitHubRepositoryName(packageInfo);
+        const validLabels = createValidLabels(packtoryConfig);
+        const prLogEngine = createEngine(deps);
+        const baseRef = await prLogEngine.resolveChangelogBaseRef({
+            packageName: input.packageName,
+            previousVersion: input.currentVersion,
+            previousGitHead: undefined,
+            packageTagFormat: packtoryConfig.changelog?.packageTagFormat,
+            explicitBaseRef: packtoryConfig.changelog?.explicitBaseRef
+        });
+        const pullRequests = await prLogEngine.collectMergedPullRequests({ githubRepo, baseRef: baseRef.ref });
+        const changedFilesByPullRequest = await prLogEngine.readPullRequestChangedFiles({
+            githubRepo,
+            pullRequests
+        });
+        const targetPullRequests = prLogEngine.filterPullRequestsByTargetFiles({
+            targetName: input.packageName,
+            targetSourceFiles: input.targetSourceFiles,
+            pullRequests,
+            changedFilesByPullRequest,
+            ignoredAttributionPaths: input.ignoredAttributionPaths
+        });
+        return prLogEngine.resolvePullRequestLabels({
+            githubRepo,
+            validLabels,
+            ignoredLabels: [],
+            pullRequests: targetPullRequests,
+            targetName: input.packageName,
+            targetScopedLabelPattern: packtoryConfig.changelog?.targetScopedLabelPattern
+        });
+    }
+
+    return (sourceInput): VersionProvider => {
+        return async (input) => {
+            if (input.currentVersion === undefined) {
+                return '0.0.1';
+            }
+            return selectNextVersion(
+                input.currentVersion,
+                await collectLabeledPullRequests(input, sourceInput.packtoryConfig),
+                createValidLabels(sourceInput.packtoryConfig)
+            );
+        };
+    };
+}

--- a/source/packages/package-processor.composition.ts
+++ b/source/packages/package-processor.composition.ts
@@ -20,6 +20,7 @@ import { createTypescriptProjectAnalyzer } from '../dependency-scanner/typescrip
 import { createFileManager, type FileManager } from '../file-manager/file-manager.ts';
 import { createBundleLinker } from '../linker/linker.ts';
 import { createPackageProcessor, type PackageProcessor } from '../packtory/package-processor.ts';
+import type { VersionSourceResolver } from '../packtory/map-config.ts';
 import { createProgressBroadcaster, type ProgressBroadcaster } from '../progress/progress-broadcaster.ts';
 import { withStageTimings } from '../report/decorators.ts';
 import { createResourceResolver, type ResourceResolver } from '../resource-resolver/resource-resolver.ts';
@@ -73,6 +74,7 @@ export type PackageProcessorCompositionOptions = {
     readonly promptForOneTimePassword?: (() => Promise<string | undefined>) | undefined;
     readonly ciEnvironment: CiEnvironment;
     readonly repositoryFolder?: string | undefined;
+    readonly resolveVersionSource?: VersionSourceResolver | undefined;
 };
 
 function getEnvironmentVariable(variableName: string): string | undefined {

--- a/source/packages/packtory.composition.ts
+++ b/source/packages/packtory.composition.ts
@@ -29,7 +29,8 @@ export function buildPacktoryComposition(options: PackageProcessorCompositionOpt
             versionManager: parts.versionManager,
             packEmitter: parts.packEmitter,
             vendorMaterializer: parts.vendorMaterializer,
-            readCurrentGitHead: parts.readCurrentGitHead
+            readCurrentGitHead: parts.readCurrentGitHead,
+            resolveVersionSource: options.resolveVersionSource
         }),
         progressBroadcaster: parts.progressBroadcaster
     };

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -36,6 +36,18 @@ type ProgressEventName =
 type PackageConfig = PacktoryConfig['packages'][number];
 type ChangelogSettings = NonNullable<PacktoryConfig['changelog']>;
 type Root = PackageConfig['roots'][string];
+type ConfigWithVersioning<TVersioning> = {
+    readonly registrySettings: {
+        readonly auth: { readonly type: 'bearer-token'; readonly token: 'any-token' };
+    };
+    readonly packages: readonly [
+        {
+            readonly name: 'pkg';
+            readonly roots: { readonly main: { readonly js: 'index.js' } };
+            readonly versioning: TVersioning;
+        }
+    ];
+};
 type OkVariant<TResult> = Extract<TResult, { isOk: true }>;
 type ErrVariant<TResult> = Extract<TResult, { isErr: true }>;
 type PublishOk = OkVariant<PublishAllResult>['value'];
@@ -171,21 +183,21 @@ describe('PacktoryConfig — accepted shapes', () => {
     });
 
     test('accepts provider manual versioning', () => {
-        expect<PacktoryConfig>().type.toBeAssignableFrom<{
-            readonly registrySettings: {
-                readonly auth: { readonly type: 'bearer-token'; readonly token: 'any-token' };
-            };
-            readonly packages: readonly [
-                {
-                    readonly name: 'pkg';
-                    readonly roots: { readonly main: { readonly js: 'index.js' } };
-                    readonly versioning: {
-                        readonly automatic: false;
-                        readonly provideVersion: (input: VersionProviderInput) => Promise<string>;
-                    };
-                }
-            ];
-        }>();
+        expect<PacktoryConfig>().type.toBeAssignableFrom<
+            ConfigWithVersioning<{
+                readonly automatic: false;
+                readonly provideVersion: (input: VersionProviderInput) => Promise<string>;
+            }>
+        >();
+    });
+
+    test('accepts source manual versioning', () => {
+        expect<PacktoryConfig>().type.toBeAssignableFrom<
+            ConfigWithVersioning<{
+                readonly automatic: false;
+                readonly source: 'pull-request-labels';
+            }>
+        >();
     });
 });
 

--- a/source/packtory/changelog-source-attribution.ts
+++ b/source/packtory/changelog-source-attribution.ts
@@ -15,14 +15,13 @@ type ReferencedMap = {
 };
 
 const sourceMappingPrefix = '//# sourceMappingURL=';
-const javaScriptFilePattern = /\.[cm]?jsx?$/u;
 
 function sortUniqueValues(values: readonly string[]): readonly string[] {
     return Array.from(new Set(values)).toSorted(compareValues);
 }
 
 function isJavaScriptFile(filePath: string): boolean {
-    return javaScriptFilePattern.test(filePath);
+    return /\.[cm]?jsx?$/u.test(filePath);
 }
 
 function toRepositoryRelativePath(repositoryFolder: string, filePath: string): string {

--- a/source/packtory/map-config.test.ts
+++ b/source/packtory/map-config.test.ts
@@ -27,6 +27,7 @@ function runMapConfig(
         readonly packageName?: string;
         readonly extraConfig?: Partial<PacktoryConfigInput>;
         readonly extraPackages?: readonly PackageConfigInput[];
+        readonly resolveVersionSource?: ConfigArgs[3]['resolveVersionSource'];
     } = {}
 ): ReturnType<typeof configToBuildAndPublishOptions> {
     const packageName = options.packageName ?? 'foo';
@@ -48,7 +49,8 @@ function runMapConfig(
         packages: [packageWithFallback, ...additionalPackages]
     } as unknown as PacktoryConfigInput;
     return configToBuildAndPublishOptions(packageName, { [packageName]: packageWithFallback }, baseConfig, {
-        existingBundles: options.bundleDependencies ?? []
+        existingBundles: options.bundleDependencies ?? [],
+        resolveVersionSource: options.resolveVersionSource
     });
 }
 
@@ -417,6 +419,44 @@ suite('map-config', function () {
         );
 
         assert.deepStrictEqual(result.versioning, { automatic: false, version: '2.3.4' });
+    });
+
+    test('resolves source package versioning settings', async function () {
+        const provideVersion = async () => {
+            return '2.3.4';
+        };
+        const result = runMapConfig(
+            { ...fooPackageConfigFactory.build(), versioning: { automatic: false, source: 'pull-request-labels' } },
+            {
+                extraPackages: [],
+                resolveVersionSource({ packageName, source }) {
+                    assert.strictEqual(packageName, 'foo');
+                    assert.deepStrictEqual(source, { automatic: false, source: 'pull-request-labels' });
+                    return provideVersion;
+                }
+            }
+        );
+
+        assert.deepStrictEqual(result.versioning, { automatic: false, provideVersion });
+        assert.strictEqual(
+            await result.versioning.provideVersion({
+                packageName: 'foo',
+                currentVersion: undefined,
+                targetSourceFiles: [],
+                ignoredAttributionPaths: [],
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                stage: false
+            }),
+            '2.3.4'
+        );
+    });
+
+    test('throws when source package versioning has no resolver', function () {
+        runMapConfigExpectingError(
+            { ...fooPackageConfigFactory.build(), versioning: { automatic: false, source: 'pull-request-labels' } },
+            'Manual version source "pull-request-labels" is not available',
+            { extraPackages: [] }
+        );
     });
 
     test('merges additionalPackageJsonAttributes from per package and common settings', function () {

--- a/source/packtory/map-config.ts
+++ b/source/packtory/map-config.ts
@@ -1,4 +1,6 @@
 import type { PackageConfigsByName, PacktoryConfig, PacktoryConfigWithoutRegistry } from '../config/config.ts';
+import type { SourceManualVersioningSettings, VersionProvider } from '../config/manual-versioning-settings.ts';
+import { hasVersionSource } from '../config/versioning-settings.ts';
 import type { BundleSubstitutionSource } from '../linker/linked-bundle.ts';
 import type { PublishedPackageWithManifest } from '../published-package/published-package.ts';
 import {
@@ -9,6 +11,8 @@ import {
 import { collectGeneratedAttributionPaths } from './generated-attribution-paths.ts';
 import { resolvePublishSettings, type PublishSettings } from './options/setting-resolvers.ts';
 
+type PublishVersioningSettings = Exclude<VersioningSettings, SourceManualVersioningSettings>;
+
 export type BuildOptions = SharedPackageOptions<PublishedPackageWithManifest> & {
     readonly version: string;
 };
@@ -16,7 +20,7 @@ export type BuildOptions = SharedPackageOptions<PublishedPackageWithManifest> & 
 export type BuildAndPublishOptions = SharedPackageOptions<PublishedPackageWithManifest> & {
     readonly registrySettings: NonNullable<PacktoryConfig['registrySettings']>;
     readonly publishSettings: PublishSettings;
-    readonly versioning: VersioningSettings;
+    readonly versioning: PublishVersioningSettings;
     readonly ignoredAttributionPaths: readonly string[];
 };
 
@@ -25,7 +29,32 @@ export type ResolveAndLinkOptions = SharedPackageOptions<BundleSubstitutionSourc
 export type BuildAndPublishMappingContext = {
     readonly existingBundles: readonly PublishedPackageWithManifest[];
     readonly repositoryFolder?: string | undefined;
+    readonly resolveVersionSource?: VersionSourceResolver | undefined;
 };
+
+export type VersionSourceResolver = (input: {
+    readonly packageName: string;
+    readonly source: SourceManualVersioningSettings;
+    readonly packtoryConfig: PacktoryConfig;
+}) => VersionProvider;
+
+function resolveVersioning(
+    packageName: string,
+    versioning: VersioningSettings,
+    packtoryConfig: PacktoryConfig,
+    resolveVersionSource: VersionSourceResolver | undefined
+): PublishVersioningSettings {
+    if (!hasVersionSource(versioning)) {
+        return versioning;
+    }
+    if (resolveVersionSource === undefined) {
+        throw new Error(`Manual version source "${versioning.source}" is not available`);
+    }
+    return {
+        automatic: false,
+        provideVersion: resolveVersionSource({ packageName, source: versioning, packtoryConfig })
+    };
+}
 
 export function configToBuildAndPublishOptions(
     packageName: string,
@@ -43,7 +72,7 @@ export function configToBuildAndPublishOptions(
 
     return {
         ...sharedOptions,
-        versioning,
+        versioning: resolveVersioning(packageName, versioning, packtoryConfig, context.resolveVersionSource),
         registrySettings: packtoryConfig.registrySettings ?? {},
         publishSettings,
         ignoredAttributionPaths: collectGeneratedAttributionPaths(context.repositoryFolder ?? '/', packtoryConfig)

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -37,8 +37,6 @@ export type GeneratedChangelog = {
     readonly packageMarkdownByName: ReadonlyMap<string, string>;
 };
 
-const changelogFileName = 'CHANGELOG.md';
-
 function selectChangedPackages(packages: readonly ReleasePlanPackage[]): readonly ReleasePlanPackage[] {
     return packages.filter((packagePlan) => {
         return packagePlan.changed;
@@ -50,7 +48,7 @@ function sortUniqueValues(values: ReadonlySet<string>): readonly string[] {
 }
 
 function isChangelogFilePath(filePath: string): boolean {
-    return path.posix.basename(filePath) === changelogFileName;
+    return path.posix.basename(filePath) === 'CHANGELOG.md';
 }
 
 function collectChangelogPaths(packages: readonly ReleasePlanPackage[]): readonly string[] {

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -51,6 +51,7 @@ import {
 } from './packtory-results.ts';
 import type { PackageProcessor } from './package-processor.ts';
 import type { Scheduler as PacktoryScheduler } from './scheduler.ts';
+import type { VersionSourceResolver } from './map-config.ts';
 
 export type BuildAndPublishAllOptions = BuildAndPublishAllOptionsBase;
 export type ResolveAndLinkAllOptions = ResolveAndLinkAllOptionsBase;
@@ -89,6 +90,7 @@ type PacktoryDependencies = {
     readonly packEmitter: PackEmitter;
     readonly vendorMaterializer: VendorMaterializer;
     readonly readCurrentGitHead: CurrentGitHeadReader;
+    readonly resolveVersionSource?: VersionSourceResolver | undefined;
 };
 
 type ValidatedRunners = {

--- a/source/packtory/stages/publish-stage.ts
+++ b/source/packtory/stages/publish-stage.ts
@@ -3,7 +3,11 @@ import type { PacktoryConfig } from '../../config/config.ts';
 import type { ValidConfigResult } from '../../config/validation.ts';
 import { collectPublicModuleUsage } from '../../package-surface/public-module-usage.ts';
 import { withFailureCapture } from '../../report/decorators.ts';
-import { configToBuildAndPublishOptions, type BuildAndPublishOptions } from '../map-config.ts';
+import {
+    configToBuildAndPublishOptions,
+    type BuildAndPublishOptions,
+    type VersionSourceResolver
+} from '../map-config.ts';
 import type {
     BuildAndPublishResult,
     DetermineVersionAndPublishOptions,
@@ -20,6 +24,7 @@ export type PublishStageDependencies = {
     readonly scheduler: PacktoryScheduler;
     readonly progressBroadcaster: ProgressBroadcaster;
     readonly repositoryFolder: string;
+    readonly resolveVersionSource?: VersionSourceResolver | undefined;
 };
 
 export type PublishStageResult = Result<readonly BuildAndPublishResult[], PartialError<BuildAndPublishResult>>;
@@ -63,7 +68,11 @@ export async function determineVersionAndPublishAll(
                 packageName,
                 validatedConfig.packageConfigs,
                 validatedConfig.packtoryConfig,
-                { existingBundles: existing, repositoryFolder: dependencies.repositoryFolder }
+                {
+                    existingBundles: existing,
+                    repositoryFolder: dependencies.repositoryFolder,
+                    resolveVersionSource: dependencies.resolveVersionSource
+                }
             );
         },
         execute: withFailureCapture(dependencies.progressBroadcaster.provider, 'publish', async (buildOptions) => {


### PR DESCRIPTION
Adds a manual version source for `pull-request-labels`, wired through the CLI composition to reuse `@pr-log/core` attribution. Config with `automatic: false` and `source: pull-request-labels` now resolves to a provider before publish and release planning, so Packtory automatic versioning remains artifact-comparison based.