### PR TITLE
Fix npm `engine-strict` config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 save-exact=true
-engines-strict=true
-
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@octokit/plugin-paginate-rest": "14.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "17.0.0",
                 "@pr-log/core": "0.0.2",
-                "@schema-hub/zod-error-formatter": "0.0.11",
+                "@schema-hub/zod-error-formatter": "0.0.12",
                 "@ts-morph/common": "0.29.0",
                 "@types/common-tags": "1.8.4",
                 "@types/hosted-git-info": "3.0.5",
@@ -4042,12 +4042,12 @@
             }
         },
         "node_modules/@schema-hub/zod-error-formatter": {
-            "version": "0.0.11",
-            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.11.tgz",
-            "integrity": "sha512-5U+75sWcq9BBzNO0ui7iJZfhkU3QLpeZiF4uuxrWqpSYfmrfzyGOjVGfSVWTWeGlIZaepaON2eVn9ugTWvjppQ==",
+            "version": "0.0.12",
+            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.12.tgz",
+            "integrity": "sha512-dTUnu48Aj3VXLq4BT+HtiiKKyvBlm07tJlQ2WA1SQtv7rZzZfV/vFTJoSkwdzQ9Axi3gVrcSpXV9qtAKQ0Ybpw==",
             "license": "MIT",
             "engines": {
-                "node": "^22 || ^24"
+                "node": "^24 || ^26"
             },
             "peerDependencies": {
                 "zod": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@octokit/plugin-paginate-rest": "14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "17.0.0",
         "@pr-log/core": "0.0.2",
-        "@schema-hub/zod-error-formatter": "0.0.11",
+        "@schema-hub/zod-error-formatter": "0.0.12",
         "@ts-morph/common": "0.29.0",
         "@types/common-tags": "1.8.4",
         "@types/hosted-git-info": "3.0.5",
@@ -103,6 +103,7 @@
         "node": "^24 || ^26"
     },
     "overrides": {
+        "@schema-hub/zod-error-formatter": "0.0.12",
         "yargs": "18.0.0"
     }
 }

