### PR TITLE
Install CI dependencies with `--ignore-scripts`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Install dependencies
-              run: npm clean-install
+              run: npm clean-install --ignore-scripts
             - name: Static Code Analysis
               run: npx just lint
             - name: Compile Typescript
@@ -58,7 +58,7 @@ jobs:
               with:
                   node-version: 26.x
             - name: Install dependencies
-              run: npm clean-install
+              run: npm clean-install --ignore-scripts
             - name: Run mutation tests
               run: npx just test-mutation
 
@@ -76,7 +76,9 @@ jobs:
               with:
                   node-version: 26.x
             - name: Install dependencies
-              run: npm clean-install
+              run: npm clean-install --ignore-scripts
+            - name: Build benchmark native dependency
+              run: npm rebuild node-pty
             - name: Run benchmarks
               run: npx just benchmark
 


### PR DESCRIPTION
This installs CI dependencies with `npm clean-install --ignore-scripts` in the main dependency installation steps. The benchmark job rebuilds `node-pty` explicitly because that native dependency is required only there.