### PR TITLE
Use local `packtory` binary in `publish-dry-run`

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,4 +60,4 @@ benchmark:
     node --experimental-strip-types --enable-source-maps ./benchmarks/run-benchmarks.ts
 
 publish-dry-run:
-    npx packtory publish
+    packtory publish


### PR DESCRIPTION
This changes `publish-dry-run` to call the repository-local `packtory` binary through the existing `PATH`. It avoids `npx` fallback behavior that can fetch a package from the registry.