### PR TITLE
Mirror `release-pr` workflow status progress

### DIFF
--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -157,7 +157,7 @@ function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
             return emptyResponse();
         }
         if (url.pathname === '/repos/owner/repo/actions/runs/11') {
-            return jsonResponse({ conclusion: 'success' });
+            return jsonResponse({ conclusion: 'success', html_url: 'https://run/11' });
         }
         if (url.pathname === '/repos/owner/repo/actions/runs/12') {
             return jsonResponse({ conclusion: null });
@@ -317,12 +317,14 @@ suite('release-pr-github-client', function () {
         assert.deepStrictEqual(await client.readWorkflowRunResult(11), {
             conclusion: 'success',
             databaseId: 11,
-            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }],
+            url: 'https://run/11'
         });
         assert.deepStrictEqual(await client.readWorkflowRunResult(12), {
             conclusion: undefined,
             databaseId: 12,
-            jobs: [{ conclusion: undefined, name: 'Node.js', url: undefined }]
+            jobs: [{ conclusion: undefined, name: 'Node.js', url: undefined }],
+            url: undefined
         });
         assert.deepStrictEqual(
             records.filter((record) => record.method === 'DELETE').map((record) => record.path),
@@ -375,6 +377,8 @@ suite('release-pr-github-client', function () {
             })
         );
         assert.strictEqual(readHeader(records[0]?.headers, 'user-agent'), 'packtory-release-pr');
+        assert.strictEqual(readHeader(records[0]?.headers, 'accept'), 'application/vnd.github+json');
+        assert.strictEqual(readHeader(records[0]?.headers, 'x-github-api-version'), '2022-11-28');
     });
 
     test('creates a release pull request when no open release pull request exists', async function () {

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -48,6 +48,7 @@ type WorkflowRunResult = {
     readonly conclusion: string | undefined;
     readonly databaseId: number;
     readonly jobs: readonly WorkflowJobResult[];
+    readonly url: string | undefined;
 };
 export type ReleasePullRequestGitHubClient = {
     readonly closeOpenReleasePullRequests: (input: {
@@ -113,6 +114,7 @@ type RawCommit = {
 };
 type RawWorkflowRun = ReleaseWorkflowRun & {
     readonly conclusion: string | null;
+    readonly html_url?: string | null | undefined;
     readonly status: string | null;
 };
 type RawWorkflowJob = {
@@ -473,7 +475,8 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
                         name: job.name,
                         url: job.html_url ?? undefined
                     };
-                })
+                }),
+                url: runResponse.data.html_url
             };
         }
     };

--- a/source/command-line-interface/runner/release-pr-workflow-runs.test.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-runs.test.ts
@@ -88,6 +88,126 @@ suite('release-pr-workflow-runs', function () {
         );
     });
 
