### PR TITLE
Validate registry tarball `origin`

### DIFF
--- a/documentation/supply-chain.md
+++ b/documentation/supply-chain.md
@@ -33,10 +33,10 @@ guarantees on top.
 
 ### Comparison
 
-| Feature                                       | Defends against                                          | Default | Configure                                      |
-| --------------------------------------------- | -------------------------------------------------------- | ------- | ---------------------------------------------- |
-| [Provenance](#provenance-attestations)        | Account compromise, package misattribution               | off     | `publishSettings.provenance: { type: 'auto' }` |
-| [Tarball host pinning](#tarball-host-pinning) | Credential exfiltration via a tampered registry response | on      | always on; not configurable                    |
+| Feature                                           | Defends against                                          | Default | Configure                                      |
+| ------------------------------------------------- | -------------------------------------------------------- | ------- | ---------------------------------------------- |
+| [Provenance](#provenance-attestations)            | Account compromise, package misattribution               | off     | `publishSettings.provenance: { type: 'auto' }` |
+| [Tarball origin pinning](#tarball-origin-pinning) | Credential exfiltration via a tampered registry response | on      | always on; not configurable                    |
 
 ## Quickstart
 
@@ -167,32 +167,32 @@ npm view <pkg> --json
 The `dist.attestations` field exposes the provenance bundle URL and
 predicate type for any version published with provenance.
 
-## Tarball host pinning
+## Tarball origin pinning
 
 **Threat:** an attacker who controls the registry response (registry
 compromise, MITM through a hostile corporate proxy, a poisoned mirror)
-returns a crafted `dist.tarball` URL on a host they own. Packtory's
+returns a crafted `dist.tarball` URL on an origin they own. Packtory's
 auto-versioning flow downloads the latest published tarball to compare
 it against the new build, and the request carries the configured npm
-credentials. Without a host check the bearer or basic auth would be
+credentials. Without an origin check the bearer or basic auth would be
 sent to the attacker.
 **Default:** on. Not configurable.
 
 Before downloading a tarball, packtory parses the URL returned by the
-registry and rejects the publish if its host does not match the host
-of the configured registry (or `registry.npmjs.org` when none is set).
-The port is part of the comparison, so a downgrade from `:443` to a
-different port is also rejected. The error names both hosts so the
-mismatch is immediately diagnosable.
+registry and rejects the publish if its origin does not match the origin
+of the configured registry (or `https://registry.npmjs.org` when none is
+set). The protocol and port are part of the comparison, so an `https` to
+`http` downgrade or a port change is rejected. The error names both
+origins so the mismatch is immediately diagnosable.
 
 ## CLI error reference
 
-### Tarball host
+### Tarball origin
 
-- `Refusing to download tarball from "<host>" because it differs from the configured registry host "<host>". A tampered registry response could redirect the request and exfiltrate publish credentials.`
-  — the registry returned a tarball URL on a different host than the
-  one configured. Investigate the registry mirror or proxy in between;
-  a legitimate registry serves tarballs from its own host.
+- `Refusing to download tarball from "<origin>" because it differs from the configured registry origin "<origin>". A tampered registry response could redirect the request and exfiltrate publish credentials.`
+  The registry returned a tarball URL on a different origin than the one
+  configured. Investigate the registry mirror or proxy in between; a
+  legitimate registry serves tarballs from its own origin.
 - `Registry returned an invalid tarball URL: "<value>"` — the registry
   response carried a non-URL `dist.tarball`. Almost always a registry
   bug or a tampered response.

--- a/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
@@ -248,11 +248,11 @@ suite('package-metadata-fetcher', function () {
         assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
     });
 
-    test('fetchPackageTarball rejects a tarball URL whose host differs from the configured registry', async function () {
+    test('fetchPackageTarball rejects a tarball URL whose origin differs from the configured registry', async function () {
         const buffer = fake.resolves(Buffer.from('tarball-bytes'));
         const expectedMessage =
-            'Refusing to download tarball from "attacker.example" because it differs from the configured ' +
-            'registry host "registry.npmjs.org". A tampered registry response could redirect the request and ' +
+            'Refusing to download tarball from "https://attacker.example" because it differs from the configured ' +
+            'registry origin "https://registry.npmjs.org". A tampered registry response could redirect the request and ' +
             'exfiltrate publish credentials.';
 
         try {
@@ -268,7 +268,7 @@ suite('package-metadata-fetcher', function () {
         assert.strictEqual(buffer.callCount, 0);
     });
 
-    test('fetchPackageTarball accepts a tarball URL whose host matches a custom configured registry', async function () {
+    test('fetchPackageTarball accepts a tarball URL whose origin matches a custom configured registry', async function () {
         const customSettings: RegistrySettings = {
             registryUrl: 'https://registry.example.test/',
             auth: { type: 'bearer-token', token: 'tok' }

--- a/source/bundle-emitter/registry/package-metadata-fetcher.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.ts
@@ -10,7 +10,7 @@ import {
     type AbbreviatedPackageResponse,
     type FullPackageResponse
 } from './registry-response-schemas.ts';
-import { assertTarballHostMatchesRegistry } from './validate-tarball-host.ts';
+import { assertTarballOriginMatchesRegistry } from './validate-tarball-host.ts';
 
 const notFoundStatusCode = 404;
 const forbiddenStatusCode = 403;
@@ -234,7 +234,7 @@ export async function fetchPackageTarball(
     tarballUrl: string,
     registrySettings: RegistrySettings
 ): Promise<Buffer> {
-    assertTarballHostMatchesRegistry(tarballUrl, registrySettings);
+    assertTarballOriginMatchesRegistry(tarballUrl, registrySettings);
     const auth = resolveMetadataAuthOptions(registrySettings);
     const response = await retryWithFallbackAuth(registrySettings, auth, async (options) => {
         return npmFetch(tarballUrl, options);

--- a/source/bundle-emitter/registry/validate-tarball-host.test.ts
+++ b/source/bundle-emitter/registry/validate-tarball-host.test.ts
@@ -1,78 +1,104 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { RegistrySettings } from '../../config/registry-settings.ts';
-import { assertTarballHostMatchesRegistry } from './validate-tarball-host.ts';
+import { assertTarballOriginMatchesRegistry } from './validate-tarball-host.ts';
 
 const bearerAuth = { type: 'bearer-token', token: 'tok' } as const;
 
 function expectError(callback: () => void, expectedMessage: string): void {
     try {
         callback();
-        assert.fail('Expected assertTarballHostMatchesRegistry() to throw but it did not');
+        assert.fail('Expected assertTarballOriginMatchesRegistry() to throw but it did not');
     } catch (error: unknown) {
         assert.strictEqual((error as Error).message, expectedMessage);
     }
 }
 
 suite('validate-tarball-host', function () {
-    test('accepts a tarball URL whose host matches the default npm registry', function () {
+    test('accepts a tarball URL whose origin matches the default npm registry', function () {
         const settings: RegistrySettings = { auth: bearerAuth };
 
         assert.doesNotThrow(() => {
-            assertTarballHostMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
+            assertTarballOriginMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
         });
     });
 
-    test('accepts a tarball URL whose host matches a configured custom registry', function () {
+    test('accepts a tarball URL whose origin matches a configured custom registry', function () {
         const settings: RegistrySettings = {
             registryUrl: 'https://registry.example.test/path/',
             auth: bearerAuth
         };
 
         assert.doesNotThrow(() => {
-            assertTarballHostMatchesRegistry('https://registry.example.test/pkg/-/pkg-1.0.0.tgz', settings);
+            assertTarballOriginMatchesRegistry('https://registry.example.test/pkg/-/pkg-1.0.0.tgz', settings);
         });
     });
 
-    test('rejects a tarball URL whose host differs from the default npm registry', function () {
+    test('accepts an http tarball URL when an http registry origin is explicitly configured', function () {
+        const settings: RegistrySettings = {
+            registryUrl: 'http://localhost:4873/',
+            auth: bearerAuth
+        };
+
+        assert.doesNotThrow(() => {
+            assertTarballOriginMatchesRegistry('http://localhost:4873/pkg/-/pkg-1.0.0.tgz', settings);
+        });
+    });
+
+    test('rejects a tarball URL whose origin differs from the default npm registry', function () {
         const settings: RegistrySettings = { auth: bearerAuth };
 
         const expectedMessage =
-            'Refusing to download tarball from "attacker.example" because it differs from the configured ' +
-            'registry host "registry.npmjs.org". A tampered registry response could redirect the request and ' +
+            'Refusing to download tarball from "https://attacker.example" because it differs from the configured ' +
+            'registry origin "https://registry.npmjs.org". A tampered registry response could redirect the request and ' +
             'exfiltrate publish credentials.';
         expectError(() => {
-            assertTarballHostMatchesRegistry('https://attacker.example/pkg-1.0.0.tgz', settings);
+            assertTarballOriginMatchesRegistry('https://attacker.example/pkg-1.0.0.tgz', settings);
         }, expectedMessage);
     });
 
-    test('rejects a tarball URL whose host differs from a configured custom registry', function () {
+    test('rejects a tarball URL whose origin differs from a configured custom registry', function () {
         const settings: RegistrySettings = {
             registryUrl: 'https://registry.example.test/',
             auth: bearerAuth
         };
 
         const expectedMessage =
-            'Refusing to download tarball from "registry.npmjs.org" because it differs from the configured ' +
-            'registry host "registry.example.test". A tampered registry response could redirect the request and ' +
+            'Refusing to download tarball from "https://registry.npmjs.org" because it differs from the configured ' +
+            'registry origin "https://registry.example.test". A tampered registry response could redirect the request and ' +
             'exfiltrate publish credentials.';
         expectError(() => {
-            assertTarballHostMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
+            assertTarballOriginMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
         }, expectedMessage);
     });
 
-    test('rejects a tarball URL whose host has a different port than the configured registry', function () {
+    test('rejects a tarball URL whose origin has a different port than the configured registry', function () {
         const settings: RegistrySettings = {
             registryUrl: 'https://registry.example.test/',
             auth: bearerAuth
         };
 
         const expectedMessage =
-            'Refusing to download tarball from "registry.example.test:8443" because it differs from the configured ' +
-            'registry host "registry.example.test". A tampered registry response could redirect the request and ' +
+            'Refusing to download tarball from "https://registry.example.test:8443" because it differs from the ' +
+            'configured registry origin "https://registry.example.test". A tampered registry response could redirect ' +
+            'the request and exfiltrate publish credentials.';
+        expectError(() => {
+            assertTarballOriginMatchesRegistry('https://registry.example.test:8443/pkg-1.0.0.tgz', settings);
+        }, expectedMessage);
+    });
+
+    test('rejects a tarball URL with an http downgrade from the configured registry origin', function () {
+        const settings: RegistrySettings = {
+            registryUrl: 'https://registry.example.test/',
+            auth: bearerAuth
+        };
+
+        const expectedMessage =
+            'Refusing to download tarball from "http://registry.example.test" because it differs from the configured ' +
+            'registry origin "https://registry.example.test". A tampered registry response could redirect the request and ' +
             'exfiltrate publish credentials.';
         expectError(() => {
-            assertTarballHostMatchesRegistry('https://registry.example.test:8443/pkg-1.0.0.tgz', settings);
+            assertTarballOriginMatchesRegistry('http://registry.example.test/pkg-1.0.0.tgz', settings);
         }, expectedMessage);
     });
 
@@ -80,7 +106,7 @@ suite('validate-tarball-host', function () {
         const settings: RegistrySettings = { auth: bearerAuth };
 
         expectError(() => {
-            assertTarballHostMatchesRegistry('not-a-url', settings);
+            assertTarballOriginMatchesRegistry('not-a-url', settings);
         }, 'Registry returned an invalid tarball URL: "not-a-url"');
     });
 
@@ -88,7 +114,7 @@ suite('validate-tarball-host', function () {
         const settings: RegistrySettings = { auth: bearerAuth };
 
         expectError(() => {
-            assertTarballHostMatchesRegistry('', settings);
+            assertTarballOriginMatchesRegistry('', settings);
         }, 'Registry returned an invalid tarball URL: ""');
     });
 });

--- a/source/bundle-emitter/registry/validate-tarball-host.ts
+++ b/source/bundle-emitter/registry/validate-tarball-host.ts
@@ -1,34 +1,34 @@
 import type { RegistrySettings } from '../../config/registry-settings.ts';
 import { npmRegistryUrl } from './registry-auth-config.ts';
 
-function resolveConfiguredHost(registrySettings: Readonly<RegistrySettings>): string {
-    return new URL(registrySettings.registryUrl ?? npmRegistryUrl).host;
+function resolveConfiguredOrigin(registrySettings: Readonly<RegistrySettings>): string {
+    return new URL(registrySettings.registryUrl ?? npmRegistryUrl).origin;
 }
 
-function parseTarballHost(tarballUrl: string): string {
+function parseTarballOrigin(tarballUrl: string): string {
     try {
-        return new URL(tarballUrl).host;
+        return new URL(tarballUrl).origin;
     } catch {
         throw new TypeError(`Registry returned an invalid tarball URL: "${tarballUrl}"`);
     }
 }
 
-function buildMismatchMessage(tarballHost: string, configuredHost: string): string {
+function buildMismatchMessage(tarballOrigin: string, configuredOrigin: string): string {
     return (
-        `Refusing to download tarball from "${tarballHost}" because it differs from the configured registry host ` +
-        `"${configuredHost}". A tampered registry response could redirect the request and exfiltrate ` +
+        `Refusing to download tarball from "${tarballOrigin}" because it differs from the configured registry origin ` +
+        `"${configuredOrigin}". A tampered registry response could redirect the request and exfiltrate ` +
         'publish credentials.'
     );
 }
 
-export function assertTarballHostMatchesRegistry(
+export function assertTarballOriginMatchesRegistry(
     tarballUrl: string,
     registrySettings: Readonly<RegistrySettings>
 ): void {
-    const tarballHost = parseTarballHost(tarballUrl);
-    const configuredHost = resolveConfiguredHost(registrySettings);
+    const tarballOrigin = parseTarballOrigin(tarballUrl);
+    const configuredOrigin = resolveConfiguredOrigin(registrySettings);
 
-    if (tarballHost !== configuredHost) {
-        throw new Error(buildMismatchMessage(tarballHost, configuredHost));
+    if (tarballOrigin !== configuredOrigin) {
+        throw new Error(buildMismatchMessage(tarballOrigin, configuredOrigin));
     }
 }


### PR DESCRIPTION
This changes registry tarball pinning from host comparison to full `origin` comparison. Protocol and port must now match the configured registry, closing downgrade and alternate-port redirects.