--- a/source/bundle-emitter/registry/registry-response-schemas.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.ts
@@ -1,5 +1,5 @@
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { z } from 'zod/mini';
+import { safeParse } from '../../common/schema-validation.ts';
 
 const packageVersionDetailsSchema = z.object({
     dist: z.object({

--- a/source/checks/rules/no-side-effects.test.ts
+++ b/source/checks/rules/no-side-effects.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../../common/schema-validation.ts';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { defaultValidLabels, type PrLogEngine } from '@pr-log/core';
-import { safeParse } from '@schema-hub/zod-error-formatter';
+import { safeParse } from '../../common/schema-validation.ts';
 import type { ChangelogOutput } from '../../config/changelog-settings.ts';
 import { packtoryConfigSchema } from '../../config/packtory-config-schema.ts';
 import type { FileManager } from '../../file-manager/file-manager.ts';

--- a/source/command-line-interface/runner/release-pull-request-config.ts
+++ b/source/command-line-interface/runner/release-pull-request-config.ts
@@ -1,5 +1,5 @@
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { z } from 'zod/mini';
+import { safeParse } from '../../common/schema-validation.ts';
 import { releasePullRequestSettingsSchema, type ReleasePullRequestSettings } from './release-pull-request-settings.ts';
 
 type GitHubActionsCiConfig = {

--- a/source/common/schema-validation.test.ts
+++ b/source/common/schema-validation.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { z } from 'zod/mini';
+import { additionalFileDescriptionSchema } from '../config/additional-files.ts';
+import { mainPackageJsonSchema } from '../config/main-package-json-schema.ts';
+import { packtoryConfigSchema } from '../config/packtory-config-schema.ts';
+import { versioningSettingsSchema } from '../config/versioning-settings.ts';
+import { safeParse } from './schema-validation.ts';
+
+function validationIssues(schema: Parameters<typeof safeParse>[0], data: unknown): readonly string[] {
+    const result = safeParse(schema, data);
+    if (result.success) {
+        assert.fail('Validation succeeded but a failure was expected');
+    }
+
+    return result.error.issues;
+}
+
+suite('schema-validation', function () {
+    test('keeps missing property messages stable', function () {
+        assert.deepStrictEqual(validationIssues(additionalFileDescriptionSchema, { targetFilePath: 'file.txt' }), [
+            'at sourceFilePath: missing property'
+        ]);
+    });
+
+    test('keeps invalid literal array messages stable', function () {
+        assert.deepStrictEqual(validationIssues(mainPackageJsonSchema, { type: [] }), [
+            'at type: invalid literal: expected "module", but got array'
+        ]);
+    });
+
+    test('keeps numeric path segments stable', function () {
+        const schema = z.tuple([z.object({ type: z.literal('module') })]);
+
+        assert.deepStrictEqual(validationIssues(schema, [{ type: 'commonjs' }]), [
+            'at [0].type: invalid literal: expected "module", but got string'
+        ]);
+    });
+
+    test('keeps refinement messages stable', function () {
+        assert.deepStrictEqual(
+            validationIssues(additionalFileDescriptionSchema, {
+                sourceFilePath: 'source.txt',
+                targetFilePath: '..'
+            }),
+            ['at targetFilePath: invalid input']
+        );
+    });
+
+    test('keeps union messages stable', function () {
+        assert.deepStrictEqual(validationIssues(versioningSettingsSchema, { automatic: false, source: 'unknown' }), [
+            'invalid value doesn’t match expected union'
+        ]);
+    });
+
+    test('keeps nested union messages stable when upstream reports only invalid input', function () {
+        assert.deepStrictEqual(
+            validationIssues(packtoryConfigSchema, {
+                registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+                commonPackageSettings: { additionalPackageJsonAttributes: { dependencies: '1.0.0' } },
+                packages: [
+                    {
+                        sourcesFolder: 'source',
+                        mainPackageJson: { type: 'module' },
+                        name: 'package',
+                        roots: { main: { js: 'index.js' } }
+                    }
+                ]
+            }),
+            ['invalid value doesn’t match expected union']
+        );
+    });
+});

--- a/source/common/schema-validation.ts
+++ b/source/common/schema-validation.ts
@@ -1,0 +1,123 @@
+import { FormattedZodError, formatZodError, type SafeParseResult } from '@schema-hub/zod-error-formatter';
+import { z } from 'zod/v4-mini';
+import type { $ZodIssue, $ZodType, output as TypeOf } from 'zod/v4/core';
+
+type NonEmptyStringArray = readonly [string, ...(readonly string[])];
+type PathSegment = PropertyKey;
+
+function normalizeValidationIssue(issue: string): string {
+    return issue
+        .replaceAll(': Invalid input', ': invalid input')
+        .replaceAll('no union alternative matched:', 'invalid value doesn’t match expected union')
+        .replaceAll(/: missing property; expected [^;|]+/gu, ': missing property');
+}
+
+function formatPath(path: readonly PathSegment[]): string {
+    return path
+        .map((segment) => {
+            return typeof segment === 'number' ? `[${segment}]` : `.${String(segment)}`;
+        })
+        .join('')
+        .replace(/^\./u, '');
+}
+
+function formatPathPrefix(path: readonly PathSegment[]): string {
+    const formattedPath = formatPath(path);
+    return formattedPath.length === 0 ? '' : `at ${formattedPath}: `;
+}
+
+function valueAtPath(value: unknown, path: readonly PathSegment[]): unknown {
+    let current = value;
+    for (const segment of path) {
+        current = Reflect.get(new Object(current), segment);
+    }
+
+    return current;
+}
+
+function formatExpectedValue(value: unknown): string {
+    return typeof value === 'string' ? `"${value}"` : String(value);
+}
+
+function formatActualType(value: unknown): string {
+    if (value === null) {
+        return 'null';
+    }
+
+    if (Array.isArray(value)) {
+        return 'array';
+    }
+
+    return typeof value;
+}
+
+function shouldUseGenericUnionIssue(issue: $ZodIssue, normalizedFallbackIssue: string): boolean {
+    return (
+        normalizedFallbackIssue === 'Invalid input' ||
+        normalizedFallbackIssue.includes('invalid value doesn’t match expected union') ||
+        (issue.path.length === 0 && normalizedFallbackIssue.startsWith('at '))
+    );
+}
+
+function formatUnionIssue(issue: $ZodIssue, fallbackIssue: string): string {
+    const normalizedFallbackIssue = normalizeValidationIssue(fallbackIssue);
+    if (shouldUseGenericUnionIssue(issue, normalizedFallbackIssue)) {
+        return `${formatPathPrefix(issue.path)}invalid value doesn’t match expected union`;
+    }
+
+    return normalizedFallbackIssue;
+}
+
+function formatInvalidValueIssue(
+    issue: Extract<$ZodIssue, { readonly code: 'invalid_value' }>,
+    input: unknown
+): string {
+    const actualValue = valueAtPath(input, issue.path);
+    if (actualValue === undefined) {
+        return `${formatPathPrefix(issue.path)}missing property`;
+    }
+
+    const [expectedValue] = issue.values;
+    const expectedValueMessage = formatExpectedValue(expectedValue);
+    const actualTypeMessage = formatActualType(actualValue);
+    const issuePath = formatPathPrefix(issue.path);
+    return `${issuePath}invalid literal: expected ${expectedValueMessage}, but got ${actualTypeMessage}`;
+}
+
+function formatStableIssue(issue: $ZodIssue, input: unknown, fallbackIssue: string): string | undefined {
+    if (issue.code === 'invalid_union') {
+        return formatUnionIssue(issue, fallbackIssue);
+    }
+
+    if (issue.code === 'invalid_key') {
+        return `${formatPathPrefix(issue.path)}invalid key`;
+    }
+
+    return issue.code === 'invalid_value' ? formatInvalidValueIssue(issue, input) : undefined;
+}
+
+function normalizeIssues(
+    issues: readonly $ZodIssue[],
+    fallbackIssues: NonEmptyStringArray,
+    value: unknown
+): NonEmptyStringArray {
+    const normalizedIssues = issues.map((issue, index) => {
+        const fallbackIssue = String(fallbackIssues[index]);
+        return formatStableIssue(issue, value, fallbackIssue) ?? normalizeValidationIssue(fallbackIssue);
+    });
+
+    return [String(normalizedIssues[0]), ...normalizedIssues.slice(1)];
+}
+
+export function safeParse<Schema extends $ZodType>(schema: Schema, value: unknown): SafeParseResult<TypeOf<Schema>> {
+    const result = z.safeParse(schema, value);
+    if (result.success) {
+        return result;
+    }
+
+    const fallbackIssues = formatZodError(result.error, value).issues;
+    return {
+        success: false,
+        error: new FormattedZodError(normalizeIssues(result.error.issues, fallbackIssues, value))
+    };
+}

--- a/source/config/additional-files.test.ts
+++ b/source/config/additional-files.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { additionalFileDescriptionSchema } from './additional-files.ts';
 

--- a/source/config/additional-package-json-attributes-schema.test.ts
+++ b/source/config/additional-package-json-attributes-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { additionalPackageJsonAttributesSchema } from './additional-package-json-attributes-schema.ts';
 

--- a/source/config/automatic-versioning-settings.test.ts
+++ b/source/config/automatic-versioning-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { automaticVersioningSettingsSchema } from './automatic-versioning-settings.ts';
 

--- a/source/config/changelog-settings.test.ts
+++ b/source/config/changelog-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { changelogSettingsSchema, validateChangelogSettings } from './changelog-settings.ts';
 import type { PacktoryConfigWithoutRegistry } from './config.ts';
 

--- a/source/config/checks-schema.test.ts
+++ b/source/config/checks-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import {
     checkValidationFailure,
     checkValidationSuccess,

--- a/source/config/common-package-settings-schemas.test.ts
+++ b/source/config/common-package-settings-schemas.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import {
     checkValidationFailure,
     checkValidationSuccess,

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import fc from 'fast-check';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { configToResolveAndLinkOptions } from '../packtory/map-config.ts';
 import { linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import type { PacktoryConfig } from './config.ts';

--- a/source/config/config.test.ts
+++ b/source/config/config.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { getBundledDependencies } from './config.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';

--- a/source/config/main-package-json-schema.test.ts
+++ b/source/config/main-package-json-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { mainPackageJsonSchema } from './main-package-json-schema.ts';
 

--- a/source/config/manual-versioning-settings.test.ts
+++ b/source/config/manual-versioning-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { manualVersioningSettingsSchema } from './manual-versioning-settings.ts';
 

--- a/source/config/optional-package-settings-schema.test.ts
+++ b/source/config/optional-package-settings-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import {
     checkValidationFailure,
     checkValidationSuccess,

--- a/source/config/package-interface.test.ts
+++ b/source/config/package-interface.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { safeParse } from '@schema-hub/zod-error-formatter';
+import { safeParse } from '../common/schema-validation.ts';
 import { packageInterfaceSchema } from './package-interface.ts';
 
 suite('package-interface', function () {

--- a/source/config/package-json.test.ts
+++ b/source/config/package-json.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { isForbiddenAdditionalPackageJsonAttributeName, packageJsonDependencyFieldNames } from './package-json.ts';
 import { additionalPackageJsonAttributesSchema } from './additional-package-json-attributes-schema.ts';

--- a/source/config/package-schemas.test.ts
+++ b/source/config/package-schemas.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import {
     packageSchemaWithAllCommonSettings,

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigSchema } from './packtory-config-schema.ts';
 

--- a/source/config/packtory-config-without-registry-schema.test.ts
+++ b/source/config/packtory-config-without-registry-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { packtoryConfigWithoutRegistrySchema } from './packtory-config-without-registry-schema.ts';
 

--- a/source/config/per-package-settings-schema.test.ts
+++ b/source/config/per-package-settings-schema.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import {
     checkValidationFailure,
     checkValidationSuccess,

--- a/source/config/publish-settings.test.ts
+++ b/source/config/publish-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { publishSettingsSchema } from './publish-settings.ts';
 

--- a/source/config/registry-settings.test.ts
+++ b/source/config/registry-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { registrySettingsSchema } from './registry-settings.ts';
 

--- a/source/config/root.test.ts
+++ b/source/config/root.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { rootSchema } from './root.ts';
 

--- a/source/config/schema-contracts.test.ts
+++ b/source/config/schema-contracts.test.ts
@@ -6,7 +6,8 @@ const probeTestTimeoutMs = 10_000;
 
 suite('schema-contracts', function () {
     test('leaf config schemas keep their expected object keys and strict object behavior', async function () {
-        const result = await runNodeProbe(`
+        const result = await runNodeProbe(
+            `
             import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
             import { rootSchema } from './source/config/root.ts';
             import { mainPackageJsonSchema } from './source/config/main-package-json-schema.ts';
@@ -21,7 +22,9 @@ suite('schema-contracts', function () {
                 rootCatchallType: rootSchema._zod.def.innerType.def.catchall.type,
                 registrySettingsCatchallType: registrySettingsSchema._zod.def.innerType.def.catchall.type
             }));
-        `);
+        `,
+            { timeoutMs: probeTestTimeoutMs }
+        );
 
         assert.deepStrictEqual(result, {
             additionalFileShape: ['sourceFilePath', 'targetFilePath'],
@@ -35,8 +38,9 @@ suite('schema-contracts', function () {
     }).timeout(probeTestTimeoutMs);
 
     test('versioning schema keeps the automatic and manual branches', async function () {
-        const result = await runNodeProbe(`
-            import { safeParse } from '@schema-hub/zod-error-formatter';
+        const result = await runNodeProbe(
+            `
+            import { safeParse } from './source/common/schema-validation.ts';
             import { versioningSettingsSchema } from './source/config/versioning-settings.ts';
 
             const unionDef = versioningSettingsSchema._zod.def.innerType.def;
@@ -75,7 +79,9 @@ suite('schema-contracts', function () {
                     minimumVersion: '1.0.0'
                 }).success
             }));
-        `);
+        `,
+            { timeoutMs: probeTestTimeoutMs }
+        );
 
         assert.deepStrictEqual(result, {
             optionCount: 2,
@@ -97,8 +103,9 @@ suite('schema-contracts', function () {
     }).timeout(probeTestTimeoutMs);
 
     test('package json schemas keep their runtime structure and forbidden key behavior', async function () {
-        const result = await runNodeProbe(`
-            import { safeParse } from '@schema-hub/zod-error-formatter';
+        const result = await runNodeProbe(
+            `
+            import { safeParse } from './source/common/schema-validation.ts';
             import {
                 additionalPackageJsonAttributesSchema
             } from './source/config/additional-package-json-attributes-schema.ts';
@@ -132,7 +139,9 @@ suite('schema-contracts', function () {
                 }).success,
                 forbiddenKeySuccesses
             }));
-        `);
+        `,
+            { timeoutMs: probeTestTimeoutMs }
+        );
 
         assert.deepStrictEqual(result, {
             mainShape: ['type', 'dependencies', 'devDependencies', 'peerDependencies', 'imports'],
@@ -147,8 +156,9 @@ suite('schema-contracts', function () {
     }).timeout(probeTestTimeoutMs);
 
     test('packtory config schemas keep their union and package tuple structure', async function () {
-        const result = await runNodeProbe(`
-            import { safeParse } from '@schema-hub/zod-error-formatter';
+        const result = await runNodeProbe(
+            `
+            import { safeParse } from './source/common/schema-validation.ts';
             import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
             import {
                 packtoryConfigWithoutRegistrySchema
@@ -187,7 +197,9 @@ suite('schema-contracts', function () {
                     ]
                 }).success
             }));
-        `);
+        `,
+            { timeoutMs: probeTestTimeoutMs }
+        );
 
         assert.deepStrictEqual(result, {
             optionCount: 4,
@@ -244,8 +256,9 @@ suite('schema-contracts', function () {
     }).timeout(probeTestTimeoutMs);
 
     test('schema source modules still validate representative valid and invalid inputs', async function () {
-        const result = await runNodeProbe(`
-            import { safeParse } from '@schema-hub/zod-error-formatter';
+        const result = await runNodeProbe(
+            `
+            import { safeParse } from './source/common/schema-validation.ts';
             import { additionalFileDescriptionSchema } from './source/config/additional-files.ts';
             import { rootSchema } from './source/config/root.ts';
             import { packtoryConfigSchema } from './source/config/packtory-config-schema.ts';
@@ -299,7 +312,9 @@ suite('schema-contracts', function () {
                     packages: []
                 }).success
             }));
-        `);
+        `,
+            { timeoutMs: probeTestTimeoutMs }
+        );
 
         assert.deepStrictEqual(result, {
             validAdditionalFileSuccess: true,

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -1,6 +1,6 @@
 import { Result } from 'true-myth';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import type { ZodMiniType } from 'zod/mini';
+import { safeParse } from '../common/schema-validation.ts';
 import type { DirectedGraph } from '../directed-graph/graph.ts';
 import type { PackageConfig, PackageConfigsByName, PacktoryConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { validateCyclicDependencies, validateDuplicatePackages } from './cross-package-validation.ts';

--- a/source/config/versioning-settings.test.ts
+++ b/source/config/versioning-settings.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { suite, test } from 'mocha';
+import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { versioningSettingsSchema } from './versioning-settings.ts';
 

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/max-dependencies -- the pack orchestrator wires resolve+link, version manager, vendor materializer, and pack emitter */
 import { Result } from 'true-myth';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { z } from 'zod/mini';
+import { safeParse } from '../common/schema-validation.ts';
 import { bundledInstalledDependencyPath } from '../common/package-layout.ts';
 import { packageNameMap } from '../common/package-name-map.ts';
 import { serializeStableJson } from '../common/stable-json.ts';

--- a/source/test-libraries/verify-schema-validation.ts
+++ b/source/test-libraries/verify-schema-validation.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import { test, type Func } from 'mocha';
 import { isPlainObject, omit } from 'remeda';
 import type { $ZodType } from 'zod/v4/core';
+import { safeParse } from '../common/schema-validation.ts';
 
 const invalidNumberValue = 2;
 const objectLikeFieldTypes = new Set(['object', 'record', 'tuple', 'array']);

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
-import { safeParse } from '@schema-hub/zod-error-formatter';
 import npa from 'npm-package-arg';
 import { Result } from 'true-myth';
 import { z } from 'zod/mini';
+import { safeParse } from '../common/schema-validation.ts';
 import {
     ancestorInstalledDependencyPathCandidates,
     bundledInstalledDependencyPath,


### PR DESCRIPTION
This fixes the npm config key to `engine-strict` so npm enforces the declared engine range. It also pins `@schema-hub/zod-error-formatter` to the Node 26-compatible release through the existing npm dependency graph so strict installs keep working in the current CI matrix.