+    test('ignores newer workflow dispatch runs with mismatched workflow identity fields', function () {
+        assert.strictEqual(
+            findWorkflowRunIdInRuns(
+                [
+                    {
+                        database_id: 20,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        name: 'Continuous Integration',
+                        path: 'enormora/packtory/.github/workflows/continuous-integration.yml',
+                        workflow_id: 101
+                    },
+                    {
+                        database_id: 23,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        name: 'Continuous Integration',
+                        path: 'enormora/packtory/.github/workflows/continuous-integration.yml',
+                        workflow_id: 102
+                    },
+                    {
+                        database_id: 22,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        name: 'Continuous Integration',
+                        path: 'enormora/packtory/.github/workflows/other.yml',
+                        workflow_id: 101
+                    },
+                    {
+                        database_id: 21,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        name: 'Other CI',
+                        path: 'enormora/packtory/.github/workflows/continuous-integration.yml',
+                        workflow_id: 101
+                    }
+                ],
+                workflow,
+                'release-head'
+            ),
+            20
+        );
+    });
+
+    test('chooses the newest matching workflow dispatch run for a head SHA', function () {
+        assert.strictEqual(
+            findWorkflowRunIdInRuns(
+                [
+                    {
+                        database_id: 10,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    },
+                    {
+                        database_id: 12,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    }
+                ],
+                workflow,
+                'release-head'
+            ),
+            12
+        );
+    });
+
+    test('keeps the first matching workflow dispatch run when later matches are older or missing ids', function () {
+        assert.strictEqual(
+            findWorkflowRunIdInRuns(
+                [
+                    {
+                        database_id: 12,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    },
+                    {
+                        database_id: 10,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    },
+                    {
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    }
+                ],
+                workflow,
+                'release-head'
+            ),
+            12
+        );
+    });
+
+    test('replaces a matching workflow dispatch run without an id when a newer identified run appears', function () {
+        assert.strictEqual(
+            findWorkflowRunIdInRuns(
+                [
+                    {
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    },
+                    {
+                        database_id: 12,
+                        event: 'workflow_dispatch',
+                        head_sha: 'release-head',
+                        workflow_id: 101
+                    }
+                ],
+                workflow,
+                'release-head'
+            ),
+            12
+        );
+    });
+
     test('collects defined workflow run ids', function () {
         assert.deepStrictEqual(
             observedWorkflowRunIds([

--- a/source/command-line-interface/runner/release-pr-workflow-runs.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-runs.ts
@@ -31,16 +31,20 @@ function workflowRunPathMatches(run: ReleaseWorkflowRun, workflow: ReleaseWorkfl
     );
 }
 
-function workflowRunIdentityComparisons(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): readonly boolean[] {
-    return [
-        run.workflow_id === undefined || run.workflow_id === null || run.workflow_id === workflow.id,
-        workflowRunPathMatches(run, workflow),
-        run.name === undefined || run.name === null || run.name === workflow.name
-    ];
+function workflowRunIdMatches(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): boolean {
+    return run.workflow_id === undefined || run.workflow_id === null || run.workflow_id === workflow.id;
+}
+
+function workflowRunNameMatches(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): boolean {
+    return run.name === undefined || run.name === null || run.name === workflow.name;
 }
 
 function workflowRunMatchesIdentity(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): boolean {
-    return workflowRunIdentityComparisons(run, workflow).every(Boolean);
+    return (
+        workflowRunIdMatches(run, workflow) &&
+        workflowRunPathMatches(run, workflow) &&
+        workflowRunNameMatches(run, workflow)
+    );
 }
 
 function workflowRunMatchesInput(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow, headSha: string): boolean {
@@ -72,10 +76,13 @@ export function findWorkflowRunIdInRuns(
     workflow: ReleaseWorkflow,
     headSha: string
 ): number | undefined {
-    const run = runs.find((workflowRun) => {
-        return workflowRunMatchesInput(workflowRun, workflow, headSha);
-    });
-    return run === undefined ? undefined : runDatabaseId(run);
+    const matchingRunIds = runs
+        .filter((workflowRun) => {
+            return workflowRunMatchesInput(workflowRun, workflow, headSha);
+        })
+        .map(runDatabaseId)
+        .filter(isDefined);
+    return matchingRunIds.length === 0 ? undefined : Math.max(...matchingRunIds);
 }
 
 export function observedWorkflowRunIds(runs: readonly ReleaseWorkflowRun[]): readonly number[] {

--- a/source/command-line-interface/runner/release-pull-request-ci.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.test.ts
@@ -11,6 +11,10 @@ type WorkflowRunResult = Awaited<ReturnType<ReleasePullRequestGitHubClient['read
 type WorkflowRunLookupInput = Parameters<ReleasePullRequestGitHubClient['findDispatchedWorkflowRun']>[0];
 type StatusInput = Parameters<ReleasePullRequestGitHubClient['createStatus']>[0];
 type StatusSpy = { readonly getCall: (index: number) => { readonly args: readonly unknown[] } };
+type WorkflowJobResult = WorkflowRunResult['jobs'][number];
+
+const workflowRunUrl = 'https://run';
+const nodeJobUrl = 'https://run/job';
 
 function workflowRunFound(runId = 1, observedRunIds: readonly number[] = [runId]): WorkflowRunLookup {
     return { event: 'workflow_dispatch', observedRunIds, runId };
@@ -44,6 +48,23 @@ function readWorkflowRunResultSequence(results: readonly [WorkflowRunResult, ...
     });
 }
 
+function workflowJob(conclusion: string | undefined, name: string, url: string | undefined): WorkflowJobResult {
+    return { conclusion, name, url };
+}
+
+function workflowRunResult(conclusion: string | undefined, jobs: readonly WorkflowJobResult[]): WorkflowRunResult {
+    return {
+        conclusion,
+        databaseId: 1,
+        jobs,
+        url: workflowRunUrl
+    };
+}
+
+function nodeJob(conclusion: string | undefined): WorkflowJobResult {
+    return workflowJob(conclusion, 'Node.js', nodeJobUrl);
+}
+
 function createConfig(requiredStatusContexts: readonly string[] = ['Node.js']): ReleasePullRequestConfig {
     return {
         automationAuthor: 'github-actions[bot]',
@@ -73,11 +94,7 @@ function createClient(overrides: Partial<ReleasePullRequestGitHubClient> = {}): 
         getPullRequest: fake.resolves(undefined as never),
         getPullRequestHead: fake.resolves(undefined as never),
         listCommitPullRequests: fake.resolves([]),
-        readWorkflowRunResult: fake.resolves({
-            conclusion: 'success',
-            databaseId: 1,
-            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
-        }),
+        readWorkflowRunResult: fake.resolves(workflowRunResult('success', [nodeJob('success')])),
         ...overrides
     };
 }
@@ -94,11 +111,7 @@ async function assertTerminalRequiredJobStatus(conclusion: string, state: Status
     const createStatus = fake.resolves(undefined);
     const client = createClient({
         createStatus,
-        readWorkflowRunResult: fake.resolves({
-            conclusion,
-            databaseId: 1,
-            jobs: [{ conclusion, name: 'Node.js', url: 'https://run/job' }]
-        })
+        readWorkflowRunResult: fake.resolves(workflowRunResult(conclusion, [nodeJob(conclusion)]))
     });
 
     assert.strictEqual(
@@ -205,7 +218,7 @@ suite('release-pull-request-ci', function () {
             context: 'Missing job',
             description: 'Missing dispatched release CI job: Missing job.',
             state: 'failure',
-            targetUrl: undefined
+            targetUrl: 'https://run'
         });
     });
 
@@ -227,7 +240,7 @@ suite('release-pull-request-ci', function () {
             context: 'Missing job',
             description: 'Missing dispatched release CI job: Missing job.',
             state: 'failure',
-            targetUrl: undefined
+            targetUrl: 'https://run'
         });
     });
 
@@ -334,19 +347,11 @@ suite('release-pull-request-ci', function () {
     test('mirrors a running required job with its job URL while waiting', async function () {
         const createStatus = fake.resolves(undefined);
         const readWorkflowRunResult = readWorkflowRunResultSequence([
-            {
-                conclusion: undefined,
-                databaseId: 1,
-                jobs: [
-                    { conclusion: undefined, name: 'Other job', url: 'https://run/other-job' },
-                    { conclusion: undefined, name: 'Node.js', url: 'https://run/job' }
-                ]
-            },
-            {
-                conclusion: 'success',
-                databaseId: 1,
-                jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
-            }
+            workflowRunResult(undefined, [
+                workflowJob(undefined, 'Other job', 'https://run/other-job'),
+                nodeJob(undefined)
+            ]),
+            workflowRunResult('success', [nodeJob('success')])
         ]);
 
         assert.strictEqual(
@@ -373,19 +378,42 @@ suite('release-pull-request-ci', function () {
         });
     });
 
+    test('mirrors missing required jobs as running with the workflow run URL while waiting', async function () {
+        const createStatus = fake.resolves(undefined);
+        const readWorkflowRunResult = readWorkflowRunResultSequence([
+            workflowRunResult(undefined, []),
+            workflowRunResult('success', [nodeJob('success')])
+        ]);
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: createClient({ createStatus, readWorkflowRunResult }),
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: fake.resolves(undefined)
+            }),
+            true
+        );
+
+        assertStatusCall(createStatus, 0, {
+            context: 'Node.js',
+            description: 'Dispatched release CI job running.',
+            state: 'pending',
+            targetUrl: 'https://run'
+        });
+        assertStatusCall(createStatus, 1, {
+            context: 'Node.js',
+            description: 'Dispatched release CI job success.',
+            state: 'success',
+            targetUrl: 'https://run/job'
+        });
+    });
+
     test('does not mirror a running status for a completed job', async function () {
         const createStatus = fake.resolves(undefined);
         const readWorkflowRunResult = readWorkflowRunResultSequence([
-            {
-                conclusion: undefined,
-                databaseId: 1,
-                jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
-            },
-            {
-                conclusion: 'success',
-                databaseId: 1,
-                jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
-            }
+            workflowRunResult(undefined, [nodeJob('success')]),
+            workflowRunResult('success', [nodeJob('success')])
         ]);
 
         assert.strictEqual(
@@ -409,15 +437,13 @@ suite('release-pull-request-ci', function () {
 
     test('finishes when required jobs completed before the workflow conclusion is indexed', async function () {
         const createStatus = fake.resolves(undefined);
-        const readWorkflowRunResult = fake.resolves({
-            conclusion: undefined,
-            databaseId: 1,
-            jobs: [
-                { conclusion: 'success', name: 'Node v22', url: 'https://run/node-22' },
-                { conclusion: 'success', name: 'Node v24', url: 'https://run/node-24' },
-                { conclusion: 'success', name: 'Node v26', url: 'https://run/node-26' }
-            ]
-        });
+        const readWorkflowRunResult = fake.resolves(
+            workflowRunResult(undefined, [
+                workflowJob('success', 'Node v22', 'https://run/node-22'),
+                workflowJob('success', 'Node v24', 'https://run/node-24'),
+                workflowJob('success', 'Node v26', 'https://run/node-26')
+            ])
+        );
 
         assert.strictEqual(
             await runConfiguredGitHubActionsCi({
@@ -453,22 +479,14 @@ suite('release-pull-request-ci', function () {
     test('mirrors completed and running required jobs while waiting for remaining jobs', async function () {
         const createStatus = fake.resolves(undefined);
         const readWorkflowRunResult = readWorkflowRunResultSequence([
-            {
-                conclusion: undefined,
-                databaseId: 1,
-                jobs: [
-                    { conclusion: 'success', name: 'Node v22', url: 'https://run/node-22' },
-                    { conclusion: undefined, name: 'Node v24', url: 'https://run/node-24' }
-                ]
-            },
-            {
-                conclusion: undefined,
-                databaseId: 1,
-                jobs: [
-                    { conclusion: 'success', name: 'Node v22', url: 'https://run/node-22' },
-                    { conclusion: 'success', name: 'Node v24', url: 'https://run/node-24' }
-                ]
-            }
+            workflowRunResult(undefined, [
+                workflowJob('success', 'Node v22', 'https://run/node-22'),
+                workflowJob(undefined, 'Node v24', 'https://run/node-24')
+            ]),
+            workflowRunResult(undefined, [
+                workflowJob('success', 'Node v22', 'https://run/node-22'),
+                workflowJob('success', 'Node v24', 'https://run/node-24')
+            ])
         ]);
 
         assert.strictEqual(
@@ -508,7 +526,7 @@ suite('release-pull-request-ci', function () {
     });
 
     test('fails when the dispatched workflow run does not complete', async function () {
-        const readWorkflowRunResult = fake.resolves({ conclusion: undefined, databaseId: 1, jobs: [] });
+        const readWorkflowRunResult = fake.resolves(workflowRunResult(undefined, []));
         const sleep = fake.resolves(undefined);
         await assert.rejects(
             runConfiguredGitHubActionsCi({

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -107,6 +107,13 @@ function workflowStatusDescription(conclusion: string): string {
     return `Dispatched release CI job ${conclusion}.`;
 }
 
+function workflowStatusTargetUrl(
+    runResult: WorkflowRunResult,
+    job: WorkflowRunResult['jobs'][number] | undefined
+): string | undefined {
+    return job?.url ?? runResult.url;
+}
+
 async function mirrorKnownWorkflowStatuses(input: {
     readonly ciConfig: GitHubActionsCiConfig;
     readonly client: ReleasePullRequestGitHubClient;
@@ -117,6 +124,13 @@ async function mirrorKnownWorkflowStatuses(input: {
         input.ciConfig.requiredStatusContexts.map(async (context) => {
             const job = requiredJobResultFor(input.runResult, context);
             if (job === undefined) {
+                await input.client.createStatus({
+                    commitSha: input.headSha,
+                    context,
+                    description: 'Dispatched release CI job running.',
+                    state: 'pending',
+                    targetUrl: input.runResult.url
+                });
                 return;
             }
             if (job.conclusion === undefined) {
@@ -125,7 +139,7 @@ async function mirrorKnownWorkflowStatuses(input: {
                     context,
                     description: 'Dispatched release CI job running.',
                     state: 'pending',
-                    targetUrl: job.url
+                    targetUrl: workflowStatusTargetUrl(input.runResult, job)
                 });
                 return;
             }
@@ -134,7 +148,7 @@ async function mirrorKnownWorkflowStatuses(input: {
                 context,
                 description: workflowStatusDescription(job.conclusion),
                 state: workflowStatusState(job.conclusion),
-                targetUrl: job.url
+                targetUrl: workflowStatusTargetUrl(input.runResult, job)
             });
         })
     );
@@ -174,12 +188,12 @@ type FinalWorkflowStatus = {
     readonly targetUrl: string | undefined;
 };
 
-function incompleteWorkflowStatus(context: string): FinalWorkflowStatus {
+function incompleteWorkflowStatus(context: string, targetUrl: string | undefined): FinalWorkflowStatus {
     return {
         description: missingWorkflowStatusDescription(context),
         passed: false,
         state: 'failure',
-        targetUrl: undefined
+        targetUrl
     };
 }
 
@@ -202,12 +216,13 @@ function completedWorkflowStatus(conclusion: string, targetUrl: string | undefin
 
 function finalWorkflowStatusFor(
     context: string,
-    job: WorkflowRunResult['jobs'][number] | undefined
+    job: WorkflowRunResult['jobs'][number] | undefined,
+    runResult: WorkflowRunResult
 ): FinalWorkflowStatus {
     if (job?.conclusion === undefined) {
-        return incompleteWorkflowStatus(context);
+        return incompleteWorkflowStatus(context, workflowStatusTargetUrl(runResult, job));
     }
-    return completedWorkflowStatus(job.conclusion, job.url);
+    return completedWorkflowStatus(job.conclusion, workflowStatusTargetUrl(runResult, job));
 }
 
 async function mirrorWorkflowStatus(input: {
@@ -217,7 +232,7 @@ async function mirrorWorkflowStatus(input: {
     readonly runResult: WorkflowRunResult;
 }): Promise<boolean> {
     const job = requiredJobResultFor(input.runResult, input.context);
-    const status = finalWorkflowStatusFor(input.context, job);
+    const status = finalWorkflowStatusFor(input.context, job, input.runResult);
     await input.client.createStatus({
         commitSha: input.headSha,
         context: input.context,

--- a/source/command-line-interface/runner/release-pull-request-handler.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.test.ts
@@ -104,7 +104,8 @@ function createReleasePullRequestClient(
         readWorkflowRunResult: fake.resolves({
             conclusion: 'success',
             databaseId: 1,
-            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }]
+            jobs: [{ conclusion: 'success', name: 'Node.js', url: 'https://run/job' }],
+            url: 'https://run'
         }),
         ...overrides
     };


### PR DESCRIPTION
Release PR maintenance now keeps pending statuses linked to the dispatched workflow run while GitHub indexes jobs, then switches them to job URLs as checks appear and complete. Workflow dispatch lookup also prefers the newest matching `workflow_dispatch` run for the exact head SHA and keeps using the resolved workflow id with current REST headers.