### PR TITLE
Revalidate vendored file paths before materialization

### DIFF
--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -284,6 +284,7 @@ suite('artifacts-builder', function () {
             [
                 {
                     sourceAbsolutePath: '/host/node_modules/pkg/index.js',
+                    sourcePackageRootPath: '/host/node_modules/pkg',
                     targetRelativePath: 'node_modules/pkg/index.js',
                     isExecutable: false
                 }
@@ -295,6 +296,7 @@ suite('artifacts-builder', function () {
         assert.deepStrictEqual(vendorArgs, [
             {
                 sourceAbsolutePath: '/host/node_modules/pkg/index.js',
+                sourcePackageRootPath: '/host/node_modules/pkg',
                 targetRelativePath: 'package/node_modules/pkg/index.js',
                 isExecutable: false
             }

--- a/source/artifacts/folder-writer.test.ts
+++ b/source/artifacts/folder-writer.test.ts
@@ -61,6 +61,7 @@ suite('folder-writer', function () {
             [
                 {
                     sourceAbsolutePath: '/repo/node_modules/pkg/index.js',
+                    sourcePackageRootPath: '/repo/node_modules/pkg',
                     targetRelativePath: 'node_modules/pkg/index.js',
                     isExecutable: false
                 }
@@ -72,5 +73,34 @@ suite('folder-writer', function () {
             from: '/repo/node_modules/pkg/index.js',
             to: '/target/node_modules/pkg/index.js'
         });
+    });
+
+    test('writeArtifactsToFolder revalidates vendor source paths before copying', async function () {
+        const fileManager = createFakeFileManager({
+            simulatedCheckReadabilityResponses: [{ value: { isReadable: false } }],
+            simulatedRealPathResponses: [{ value: '/repo/secret.js' }]
+        });
+
+        await assert.rejects(
+            writeArtifactsToFolder(
+                fileManager,
+                '/target',
+                [],
+                [
+                    {
+                        sourceAbsolutePath: '/repo/node_modules/pkg/index.js',
+                        sourcePackageRootPath: '/repo/node_modules/pkg',
+                        targetRelativePath: 'node_modules/pkg/index.js',
+                        isExecutable: false
+                    }
+                ]
+            ),
+            {
+                message:
+                    'Vendored file "/repo/node_modules/pkg/index.js" resolved outside package root ' +
+                    '"/repo/node_modules/pkg"'
+            }
+        );
+        assert.strictEqual(fileManager.getCopyFileBytesCallCount(), 0);
     });
 });

--- a/source/artifacts/folder-writer.ts
+++ b/source/artifacts/folder-writer.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
-import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
+import { validateVendorEntrySource, type VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
 async function writeFileDescriptions(
     fileManager: FileManager,
@@ -22,6 +22,7 @@ async function copyVendorEntries(
 ): Promise<void> {
     for (const vendorEntry of vendorEntries) {
         const targetFilePath = path.join(targetFolder, vendorEntry.targetRelativePath);
+        await validateVendorEntrySource(fileManager, vendorEntry);
         await fileManager.copyFileBytes(vendorEntry.sourceAbsolutePath, targetFilePath);
         await fileManager.setExecutable(targetFilePath, vendorEntry.isExecutable);
     }

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -92,6 +92,7 @@ function createDependencies(overrides: {
     readonly materializerSpy?: SinonSpy;
     readonly vendorEntries?: readonly {
         readonly sourceAbsolutePath: string;
+        readonly sourcePackageRootPath: string;
         readonly targetRelativePath: string;
         readonly isExecutable: boolean;
     }[];
@@ -531,6 +532,7 @@ suite('packtory-pack', function () {
         const vendorEntries = [
             {
                 sourceAbsolutePath: '/repo/node_modules/left-pad/index.js',
+                sourcePackageRootPath: '/repo/node_modules/left-pad',
                 targetRelativePath: 'node_modules/left-pad/index.js',
                 isExecutable: false
             }

--- a/source/tar/tarball-builder.test.ts
+++ b/source/tar/tarball-builder.test.ts
@@ -153,6 +153,9 @@ suite('tarball-builder', function () {
     test('includes vendor entries with raw bytes from the file manager alongside inline file descriptions', async function () {
         const builder = createTarballBuilder({
             fileManager: {
+                getRealPath: async (filePath) => {
+                    return filePath;
+                },
                 readFileBytes: async () => {
                     return Buffer.from('vendored-bytes', 'utf8');
                 }
@@ -164,6 +167,7 @@ suite('tarball-builder', function () {
             [
                 {
                     sourceAbsolutePath: '/repo/node_modules/pkg/dist/main.js',
+                    sourcePackageRootPath: '/repo/node_modules/pkg',
                     targetRelativePath: 'node_modules/pkg/main.js',
                     isExecutable: false
                 }
@@ -185,6 +189,9 @@ suite('tarball-builder', function () {
     test('marks executable vendor entries with the executable mode in the tarball', async function () {
         const builder = createTarballBuilder({
             fileManager: {
+                getRealPath: async (filePath) => {
+                    return filePath;
+                },
                 readFileBytes: async () => {
                     return Buffer.from('#!/bin/sh', 'utf8');
                 }
@@ -196,6 +203,7 @@ suite('tarball-builder', function () {
             [
                 {
                     sourceAbsolutePath: '/repo/bin/run.sh',
+                    sourcePackageRootPath: '/repo',
                     targetRelativePath: 'node_modules/pkg/bin/run.sh',
                     isExecutable: true
                 }
@@ -210,6 +218,7 @@ suite('tarball-builder', function () {
         const builder = createTarballBuilder();
         const vendorEntry = {
             sourceAbsolutePath: '/missing',
+            sourcePackageRootPath: '/missing',
             targetRelativePath: 'node_modules/pkg/lib.js',
             isExecutable: false
         };
@@ -221,5 +230,37 @@ suite('tarball-builder', function () {
             capturedMessage = (error as Error).message;
         }
         assert.strictEqual(capturedMessage, 'readFileBytes is required to materialize vendor entries into the tarball');
+    });
+
+    test('revalidates vendor source paths before reading tarball bytes', async function () {
+        const builder = createTarballBuilder({
+            fileManager: {
+                getRealPath: async () => {
+                    return '/repo/secret.js';
+                },
+                readFileBytes: async () => {
+                    assert.fail('expected readFileBytes not to be called');
+                }
+            }
+        });
+
+        await assert.rejects(
+            builder.build(
+                [],
+                [
+                    {
+                        sourceAbsolutePath: '/repo/node_modules/pkg/index.js',
+                        sourcePackageRootPath: '/repo/node_modules/pkg',
+                        targetRelativePath: 'node_modules/pkg/index.js',
+                        isExecutable: false
+                    }
+                ]
+            ),
+            {
+                message:
+                    'Vendored file "/repo/node_modules/pkg/index.js" resolved outside package root ' +
+                    '"/repo/node_modules/pkg"'
+            }
+        );
     });
 });

--- a/source/tar/tarball-builder.ts
+++ b/source/tar/tarball-builder.ts
@@ -2,7 +2,7 @@ import zlib from 'node:zlib';
 import tar, { type Pack } from 'tar-stream';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
-import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
+import { validateVendorEntrySource, type VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
 export type TarballBuilder = {
     build: (fileDescriptions: readonly FileDescription[], vendorEntries?: readonly VendorEntry[]) => Promise<Buffer>;
@@ -10,7 +10,7 @@ export type TarballBuilder = {
 
 type TarballBuilderDependencies = {
     readonly createGzip: typeof zlib.createGzip;
-    readonly fileManager: Pick<FileManager, 'readFileBytes'>;
+    readonly fileManager: Pick<FileManager, 'getRealPath' | 'readFileBytes'>;
 };
 
 const gzipHeaderOperationSystemTypeFieldIndex = 9;
@@ -33,6 +33,9 @@ const nonExecutableFileMode = 420;
 export function createTarballBuilder(dependencies: Partial<TarballBuilderDependencies> = {}): TarballBuilder {
     const createGzip = dependencies.createGzip ?? zlib.createGzip;
     const fileManager = dependencies.fileManager ?? {
+        async getRealPath(filePath: string): Promise<string> {
+            return filePath;
+        },
         async readFileBytes(): Promise<Buffer> {
             throw new Error('readFileBytes is required to materialize vendor entries into the tarball');
         }
@@ -60,6 +63,7 @@ export function createTarballBuilder(dependencies: Partial<TarballBuilderDepende
             addEntry(pack, fileDescription.filePath, fileDescription.isExecutable, fileDescription.content);
         }
         for (const vendorEntry of vendorEntries) {
+            await validateVendorEntrySource(fileManager, vendorEntry);
             const payload = await fileManager.readFileBytes(vendorEntry.sourceAbsolutePath);
             addEntry(pack, vendorEntry.targetRelativePath, vendorEntry.isExecutable, payload);
         }

--- a/source/vendor-materializer/vendor-entry.test.ts
+++ b/source/vendor-materializer/vendor-entry.test.ts
@@ -1,19 +1,60 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { applyPrefixToVendorEntry } from './vendor-entry.ts';
+import { applyPrefixToVendorEntry, validateVendorEntrySource } from './vendor-entry.ts';
 
-suite('applyPrefixToVendorEntry', function () {
+suite('vendor-entry', function () {
     test('prepends the supplied prefix to the target relative path while preserving the other fields', function () {
         const prefixed = applyPrefixToVendorEntry('package', {
             sourceAbsolutePath: '/src/index.js',
+            sourcePackageRootPath: '/src',
             targetRelativePath: 'node_modules/pkg/index.js',
             isExecutable: true
         });
 
         assert.deepStrictEqual(prefixed, {
             sourceAbsolutePath: '/src/index.js',
+            sourcePackageRootPath: '/src',
             targetRelativePath: 'package/node_modules/pkg/index.js',
             isExecutable: true
         });
+    });
+
+    test('accepts a vendored source path that resolves to the package root itself', async function () {
+        await validateVendorEntrySource(
+            {
+                getRealPath: async () => {
+                    return '/src';
+                }
+            },
+            {
+                sourceAbsolutePath: '/src',
+                sourcePackageRootPath: '/src',
+                targetRelativePath: 'node_modules/pkg',
+                isExecutable: true
+            }
+        );
+    });
+
+    test('rejects a vendored source path that resolves outside the package root', async function () {
+        await assert.rejects(
+            async () => {
+                await validateVendorEntrySource(
+                    {
+                        getRealPath: async () => {
+                            return '/src/pkg-other/index.js';
+                        }
+                    },
+                    {
+                        sourceAbsolutePath: '/src/pkg/index.js',
+                        sourcePackageRootPath: '/src/pkg',
+                        targetRelativePath: 'node_modules/pkg/index.js',
+                        isExecutable: false
+                    }
+                );
+            },
+            {
+                message: 'Vendored file "/src/pkg/index.js" resolved outside package root "/src/pkg"'
+            }
+        );
     });
 });

--- a/source/vendor-materializer/vendor-entry.ts
+++ b/source/vendor-materializer/vendor-entry.ts
@@ -1,12 +1,38 @@
+import path from 'node:path';
+import type { FileManager } from '../file-manager/file-manager.ts';
+
 export type VendorEntry = {
     readonly sourceAbsolutePath: string;
+    readonly sourcePackageRootPath: string;
     readonly targetRelativePath: string;
     readonly isExecutable: boolean;
 };
 
+type VendorEntrySourceValidator = Pick<FileManager, 'getRealPath'>;
+
+function isInFolder(folder: string, candidate: string): boolean {
+    const relativePath = path.relative(folder, candidate);
+    return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+}
+
+export async function validateVendorEntrySource(
+    validator: VendorEntrySourceValidator,
+    entry: VendorEntry
+): Promise<void> {
+    const rootPath = path.resolve(entry.sourcePackageRootPath);
+    const realSourcePath = await validator.getRealPath(entry.sourceAbsolutePath);
+
+    if (!isInFolder(rootPath, path.resolve(realSourcePath))) {
+        throw new Error(
+            `Vendored file "${entry.sourceAbsolutePath}" resolved outside package root "${entry.sourcePackageRootPath}"`
+        );
+    }
+}
+
 export function applyPrefixToVendorEntry(prefix: string, entry: VendorEntry): VendorEntry {
     return {
         sourceAbsolutePath: entry.sourceAbsolutePath,
+        sourcePackageRootPath: entry.sourcePackageRootPath,
         targetRelativePath: `${prefix}/${entry.targetRelativePath}`,
         isExecutable: entry.isExecutable
     };

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -37,6 +37,7 @@ type MaterializedSnapshot = {
     readonly entries: readonly {
         readonly targetRelativePath: string;
         readonly sourceAbsolutePath: string;
+        readonly sourcePackageRootPath: string;
         readonly isExecutable: boolean;
     }[];
     readonly packageNames: readonly string[];
@@ -112,6 +113,7 @@ suite('vendor-materializer', function () {
         assert.deepStrictEqual(result.entries, [
             {
                 sourceAbsolutePath: '/repo/node_modules/broken/index.js',
+                sourcePackageRootPath: '/repo/node_modules/broken',
                 targetRelativePath: 'node_modules/broken/index.js',
                 isExecutable: false
             }
@@ -161,11 +163,13 @@ suite('vendor-materializer', function () {
         assert.deepStrictEqual(result.entries, [
             {
                 sourceAbsolutePath: '/repo/node_modules/leaf/index.js',
+                sourcePackageRootPath: '/repo/node_modules/leaf',
                 targetRelativePath: 'node_modules/leaf/index.js',
                 isExecutable: false
             },
             {
                 sourceAbsolutePath: '/repo/node_modules/leaf/package.json',
+                sourcePackageRootPath: '/repo/node_modules/leaf',
                 targetRelativePath: 'node_modules/leaf/package.json',
                 isExecutable: false
             }
@@ -267,6 +271,7 @@ suite('vendor-materializer', function () {
         assert.deepStrictEqual(result.entries, [
             {
                 sourceAbsolutePath: '/repo/node_modules/pkg/src/index.js',
+                sourcePackageRootPath: '/repo/node_modules/pkg',
                 targetRelativePath: 'node_modules/pkg/src/index.js',
                 isExecutable: false
             }
@@ -302,6 +307,7 @@ suite('vendor-materializer', function () {
         assert.deepStrictEqual(result.entries, [
             {
                 sourceAbsolutePath: '/workspace/node_modules/hoisted/index.js',
+                sourcePackageRootPath: '/workspace/node_modules/hoisted',
                 targetRelativePath: 'node_modules/hoisted/index.js',
                 isExecutable: false
             }

--- a/source/vendor-materializer/vendor-materializer.ts
+++ b/source/vendor-materializer/vendor-materializer.ts
@@ -212,6 +212,7 @@ const walkPackageDirectory = async (
 
         state.collected.push({
             sourceAbsolutePath: path.join(state.packageDirectory.rootDirectory, relativeEntryPath),
+            sourcePackageRootPath: state.packageDirectory.rootDirectory,
             targetRelativePath: bundledInstalledDependencyPath(state.packageDirectory.packageName, relativeEntryPath),
             isExecutable: false
         });

--- a/source/zip/zip-builder.test.ts
+++ b/source/zip/zip-builder.test.ts
@@ -149,6 +149,9 @@ suite('zip-builder', function () {
     test('includes vendor entries with raw bytes from the file manager alongside inline file descriptions', async function () {
         const builder = createZipBuilder({
             fileManager: {
+                getRealPath: async (filePath) => {
+                    return filePath;
+                },
                 readFileBytes: async () => {
                     return Buffer.from('vendored-bytes', 'utf8');
                 }
@@ -161,6 +164,7 @@ suite('zip-builder', function () {
             [
                 {
                     sourceAbsolutePath: '/repo/node_modules/pkg/dist/main.js',
+                    sourcePackageRootPath: '/repo/node_modules/pkg',
                     targetRelativePath: 'node_modules/pkg/main.js',
                     isExecutable: false
                 }
@@ -187,6 +191,9 @@ suite('zip-builder', function () {
     test('marks executable vendor entries with the executable unix mode in the zip output', async function () {
         const builder = createZipBuilder({
             fileManager: {
+                getRealPath: async (filePath) => {
+                    return filePath;
+                },
                 readFileBytes: async () => {
                     return Buffer.from('#!/bin/sh\necho hi', 'utf8');
                 }
@@ -199,6 +206,7 @@ suite('zip-builder', function () {
             [
                 {
                     sourceAbsolutePath: '/repo/node_modules/pkg/bin/run.sh',
+                    sourcePackageRootPath: '/repo/node_modules/pkg',
                     targetRelativePath: 'node_modules/pkg/bin/run.sh',
                     isExecutable: true
                 }
@@ -225,6 +233,7 @@ suite('zip-builder', function () {
                 [
                     {
                         sourceAbsolutePath: '/anywhere',
+                        sourcePackageRootPath: '/anywhere',
                         targetRelativePath: 'node_modules/pkg/index.js',
                         isExecutable: false
                     }
@@ -237,6 +246,39 @@ suite('zip-builder', function () {
                 'readFileBytes is required to materialize vendor entries into the zip'
             );
         }
+    });
+
+    test('revalidates vendor source paths before reading zip bytes', async function () {
+        const builder = createZipBuilder({
+            fileManager: {
+                getRealPath: async () => {
+                    return '/repo/secret.js';
+                },
+                readFileBytes: async () => {
+                    assert.fail('expected readFileBytes not to be called');
+                }
+            }
+        });
+
+        await assert.rejects(
+            buildZipWithDeadline(
+                builder,
+                [],
+                [
+                    {
+                        sourceAbsolutePath: '/repo/node_modules/pkg/index.js',
+                        sourcePackageRootPath: '/repo/node_modules/pkg',
+                        targetRelativePath: 'node_modules/pkg/index.js',
+                        isExecutable: false
+                    }
+                ]
+            ),
+            {
+                message:
+                    'Vendored file "/repo/node_modules/pkg/index.js" resolved outside package root ' +
+                    '"/repo/node_modules/pkg"'
+            }
+        );
     });
 
     test('rejects when fflate reports an error', async function () {

--- a/source/zip/zip-builder.ts
+++ b/source/zip/zip-builder.ts
@@ -1,7 +1,7 @@
 import { zip as fflateZip } from 'fflate';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
-import type { VendorEntry } from '../vendor-materializer/vendor-entry.ts';
+import { validateVendorEntrySource, type VendorEntry } from '../vendor-materializer/vendor-entry.ts';
 
 type ZipEntryOptions = {
     readonly os: number;
@@ -20,7 +20,7 @@ export type ZipBuilder = {
 
 type ZipBuilderDependencies = {
     readonly zip?: AsyncZipFunction;
-    readonly fileManager?: Pick<FileManager, 'readFileBytes'>;
+    readonly fileManager?: Pick<FileManager, 'getRealPath' | 'readFileBytes'>;
 };
 
 const unixOperatingSystem = 3;
@@ -71,7 +71,7 @@ function buildFileEntry(payload: Uint8Array, isExecutable: boolean): [Uint8Array
 async function toFileMap(
     fileDescriptions: readonly FileDescription[],
     vendorEntries: readonly VendorEntry[],
-    readFileBytes: (filePath: string) => Promise<Buffer>
+    fileManager: Pick<FileManager, 'getRealPath' | 'readFileBytes'>
 ): Promise<ZippableFileMap> {
     const fileMap: ZippableFileMap = {};
     for (const fileDescription of fileDescriptions) {
@@ -81,7 +81,8 @@ async function toFileMap(
         );
     }
     for (const vendorEntry of vendorEntries) {
-        const payload = await readFileBytes(vendorEntry.sourceAbsolutePath);
+        await validateVendorEntrySource(fileManager, vendorEntry);
+        const payload = await fileManager.readFileBytes(vendorEntry.sourceAbsolutePath);
         fileMap[vendorEntry.targetRelativePath] = buildFileEntry(payload, vendorEntry.isExecutable);
     }
     return fileMap;
@@ -89,6 +90,9 @@ async function toFileMap(
 
 export function createZipBuilder(dependencies: ZipBuilderDependencies = {}): ZipBuilder {
     const fileManager = dependencies.fileManager ?? {
+        async getRealPath(filePath: string): Promise<string> {
+            return filePath;
+        },
         async readFileBytes(): Promise<Buffer> {
             throw new Error('readFileBytes is required to materialize vendor entries into the zip');
         }
@@ -97,9 +101,7 @@ export function createZipBuilder(dependencies: ZipBuilderDependencies = {}): Zip
 
     return {
         async build(fileDescriptions, vendorEntries = []) {
-            const fileMap = await toFileMap(fileDescriptions, vendorEntries, async (filePath) => {
-                return fileManager.readFileBytes(filePath);
-            });
+            const fileMap = await toFileMap(fileDescriptions, vendorEntries, fileManager);
             const data = await new Promise<Uint8Array>((resolve, reject) => {
                 zip(fileMap, {}, (error, zippedData) => {
                     if (error === null || error === undefined) {


### PR DESCRIPTION
This carries each vendored entry package root through materialization and revalidates realpaths before copying or reading bytes. Folder, tarball, and zip outputs now reject vendored sources that resolve outside their package root.