### PR TITLE
Fix `release-pr` attribution and status mirroring

### DIFF
--- a/source/command-line-interface/runner/release-pull-request-ci.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import type { Except } from 'type-fest';
 import { runConfiguredGitHubActionsCi } from './release-pull-request-ci.ts';
 import type { ReleasePullRequestConfig } from './release-pull-request-config.ts';
 import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
@@ -8,6 +9,8 @@ import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.
 type WorkflowRunLookup = Awaited<ReturnType<ReleasePullRequestGitHubClient['findDispatchedWorkflowRun']>>;
 type WorkflowRunResult = Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
 type WorkflowRunLookupInput = Parameters<ReleasePullRequestGitHubClient['findDispatchedWorkflowRun']>[0];
+type StatusInput = Parameters<ReleasePullRequestGitHubClient['createStatus']>[0];
+type StatusSpy = { readonly getCall: (index: number) => { readonly args: readonly unknown[] } };
 
 function workflowRunFound(runId = 1, observedRunIds: readonly number[] = [runId]): WorkflowRunLookup {
     return { event: 'workflow_dispatch', observedRunIds, runId };
@@ -79,6 +82,43 @@ function createClient(overrides: Partial<ReleasePullRequestGitHubClient> = {}): 
     };
 }
 
+function releaseStatus(input: Except<StatusInput, 'commitSha'>): StatusInput {
+    return { commitSha: 'release-head', ...input };
+}
+
+function assertStatusCall(createStatus: StatusSpy, callIndex: number, input: Except<StatusInput, 'commitSha'>): void {
+    assert.deepStrictEqual(createStatus.getCall(callIndex).args[0], releaseStatus(input));
+}
+
+async function assertTerminalRequiredJobStatus(conclusion: string, state: StatusInput['state']): Promise<void> {
+    const createStatus = fake.resolves(undefined);
+    const client = createClient({
+        createStatus,
+        readWorkflowRunResult: fake.resolves({
+            conclusion,
+            databaseId: 1,
+            jobs: [{ conclusion, name: 'Node.js', url: 'https://run/job' }]
+        })
+    });
+
+    assert.strictEqual(
+        await runConfiguredGitHubActionsCi({
+            client,
+            config: createConfig(),
+            headSha: 'release-head',
+            sleep: fake.resolves(undefined)
+        }),
+        false
+    );
+
+    assertStatusCall(createStatus, 0, {
+        context: 'Node.js',
+        description: `Dispatched release CI job ${conclusion}.`,
+        state,
+        targetUrl: 'https://run/job'
+    });
+}
+
 suite('release-pull-request-ci', function () {
     test('returns true without dispatch when GitHub Actions CI is not configured', async function () {
         assert.strictEqual(
@@ -114,15 +154,13 @@ suite('release-pull-request-ci', function () {
             true
         );
 
-        assert.deepStrictEqual(createStatus.firstCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 0, {
             context: 'Node.js',
             description: 'Waiting for dispatched release CI.',
             state: 'pending',
             targetUrl: undefined
         });
-        assert.deepStrictEqual(createStatus.secondCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 1, {
             context: 'Node.js',
             description: 'Dispatched release CI job success.',
             state: 'success',
@@ -157,15 +195,13 @@ suite('release-pull-request-ci', function () {
             false
         );
 
-        assert.deepStrictEqual(createStatus.firstCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 0, {
             context: 'Node.js',
             description: 'Dispatched release CI job success.',
             state: 'success',
             targetUrl: 'https://run/job'
         });
-        assert.deepStrictEqual(createStatus.secondCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 1, {
             context: 'Missing job',
             description: 'Missing dispatched release CI job: Missing job.',
             state: 'failure',
@@ -187,8 +223,7 @@ suite('release-pull-request-ci', function () {
             false
         );
 
-        assert.deepStrictEqual(createStatus.firstCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 0, {
             context: 'Missing job',
             description: 'Missing dispatched release CI job: Missing job.',
             state: 'failure',
@@ -197,33 +232,11 @@ suite('release-pull-request-ci', function () {
     });
 
     test('returns false and mirrors a failed required job', async function () {
-        const createStatus = fake.resolves(undefined);
-        const client = createClient({
-            createStatus,
-            readWorkflowRunResult: fake.resolves({
-                conclusion: 'failure',
-                databaseId: 1,
-                jobs: [{ conclusion: 'failure', name: 'Node.js', url: 'https://run/job' }]
-            })
-        });
+        await assertTerminalRequiredJobStatus('failure', 'failure');
+    });
 
-        assert.strictEqual(
-            await runConfiguredGitHubActionsCi({
-                client,
-                config: createConfig(),
-                headSha: 'release-head',
-                sleep: fake.resolves(undefined)
-            }),
-            false
-        );
-
-        assert.deepStrictEqual(createStatus.firstCall.args[0], {
-            commitSha: 'release-head',
-            context: 'Node.js',
-            description: 'Dispatched release CI job failure.',
-            state: 'failure',
-            targetUrl: 'https://run/job'
-        });
+    test('returns false and mirrors a cancelled required job as an error', async function () {
+        await assertTerminalRequiredJobStatus('cancelled', 'error');
     });
 
     test('does not delete blocked pull request runs when cleanup is disabled', async function () {
@@ -272,8 +285,7 @@ suite('release-pull-request-ci', function () {
         );
         assert.strictEqual(findDispatchedWorkflowRun.callCount, 31);
         assert.strictEqual(sleep.callCount, 29);
-        assert.deepStrictEqual(createStatus.secondCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 1, {
             context: 'Node.js',
             description: 'Dispatched release CI did not start.',
             state: 'error',
@@ -347,15 +359,13 @@ suite('release-pull-request-ci', function () {
             true
         );
 
-        assert.deepStrictEqual(createStatus.firstCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 0, {
             context: 'Node.js',
             description: 'Dispatched release CI job running.',
             state: 'pending',
             targetUrl: 'https://run/job'
         });
-        assert.deepStrictEqual(createStatus.secondCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 1, {
             context: 'Node.js',
             description: 'Dispatched release CI job success.',
             state: 'success',
@@ -389,12 +399,111 @@ suite('release-pull-request-ci', function () {
         );
 
         assert.strictEqual(createStatus.callCount, 1);
-        assert.deepStrictEqual(createStatus.firstCall.args[0], {
-            commitSha: 'release-head',
+        assertStatusCall(createStatus, 0, {
             context: 'Node.js',
             description: 'Dispatched release CI job success.',
             state: 'success',
             targetUrl: 'https://run/job'
+        });
+    });
+
+    test('finishes when required jobs completed before the workflow conclusion is indexed', async function () {
+        const createStatus = fake.resolves(undefined);
+        const readWorkflowRunResult = fake.resolves({
+            conclusion: undefined,
+            databaseId: 1,
+            jobs: [
+                { conclusion: 'success', name: 'Node v22', url: 'https://run/node-22' },
+                { conclusion: 'success', name: 'Node v24', url: 'https://run/node-24' },
+                { conclusion: 'success', name: 'Node v26', url: 'https://run/node-26' }
+            ]
+        });
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: createClient({ createStatus, readWorkflowRunResult }),
+                config: createConfig(['Node v22', 'Node v24', 'Node v26']),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+
+        assert.strictEqual(readWorkflowRunResult.callCount, 1);
+        assertStatusCall(createStatus, 0, {
+            context: 'Node v22',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/node-22'
+        });
+        assertStatusCall(createStatus, 1, {
+            context: 'Node v24',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/node-24'
+        });
+        assertStatusCall(createStatus, 2, {
+            context: 'Node v26',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/node-26'
+        });
+    });
+
+    test('mirrors completed and running required jobs while waiting for remaining jobs', async function () {
+        const createStatus = fake.resolves(undefined);
+        const readWorkflowRunResult = readWorkflowRunResultSequence([
+            {
+                conclusion: undefined,
+                databaseId: 1,
+                jobs: [
+                    { conclusion: 'success', name: 'Node v22', url: 'https://run/node-22' },
+                    { conclusion: undefined, name: 'Node v24', url: 'https://run/node-24' }
+                ]
+            },
+            {
+                conclusion: undefined,
+                databaseId: 1,
+                jobs: [
+                    { conclusion: 'success', name: 'Node v22', url: 'https://run/node-22' },
+                    { conclusion: 'success', name: 'Node v24', url: 'https://run/node-24' }
+                ]
+            }
+        ]);
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: createClient({ createStatus, readWorkflowRunResult }),
+                config: createConfig(['Node v22', 'Node v24']),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+
+        assertStatusCall(createStatus, 0, {
+            context: 'Node v22',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/node-22'
+        });
+        assertStatusCall(createStatus, 1, {
+            context: 'Node v24',
+            description: 'Dispatched release CI job running.',
+            state: 'pending',
+            targetUrl: 'https://run/node-24'
+        });
+        assertStatusCall(createStatus, 2, {
+            context: 'Node v22',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/node-22'
+        });
+        assertStatusCall(createStatus, 3, {
+            context: 'Node v24',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/node-24'
         });
     });
 

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -81,7 +81,36 @@ async function waitForDispatchedWorkflowRun(input: {
     );
 }
 
-async function mirrorRunningWorkflowStatuses(input: {
+function requiredJobResultFor(
+    runResult: WorkflowRunResult,
+    context: string
+): WorkflowRunResult['jobs'][number] | undefined {
+    return runResult.jobs.find((candidate) => {
+        return candidate.name === context;
+    });
+}
+
+function allRequiredJobsCompleted(runResult: WorkflowRunResult, contexts: readonly string[]): boolean {
+    return contexts.every((context) => {
+        return requiredJobResultFor(runResult, context)?.conclusion !== undefined;
+    });
+}
+
+function workflowStatusState(conclusion: string): 'error' | 'failure' | 'success' {
+    if (conclusion === 'success') {
+        return 'success';
+    }
+    return conclusion === 'failure' ? 'failure' : 'error';
+}
+
+function workflowStatusDescription(conclusion: string): string {
+    if (conclusion === 'success') {
+        return 'Dispatched release CI job success.';
+    }
+    return `Dispatched release CI job ${conclusion}.`;
+}
+
+async function mirrorKnownWorkflowStatuses(input: {
     readonly ciConfig: GitHubActionsCiConfig;
     readonly client: ReleasePullRequestGitHubClient;
     readonly headSha: string;
@@ -89,17 +118,25 @@ async function mirrorRunningWorkflowStatuses(input: {
 }): Promise<void> {
     await Promise.all(
         input.ciConfig.requiredStatusContexts.map(async (context) => {
-            const job = input.runResult.jobs.find((candidate) => {
-                return candidate.name === context;
-            });
-            if (job === undefined || job.conclusion !== undefined) {
+            const job = requiredJobResultFor(input.runResult, context);
+            if (job === undefined) {
+                return;
+            }
+            if (job.conclusion === undefined) {
+                await input.client.createStatus({
+                    commitSha: input.headSha,
+                    context,
+                    description: 'Dispatched release CI job running.',
+                    state: 'pending',
+                    targetUrl: job.url
+                });
                 return;
             }
             await input.client.createStatus({
                 commitSha: input.headSha,
                 context,
-                description: 'Dispatched release CI job running.',
-                state: 'pending',
+                description: workflowStatusDescription(job.conclusion),
+                state: workflowStatusState(job.conclusion),
                 targetUrl: job.url
             });
         })
@@ -115,10 +152,13 @@ async function waitForWorkflowCompletion(input: {
 }): Promise<WorkflowRunResult> {
     for (const attempt of createRetryAttempts(workflowRunCompletionAttempts)) {
         const result = await input.client.readWorkflowRunResult(input.runId);
-        if (result.conclusion !== undefined) {
+        if (
+            result.conclusion !== undefined ||
+            allRequiredJobsCompleted(result, input.ciConfig.requiredStatusContexts)
+        ) {
             return result;
         }
-        await mirrorRunningWorkflowStatuses({ ...input, runResult: result });
+        await mirrorKnownWorkflowStatuses({ ...input, runResult: result });
         if (!isLastAttempt(attempt, workflowRunCompletionAttempts)) {
             await input.sleep(workflowPollIntervalMilliseconds);
         }
@@ -126,11 +166,51 @@ async function waitForWorkflowCompletion(input: {
     throw new Error(`Release workflow run ${input.runId} did not complete`);
 }
 
-function formatWorkflowStatusFailure(context: string, conclusion: string | undefined): string {
-    if (conclusion === undefined) {
-        return `Missing dispatched release CI job: ${context}.`;
+function missingWorkflowStatusDescription(context: string): string {
+    return `Missing dispatched release CI job: ${context}.`;
+}
+
+type FinalWorkflowStatus = {
+    readonly description: string;
+    readonly passed: boolean;
+    readonly state: 'error' | 'failure' | 'success';
+    readonly targetUrl: string | undefined;
+};
+
+function incompleteWorkflowStatus(context: string): FinalWorkflowStatus {
+    return {
+        description: missingWorkflowStatusDescription(context),
+        passed: false,
+        state: 'failure',
+        targetUrl: undefined
+    };
+}
+
+function completedWorkflowStatus(conclusion: string, targetUrl: string | undefined): FinalWorkflowStatus {
+    if (conclusion === 'success') {
+        return {
+            description: 'Dispatched release CI job success.',
+            passed: true,
+            state: 'success',
+            targetUrl
+        };
     }
-    return `Dispatched release CI job ${conclusion}.`;
+    return {
+        description: workflowStatusDescription(conclusion),
+        passed: false,
+        state: workflowStatusState(conclusion),
+        targetUrl
+    };
+}
+
+function finalWorkflowStatusFor(
+    context: string,
+    job: WorkflowRunResult['jobs'][number] | undefined
+): FinalWorkflowStatus {
+    if (job?.conclusion === undefined) {
+        return incompleteWorkflowStatus(context);
+    }
+    return completedWorkflowStatus(job.conclusion, job.url);
 }
 
 async function mirrorWorkflowStatus(input: {
@@ -139,27 +219,16 @@ async function mirrorWorkflowStatus(input: {
     readonly headSha: string;
     readonly runResult: WorkflowRunResult;
 }): Promise<boolean> {
-    const job = input.runResult.jobs.find((candidate) => {
-        return candidate.name === input.context;
-    });
-    if (job?.conclusion === 'success') {
-        await input.client.createStatus({
-            commitSha: input.headSha,
-            context: input.context,
-            description: 'Dispatched release CI job success.',
-            state: 'success',
-            targetUrl: job.url
-        });
-        return true;
-    }
+    const job = requiredJobResultFor(input.runResult, input.context);
+    const status = finalWorkflowStatusFor(input.context, job);
     await input.client.createStatus({
         commitSha: input.headSha,
         context: input.context,
-        description: formatWorkflowStatusFailure(input.context, job?.conclusion),
-        state: 'failure',
-        targetUrl: job?.url
+        description: status.description,
+        state: status.state,
+        targetUrl: status.targetUrl
     });
-    return false;
+    return status.passed;
 }
 
 async function mirrorWorkflowStatuses(input: {

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -104,9 +104,6 @@ function workflowStatusState(conclusion: string): 'error' | 'failure' | 'success
 }
 
 function workflowStatusDescription(conclusion: string): string {
-    if (conclusion === 'success') {
-        return 'Dispatched release CI job success.';
-    }
     return `Dispatched release CI job ${conclusion}.`;
 }
 

--- a/source/packtory/changelog-source-attribution.ts
+++ b/source/packtory/changelog-source-attribution.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { TraceMap } from '@jridgewell/trace-mapping';
+import { bundleRelativePath } from '../common/package-layout.ts';
 import { compareValues } from '../common/sort-values.ts';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
@@ -162,6 +163,22 @@ export async function attributeChangelogSourceFiles(
     const attributedFiles: string[] = Array.from(additionalSourceFiles);
     for (const entry of analyzedBundle.contents) {
         if (!entry.isGeneratedManifest) {
+            attributedFiles.push(...(await collectAttributedFiles(dependencies, entry)));
+        }
+    }
+    return sortUniqueValues(attributedFiles);
+}
+
+export async function attributeSelectedChangelogSourceFiles(
+    dependencies: ChangelogSourceAttributionDependencies,
+    analyzedBundle: AnalyzedBundle,
+    additionalSourceFiles: readonly string[],
+    selectedArtifactFiles: ReadonlySet<string>
+): Promise<readonly string[]> {
+    const attributedFiles: string[] = Array.from(additionalSourceFiles);
+    for (const entry of analyzedBundle.contents) {
+        const targetFilePath = bundleRelativePath(entry.fileDescription.targetFilePath);
+        if (!entry.isGeneratedManifest && selectedArtifactFiles.has(targetFilePath)) {
             attributedFiles.push(...(await collectAttributedFiles(dependencies, entry)));
         }
     }

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -24,6 +24,7 @@ type BuildAndPublishResult = Awaited<ReturnType<ReleaseTestDependencies['package
 type PackageProcessor = ReleaseTestDependencies['packageProcessor'];
 type FileCollection = ReleaseFileCollection;
 type ReleasePlanFileManager = ReleaseTestDependencies['fileManager'];
+type ReleaseArtifactFile = { readonly content: string; readonly filePath: string; readonly isExecutable: false };
 
 function createPlanner(spec: {
     readonly packageNames: readonly string[];
@@ -44,7 +45,7 @@ function resolvedPackagesFor(
     return sharedResolvedPackagesFor(validated, {
         bundleContents,
         defaultContents(packageName) {
-            return [analyzedBundleResource(`/source/${packageName}.js`)];
+            return [analyzedBundleResource(`/source/${packageName}.js`, { targetFilePath: 'index.js' })];
         }
     });
 }
@@ -90,11 +91,68 @@ function publishedBuildResultFor(status: BuildAndPublishResult['status'] = 'new-
     });
 }
 
+function releaseArtifactFile(filePath: string, content: string): ReleaseArtifactFile {
+    return { filePath, content, isExecutable: false };
+}
+
+function packageManifest(content: string): ReleaseArtifactFile {
+    return releaseArtifactFile('package/package.json', content);
+}
+
+function validatedManifestAttributionConfig(): ValidConfigResult {
+    return validatedReleaseConfig({
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        commonPackageSettings: {
+            additionalChangelogSourceFiles: ['package-lock.json'],
+            mainPackageJson: { type: 'module', dependencies: { commander: '^14.0.0' } },
+            publishSettings: { access: 'public' },
+            sourcesFolder: 'source'
+        },
+        packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a.js' } } }]
+    });
+}
+
 function expectPlan(result: ReleasePlanResult) {
     if (result.isErr) {
         assert.fail(`Expected release plan, got ${result.error.type}`);
     }
     return result.value;
+}
+
+async function planManifestAttribution(spec: {
+    readonly currentIndex: string;
+    readonly currentPackageJson: string;
+    readonly previousIndex: string;
+    readonly previousPackageJson: string;
+}): Promise<readonly string[]> {
+    const validated = validatedManifestAttributionConfig();
+    const plan = createPlanner({
+        packageNames: ['pkg-a'],
+        buildResults: [
+            buildResultFor({
+                previousReleaseArtifacts: previousReleaseArtifactsFor({
+                    version: '1.0.0',
+                    publishedAt: new Date('2026-05-01T00:00:00.000Z'),
+                    files: [
+                        packageManifest(spec.previousPackageJson),
+                        releaseArtifactFile('package/index.js', spec.previousIndex)
+                    ]
+                })
+            })
+        ],
+        collectContents() {
+            return [
+                packageManifest(spec.currentPackageJson),
+                releaseArtifactFile('package/index.js', spec.currentIndex)
+            ];
+        }
+    });
+
+    const result = await plan(validated, async () => {
+        return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
+    });
+
+    return expectPlan(result).packages[0]?.changelogSourceFiles ?? [];
 }
 
 function expectPartialFailure(result: ReleasePlanResult) {
@@ -373,7 +431,7 @@ suite('packtory-release-plan', function () {
         assert.fail('Expected an error result');
     });
 
-    test('excludes generated manifests and includes substituted and additional source files', async function () {
+    test('attributes only source files for changed artifacts in substantive releases', async function () {
         const generatedManifest = {
             ...analyzedBundleResource('/source/package.json', { targetFilePath: 'package.json' }),
             isGeneratedManifest: true as const
@@ -387,9 +445,12 @@ suite('packtory-release-plan', function () {
             bundleContents: {
                 'pkg-a': [
                     generatedManifest,
-                    analyzedBundleResource('/source/index.js'),
-                    analyzedBundleResource('/source/index.js'),
-                    analyzedBundleResource('/source/substituted.js', { isSubstituted: true }),
+                    analyzedBundleResource('/source/index.js', { targetFilePath: 'index.js' }),
+                    analyzedBundleResource('/source/index.js', { targetFilePath: 'index.js' }),
+                    analyzedBundleResource('/source/substituted.js', {
+                        isSubstituted: true,
+                        targetFilePath: 'substituted.js'
+                    }),
                     analyzedBundleResource('/assets/readme.md', { targetFilePath: 'readme.md' })
                 ]
             }
@@ -400,41 +461,33 @@ suite('packtory-release-plan', function () {
             '/source/index.js',
             '/source/substituted.js'
         ]);
-        assert.deepStrictEqual(expectPlan(result).packages[0]?.changelogSourceFiles, [
-            'assets/readme.md',
-            'source/index.js',
-            'source/substituted.js'
-        ]);
+        assert.deepStrictEqual(expectPlan(result).packages[0]?.changelogSourceFiles, ['source/index.js']);
     });
 
-    test('attributes root package manifest inputs used by generated package manifests', async function () {
-        const validated = validatedReleaseConfig({
-            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
-            commonPackageSettings: {
-                additionalChangelogSourceFiles: ['package-lock.json'],
-                mainPackageJson: { type: 'module', dependencies: { commander: '^14.0.0' } },
-                publishSettings: { access: 'public' },
-                sourcesFolder: 'source'
-            },
-            packages: [{ name: 'pkg-a', roots: { main: { js: 'pkg-a.js' } } }]
-        });
-        const plan = createPlanner({
-            packageNames: ['pkg-a'],
-            buildResults: [buildResultFor()],
-            collectContents() {
-                return [{ filePath: 'package/index.js', content: 'new', isExecutable: false }];
-            }
-        });
+    test('attributes root package manifest inputs when generated package manifests change', async function () {
+        assert.deepStrictEqual(
+            await planManifestAttribution({
+                currentIndex: 'same',
+                currentPackageJson: '{"name":"pkg-a","version":"1.0.1","dependencies":{"commander":"^14.0.0"}}',
+                previousIndex: 'same',
+                previousPackageJson: '{"name":"pkg-a","version":"1.0.0","dependencies":{"commander":"^13.0.0"}}'
+            }),
+            ['package-lock.json', 'package.json', 'source/pkg-a.js']
+        );
+    });
 
-        const result = await plan(validated, async () => {
-            return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(resolvedPackagesFor(validated));
-        });
+    test('skips root package manifest inputs when generated package manifests do not change', async function () {
+        const packageJsonContent = '{"name":"pkg-a","version":"1.0.1","dependencies":{"commander":"^14.0.0"}}';
 
-        assert.deepStrictEqual(expectPlan(result).packages[0]?.changelogSourceFiles, [
-            'package-lock.json',
-            'package.json',
-            'source/pkg-a.js'
-        ]);
+        assert.deepStrictEqual(
+            await planManifestAttribution({
+                currentIndex: 'new',
+                currentPackageJson: packageJsonContent,
+                previousIndex: 'old',
+                previousPackageJson: packageJsonContent
+            }),
+            ['source/pkg-a.js']
+        );
     });
 
     test('plans substitution-driven generated dependency changes as dependency-only releases', async function () {
@@ -478,8 +531,8 @@ suite('packtory-release-plan', function () {
             },
             bundleContents: {
                 'pkg-a': [
-                    analyzedBundleResource('/source/pkg-a.js'),
-                    analyzedBundleResource('/source/pkg-b.js', { isSubstituted: true })
+                    analyzedBundleResource('/source/pkg-a.js', { targetFilePath: 'index.js' }),
+                    analyzedBundleResource('/source/pkg-b.js', { isSubstituted: true, targetFilePath: 'pkg-b.js' })
                 ]
             }
         });

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -103,7 +103,7 @@ function validatedManifestAttributionConfig(): ValidConfigResult {
     return validatedReleaseConfig({
         registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
         commonPackageSettings: {
-            additionalChangelogSourceFiles: ['package-lock.json'],
+            additionalChangelogSourceFiles: ['npm-shrinkwrap.json', 'package-lock.json', 'pnpm-lock.yaml', 'yarn.lock'],
             mainPackageJson: { type: 'module', dependencies: { commander: '^14.0.0' } },
             publishSettings: { access: 'public' },
             sourcesFolder: 'source'
@@ -472,7 +472,14 @@ suite('packtory-release-plan', function () {
                 previousIndex: 'same',
                 previousPackageJson: '{"name":"pkg-a","version":"1.0.0","dependencies":{"commander":"^13.0.0"}}'
             }),
-            ['package-lock.json', 'package.json', 'source/pkg-a.js']
+            [
+                'npm-shrinkwrap.json',
+                'package-lock.json',
+                'package.json',
+                'pnpm-lock.yaml',
+                'source/pkg-a.js',
+                'yarn.lock'
+            ]
         );
     });
 

--- a/source/packtory/packtory-release-plan.ts
+++ b/source/packtory/packtory-release-plan.ts
@@ -12,7 +12,6 @@ import {
 import type { BuildAndPublishResult } from './package-processor.ts';
 import { mapResolvePartialFailure, succeededResultsFrom } from './partial-result.ts';
 import {
-    collectReleasePlanChangelogSourceFiles,
     createReleasePlanPackage,
     type CollectReleaseArtifactFiles,
     type ReleasePlanMapperDependencies
@@ -76,7 +75,7 @@ async function appendPackagePlan(args: {
     );
     args.packages.push(
         await createReleasePlanPackage(args, resolvedPackage.analyzedBundle, args.buildResult, {
-            changelogSourceFiles: collectReleasePlanChangelogSourceFiles(resolvedPackage.resolveOptions),
+            changelogSourceOptions: resolvedPackage.resolveOptions,
             currentGitHead: args.currentGitHead,
             releaseArtifactFiles,
             releaseClassification: classifyPackageRelease(args.buildResult, releaseArtifactFiles).classification

--- a/source/packtory/release-plan.ts
+++ b/source/packtory/release-plan.ts
@@ -1,13 +1,18 @@
-import { bundleRelativePath } from '../common/package-layout.ts';
+import { bundleRelativePath, packageManifestFilePath } from '../common/package-layout.ts';
 import { compareValues } from '../common/sort-values.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import { buildFileSetDiff } from '../report/release-diff/file-set-diff.ts';
 import { canonicalizeReleaseArtifactFiles } from '../bundle-emitter/release-artifact-canonicalizer.ts';
-import type { ReleasePlanPackage, ReleasePlanRegistryMetadata } from './packtory-results.ts';
+import {
+    releaseAnalysisClassification,
+    type ReleasePlanPackage,
+    type ReleasePlanRegistryMetadata
+} from './packtory-results.ts';
 import type { BuildAndPublishResult } from './package-processor.ts';
 import { publishedReleaseArtifactsOf, wasAlreadyPublished } from './published-release-state.ts';
 import {
+    attributeSelectedChangelogSourceFiles,
     attributeChangelogSourceFiles,
     collectManifestChangelogSourceFiles,
     type ChangelogSourceAttributionDependencies
@@ -25,7 +30,7 @@ type ChangelogSourceInputOptions = {
     readonly mainPackageJson: Parameters<typeof collectManifestChangelogSourceFiles>[0];
 };
 type ReleasePlanPackageInput = {
-    readonly changelogSourceFiles: readonly string[];
+    readonly changelogSourceOptions: ChangelogSourceInputOptions;
     readonly currentGitHead: string | undefined;
     readonly releaseClassification: ReleasePlanPackage['releaseClassification'];
     readonly releaseArtifactFiles: readonly FileDescription[];
@@ -37,11 +42,32 @@ function sortedUnique(values: readonly string[]): readonly string[] {
     return Array.from(new Set(values)).toSorted(compareValues);
 }
 
-export function collectReleasePlanChangelogSourceFiles(resolveOptions: ChangelogSourceInputOptions): readonly string[] {
-    return collectManifestChangelogSourceFiles(
-        resolveOptions.mainPackageJson,
-        resolveOptions.additionalChangelogSourceFiles
+function isPackageManifestInputPath(filePath: string): boolean {
+    return ['package-lock.json', 'npm-shrinkwrap.json', 'pnpm-lock.yaml', 'yarn.lock'].includes(filePath);
+}
+
+function collectConfiguredChangelogSourceFiles(
+    additionalSourceFiles: readonly string[],
+    includeManifestInputFiles: boolean
+): readonly string[] {
+    return additionalSourceFiles.filter((filePath) => {
+        return includeManifestInputFiles || !isPackageManifestInputPath(filePath);
+    });
+}
+
+function collectReleasePlanChangelogSourceFiles(
+    resolveOptions: ChangelogSourceInputOptions,
+    changedArtifactFiles: readonly string[]
+): readonly string[] {
+    const includeManifestInputFiles = changedArtifactFiles.includes(packageManifestFilePath);
+    const configuredSourceFiles = collectConfiguredChangelogSourceFiles(
+        resolveOptions.additionalChangelogSourceFiles,
+        includeManifestInputFiles
     );
+    if (!includeManifestInputFiles) {
+        return configuredSourceFiles;
+    }
+    return collectManifestChangelogSourceFiles(resolveOptions.mainPackageJson, configuredSourceFiles);
 }
 
 function packageRelativeFiles(files: readonly FileDescription[]): readonly string[] {
@@ -108,6 +134,32 @@ function changedArtifactFilesFrom(
     ]);
 }
 
+function shouldAttributeAllBundleSources(releaseClassification: ReleasePlanPackage['releaseClassification']): boolean {
+    return (
+        releaseClassification === releaseAnalysisClassification.dependencyOnly ||
+        releaseClassification === releaseAnalysisClassification.unchanged
+    );
+}
+
+async function attributedChangelogSourceFiles(input: {
+    readonly analyzedBundle: AnalyzedBundle;
+    readonly changelogSourceFiles: readonly string[];
+    readonly changedArtifactFiles: readonly string[];
+    readonly dependencies: ReleasePlanMapperDependencies;
+    readonly releaseClassification: ReleasePlanPackage['releaseClassification'];
+}): Promise<readonly string[]> {
+    if (shouldAttributeAllBundleSources(input.releaseClassification)) {
+        return attributeChangelogSourceFiles(input.dependencies, input.analyzedBundle, input.changelogSourceFiles);
+    }
+
+    return attributeSelectedChangelogSourceFiles(
+        input.dependencies,
+        input.analyzedBundle,
+        input.changelogSourceFiles,
+        new Set(input.changedArtifactFiles)
+    );
+}
+
 export async function createReleasePlanPackage(
     dependencies: ReleasePlanMapperDependencies,
     analyzedBundle: AnalyzedBundle,
@@ -116,6 +168,11 @@ export async function createReleasePlanPackage(
 ): Promise<ReleasePlanPackage> {
     const artifactState = artifactStateFrom(buildResult);
     const latestRegistryMetadata = registryMetadataFrom(buildResult);
+    const changedArtifactFiles = changedArtifactFilesFrom(artifactState, buildResult, input.releaseArtifactFiles);
+    const changelogSourceFiles = collectReleasePlanChangelogSourceFiles(
+        input.changelogSourceOptions,
+        changedArtifactFiles
+    );
     return {
         name: buildResult.bundle.name,
         previousVersion: latestRegistryMetadata?.version,
@@ -127,12 +184,14 @@ export async function createReleasePlanPackage(
         currentGitHead: input.currentGitHead,
         latestRegistryMetadata,
         artifactFiles: packageRelativeFiles(input.releaseArtifactFiles),
-        changedArtifactFiles: changedArtifactFilesFrom(artifactState, buildResult, input.releaseArtifactFiles),
+        changedArtifactFiles,
         sourceFiles: sourceFilesFrom(analyzedBundle),
-        changelogSourceFiles: await attributeChangelogSourceFiles(
-            dependencies,
+        changelogSourceFiles: await attributedChangelogSourceFiles({
             analyzedBundle,
-            input.changelogSourceFiles
-        )
+            changedArtifactFiles,
+            changelogSourceFiles,
+            dependencies,
+            releaseClassification: input.releaseClassification
+        })
     };
 }


### PR DESCRIPTION
Narrow release changelog attribution to artifact-affecting inputs so root runtime manifest changes still attribute to affected packages while dev tooling-only changes do not. Also mirror required workflow job statuses while runs are active and finish from completed jobs when the workflow conclusion has not indexed yet.