### PR TITLE
Resolve release workflow ids before dispatch lookup

### DIFF
--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -165,17 +165,35 @@ function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
                 total_count: 1
             });
         }
-        if (url.pathname === '/repos/owner/repo/actions/workflows/ci.yml/dispatches') {
-            return emptyResponse();
-        }
-        if (url.pathname === '/repos/owner/repo/actions/workflows/ci.yml/runs') {
+        if (url.pathname === '/repos/owner/repo/actions/workflows') {
             return jsonResponse({
-                workflow_runs: [{ database_id: 11, event: 'workflow_dispatch', head_sha: 'release-head' }]
+                total_count: 2,
+                workflows: [
+                    { id: 101, name: 'Continuous Integration', path: '.github/workflows/ci.yml' },
+                    { id: 102, name: 'Database CI', path: '.github/workflows/ci-db.yml' }
+                ]
             });
         }
-        if (url.pathname === '/repos/owner/repo/actions/workflows/ci-db.yml/runs') {
+        if (url.pathname === '/repos/owner/repo/actions/workflows/101/dispatches') {
+            return emptyResponse();
+        }
+        if (url.pathname === '/repos/owner/repo/actions/workflows/101/runs') {
             return jsonResponse({
-                workflow_runs: [{ databaseId: 12, event: 'workflow_dispatch', head_sha: 'release-head' }]
+                workflow_runs: []
+            });
+        }
+        if (url.pathname === '/repos/owner/repo/actions/workflows/102/runs') {
+            return jsonResponse({
+                workflow_runs: [
+                    {
+                        databaseId: 12,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        name: 'Database CI',
+                        path: 'enormora/packtory/.github/workflows/ci-db.yml',
+                        workflow_id: 102
+                    }
+                ]
             });
         }
         if (url.pathname === '/repos/owner/repo/branches/main') {
@@ -184,6 +202,37 @@ function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
 
         return jsonResponse({ message: `Unhandled ${method} ${url.pathname}` }, 500);
     };
+}
+
+function createWorkflowListFetch(workflows: readonly Record<string, unknown>[]): typeof globalThis.fetch {
+    return async (input) => {
+        const url = requestUrl(input);
+
+        if (url.pathname === '/repos/owner/repo/actions/workflows') {
+            return jsonResponse({ total_count: workflows.length, workflows });
+        }
+
+        return jsonResponse({ message: `Unhandled ${url.pathname}` }, 500);
+    };
+}
+
+async function assertDispatchedWorkflowLookupFails(
+    workflows: readonly Record<string, unknown>[],
+    workflowFile: string,
+    message: string
+): Promise<void> {
+    const client = createClient(createWorkflowListFetch(workflows));
+
+    await assert.rejects(
+        async () => {
+            await client.findDispatchedWorkflowRunId({
+                branch: 'release/packtory',
+                headSha: 'release-head',
+                workflowFile
+            });
+        },
+        { message }
+    );
 }
 
 suite('release-pr-github-client', function () {
@@ -302,13 +351,22 @@ suite('release-pr-github-client', function () {
             hasRequestWithBody(
                 records,
                 'POST',
-                '/repos/owner/repo/actions/workflows/ci.yml/dispatches',
+                '/repos/owner/repo/actions/workflows/101/dispatches',
                 '"ref":"release/packtory"'
             ),
             true
         );
         assert.ok(records.some((record) => record.search.includes('event=pull_request')));
         assert.ok(records.some((record) => record.search.includes('event=workflow_dispatch')));
+        assert.ok(
+            records.some((record) => {
+                return (
+                    record.method === 'GET' &&
+                    record.path === '/repos/owner/repo/actions/runs' &&
+                    requestHasSearchParameter(record, 'event', 'workflow_dispatch')
+                );
+            })
+        );
         assert.strictEqual(readHeader(records[0]?.headers, 'user-agent'), 'packtory-release-pr');
     });
 
@@ -344,6 +402,150 @@ suite('release-pr-github-client', function () {
         assert.strictEqual(
             records.some((record) => record.method === 'POST' && record.path === '/repos/owner/repo/pulls'),
             true
+        );
+    });
+
+    test('resolves dispatched workflows by id, name, and path', async function () {
+        const records: RecordedRequest[] = [];
+        const fetchMock: typeof globalThis.fetch = async (input, init) => {
+            const { method, url } = recordRequest(records, input, init);
+
+            if (url.pathname === '/repos/owner/repo/actions/workflows') {
+                return jsonResponse({
+                    total_count: 3,
+                    workflows: [
+                        { id: 101, name: 'Continuous Integration', path: '.github/workflows/ci.yml' },
+                        { id: 102, name: 'Database CI', path: '.github/workflows/ci-db.yml' },
+                        { id: 103, name: 'Release CI', path: '.github/workflows/release.yml' }
+                    ]
+                });
+            }
+            if (url.pathname.endsWith('/dispatches') && method === 'POST') {
+                return emptyResponse();
+            }
+
+            return jsonResponse({ message: `Unhandled ${method} ${url.pathname}` }, 500);
+        };
+        const client = createClient(fetchMock);
+
+        await client.dispatchWorkflow({ ref: 'release/packtory', workflowFile: '101' });
+        await client.dispatchWorkflow({ ref: 'release/packtory', workflowFile: 'Database CI' });
+        await client.dispatchWorkflow({ ref: 'release/packtory', workflowFile: '.github/workflows/release.yml' });
+
+        assert.deepStrictEqual(
+            records.filter((record) => record.method === 'POST').map((record) => record.path),
+            [
+                '/repos/owner/repo/actions/workflows/101/dispatches',
+                '/repos/owner/repo/actions/workflows/102/dispatches',
+                '/repos/owner/repo/actions/workflows/103/dispatches'
+            ]
+        );
+    });
+
+    test('matches dispatched workflow runs by workflow identity fields', async function () {
+        const fetchMock: typeof globalThis.fetch = async (input) => {
+            const url = requestUrl(input);
+
+            if (url.pathname === '/repos/owner/repo/actions/workflows') {
+                return jsonResponse({
+                    total_count: 1,
+                    workflows: [{ id: 101, name: 'Continuous Integration', path: '.github/workflows/ci.yml' }]
+                });
+            }
+            if (url.pathname === '/repos/owner/repo/actions/workflows/101/runs') {
+                assert.strictEqual(url.searchParams.get('event'), 'workflow_dispatch');
+                return jsonResponse({
+                    workflow_runs: [
+                        {
+                            database_id: 20,
+                            event: 'workflow_dispatch',
+                            head_sha: 'exact-head',
+                            name: 'Continuous Integration',
+                            path: '.github/workflows/ci.yml',
+                            workflow_id: 101
+                        },
+                        {
+                            database_id: 10,
+                            event: 'workflow_dispatch',
+                            head_sha: 'suffix-head',
+                            name: 'Continuous Integration',
+                            path: '.github/workflows/ci.yml',
+                            workflow_id: 999
+                        },
+                        {
+                            database_id: 11,
+                            event: 'workflow_dispatch',
+                            head_sha: 'suffix-head',
+                            name: 'Continuous Integration',
+                            path: '.github/workflows/other.yml',
+                            workflow_id: 101
+                        },
+                        {
+                            database_id: 12,
+                            event: 'workflow_dispatch',
+                            head_sha: 'suffix-head',
+                            name: 'Other CI',
+                            path: '.github/workflows/ci.yml',
+                            workflow_id: 101
+                        },
+                        {
+                            database_id: 13,
+                            event: 'workflow_dispatch',
+                            head_sha: 'suffix-head',
+                            name: 'Continuous Integration',
+                            path: 'owner/repo/.github/workflows/ci.yml',
+                            workflow_id: 101
+                        },
+                        {
+                            database_id: 14,
+                            event: 'workflow_dispatch',
+                            head_sha: 'null-head',
+                            name: null,
+                            path: null,
+                            workflow_id: null
+                        },
+                        {
+                            database_id: 15,
+                            event: 'workflow_dispatch',
+                            head_sha: 'omitted-head'
+                        }
+                    ]
+                });
+            }
+
+            return jsonResponse({ message: `Unhandled ${url.pathname}` }, 500);
+        };
+        const client = createClient(fetchMock);
+        async function findRunId(headSha: string): Promise<number | undefined> {
+            return client.findDispatchedWorkflowRunId({
+                branch: 'release/packtory',
+                headSha,
+                workflowFile: 'ci.yml'
+            });
+        }
+
+        assert.strictEqual(await findRunId('exact-head'), 20);
+        assert.strictEqual(await findRunId('suffix-head'), 13);
+        assert.strictEqual(await findRunId('null-head'), 14);
+        assert.strictEqual(await findRunId('omitted-head'), 15);
+    });
+
+    test('fails when a dispatched workflow identifier matches no workflow', async function () {
+        await assertDispatchedWorkflowLookupFails(
+            [],
+            'missing.yml',
+            'GitHub Actions workflow "missing.yml" was not found'
+        );
+    });
+
+    test('fails when a dispatched workflow identifier matches multiple workflows', async function () {
+        await assertDispatchedWorkflowLookupFails(
+            [
+                { id: 101, name: 'CI', path: '.github/workflows/ci.yml' },
+                { id: 102, name: 'CI copy', path: '.github/workflows/ci.yml' }
+            ],
+            'ci.yml',
+            'GitHub Actions workflow "ci.yml" matched multiple workflows'
         );
     });
 

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -108,13 +108,17 @@ type RawWorkflowRun = {
     readonly database_id?: number | undefined;
     readonly event: string;
     readonly head_sha: string;
+    readonly name?: string | null | undefined;
+    readonly path?: string | null | undefined;
     readonly status: string | null;
+    readonly workflow_id?: number | null | undefined;
 };
 type RawWorkflowJob = {
     readonly conclusion: string | null;
     readonly html_url?: string | null | undefined;
     readonly name: string;
 };
+type RawWorkflow = { readonly id: number; readonly name: string; readonly path: string };
 
 type RequestContext = {
     readonly headers: Readonly<Record<string, string>>;
@@ -140,6 +144,62 @@ function commitSubject(commit: RawCommit): string {
 
 function runDatabaseId(run: RawWorkflowRun): number | undefined {
     return run.database_id ?? run.databaseId;
+}
+
+function workflowMatchesIdentifier(workflow: RawWorkflow, identifier: string): boolean {
+    return (
+        String(workflow.id) === identifier ||
+        workflow.name === identifier ||
+        workflow.path === identifier ||
+        workflow.path.endsWith(`/${identifier}`)
+    );
+}
+
+function workflowRunPathMatches(run: RawWorkflowRun, workflow: RawWorkflow): boolean {
+    return (
+        run.path === undefined ||
+        run.path === null ||
+        run.path === workflow.path ||
+        run.path.endsWith(`/${workflow.path}`)
+    );
+}
+
+function workflowRunIdentityComparisons(run: RawWorkflowRun, workflow: RawWorkflow): readonly boolean[] {
+    return [
+        run.workflow_id === undefined || run.workflow_id === null || run.workflow_id === workflow.id,
+        workflowRunPathMatches(run, workflow),
+        run.name === undefined || run.name === null || run.name === workflow.name
+    ];
+}
+
+function workflowRunMatchesIdentity(run: RawWorkflowRun, workflow: RawWorkflow): boolean {
+    return workflowRunIdentityComparisons(run, workflow).every(Boolean);
+}
+
+function workflowRunMatchesInput(run: RawWorkflowRun, workflow: RawWorkflow, headSha: string): boolean {
+    return run.head_sha === headSha && run.event === 'workflow_dispatch' && workflowRunMatchesIdentity(run, workflow);
+}
+
+function selectRawWorkflow(identifier: string, matches: readonly RawWorkflow[]): RawWorkflow {
+    const workflow = matches[0];
+    if (workflow === undefined) {
+        throw new Error(`GitHub Actions workflow "${identifier}" was not found`);
+    }
+    if (matches.length === 1) {
+        return { id: workflow.id, name: workflow.name, path: workflow.path };
+    }
+    throw new Error(`GitHub Actions workflow "${identifier}" matched multiple workflows`);
+}
+
+function findWorkflowRunIdInRuns(
+    runs: readonly RawWorkflowRun[],
+    workflow: RawWorkflow,
+    headSha: string
+): number | undefined {
+    const run = runs.find((workflowRun) => {
+        return workflowRunMatchesInput(workflowRun, workflow, headSha);
+    });
+    return run === undefined ? undefined : runDatabaseId(run);
 }
 
 function pullRequestIsMerged(pullRequest: RawPullRequest): boolean {
@@ -254,6 +314,20 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
         return response.data.number;
     }
 
+    async function resolveRawWorkflow(identifier: string): Promise<RawWorkflow> {
+        const response = await resolveGitHubResponse(
+            octokit.rest.actions.listRepoWorkflows({
+                ...requestContext,
+                per_page: 100
+            })
+        );
+        const workflows = response.data.workflows as readonly RawWorkflow[];
+        const matches = workflows.filter((workflow) => {
+            return workflowMatchesIdentifier(workflow, identifier);
+        });
+        return selectRawWorkflow(identifier, matches);
+    }
+
     return {
         async closeOpenReleasePullRequests(input) {
             const pullRequests = await resolveGitHubResponse(
@@ -338,29 +412,49 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
         },
 
         async dispatchWorkflow(input) {
+            const workflow = await resolveRawWorkflow(input.workflowFile);
             await resolveGitHubResponse(
                 octokit.rest.actions.createWorkflowDispatch({
                     ...requestContext,
                     ref: input.ref,
-                    workflow_id: input.workflowFile
+                    workflow_id: workflow.id
                 })
             );
         },
 
         async findDispatchedWorkflowRunId(input) {
-            const response = await resolveGitHubResponse(
+            const workflow = await resolveRawWorkflow(input.workflowFile);
+            const workflowResponse = await resolveGitHubResponse(
                 octokit.rest.actions.listWorkflowRuns({
                     ...requestContext,
                     branch: input.branch,
                     event: 'workflow_dispatch',
-                    workflow_id: input.workflowFile,
+                    workflow_id: workflow.id,
                     per_page: 100
                 })
             );
-            const run = response.data.workflow_runs.find((workflowRun) => {
-                return workflowRun.head_sha === input.headSha;
-            });
-            return run === undefined ? undefined : runDatabaseId(run as RawWorkflowRun);
+            const workflowRunId = findWorkflowRunIdInRuns(
+                workflowResponse.data.workflow_runs as readonly RawWorkflowRun[],
+                workflow,
+                input.headSha
+            );
+            if (workflowRunId !== undefined) {
+                return workflowRunId;
+            }
+
+            const repoResponse = await resolveGitHubResponse(
+                octokit.rest.actions.listWorkflowRunsForRepo({
+                    ...requestContext,
+                    branch: input.branch,
+                    event: 'workflow_dispatch',
+                    per_page: 100
+                })
+            );
+            return findWorkflowRunIdInRuns(
+                repoResponse.data.workflow_runs as readonly RawWorkflowRun[],
+                workflow,
+                input.headSha
+            );
         },
 
         async getBranchHeadSha(branch) {


### PR DESCRIPTION
This resolves configured release workflow identifiers to the GitHub workflow id before dispatching or listing runs, avoiding path-style dispatch URLs. Lookup now checks both workflow-specific and repository-wide `workflow_dispatch` runs for the release branch and head SHA.

Stacked on #788.