### PR TITLE
Reject resolved local files outside `sourcesFolder`

### DIFF
--- a/source/resource-resolver/content.test.ts
+++ b/source/resource-resolver/content.test.ts
@@ -32,6 +32,48 @@ suite('content', function () {
         ]);
     });
 
+    test('rejects local dependency paths outside sourcesFolder', function () {
+        assert.throws(
+            () => {
+                combineAllBundleFiles(
+                    '/src',
+                    [
+                        {
+                            filePath: '/secret.js',
+                            directDependencies: new Set(),
+                            project: 'project' as never
+                        }
+                    ],
+                    []
+                );
+            },
+            {
+                message: 'Local file "/secret.js" must resolve inside sourcesFolder "/src"'
+            }
+        );
+    });
+
+    test('rejects local dependency paths that resolve to sourcesFolder itself', function () {
+        assert.throws(
+            () => {
+                combineAllBundleFiles(
+                    '/src',
+                    [
+                        {
+                            filePath: '/src',
+                            directDependencies: new Set(),
+                            project: 'project' as never
+                        }
+                    ],
+                    []
+                );
+            },
+            {
+                message: 'Local file "/src" must resolve inside sourcesFolder "/src"'
+            }
+        );
+    });
+
     test('pins generated manifest resources to package.json at package root', function () {
         const result = combineAllBundleFiles(
             '/src',

--- a/source/resource-resolver/content.ts
+++ b/source/resource-resolver/content.ts
@@ -35,6 +35,15 @@ type ResolvedBundleFile = {
     readonly isGeneratedManifest?: true | undefined;
 };
 
+function toSourceRelativeTargetPath(sourcesFolder: string, filePath: string): string {
+    const targetFilePath = path.relative(sourcesFolder, filePath);
+    if (targetFilePath.startsWith('..') || path.isAbsolute(targetFilePath) || targetFilePath.length === 0) {
+        throw new Error(`Local file "${filePath}" must resolve inside sourcesFolder "${sourcesFolder}"`);
+    }
+
+    return targetFilePath;
+}
+
 export function combineAllBundleFiles(
     sourcesFolder: string,
     localDependencies: readonly LocalFile[],
@@ -43,7 +52,7 @@ export function combineAllBundleFiles(
     const resolvedLocalFiles = localDependencies.map((localFile) => {
         const targetFilePath = localFile.isGeneratedManifest
             ? packageManifestFilePath
-            : path.relative(sourcesFolder, localFile.filePath);
+            : toSourceRelativeTargetPath(sourcesFolder, localFile.filePath);
         const resolvedBundleFile: ResolvedBundleFile = {
             sourceFilePath: localFile.filePath,
             targetFilePath,


### PR DESCRIPTION
This validates local dependency targets against `sourcesFolder` before deriving package-relative output paths. Files that resolve outside the source tree, or to the source root itself, are rejected.