### PR TITLE
Limit registry tarball download and extraction sizes

### DIFF
--- a/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
@@ -11,6 +11,7 @@ import {
 } from './package-metadata-fetcher.ts';
 
 type FakeNpmFetch = SinonSpy & { json: SinonSpy };
+type FakeResponseHeaders = { readonly get: (name: string) => string | null };
 
 const settings: RegistrySettings = { auth: { type: 'bearer-token', token: 'tok' } };
 const latestVersion = '1.2.3';
@@ -20,6 +21,24 @@ function fakeNpmFetch(json: SinonSpy, buffer: SinonSpy = fake.resolves(Buffer.fr
     const npmFetch: FakeNpmFetch = fake.resolves({ buffer }) as FakeNpmFetch;
     npmFetch.json = json;
     return npmFetch as unknown as typeof _npmFetch;
+}
+
+function fakeNpmFetchWithHeaders(json: SinonSpy, buffer: SinonSpy, headers: FakeResponseHeaders): typeof _npmFetch {
+    const npmFetch: FakeNpmFetch = fake.resolves({ buffer, headers }) as FakeNpmFetch;
+    npmFetch.json = json;
+    return npmFetch as unknown as typeof _npmFetch;
+}
+
+async function fetchTarballWithContentLength(contentLength: string | null): Promise<{
+    readonly buffer: SinonSpy;
+    readonly headers: { readonly get: SinonSpy };
+    readonly result: Buffer;
+}> {
+    const buffer = fake.resolves(Buffer.from('tarball-bytes'));
+    const headers = { get: fake.returns(contentLength) };
+    const result = await fetchPackageTarball(fakeNpmFetchWithHeaders(fake(), buffer, headers), tarballUrl, settings);
+
+    return { buffer, headers, result };
 }
 
 function latestPackageResponse(time?: string): Record<string, unknown> {
@@ -246,6 +265,55 @@ suite('package-metadata-fetcher', function () {
         const result = await fetchPackageTarball(fakeNpmFetch(fake(), buffer), tarballUrl, settings);
 
         assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+    });
+
+    test('fetchPackageTarball rejects when the content length is above the download limit', async function () {
+        const buffer = fake.resolves(Buffer.from('tarball-bytes'));
+        const headers = { get: fake.returns(String(256 * 1024 * 1024 + 1)) };
+
+        try {
+            await fetchPackageTarball(fakeNpmFetchWithHeaders(fake(), buffer, headers), tarballUrl, settings);
+            assert.fail('Expected fetchPackageTarball() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Refusing to download tarball larger than 268435456 bytes');
+        }
+        assert.strictEqual(buffer.callCount, 0);
+        assert.deepStrictEqual(headers.get.firstCall.args, ['content-length']);
+    });
+
+    test('fetchPackageTarball accepts when the content length equals the download limit', async function () {
+        const { buffer, result } = await fetchTarballWithContentLength(String(256 * 1024 * 1024));
+
+        assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+        assert.strictEqual(buffer.callCount, 1);
+    });
+
+    test('fetchPackageTarball treats a null content length header as absent', async function () {
+        const { buffer, result } = await fetchTarballWithContentLength(null);
+
+        assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
+        assert.strictEqual(buffer.callCount, 1);
+    });
+
+    test('fetchPackageTarball ignores invalid content length headers', async function () {
+        for (const contentLength of ['not-a-number', '-1']) {
+            const { buffer, result } = await fetchTarballWithContentLength(contentLength);
+
+            assert.deepStrictEqual(result, Buffer.from('tarball-bytes'), contentLength);
+            assert.strictEqual(buffer.callCount, 1, contentLength);
+        }
+    });
+
+    test('fetchPackageTarball rejects when the buffered tarball is above the download limit', async function () {
+        const buffer = fake.resolves({ length: 256 * 1024 * 1024 + 1 } as Buffer);
+
+        try {
+            await fetchPackageTarball(fakeNpmFetch(fake(), buffer), tarballUrl, settings);
+            assert.fail('Expected fetchPackageTarball() to throw but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual((error as Error).message, 'Refusing to download tarball larger than 268435456 bytes');
+        }
+        assert.strictEqual(buffer.callCount, 1);
     });
 
     test('fetchPackageTarball rejects a tarball URL whose origin differs from the configured registry', async function () {

--- a/source/bundle-emitter/registry/package-metadata-fetcher.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.ts
@@ -15,6 +15,7 @@ import { assertTarballOriginMatchesRegistry } from './validate-tarball-host.ts';
 const notFoundStatusCode = 404;
 const forbiddenStatusCode = 403;
 const abbreviatedResponseAcceptHeader = 'application/vnd.npm.install-v1+json';
+const maxDownloadedTarballBytes = 268_435_456;
 
 export type PackageVersionDetails = {
     readonly version: string;
@@ -31,6 +32,21 @@ export type PackageReleaseMetadata = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return value instanceof Object;
+}
+
+type BufferedRegistryResponse = {
+    readonly buffer: () => Promise<Buffer>;
+    readonly headers: { readonly get: (name: string) => string | null } | undefined;
+};
+
+function assertDownloadedTarballSize(size: number): void {
+    if (size > maxDownloadedTarballBytes) {
+        throw new Error(`Refusing to download tarball larger than ${maxDownloadedTarballBytes} bytes`);
+    }
+}
+
+function assertContentLengthWithinDownloadLimit(response: BufferedRegistryResponse): void {
+    assertDownloadedTarballSize(Number(response.headers?.get('content-length')));
 }
 
 function isMissingPackageError(error: unknown): boolean {
@@ -239,5 +255,8 @@ export async function fetchPackageTarball(
     const response = await retryWithFallbackAuth(registrySettings, auth, async (options) => {
         return npmFetch(tarballUrl, options);
     });
-    return response.buffer();
+    assertContentLengthWithinDownloadLimit(response);
+    const tarball = await response.buffer();
+    assertDownloadedTarballSize(tarball.length);
+    return tarball;
 }

--- a/source/tar/extract-tar.test.ts
+++ b/source/tar/extract-tar.test.ts
@@ -20,6 +20,24 @@ async function expectFailure(action: () => Promise<unknown>, expectedError: RegE
     }
 }
 
+async function buildTwoFileTar(): Promise<Buffer> {
+    const builder = createTarballBuilder();
+    return await builder.build([
+        { filePath: 'first.txt', content: 'first', isExecutable: false },
+        { filePath: 'second.txt', content: 'second', isExecutable: false }
+    ]);
+}
+
+async function extractSingleFile(
+    filePath: string,
+    content: string,
+    limits: Parameters<typeof extractTarEntries>[2]
+): Promise<Awaited<ReturnType<typeof extractTarEntries>>> {
+    const builder = createTarballBuilder();
+    const tar = await builder.build([{ filePath, content, isExecutable: false }]);
+    return await extractTarEntries(tar, {}, limits);
+}
+
 suite('extract-tar', function () {
     test('returns an empty array when the given tar buffer has no files', async function () {
         const builder = createTarballBuilder();
@@ -69,11 +87,7 @@ suite('extract-tar', function () {
     });
 
     test('returns every extracted entry in tar order when the tarball contains multiple files', async function () {
-        const builder = createTarballBuilder();
-        const tar = await builder.build([
-            { filePath: 'first.txt', content: 'first', isExecutable: false },
-            { filePath: 'second.txt', content: 'second', isExecutable: false }
-        ]);
+        const tar = await buildTwoFileTar();
 
         const entries = await withPromiseDeadline(extractTarEntries(tar), 'multi-file tar extraction');
 
@@ -85,6 +99,71 @@ suite('extract-tar', function () {
                 ['first.txt', 'first'],
                 ['second.txt', 'second']
             ]
+        );
+    });
+
+    test('rejects tarballs with too many entries', async function () {
+        const tar = await buildTwoFileTar();
+
+        await expectFailure(async () => {
+            await extractTarEntries(tar, {}, { maxEntryCount: 1, maxEntryPathLength: 4096, maxExtractedBytes: 1024 });
+        }, /^Error: Refusing to extract tarball with more than 1 entries$/u);
+    });
+
+    test('rejects tarballs with paths above the configured length limit', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([{ filePath: 'long-file-name.txt', content: 'content', isExecutable: false }]);
+
+        await expectFailure(async () => {
+            await extractTarEntries(tar, {}, { maxEntryCount: 1, maxEntryPathLength: 8, maxExtractedBytes: 1024 });
+        }, /^Error: Refusing to extract tarball entry with path longer than 8 characters$/u);
+    });
+
+    test('rejects tarballs with paths above the default length limit', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([{ filePath: 'a'.repeat(4097), content: 'content', isExecutable: false }]);
+
+        await expectFailure(async () => {
+            await extractTarEntries(tar);
+        }, /^Error: Refusing to extract tarball entry with path longer than 4096 characters$/u);
+    });
+
+    test('accepts tarballs with paths at the configured length limit', async function () {
+        const entries = await extractSingleFile('12345678', 'content', {
+            maxEntryCount: 1,
+            maxEntryPathLength: 8,
+            maxExtractedBytes: 1024
+        });
+
+        assert.deepStrictEqual(
+            entries.map((entry) => {
+                return entry.header.name;
+            }),
+            ['12345678']
+        );
+    });
+
+    test('rejects tarballs whose extracted content exceeds the configured size limit', async function () {
+        const builder = createTarballBuilder();
+        const tar = await builder.build([{ filePath: 'file.txt', content: 'content', isExecutable: false }]);
+
+        await expectFailure(async () => {
+            await extractTarEntries(tar, {}, { maxEntryCount: 1, maxEntryPathLength: 4096, maxExtractedBytes: 3 });
+        }, /^Error: Refusing to extract tarball larger than 3 bytes$/u);
+    });
+
+    test('accepts tarballs whose extracted content equals the configured size limit', async function () {
+        const entries = await extractSingleFile('file.txt', 'content', {
+            maxEntryCount: 1,
+            maxEntryPathLength: 4096,
+            maxExtractedBytes: 7
+        });
+
+        assert.deepStrictEqual(
+            entries.map((entry) => {
+                return entry.content;
+            }),
+            ['content']
         );
     });
 

--- a/source/tar/extract-tar.ts
+++ b/source/tar/extract-tar.ts
@@ -11,6 +11,30 @@ type ExtractTarDependencies = {
     readonly createSource: (buffer: Buffer) => Readable;
 };
 
+type ExtractTarLimits = {
+    readonly maxEntryCount: number;
+    readonly maxEntryPathLength: number;
+    readonly maxExtractedBytes: number;
+};
+
+type EntryContent = {
+    readonly content: string;
+    readonly extractedBytes: number;
+};
+
+type ExtractionStreams = {
+    readonly extractStream: ErrorEmitter;
+    readonly gunzip: ErrorEmitter;
+    readonly source: ErrorEmitter;
+    readonly tarEntries: AsyncIterable<TarStreamEntry>;
+};
+
+const defaultExtractTarLimits: ExtractTarLimits = {
+    maxEntryCount: 50_000,
+    maxEntryPathLength: 4096,
+    maxExtractedBytes: 1_073_741_824
+};
+
 function toError(error: unknown): Error {
     return error instanceof Error ? error : new Error(String(error));
 }
@@ -23,15 +47,53 @@ type ErrorEmitter = {
     readonly once: (eventName: 'error', listener: (error: unknown) => void) => unknown;
 };
 
-async function collectTarEntries(stream: AsyncIterable<TarStreamEntry>): Promise<TarEntry[]> {
+function assertWithinEntryCountLimit(entries: readonly TarEntry[], limits: ExtractTarLimits): void {
+    if (entries.length >= limits.maxEntryCount) {
+        throw new Error(`Refusing to extract tarball with more than ${limits.maxEntryCount} entries`);
+    }
+}
+
+function assertWithinEntryPathLimit(entry: TarStreamEntry, limits: ExtractTarLimits): void {
+    if (entry.header.name.length > limits.maxEntryPathLength) {
+        throw new Error(
+            `Refusing to extract tarball entry with path longer than ${limits.maxEntryPathLength} characters`
+        );
+    }
+}
+
+function assertWithinExtractedSizeLimit(extractedBytes: number, limits: ExtractTarLimits): void {
+    if (extractedBytes > limits.maxExtractedBytes) {
+        throw new Error(`Refusing to extract tarball larger than ${limits.maxExtractedBytes} bytes`);
+    }
+}
+
+async function readEntryContent(
+    entry: TarStreamEntry,
+    currentExtractedBytes: number,
+    limits: ExtractTarLimits
+): Promise<EntryContent> {
+    let result = '';
+    let extractedBytes = currentExtractedBytes;
+
+    for await (const chunk of entry) {
+        extractedBytes += chunk.length;
+        assertWithinExtractedSizeLimit(extractedBytes, limits);
+        result += chunk.toString();
+    }
+
+    return { content: result, extractedBytes };
+}
+
+async function collectTarEntries(stream: AsyncIterable<TarStreamEntry>, limits: ExtractTarLimits): Promise<TarEntry[]> {
     const entries: TarEntry[] = [];
+    let extractedBytes = 0;
 
     for await (const entry of stream) {
-        let result = '';
-        for await (const chunk of entry) {
-            result += chunk.toString();
-        }
-        entries.push({ header: entry.header, content: result });
+        assertWithinEntryCountLimit(entries, limits);
+        assertWithinEntryPathLimit(entry, limits);
+        const content = await readEntryContent(entry, extractedBytes, limits);
+        extractedBytes = content.extractedBytes;
+        entries.push({ header: entry.header, content: content.content });
     }
 
     return entries;
@@ -50,38 +112,34 @@ function appendOutcome(outcomes: Set<Promise<TarEntry[]>>, outcome: Promise<TarE
     return outcomes;
 }
 
-async function raceExtractionOutcomes(
-    stream: AsyncIterable<TarStreamEntry>,
-    source: ErrorEmitter,
-    gunzip: ErrorEmitter,
-    extractStream: ErrorEmitter
-): Promise<TarEntry[]> {
+async function raceExtractionOutcomes(streams: ExtractionStreams, limits: ExtractTarLimits): Promise<TarEntry[]> {
     return await Promise.race(
         appendOutcome(
             appendOutcome(
                 appendOutcome(
-                    appendOutcome(new Set<Promise<TarEntry[]>>(), collectTarEntries(stream)),
-                    waitForStreamError(source)
+                    appendOutcome(new Set<Promise<TarEntry[]>>(), collectTarEntries(streams.tarEntries, limits)),
+                    waitForStreamError(streams.source)
                 ),
-                waitForStreamError(gunzip)
+                waitForStreamError(streams.gunzip)
             ),
-            waitForStreamError(extractStream)
+            waitForStreamError(streams.extractStream)
         )
     );
 }
 
 export async function extractTarEntries(
     buffer: Buffer,
-    dependencies: Partial<ExtractTarDependencies> = {}
+    dependencies: Partial<ExtractTarDependencies> = {},
+    limits: ExtractTarLimits = defaultExtractTarLimits
 ): Promise<TarEntry[]> {
     const createSource = dependencies.createSource ?? Readable.from;
     const extractStream = extract();
     const source = createSource(buffer);
     const gunzip = createGunzip();
-    const stream = source.pipe(gunzip).pipe(extractStream) as AsyncIterable<TarStreamEntry>;
+    const tarEntries = source.pipe(gunzip).pipe(extractStream) as AsyncIterable<TarStreamEntry>;
 
     try {
-        return await raceExtractionOutcomes(stream, source, gunzip, extractStream);
+        return await raceExtractionOutcomes({ extractStream, gunzip, source, tarEntries }, limits);
     } catch (error: unknown) {
         throw toError(error);
     }


### PR DESCRIPTION
This caps registry tarball downloads by `content-length` and buffered size, and caps tar extraction by entry count, path length, and extracted bytes. The limits turn oversized or zip-bomb-style tarballs into explicit failures before materialization proceeds.