### PR TITLE
Mirror release workflow progress statuses

### DIFF
--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -133,13 +133,22 @@ function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
         if (url.pathname === '/repos/owner/repo/statuses/release-head') {
             return jsonResponse({});
         }
-        if (url.pathname === '/repos/owner/repo/actions/runs') {
+        if (url.pathname === '/repos/owner/repo/actions/runs' && url.searchParams.get('event') === 'pull_request') {
             return jsonResponse({
                 workflow_runs: [
                     { conclusion: 'action_required', database_id: 10, event: 'pull_request', head_sha: 'release-head' },
                     { conclusion: 'action_required', event: 'pull_request', head_sha: 'release-head' },
                     { conclusion: 'action_required', database_id: 12, event: 'pull_request', head_sha: 'other-head' },
-                    { conclusion: 'success', database_id: 13, event: 'pull_request', head_sha: 'release-head' },
+                    { conclusion: 'success', database_id: 13, event: 'pull_request', head_sha: 'release-head' }
+                ]
+            });
+        }
+        if (
+            url.pathname === '/repos/owner/repo/actions/runs' &&
+            url.searchParams.get('event') === 'workflow_dispatch'
+        ) {
+            return jsonResponse({
+                workflow_runs: [
                     { conclusion: 'success', database_id: 11, event: 'workflow_dispatch', head_sha: 'release-head' }
                 ]
             });
@@ -225,7 +234,7 @@ async function assertDispatchedWorkflowLookupFails(
 
     await assert.rejects(
         async () => {
-            await client.findDispatchedWorkflowRunId({
+            await client.findDispatchedWorkflowRun({
                 branch: 'release/packtory',
                 headSha: 'release-head',
                 workflowFile
@@ -241,7 +250,7 @@ suite('release-pr-github-client', function () {
         const client = createClient(createFetch(records));
 
         await client.closeOpenReleasePullRequests({ baseBranch: 'main', releaseBranch: 'release/packtory' });
-        assert.strictEqual(
+        assert.deepStrictEqual(
             await client.createOrUpdateReleasePullRequest({
                 baseBranch: 'main',
                 body: 'Body',
@@ -268,29 +277,27 @@ suite('release-pr-github-client', function () {
         await client.deleteActionRequiredPullRequestRuns({ branch: 'release/packtory', headSha: 'release-head' });
         await client.dispatchWorkflow({ ref: 'release/packtory', workflowFile: 'ci.yml' });
 
-        assert.strictEqual(
-            await client.findDispatchedWorkflowRunId({
+        assert.deepStrictEqual(
+            await client.findDispatchedWorkflowRun({
                 branch: 'release/packtory',
                 headSha: 'release-head',
                 workflowFile: 'ci.yml'
             }),
-            11
+            { event: 'workflow_dispatch', observedRunIds: [11], runId: 11 }
         );
-        assert.strictEqual(
-            await client.findDispatchedWorkflowRunId({
-                branch: 'release/packtory',
-                headSha: 'missing-head',
-                workflowFile: 'ci.yml'
-            }),
-            undefined
-        );
-        assert.strictEqual(
-            await client.findDispatchedWorkflowRunId({
+        const missingRun = await client.findDispatchedWorkflowRun({
+            branch: 'release/packtory',
+            headSha: 'missing-head',
+            workflowFile: 'ci.yml'
+        });
+        assert.strictEqual(missingRun.runId, undefined);
+        assert.deepStrictEqual(
+            await client.findDispatchedWorkflowRun({
                 branch: 'release/packtory',
                 headSha: 'release-head',
                 workflowFile: 'ci-db.yml'
             }),
-            12
+            { event: 'workflow_dispatch', observedRunIds: [12], runId: 12 }
         );
         assert.strictEqual(await client.getBranchHeadSha('main'), 'main-head');
         assert.deepStrictEqual(await client.getPullRequestHead(12), {
@@ -517,11 +524,12 @@ suite('release-pr-github-client', function () {
         };
         const client = createClient(fetchMock);
         async function findRunId(headSha: string): Promise<number | undefined> {
-            return client.findDispatchedWorkflowRunId({
+            const result = await client.findDispatchedWorkflowRun({
                 branch: 'release/packtory',
                 headSha,
                 workflowFile: 'ci.yml'
             });
+            return result.runId;
         }
 
         assert.strictEqual(await findRunId('exact-head'), 20);

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -3,6 +3,16 @@ import { Octokit } from '@octokit/core';
 import { paginateRest } from '@octokit/plugin-paginate-rest';
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
 import { createGitHubJsonRequestHeaders } from './github-api-request.ts';
+import {
+    findWorkflowRunIdInRuns,
+    observedWorkflowRunIds,
+    runDatabaseId,
+    selectReleaseWorkflow,
+    workflowMatchesIdentifier,
+    type ReleaseWorkflow,
+    type ReleaseWorkflowRun,
+    type WorkflowRunLookupResult
+} from './release-pr-workflow-runs.ts';
 
 export type PullRequestDetails = {
     readonly author: string;
@@ -39,7 +49,6 @@ type WorkflowRunResult = {
     readonly databaseId: number;
     readonly jobs: readonly WorkflowJobResult[];
 };
-
 export type ReleasePullRequestGitHubClient = {
     readonly closeOpenReleasePullRequests: (input: {
         readonly baseBranch: string;
@@ -64,11 +73,11 @@ export type ReleasePullRequestGitHubClient = {
         readonly headSha: string;
     }) => Promise<void>;
     readonly dispatchWorkflow: (input: { readonly ref: string; readonly workflowFile: string }) => Promise<void>;
-    readonly findDispatchedWorkflowRunId: (input: {
+    readonly findDispatchedWorkflowRun: (input: {
         readonly branch: string;
         readonly headSha: string;
         readonly workflowFile: string;
-    }) => Promise<number | undefined>;
+    }) => Promise<WorkflowRunLookupResult>;
     readonly getBranchHeadSha: (branch: string) => Promise<string>;
     readonly getPullRequest: (pullRequestNumber: number) => Promise<PullRequestDetails>;
     readonly getPullRequestHead: (pullRequestNumber: number) => Promise<PullRequestHeadDetails>;
@@ -102,23 +111,15 @@ type RawCommit = {
     readonly commit: { readonly message: string };
     readonly parents: readonly { readonly sha: string }[];
 };
-type RawWorkflowRun = {
+type RawWorkflowRun = ReleaseWorkflowRun & {
     readonly conclusion: string | null;
-    readonly databaseId?: number | undefined;
-    readonly database_id?: number | undefined;
-    readonly event: string;
-    readonly head_sha: string;
-    readonly name?: string | null | undefined;
-    readonly path?: string | null | undefined;
     readonly status: string | null;
-    readonly workflow_id?: number | null | undefined;
 };
 type RawWorkflowJob = {
     readonly conclusion: string | null;
     readonly html_url?: string | null | undefined;
     readonly name: string;
 };
-type RawWorkflow = { readonly id: number; readonly name: string; readonly path: string };
 
 type RequestContext = {
     readonly headers: Readonly<Record<string, string>>;
@@ -140,66 +141,6 @@ function commitSubject(commit: RawCommit): string {
         return commit.commit.message;
     }
     return commit.commit.message.slice(0, firstLineBreak);
-}
-
-function runDatabaseId(run: RawWorkflowRun): number | undefined {
-    return run.database_id ?? run.databaseId;
-}
-
-function workflowMatchesIdentifier(workflow: RawWorkflow, identifier: string): boolean {
-    return (
-        String(workflow.id) === identifier ||
-        workflow.name === identifier ||
-        workflow.path === identifier ||
-        workflow.path.endsWith(`/${identifier}`)
-    );
-}
-
-function workflowRunPathMatches(run: RawWorkflowRun, workflow: RawWorkflow): boolean {
-    return (
-        run.path === undefined ||
-        run.path === null ||
-        run.path === workflow.path ||
-        run.path.endsWith(`/${workflow.path}`)
-    );
-}
-
-function workflowRunIdentityComparisons(run: RawWorkflowRun, workflow: RawWorkflow): readonly boolean[] {
-    return [
-        run.workflow_id === undefined || run.workflow_id === null || run.workflow_id === workflow.id,
-        workflowRunPathMatches(run, workflow),
-        run.name === undefined || run.name === null || run.name === workflow.name
-    ];
-}
-
-function workflowRunMatchesIdentity(run: RawWorkflowRun, workflow: RawWorkflow): boolean {
-    return workflowRunIdentityComparisons(run, workflow).every(Boolean);
-}
-
-function workflowRunMatchesInput(run: RawWorkflowRun, workflow: RawWorkflow, headSha: string): boolean {
-    return run.head_sha === headSha && run.event === 'workflow_dispatch' && workflowRunMatchesIdentity(run, workflow);
-}
-
-function selectRawWorkflow(identifier: string, matches: readonly RawWorkflow[]): RawWorkflow {
-    const workflow = matches[0];
-    if (workflow === undefined) {
-        throw new Error(`GitHub Actions workflow "${identifier}" was not found`);
-    }
-    if (matches.length === 1) {
-        return { id: workflow.id, name: workflow.name, path: workflow.path };
-    }
-    throw new Error(`GitHub Actions workflow "${identifier}" matched multiple workflows`);
-}
-
-function findWorkflowRunIdInRuns(
-    runs: readonly RawWorkflowRun[],
-    workflow: RawWorkflow,
-    headSha: string
-): number | undefined {
-    const run = runs.find((workflowRun) => {
-        return workflowRunMatchesInput(workflowRun, workflow, headSha);
-    });
-    return run === undefined ? undefined : runDatabaseId(run);
 }
 
 function pullRequestIsMerged(pullRequest: RawPullRequest): boolean {
@@ -314,18 +255,18 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
         return response.data.number;
     }
 
-    async function resolveRawWorkflow(identifier: string): Promise<RawWorkflow> {
+    async function resolveRawWorkflow(identifier: string): Promise<ReleaseWorkflow> {
         const response = await resolveGitHubResponse(
             octokit.rest.actions.listRepoWorkflows({
                 ...requestContext,
                 per_page: 100
             })
         );
-        const workflows = response.data.workflows as readonly RawWorkflow[];
+        const workflows = response.data.workflows as readonly ReleaseWorkflow[];
         const matches = workflows.filter((workflow) => {
             return workflowMatchesIdentifier(workflow, identifier);
         });
-        return selectRawWorkflow(identifier, matches);
+        return selectReleaseWorkflow(identifier, matches);
     }
 
     return {
@@ -422,7 +363,7 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
             );
         },
 
-        async findDispatchedWorkflowRunId(input) {
+        async findDispatchedWorkflowRun(input) {
             const workflow = await resolveRawWorkflow(input.workflowFile);
             const workflowResponse = await resolveGitHubResponse(
                 octokit.rest.actions.listWorkflowRuns({
@@ -433,13 +374,14 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
                     per_page: 100
                 })
             );
-            const workflowRunId = findWorkflowRunIdInRuns(
-                workflowResponse.data.workflow_runs as readonly RawWorkflowRun[],
-                workflow,
-                input.headSha
-            );
+            const workflowRuns = workflowResponse.data.workflow_runs as readonly RawWorkflowRun[];
+            const workflowRunId = findWorkflowRunIdInRuns(workflowRuns, workflow, input.headSha);
             if (workflowRunId !== undefined) {
-                return workflowRunId;
+                return {
+                    event: 'workflow_dispatch',
+                    observedRunIds: observedWorkflowRunIds(workflowRuns),
+                    runId: workflowRunId
+                };
             }
 
             const repoResponse = await resolveGitHubResponse(
@@ -450,11 +392,12 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
                     per_page: 100
                 })
             );
-            return findWorkflowRunIdInRuns(
-                repoResponse.data.workflow_runs as readonly RawWorkflowRun[],
-                workflow,
-                input.headSha
-            );
+            const repoRuns = repoResponse.data.workflow_runs as readonly RawWorkflowRun[];
+            return {
+                event: 'workflow_dispatch',
+                observedRunIds: [...observedWorkflowRunIds(workflowRuns), ...observedWorkflowRunIds(repoRuns)],
+                runId: findWorkflowRunIdInRuns(repoRuns, workflow, input.headSha)
+            };
         },
 
         async getBranchHeadSha(branch) {

--- a/source/command-line-interface/runner/release-pr-workflow-runs.test.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-runs.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import {
+    findWorkflowRunIdInRuns,
+    observedWorkflowRunIds,
+    selectReleaseWorkflow,
+    workflowMatchesIdentifier,
+    type ReleaseWorkflow
+} from './release-pr-workflow-runs.ts';
+
+const workflow: ReleaseWorkflow = {
+    id: 101,
+    name: 'Continuous Integration',
+    path: '.github/workflows/continuous-integration.yml'
+};
+
+suite('release-pr-workflow-runs', function () {
+    test('matches workflows by id, name, path, and basename', function () {
+        assert.strictEqual(workflowMatchesIdentifier(workflow, '101'), true);
+        assert.strictEqual(workflowMatchesIdentifier(workflow, 'Continuous Integration'), true);
+        assert.strictEqual(workflowMatchesIdentifier(workflow, '.github/workflows/continuous-integration.yml'), true);
+        assert.strictEqual(workflowMatchesIdentifier(workflow, 'continuous-integration.yml'), true);
+        assert.strictEqual(workflowMatchesIdentifier(workflow, 'other.yml'), false);
+    });
+
+    test('selects exactly one release workflow', function () {
+        assert.deepStrictEqual(selectReleaseWorkflow('continuous-integration.yml', [workflow]), workflow);
+    });
+
+    test('fails when no release workflow matches the identifier', function () {
+        assert.throws(() => {
+            selectReleaseWorkflow('missing.yml', []);
+        }, /GitHub Actions workflow "missing\.yml" was not found/u);
+    });
+
+    test('fails when multiple release workflows match the identifier', function () {
+        assert.throws(() => {
+            selectReleaseWorkflow('ci.yml', [
+                { id: 101, name: 'CI', path: '.github/workflows/ci.yml' },
+                { id: 102, name: 'CI copy', path: '.github/workflows/ci.yml' }
+            ]);
+        }, /GitHub Actions workflow "ci\.yml" matched multiple workflows/u);
+    });
+
+    test('finds matching workflow dispatch runs by workflow identity and head SHA', function () {
+        assert.strictEqual(
+            findWorkflowRunIdInRuns(
+                [
+                    {
+                        database_id: 1,
+                        event: 'workflow_dispatch',
+                        head_sha: 'other-head',
+                        workflow_id: 101
+                    },
+                    {
+                        databaseId: 2,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        name: 'Continuous Integration',
+                        path: 'enormora/packtory/.github/workflows/continuous-integration.yml',
+                        workflow_id: 101
+                    }
+                ],
+                workflow,
+                'release-head'
+            ),
+            2
+        );
+    });
+
+    test('ignores matching workflow runs from other events', function () {
+        assert.strictEqual(
+            findWorkflowRunIdInRuns(
+                [
+                    {
+                        database_id: 1,
+                        event: 'pull_request',
+                        head_sha: 'release-head',
+                        name: 'Continuous Integration',
+                        path: 'enormora/packtory/.github/workflows/continuous-integration.yml',
+                        workflow_id: 101
+                    }
+                ],
+                workflow,
+                'release-head'
+            ),
+            undefined
+        );
+    });
+
+    test('collects defined workflow run ids', function () {
+        assert.deepStrictEqual(
+            observedWorkflowRunIds([
+                { database_id: 1, event: 'workflow_dispatch', head_sha: 'release-head' },
+                { event: 'workflow_dispatch', head_sha: 'release-head' },
+                { databaseId: 2, event: 'workflow_dispatch', head_sha: 'release-head' }
+            ]),
+            [1, 2]
+        );
+    });
+});

--- a/source/command-line-interface/runner/release-pr-workflow-runs.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-runs.ts
@@ -1,0 +1,83 @@
+import { isDefined } from 'remeda';
+
+export type ReleaseWorkflow = { readonly id: number; readonly name: string; readonly path: string };
+
+export type ReleaseWorkflowRun = {
+    readonly databaseId?: number | undefined;
+    readonly database_id?: number | undefined;
+    readonly event: string;
+    readonly head_sha: string;
+    readonly name?: string | null | undefined;
+    readonly path?: string | null | undefined;
+    readonly workflow_id?: number | null | undefined;
+};
+
+export type WorkflowRunLookupResult = {
+    readonly event: 'workflow_dispatch';
+    readonly observedRunIds: readonly number[];
+    readonly runId: number | undefined;
+};
+
+export function runDatabaseId(run: ReleaseWorkflowRun): number | undefined {
+    return run.database_id ?? run.databaseId;
+}
+
+function workflowRunPathMatches(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): boolean {
+    return (
+        run.path === undefined ||
+        run.path === null ||
+        run.path === workflow.path ||
+        run.path.endsWith(`/${workflow.path}`)
+    );
+}
+
+function workflowRunIdentityComparisons(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): readonly boolean[] {
+    return [
+        run.workflow_id === undefined || run.workflow_id === null || run.workflow_id === workflow.id,
+        workflowRunPathMatches(run, workflow),
+        run.name === undefined || run.name === null || run.name === workflow.name
+    ];
+}
+
+function workflowRunMatchesIdentity(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): boolean {
+    return workflowRunIdentityComparisons(run, workflow).every(Boolean);
+}
+
+function workflowRunMatchesInput(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow, headSha: string): boolean {
+    return run.head_sha === headSha && run.event === 'workflow_dispatch' && workflowRunMatchesIdentity(run, workflow);
+}
+
+export function workflowMatchesIdentifier(workflow: ReleaseWorkflow, identifier: string): boolean {
+    return (
+        String(workflow.id) === identifier ||
+        workflow.name === identifier ||
+        workflow.path === identifier ||
+        workflow.path.endsWith(`/${identifier}`)
+    );
+}
+
+export function selectReleaseWorkflow(identifier: string, matches: readonly ReleaseWorkflow[]): ReleaseWorkflow {
+    const workflow = matches[0];
+    if (workflow === undefined) {
+        throw new Error(`GitHub Actions workflow "${identifier}" was not found`);
+    }
+    if (matches.length === 1) {
+        return { id: workflow.id, name: workflow.name, path: workflow.path };
+    }
+    throw new Error(`GitHub Actions workflow "${identifier}" matched multiple workflows`);
+}
+
+export function findWorkflowRunIdInRuns(
+    runs: readonly ReleaseWorkflowRun[],
+    workflow: ReleaseWorkflow,
+    headSha: string
+): number | undefined {
+    const run = runs.find((workflowRun) => {
+        return workflowRunMatchesInput(workflowRun, workflow, headSha);
+    });
+    return run === undefined ? undefined : runDatabaseId(run);
+}
+
+export function observedWorkflowRunIds(runs: readonly ReleaseWorkflowRun[]): readonly number[] {
+    return runs.map(runDatabaseId).filter(isDefined);
+}

--- a/source/command-line-interface/runner/release-pull-request-ci.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.test.ts
@@ -5,6 +5,42 @@ import { runConfiguredGitHubActionsCi } from './release-pull-request-ci.ts';
 import type { ReleasePullRequestConfig } from './release-pull-request-config.ts';
 import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
 
+type WorkflowRunLookup = Awaited<ReturnType<ReleasePullRequestGitHubClient['findDispatchedWorkflowRun']>>;
+type WorkflowRunResult = Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
+type WorkflowRunLookupInput = Parameters<ReleasePullRequestGitHubClient['findDispatchedWorkflowRun']>[0];
+
+function workflowRunFound(runId = 1, observedRunIds: readonly number[] = [runId]): WorkflowRunLookup {
+    return { event: 'workflow_dispatch', observedRunIds, runId };
+}
+
+function workflowRunMissing(observedRunIds: readonly number[] = []): WorkflowRunLookup {
+    return { event: 'workflow_dispatch', observedRunIds, runId: undefined };
+}
+
+function findWorkflowRunSequence(results: readonly [WorkflowRunLookup, ...WorkflowRunLookup[]]) {
+    let index = 0;
+    return fake(async (_: WorkflowRunLookupInput) => {
+        const result = results[Math.min(index, results.length - 1)];
+        index += 1;
+        if (result === undefined) {
+            throw new Error('Missing workflow run lookup fixture');
+        }
+        return result;
+    });
+}
+
+function readWorkflowRunResultSequence(results: readonly [WorkflowRunResult, ...WorkflowRunResult[]]) {
+    let index = 0;
+    return fake(async (_: number) => {
+        const result = results[Math.min(index, results.length - 1)];
+        index += 1;
+        if (result === undefined) {
+            throw new Error('Missing workflow run result fixture');
+        }
+        return result;
+    });
+}
+
 function createConfig(requiredStatusContexts: readonly string[] = ['Node.js']): ReleasePullRequestConfig {
     return {
         automationAuthor: 'github-actions[bot]',
@@ -29,7 +65,7 @@ function createClient(overrides: Partial<ReleasePullRequestGitHubClient> = {}): 
         createStatus: fake.resolves(undefined),
         deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
         dispatchWorkflow: fake.resolves(undefined),
-        findDispatchedWorkflowRunId: fake.resolves(1),
+        findDispatchedWorkflowRun: fake.resolves(workflowRunFound()),
         getBranchHeadSha: fake.resolves('main-head'),
         getPullRequest: fake.resolves(undefined as never),
         getPullRequestHead: fake.resolves(undefined as never),
@@ -60,12 +96,12 @@ suite('release-pull-request-ci', function () {
         const createStatus = fake.resolves(undefined);
         const deleteActionRequiredPullRequestRuns = fake.resolves(undefined);
         const dispatchWorkflow = fake.resolves(undefined);
-        const findDispatchedWorkflowRunId = fake.resolves(1);
+        const findDispatchedWorkflowRun = findWorkflowRunSequence([workflowRunMissing(), workflowRunFound()]);
         const client = createClient({
             createStatus,
             deleteActionRequiredPullRequestRuns,
             dispatchWorkflow,
-            findDispatchedWorkflowRunId
+            findDispatchedWorkflowRun
         });
 
         assert.strictEqual(
@@ -96,7 +132,7 @@ suite('release-pull-request-ci', function () {
             ref: 'release/packtory',
             workflowFile: 'ci.yml'
         });
-        assert.deepStrictEqual(findDispatchedWorkflowRunId.firstCall.args[0], {
+        assert.deepStrictEqual(findDispatchedWorkflowRun.secondCall.args[0], {
             branch: 'release/packtory',
             headSha: 'release-head',
             workflowFile: 'ci.yml'
@@ -121,14 +157,14 @@ suite('release-pull-request-ci', function () {
             false
         );
 
-        assert.deepStrictEqual(createStatus.thirdCall.args[0], {
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
             commitSha: 'release-head',
             context: 'Node.js',
             description: 'Dispatched release CI job success.',
             state: 'success',
             targetUrl: 'https://run/job'
         });
-        assert.deepStrictEqual(createStatus.getCall(3).args[0], {
+        assert.deepStrictEqual(createStatus.secondCall.args[0], {
             commitSha: 'release-head',
             context: 'Missing job',
             description: 'Missing dispatched release CI job: Missing job.',
@@ -151,7 +187,7 @@ suite('release-pull-request-ci', function () {
             false
         );
 
-        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
             commitSha: 'release-head',
             context: 'Missing job',
             description: 'Missing dispatched release CI job: Missing job.',
@@ -181,7 +217,7 @@ suite('release-pull-request-ci', function () {
             false
         );
 
-        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
             commitSha: 'release-head',
             context: 'Node.js',
             description: 'Dispatched release CI job failure.',
@@ -218,19 +254,148 @@ suite('release-pull-request-ci', function () {
     });
 
     test('fails when the dispatched workflow run is not created', async function () {
-        const findDispatchedWorkflowRunId = fake.resolves(undefined);
+        const createStatus = fake.resolves(undefined);
+        const findDispatchedWorkflowRun = fake.resolves(workflowRunMissing([2, 3]));
         const sleep = fake.resolves(undefined);
         await assert.rejects(
             runConfiguredGitHubActionsCi({
-                client: createClient({ findDispatchedWorkflowRunId }),
+                client: createClient({ createStatus, findDispatchedWorkflowRun }),
                 config: createConfig(),
                 headSha: 'release-head',
                 sleep
             }),
-            { message: 'Release workflow run was not created for release-head' }
+            {
+                message:
+                    'Release workflow run was not created for release-head; workflow=ci.yml, ' +
+                    'branch=release/packtory, event=workflow_dispatch, observedRunIds=2, 3'
+            }
         );
-        assert.strictEqual(findDispatchedWorkflowRunId.callCount, 30);
+        assert.strictEqual(findDispatchedWorkflowRun.callCount, 31);
         assert.strictEqual(sleep.callCount, 29);
+        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI did not start.',
+            state: 'error',
+            targetUrl: undefined
+        });
+    });
+
+    test('reports none when a dispatched workflow lookup observes no runs', async function () {
+        await assert.rejects(
+            runConfiguredGitHubActionsCi({
+                client: createClient({ findDispatchedWorkflowRun: fake.resolves(workflowRunMissing()) }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            {
+                message:
+                    'Release workflow run was not created for release-head; workflow=ci.yml, ' +
+                    'branch=release/packtory, event=workflow_dispatch, observedRunIds=none'
+            }
+        );
+    });
+
+    test('reports run ids from the latest dispatched workflow lookup', async function () {
+        await assert.rejects(
+            runConfiguredGitHubActionsCi({
+                client: createClient({
+                    findDispatchedWorkflowRun: findWorkflowRunSequence([
+                        workflowRunMissing([1]),
+                        workflowRunMissing([2]),
+                        workflowRunMissing([3])
+                    ])
+                }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            {
+                message:
+                    'Release workflow run was not created for release-head; workflow=ci.yml, ' +
+                    'branch=release/packtory, event=workflow_dispatch, observedRunIds=3'
+            }
+        );
+    });
+
+    test('mirrors a running required job with its job URL while waiting', async function () {
+        const createStatus = fake.resolves(undefined);
+        const readWorkflowRunResult = readWorkflowRunResultSequence([
+            {
+                conclusion: undefined,
+                databaseId: 1,
+                jobs: [
+                    { conclusion: undefined, name: 'Other job', url: 'https://run/other-job' },
+                    { conclusion: undefined, name: 'Node.js', url: 'https://run/job' }
+                ]
+            },
+            {
+                conclusion: 'success',
+                databaseId: 1,
+                jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+            }
+        ]);
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: createClient({ createStatus, readWorkflowRunResult }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI job running.',
+            state: 'pending',
+            targetUrl: 'https://run/job'
+        });
+        assert.deepStrictEqual(createStatus.secondCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/job'
+        });
+    });
+
+    test('does not mirror a running status for a completed job', async function () {
+        const createStatus = fake.resolves(undefined);
+        const readWorkflowRunResult = readWorkflowRunResultSequence([
+            {
+                conclusion: undefined,
+                databaseId: 1,
+                jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+            },
+            {
+                conclusion: 'success',
+                databaseId: 1,
+                jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+            }
+        ]);
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: createClient({ createStatus, readWorkflowRunResult }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+
+        assert.strictEqual(createStatus.callCount, 1);
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/job'
+        });
     });
 
     test('fails when the dispatched workflow run does not complete', async function () {

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -2,6 +2,8 @@ import type { ReleasePullRequestConfig } from './release-pull-request-config.ts'
 import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
 
 type GitHubActionsCiConfig = NonNullable<ReleasePullRequestConfig['githubActionsCi']>;
+type WorkflowRunLookup = Awaited<ReturnType<ReleasePullRequestGitHubClient['findDispatchedWorkflowRun']>>;
+type WorkflowRunResult = Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
 
 const workflowRunLookupAttempts = 30;
 const workflowRunCompletionAttempts = 120;
@@ -17,6 +19,39 @@ function isLastAttempt(attempt: number, count: number): boolean {
     return attempt === count - 1;
 }
 
+function formatObservedRunIds(observedRunIds: readonly number[]): string {
+    if (observedRunIds.length === 0) {
+        return 'none';
+    }
+    return observedRunIds.join(', ');
+}
+
+function formatWorkflowRunLookupFailure(input: {
+    readonly branch: string;
+    readonly headSha: string;
+    readonly observedRunIds: readonly number[];
+    readonly workflowFile: string;
+}): string {
+    return (
+        `Release workflow run was not created for ${input.headSha}; ` +
+        `workflow=${input.workflowFile}, branch=${input.branch}, event=workflow_dispatch, ` +
+        `observedRunIds=${formatObservedRunIds(input.observedRunIds)}`
+    );
+}
+
+async function findDispatchedWorkflowRun(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly headSha: string;
+}): Promise<WorkflowRunLookup> {
+    return input.client.findDispatchedWorkflowRun({
+        branch: input.config.branch,
+        headSha: input.headSha,
+        workflowFile: input.ciConfig.workflowFile
+    });
+}
+
 async function waitForDispatchedWorkflowRun(input: {
     readonly ciConfig: GitHubActionsCiConfig;
     readonly client: ReleasePullRequestGitHubClient;
@@ -24,32 +59,66 @@ async function waitForDispatchedWorkflowRun(input: {
     readonly headSha: string;
     readonly sleep: (milliseconds: number) => Promise<void>;
 }): Promise<number> {
+    let lookup = await findDispatchedWorkflowRun(input);
     for (const attempt of createRetryAttempts(workflowRunLookupAttempts)) {
-        const runId = await input.client.findDispatchedWorkflowRunId({
-            branch: input.config.branch,
-            headSha: input.headSha,
-            workflowFile: input.ciConfig.workflowFile
-        });
-        if (runId !== undefined) {
-            return runId;
+        if (attempt !== 0) {
+            lookup = await findDispatchedWorkflowRun(input);
+        }
+        if (lookup.runId !== undefined) {
+            return lookup.runId;
         }
         if (!isLastAttempt(attempt, workflowRunLookupAttempts)) {
             await input.sleep(workflowPollIntervalMilliseconds);
         }
     }
-    throw new Error(`Release workflow run was not created for ${input.headSha}`);
+    throw new Error(
+        formatWorkflowRunLookupFailure({
+            branch: input.config.branch,
+            headSha: input.headSha,
+            observedRunIds: lookup.observedRunIds,
+            workflowFile: input.ciConfig.workflowFile
+        })
+    );
+}
+
+async function mirrorRunningWorkflowStatuses(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly headSha: string;
+    readonly runResult: WorkflowRunResult;
+}): Promise<void> {
+    await Promise.all(
+        input.ciConfig.requiredStatusContexts.map(async (context) => {
+            const job = input.runResult.jobs.find((candidate) => {
+                return candidate.name === context;
+            });
+            if (job === undefined || job.conclusion !== undefined) {
+                return;
+            }
+            await input.client.createStatus({
+                commitSha: input.headSha,
+                context,
+                description: 'Dispatched release CI job running.',
+                state: 'pending',
+                targetUrl: job.url
+            });
+        })
+    );
 }
 
 async function waitForWorkflowCompletion(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
     readonly client: ReleasePullRequestGitHubClient;
+    readonly headSha: string;
     readonly runId: number;
     readonly sleep: (milliseconds: number) => Promise<void>;
-}): Promise<Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>> {
+}): Promise<WorkflowRunResult> {
     for (const attempt of createRetryAttempts(workflowRunCompletionAttempts)) {
         const result = await input.client.readWorkflowRunResult(input.runId);
         if (result.conclusion !== undefined) {
             return result;
         }
+        await mirrorRunningWorkflowStatuses({ ...input, runResult: result });
         if (!isLastAttempt(attempt, workflowRunCompletionAttempts)) {
             await input.sleep(workflowPollIntervalMilliseconds);
         }
@@ -68,7 +137,7 @@ async function mirrorWorkflowStatus(input: {
     readonly client: ReleasePullRequestGitHubClient;
     readonly context: string;
     readonly headSha: string;
-    readonly runResult: Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
+    readonly runResult: WorkflowRunResult;
 }): Promise<boolean> {
     const job = input.runResult.jobs.find((candidate) => {
         return candidate.name === input.context;
@@ -97,7 +166,7 @@ async function mirrorWorkflowStatuses(input: {
     readonly ciConfig: GitHubActionsCiConfig;
     readonly client: ReleasePullRequestGitHubClient;
     readonly headSha: string;
-    readonly runResult: Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
+    readonly runResult: WorkflowRunResult;
 }): Promise<boolean> {
     const statuses = await Promise.all(
         input.ciConfig.requiredStatusContexts.map(async (context) => {
@@ -123,6 +192,58 @@ async function createPendingWorkflowStatuses(input: {
     }
 }
 
+async function createFailedWorkflowStatuses(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly description: string;
+    readonly headSha: string;
+}): Promise<void> {
+    for (const context of input.ciConfig.requiredStatusContexts) {
+        await input.client.createStatus({
+            commitSha: input.headSha,
+            context,
+            description: input.description,
+            state: 'error',
+            targetUrl: undefined
+        });
+    }
+}
+
+async function dispatchWorkflowRun(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly headSha: string;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+}): Promise<number> {
+    await createPendingWorkflowStatuses(input);
+    try {
+        await input.client.dispatchWorkflow({
+            ref: input.config.branch,
+            workflowFile: input.ciConfig.workflowFile
+        });
+        const runId = await waitForDispatchedWorkflowRun(input);
+        return runId;
+    } catch (error) {
+        await createFailedWorkflowStatuses({
+            ...input,
+            description: 'Dispatched release CI did not start.'
+        });
+        throw error;
+    }
+}
+
+async function resolveWorkflowRunId(input: {
+    readonly ciConfig: GitHubActionsCiConfig;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly config: ReleasePullRequestConfig;
+    readonly headSha: string;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+}): Promise<number> {
+    const { runId } = await findDispatchedWorkflowRun(input);
+    return runId ?? dispatchWorkflowRun(input);
+}
+
 export async function runConfiguredGitHubActionsCi(input: {
     readonly client: ReleasePullRequestGitHubClient;
     readonly config: ReleasePullRequestConfig;
@@ -133,10 +254,14 @@ export async function runConfiguredGitHubActionsCi(input: {
     if (githubActionsCi === undefined) {
         return true;
     }
-    await createPendingWorkflowStatuses({ ...input, ciConfig: githubActionsCi });
-    await input.client.dispatchWorkflow({ ref: input.config.branch, workflowFile: githubActionsCi.workflowFile });
-    const runId = await waitForDispatchedWorkflowRun({ ...input, ciConfig: githubActionsCi });
-    const runResult = await waitForWorkflowCompletion({ client: input.client, runId, sleep: input.sleep });
+    const runId = await resolveWorkflowRunId({ ...input, ciConfig: githubActionsCi });
+    const runResult = await waitForWorkflowCompletion({
+        ciConfig: githubActionsCi,
+        client: input.client,
+        headSha: input.headSha,
+        runId,
+        sleep: input.sleep
+    });
     if (githubActionsCi.deleteActionRequiredPullRequestRuns) {
         await input.client.deleteActionRequiredPullRequestRuns({ branch: input.config.branch, headSha: input.headSha });
     }

--- a/source/command-line-interface/runner/release-pull-request-handler.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.test.ts
@@ -75,7 +75,7 @@ function createReleasePullRequestClient(
         createStatus: fake.resolves(undefined),
         deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
         dispatchWorkflow: fake.resolves(undefined),
-        findDispatchedWorkflowRunId: fake.resolves(1),
+        findDispatchedWorkflowRun: fake.resolves({ event: 'workflow_dispatch', observedRunIds: [1], runId: 1 }),
         getBranchHeadSha: fake.resolves('main-head'),
         getPullRequest: fake.resolves({
             author: 'github-actions[bot]',

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -106,7 +106,11 @@ function createRunner(overrides: Overrides = {}): CommandLineInterfaceRunner {
                 createStatus: fake.resolves(undefined),
                 deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
                 dispatchWorkflow: fake.resolves(undefined),
-                findDispatchedWorkflowRunId: fake.resolves(undefined),
+                findDispatchedWorkflowRun: fake.resolves({
+                    event: 'workflow_dispatch',
+                    observedRunIds: [],
+                    runId: undefined
+                }),
                 getBranchHeadSha: fake.resolves('main-head'),
                 getPullRequest: fake.resolves(undefined),
                 getPullRequestHead: fake.resolves(undefined),
@@ -239,7 +243,7 @@ function createReleasePullRequestClient(overrides: Record<string, unknown>) {
         createStatus: fake.resolves(undefined),
         deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
         dispatchWorkflow: fake.resolves(undefined),
-        findDispatchedWorkflowRunId: fake.resolves(undefined),
+        findDispatchedWorkflowRun: fake.resolves({ event: 'workflow_dispatch', observedRunIds: [], runId: undefined }),
         getBranchHeadSha: fake.resolves('main-head'),
         getPullRequest: fake.resolves(undefined),
         getPullRequestHead: fake.resolves(undefined),


### PR DESCRIPTION
This lets release PR CI maintenance recover an existing dispatched run before dispatching a duplicate. While waiting, Packtory mirrors found required jobs as pending statuses with job URLs, marks startup failures as error statuses, and includes lookup details when no matching run appears.

Stacked on #789.