### PR TITLE
Add Renovate `minimumReleaseAge` cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "labels": ["renovate", "upgrade"],
     "dependencyDashboard": false,
     "rebaseStalePrs": true,
+    "minimumReleaseAge": "3 days",
     "lockFileMaintenance": {
         "enabled": true,
         "automerge": true


### PR DESCRIPTION
This adds Renovate `minimumReleaseAge` of `3 days` so automerge waits before accepting freshly published dependency releases. The delay reduces exposure to fast-moving compromised package releases.