### PR TITLE
Fix source map discovery to stay within `sourcesFolder`

### DIFF
--- a/source/dependency-scanner/scanner.test.ts
+++ b/source/dependency-scanner/scanner.test.ts
@@ -29,7 +29,7 @@ type Overrides = {
 };
 
 function dependencyScannerFactory(overrides: Overrides = {}): DependencyScanner {
-    const { analyzeProject = createFakeAnalyzeProject(), locate = fake.resolves(null) } = overrides;
+    const { analyzeProject = createFakeAnalyzeProject(), locate = fake.resolves(Maybe.nothing()) } = overrides;
     const fakeDependencies = {
         sourceMapFileLocator: { locate },
         typescriptProjectAnalyzer: { analyzeProject }
@@ -143,8 +143,8 @@ suite('scanner', function () {
         });
 
         assert.strictEqual(locate.callCount, 2);
-        assert.deepStrictEqual(locate.firstCall.args, ['/dir/entry.js']);
-        assert.deepStrictEqual(locate.secondCall.args, ['/dir/foo.js']);
+        assert.deepStrictEqual(locate.firstCall.args, ['/dir/entry.js', '/dir']);
+        assert.deepStrictEqual(locate.secondCall.args, ['/dir/foo.js', '/dir']);
     });
 
     async function scanWithSourceMapLocate(locate: SinonSpy): Promise<DependencyFiles> {

--- a/source/dependency-scanner/scanner.ts
+++ b/source/dependency-scanner/scanner.ts
@@ -39,26 +39,34 @@ type ReferenceLists = {
     readonly externalDependencies: readonly string[];
 };
 
+type ScanContext = {
+    readonly folder: string;
+    readonly graph: DependencyGraph;
+    readonly options: Required<ScanOptions>;
+    readonly project: TypescriptProject;
+};
+
 export function createDependencyScanner(
     dependencyScannerDependencies: Readonly<DependencyScannerDependencies>
 ): DependencyScanner {
     const { sourceMapFileLocator, typescriptProjectAnalyzer } = dependencyScannerDependencies;
 
-    async function getDependencyNodeData(
-        project: TypescriptProject | undefined,
-        sourceFilePath: string,
-        externalDependencies: readonly string[],
-        options: Required<ScanOptions>
-    ): Promise<DependencyGraphNodeData> {
+    async function getDependencyNodeData(args: {
+        readonly externalDependencies: readonly string[];
+        readonly options: Required<ScanOptions>;
+        readonly project: TypescriptProject | undefined;
+        readonly sourceFilePath: string;
+        readonly sourcesFolder: string;
+    }): Promise<DependencyGraphNodeData> {
         const sourceMapFilePath =
-            options.includeSourceMapFiles && isCodeFile(sourceFilePath)
-                ? await sourceMapFileLocator.locate(sourceFilePath)
+            args.options.includeSourceMapFiles && isCodeFile(args.sourceFilePath)
+                ? await sourceMapFileLocator.locate(args.sourceFilePath, args.sourcesFolder)
                 : Maybe.nothing<string>();
 
         return {
             sourceMapFilePath,
-            externalDependencies,
-            project
+            externalDependencies: args.externalDependencies,
+            project: args.project
         };
     }
 
@@ -80,59 +88,52 @@ export function createDependencyScanner(
         };
     }
 
-    async function connectLocalReferences(args: {
-        readonly graph: DependencyGraph;
-        readonly localReferences: readonly ScannableLocalReference[];
-        readonly options: Required<ScanOptions>;
-        readonly project: TypescriptProject;
-        readonly scanReference: (
-            project: TypescriptProject,
-            reference: ScannableLocalReference,
-            graph: DependencyGraph,
-            options: Required<ScanOptions>
-        ) => Promise<void>;
-        readonly sourceFilePath: string;
-    }): Promise<void> {
-        for (const localReference of args.localReferences) {
-            if (!args.graph.isKnown(localReference.filePath)) {
-                await args.scanReference(args.project, localReference, args.graph, args.options);
-            }
-            if (!args.graph.hasConnection(args.sourceFilePath, localReference.filePath)) {
-                args.graph.connect(args.sourceFilePath, localReference.filePath);
-            }
-        }
+    function getReferencedModules(
+        project: TypescriptProject,
+        reference: ScannableLocalReference
+    ): readonly ModuleReference[] {
+        return reference.kind === moduleReferenceKind.localCode ? project.getReferencedModules(reference.filePath) : [];
+    }
+
+    function getNodeProject(
+        project: TypescriptProject,
+        reference: ScannableLocalReference
+    ): TypescriptProject | undefined {
+        return reference.kind === moduleReferenceKind.localCode ? project : undefined;
+    }
+
+    function toDependencyNode(
+        reference: ScannableLocalReference,
+        nodeData: DependencyGraphNodeData
+    ): DependencyGraphNodeData {
+        return reference.kind === moduleReferenceKind.generatedManifest
+            ? { ...nodeData, isGeneratedManifest: true }
+            : nodeData;
     }
 
     async function scanDependenciesOfReference(
-        project: TypescriptProject,
-        reference: ScannableLocalReference,
-        graph: DependencyGraph,
-        options: Required<ScanOptions>
+        context: ScanContext,
+        reference: ScannableLocalReference
     ): Promise<void> {
         const sourceFilePath = reference.filePath;
-        const referencedModules =
-            reference.kind === moduleReferenceKind.localCode ? project.getReferencedModules(sourceFilePath) : [];
+        const referencedModules = getReferencedModules(context.project, reference);
         const { localReferences, externalDependencies } = collectReferenceLists(referencedModules);
-        const nodeData = await getDependencyNodeData(
-            reference.kind === moduleReferenceKind.localCode ? project : undefined,
-            sourceFilePath,
+        const nodeData = await getDependencyNodeData({
             externalDependencies,
-            options
-        );
-        graph.addDependency(
+            options: context.options,
+            project: getNodeProject(context.project, reference),
             sourceFilePath,
-            reference.kind === moduleReferenceKind.generatedManifest
-                ? { ...nodeData, isGeneratedManifest: true }
-                : nodeData
-        );
-        await connectLocalReferences({
-            graph,
-            localReferences,
-            options,
-            project,
-            scanReference: scanDependenciesOfReference,
-            sourceFilePath
+            sourcesFolder: context.folder
         });
+        context.graph.addDependency(sourceFilePath, toDependencyNode(reference, nodeData));
+        for (const localReference of localReferences) {
+            if (!context.graph.isKnown(localReference.filePath)) {
+                await scanDependenciesOfReference(context, localReference);
+            }
+            if (!context.graph.hasConnection(sourceFilePath, localReference.filePath)) {
+                context.graph.connect(sourceFilePath, localReference.filePath);
+            }
+        }
     }
 
     return {
@@ -151,10 +152,13 @@ export function createDependencyScanner(
             });
 
             await scanDependenciesOfReference(
-                project,
-                { kind: moduleReferenceKind.localCode, filePath: entryPointFile },
-                graph,
-                scanOptions
+                {
+                    folder,
+                    graph,
+                    options: scanOptions,
+                    project
+                },
+                { kind: moduleReferenceKind.localCode, filePath: entryPointFile }
             );
 
             return graph;

--- a/source/dependency-scanner/source-map-file-locator.property.ts
+++ b/source/dependency-scanner/source-map-file-locator.property.ts
@@ -21,7 +21,7 @@ suite('source-map-file-locator', function () {
                     return !/^\/\/# sourceMappingURL=(?<url>.+)$/m.test(value);
                 }),
                 async (fileContent) => {
-                    const result = await createLocator(fileContent, true).locate('/src/file.js');
+                    const result = await createLocator(fileContent, true).locate('/src/file.js', '/src');
                     assert.deepStrictEqual(result, Maybe.nothing());
                 }
             )
@@ -31,7 +31,10 @@ suite('source-map-file-locator', function () {
     test('locate() returns Maybe.nothing() when the referenced source-map file is unreadable', async function () {
         await fc.assert(
             fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
-                const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, false).locate('/src/file.js');
+                const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, false).locate(
+                    '/src/file.js',
+                    '/src'
+                );
                 assert.deepStrictEqual(result, Maybe.nothing());
             })
         );
@@ -40,7 +43,10 @@ suite('source-map-file-locator', function () {
     test('locate() returns Maybe.just() when the referenced source-map file is readable', async function () {
         await fc.assert(
             fc.asyncProperty(fc.stringMatching(/^[a-z][\da-z-]{0,7}\.map$/), async (mapFileName) => {
-                const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, true).locate('/src/file.js');
+                const result = await createLocator(`//# sourceMappingURL=${mapFileName}`, true).locate(
+                    '/src/file.js',
+                    '/src'
+                );
                 assert.deepStrictEqual(result, Maybe.just(`/src/${mapFileName}`));
             })
         );

--- a/source/dependency-scanner/source-map-file-locator.test.ts
+++ b/source/dependency-scanner/source-map-file-locator.test.ts
@@ -29,7 +29,7 @@ suite('source-map-file-locator', function () {
     test('reads the content of the given source file', async function () {
         const { locator, fileManager } = sourceMapFileLocatorFactory();
 
-        await locator.locate('/foo/bar.js');
+        await locator.locate('/foo/bar.js', '/foo');
 
         assert.strictEqual(fileManager.getReadFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/foo/bar.js' });
@@ -38,7 +38,7 @@ suite('source-map-file-locator', function () {
     async function expectLocateReturnsNothingWithoutCheckReadability(content: string): Promise<void> {
         const { locator, fileManager } = sourceMapFileLocatorFactory({ readFileContent: content, isReadable: true });
 
-        const result = await locator.locate('/foo/bar.js');
+        const result = await locator.locate('/foo/bar.js', '/foo');
 
         assert.deepStrictEqual(result, Maybe.nothing());
         assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 0);
@@ -46,6 +46,7 @@ suite('source-map-file-locator', function () {
 
     test('returns nothing when there is no external source mapping URL referenced in the given file', async function () {
         await expectLocateReturnsNothingWithoutCheckReadability('no sourceMappingURL comment');
+        await expectLocateReturnsNothingWithoutCheckReadability('baz.map');
     });
 
     test('returns nothing when the sourceMappingURL text is not at the start of a line comment', async function () {
@@ -62,59 +63,107 @@ suite('source-map-file-locator', function () {
         await expectLocateReturnsNothingWithoutCheckReadability('foo\n//# sourceMappingURL=');
     });
 
-    test('reads the named capture group value as the source map file name', async function () {
-        const { locator, fileManager } = sourceMapFileLocatorFactory({
-            readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
-            isReadable: false
-        });
+    test('returns nothing for source map paths that are not contained relative map files', async function () {
+        for (const sourceMappingUrl of [
+            '../maps/baz.map',
+            'maps/baz.map?hash=1',
+            '/foo/baz.map',
+            '/outside/secret.map',
+            'C:\\secret.map',
+            '\\\\server\\share\\file.map',
+            'https://example.test/file.map',
+            'secret.txt'
+        ]) {
+            const { locator, fileManager } = sourceMapFileLocatorFactory({
+                readFileContent: `foo\n//# sourceMappingURL=${sourceMappingUrl}`,
+                isReadable: true
+            });
 
-        const result = await locator.locate('/foo/bar.js');
+            const result = await locator.locate('/foo/bar.js', '/foo');
 
-        assert.deepStrictEqual(result, Maybe.nothing());
-        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js' });
-    });
-
-    test('uses the full sourceMappingURL capture up to the end of the line', async function () {
-        const { locator, fileManager } = sourceMapFileLocatorFactory({
-            readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js?hash=1',
-            isReadable: false
-        });
-
-        await locator.locate('/foo/bar.js');
-
-        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/maps/baz.map.js?hash=1' });
+            assert.deepStrictEqual(result, Maybe.nothing(), sourceMappingUrl);
+            assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 0, sourceMappingUrl);
+        }
     });
 
     test('checks if the referenced source mapping file is readable on the file system', async function () {
         const { locator, fileManager } = sourceMapFileLocatorFactory({
-            readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
+            readFileContent: 'foo\n//# sourceMappingURL=baz.map',
             isReadable: false
         });
 
-        await locator.locate('/foo/bar.js');
+        await locator.locate('/foo/bar.js', '/foo');
 
         assert.strictEqual(fileManager.getCheckReadabilityCallCount(), 1);
-        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/foo/baz.map.js' });
+        assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), { fileOrFolderPath: '/foo/baz.map' });
     });
 
     test('returns the path to the referenced source map file when it is readable', async function () {
         const { locator } = sourceMapFileLocatorFactory({
-            readFileContent: 'foo\n//# sourceMappingURL=../maps/baz.map.js',
+            readFileContent: 'foo\n//# sourceMappingURL=maps/baz.map',
             isReadable: true
         });
 
-        const result = await locator.locate('/foo/bar.js');
+        const result = await locator.locate('/foo/bar.js', '/foo');
 
-        assert.deepStrictEqual(result, Maybe.just('/maps/baz.map.js'));
+        assert.deepStrictEqual(result, Maybe.just('/foo/maps/baz.map'));
+    });
+
+    test('ignores plain map file names before the sourceMappingURL comment', async function () {
+        const { locator } = sourceMapFileLocatorFactory({
+            readFileContent: 'maps/ignored.map\n//# sourceMappingURL=maps/baz.map',
+            isReadable: true
+        });
+
+        const result = await locator.locate('/foo/bar.js', '/foo');
+
+        assert.deepStrictEqual(result, Maybe.just('/foo/maps/baz.map'));
+    });
+
+    test('returns a relative source map path whose later path segment contains a colon', async function () {
+        const { locator } = sourceMapFileLocatorFactory({
+            readFileContent: 'foo\n//# sourceMappingURL=maps/http:file.map',
+            isReadable: true
+        });
+
+        const result = await locator.locate('/foo/bar.js', '/foo');
+
+        assert.deepStrictEqual(result, Maybe.just('/foo/maps/http:file.map'));
+    });
+
+    test('returns nothing when a readable source map resolves outside the sources folder', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: 'foo\n//# sourceMappingURL=linked.map' }],
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }],
+            simulatedRealPathResponses: [{ value: '/foo' }, { value: '/outside/linked.map' }]
+        });
+        const locator = createSourceMapFileLocator({ fileManager });
+
+        const result = await locator.locate('/foo/bar.js', '/foo');
+
+        assert.deepStrictEqual(result, Maybe.nothing());
+    });
+
+    test('returns nothing when a readable source map resolves to the sources folder itself', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedReadFileResponses: [{ value: 'foo\n//# sourceMappingURL=linked.map' }],
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: true } }],
+            simulatedRealPathResponses: [{ value: '/foo' }, { value: '/foo' }]
+        });
+        const locator = createSourceMapFileLocator({ fileManager });
+
+        const result = await locator.locate('/foo/bar.js', '/foo');
+
+        assert.deepStrictEqual(result, Maybe.nothing());
     });
 
     test('returns nothing when there is an external source mapping file referenced but it can’t be read', async function () {
         const { locator } = sourceMapFileLocatorFactory({
-            readFileContent: 'foo\n//# sourceMappingURL=baz.map.js',
+            readFileContent: 'foo\n//# sourceMappingURL=baz.map',
             isReadable: false
         });
 
-        const result = await locator.locate('/foo/bar.js');
+        const result = await locator.locate('/foo/bar.js', '/foo');
 
         assert.deepStrictEqual(result, Maybe.nothing());
     });

--- a/source/dependency-scanner/source-map-file-locator.ts
+++ b/source/dependency-scanner/source-map-file-locator.ts
@@ -7,18 +7,51 @@ export type SourceMapFileLocatorDependencies = {
 };
 
 export type SourceMapFileLocator = {
-    locate: (sourceFile: string) => Promise<Maybe<string>>;
+    locate: (sourceFile: string, sourcesFolder: string) => Promise<Maybe<string>>;
 };
 
+function sourceMappingUrlPrefix(): string {
+    return '//# sourceMappingURL=';
+}
+
 function getSourceMappingUrl(fileContent: string): string | undefined {
+    const prefix = sourceMappingUrlPrefix();
     for (const line of fileContent.split('\n')) {
-        if (line.startsWith('//# sourceMappingURL=')) {
-            const sourceMappingUrl = line.slice('//# sourceMappingURL='.length);
-            return sourceMappingUrl === '' ? undefined : sourceMappingUrl;
+        if (line.startsWith(prefix)) {
+            const sourceMappingUrl = line.slice(prefix.length);
+            return sourceMappingUrl;
         }
     }
 
     return undefined;
+}
+
+function isUrlLike(filePath: string): boolean {
+    return /^[a-z][\d+.a-z-]*:/iu.test(filePath);
+}
+
+function isRelativeMapFilePath(filePath: string): boolean {
+    if (path.posix.isAbsolute(filePath) || path.win32.isAbsolute(filePath)) {
+        return false;
+    }
+    if (isUrlLike(filePath) || filePath.includes('?') || filePath.includes('#')) {
+        return false;
+    }
+    return path.extname(filePath) === '.map';
+}
+
+function isInFolder(folder: string, candidate: string): boolean {
+    const relativePath = path.relative(folder, candidate);
+    return relativePath.length > 0 && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+}
+
+function resolveSourceMapFile(sourceFile: string, sourcesFolder: string, sourceMappingUrl: string): Maybe<string> {
+    if (!isRelativeMapFilePath(sourceMappingUrl)) {
+        return Maybe.nothing();
+    }
+
+    const sourceMapFile = path.resolve(path.dirname(sourceFile), sourceMappingUrl);
+    return isInFolder(path.resolve(sourcesFolder), sourceMapFile) ? Maybe.just(sourceMapFile) : Maybe.nothing();
 }
 
 export function createSourceMapFileLocator(
@@ -26,22 +59,34 @@ export function createSourceMapFileLocator(
 ): SourceMapFileLocator {
     const { fileManager } = dependencies;
 
+    async function isReadableSourceMap(sourcesFolder: string, sourceMapFile: string): Promise<boolean> {
+        const { isReadable } = await fileManager.checkReadability(sourceMapFile);
+        if (!isReadable) {
+            return false;
+        }
+
+        const realSourcesFolder = await fileManager.getRealPath(sourcesFolder);
+        const realSourceMapFile = await fileManager.getRealPath(sourceMapFile);
+        return isInFolder(realSourcesFolder, realSourceMapFile);
+    }
+
     return {
-        async locate(sourceFile) {
+        async locate(sourceFile, sourcesFolder) {
             const fileContent = await fileManager.readFile(sourceFile);
             const sourceMappingUrl = getSourceMappingUrl(fileContent);
 
-            if (sourceMappingUrl !== undefined) {
-                const folder = path.dirname(sourceFile);
-                const sourceMappingFile = path.join(folder, sourceMappingUrl);
-                const { isReadable } = await fileManager.checkReadability(sourceMappingFile);
-
-                if (isReadable) {
-                    return Maybe.just(sourceMappingFile);
-                }
+            if (sourceMappingUrl === undefined) {
+                return Maybe.nothing();
             }
 
-            return Maybe.nothing();
+            const sourceMapFile = resolveSourceMapFile(sourceFile, sourcesFolder, sourceMappingUrl);
+            if (sourceMapFile.isNothing) {
+                return Maybe.nothing();
+            }
+
+            return (await isReadableSourceMap(sourcesFolder, sourceMapFile.value))
+                ? Maybe.just(sourceMapFile.value)
+                : Maybe.nothing();
         }
     };
 }


### PR DESCRIPTION
This constrains external source-map discovery to relative `.map` files that stay inside `sourcesFolder` after lexical and realpath checks. It prevents a source map comment from pulling arbitrary local files into package dependency analysis.