### PR TITLE
Fix `release-pr` workflow run lookup ids

### DIFF
--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -136,10 +136,10 @@ function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
         if (url.pathname === '/repos/owner/repo/actions/runs' && url.searchParams.get('event') === 'pull_request') {
             return jsonResponse({
                 workflow_runs: [
-                    { conclusion: 'action_required', database_id: 10, event: 'pull_request', head_sha: 'release-head' },
+                    { conclusion: 'action_required', event: 'pull_request', head_sha: 'release-head', id: 10 },
                     { conclusion: 'action_required', event: 'pull_request', head_sha: 'release-head' },
-                    { conclusion: 'action_required', database_id: 12, event: 'pull_request', head_sha: 'other-head' },
-                    { conclusion: 'success', database_id: 13, event: 'pull_request', head_sha: 'release-head' }
+                    { conclusion: 'action_required', event: 'pull_request', head_sha: 'other-head', id: 12 },
+                    { conclusion: 'success', event: 'pull_request', head_sha: 'release-head', id: 13 }
                 ]
             });
         }
@@ -148,9 +148,7 @@ function createFetch(records: RecordedRequest[]): typeof globalThis.fetch {
             url.searchParams.get('event') === 'workflow_dispatch'
         ) {
             return jsonResponse({
-                workflow_runs: [
-                    { conclusion: 'success', database_id: 11, event: 'workflow_dispatch', head_sha: 'release-head' }
-                ]
+                workflow_runs: [{ conclusion: 'success', event: 'workflow_dispatch', head_sha: 'release-head', id: 11 }]
             });
         }
         if (url.pathname === '/repos/owner/repo/actions/runs/10' && method === 'DELETE') {
@@ -468,57 +466,57 @@ suite('release-pr-github-client', function () {
                 return jsonResponse({
                     workflow_runs: [
                         {
-                            database_id: 20,
                             event: 'workflow_dispatch',
                             head_sha: 'exact-head',
+                            id: 20,
                             name: 'Continuous Integration',
                             path: '.github/workflows/ci.yml',
                             workflow_id: 101
                         },
                         {
-                            database_id: 10,
                             event: 'workflow_dispatch',
                             head_sha: 'suffix-head',
+                            id: 10,
                             name: 'Continuous Integration',
                             path: '.github/workflows/ci.yml',
                             workflow_id: 999
                         },
                         {
-                            database_id: 11,
                             event: 'workflow_dispatch',
                             head_sha: 'suffix-head',
+                            id: 11,
                             name: 'Continuous Integration',
                             path: '.github/workflows/other.yml',
                             workflow_id: 101
                         },
                         {
-                            database_id: 12,
                             event: 'workflow_dispatch',
                             head_sha: 'suffix-head',
+                            id: 12,
                             name: 'Other CI',
                             path: '.github/workflows/ci.yml',
                             workflow_id: 101
                         },
                         {
-                            database_id: 13,
                             event: 'workflow_dispatch',
                             head_sha: 'suffix-head',
+                            id: 13,
                             name: 'Continuous Integration',
                             path: 'owner/repo/.github/workflows/ci.yml',
                             workflow_id: 101
                         },
                         {
-                            database_id: 14,
                             event: 'workflow_dispatch',
                             head_sha: 'null-head',
+                            id: 14,
                             name: null,
                             path: null,
                             workflow_id: null
                         },
                         {
-                            database_id: 15,
                             event: 'workflow_dispatch',
-                            head_sha: 'omitted-head'
+                            head_sha: 'omitted-head',
+                            id: 15
                         }
                     ]
                 });

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -6,7 +6,7 @@ import { createGitHubJsonRequestHeaders } from './github-api-request.ts';
 import {
     findWorkflowRunIdInRuns,
     observedWorkflowRunIds,
-    runDatabaseId,
+    readWorkflowRunId,
     selectReleaseWorkflow,
     workflowMatchesIdentifier,
     type ReleaseWorkflow,
@@ -344,12 +344,12 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
             });
             const blockedRunIds = blockedRuns
                 .map((run) => {
-                    return runDatabaseId(run as RawWorkflowRun);
+                    return readWorkflowRunId(run as RawWorkflowRun);
                 })
                 .filter(isDefined);
-            for (const databaseId of blockedRunIds) {
+            for (const runId of blockedRunIds) {
                 await resolveGitHubResponse(
-                    octokit.rest.actions.deleteWorkflowRun({ ...requestContext, run_id: databaseId })
+                    octokit.rest.actions.deleteWorkflowRun({ ...requestContext, run_id: runId })
                 );
             }
         },

--- a/source/command-line-interface/runner/release-pr-workflow-runs.test.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-runs.test.ts
@@ -53,9 +53,9 @@ suite('release-pr-workflow-runs', function () {
                         workflow_id: 101
                     },
                     {
-                        databaseId: 2,
                         event: 'workflow_dispatch',
                         head_sha: 'release-head',
+                        id: 2,
                         name: 'Continuous Integration',
                         path: 'enormora/packtory/.github/workflows/continuous-integration.yml',
                         workflow_id: 101
@@ -211,11 +211,12 @@ suite('release-pr-workflow-runs', function () {
     test('collects defined workflow run ids', function () {
         assert.deepStrictEqual(
             observedWorkflowRunIds([
-                { database_id: 1, event: 'workflow_dispatch', head_sha: 'release-head' },
+                { id: 1, event: 'workflow_dispatch', head_sha: 'release-head' },
                 { event: 'workflow_dispatch', head_sha: 'release-head' },
-                { databaseId: 2, event: 'workflow_dispatch', head_sha: 'release-head' }
+                { database_id: 2, event: 'workflow_dispatch', head_sha: 'release-head' },
+                { databaseId: 3, event: 'workflow_dispatch', head_sha: 'release-head' }
             ]),
-            [1, 2]
+            [1, 2, 3]
         );
     });
 });

--- a/source/command-line-interface/runner/release-pr-workflow-runs.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-runs.ts
@@ -7,6 +7,7 @@ export type ReleaseWorkflowRun = {
     readonly database_id?: number | undefined;
     readonly event: string;
     readonly head_sha: string;
+    readonly id?: number | undefined;
     readonly name?: string | null | undefined;
     readonly path?: string | null | undefined;
     readonly workflow_id?: number | null | undefined;
@@ -18,8 +19,8 @@ export type WorkflowRunLookupResult = {
     readonly runId: number | undefined;
 };
 
-export function runDatabaseId(run: ReleaseWorkflowRun): number | undefined {
-    return run.database_id ?? run.databaseId;
+export function readWorkflowRunId(workflowRun: ReleaseWorkflowRun): number | undefined {
+    return workflowRun.id ?? workflowRun.database_id ?? workflowRun.databaseId;
 }
 
 function workflowRunPathMatches(run: ReleaseWorkflowRun, workflow: ReleaseWorkflow): boolean {
@@ -80,11 +81,11 @@ export function findWorkflowRunIdInRuns(
         .filter((workflowRun) => {
             return workflowRunMatchesInput(workflowRun, workflow, headSha);
         })
-        .map(runDatabaseId)
+        .map(readWorkflowRunId)
         .filter(isDefined);
     return matchingRunIds.length === 0 ? undefined : Math.max(...matchingRunIds);
 }
 
 export function observedWorkflowRunIds(runs: readonly ReleaseWorkflowRun[]): readonly number[] {
-    return runs.map(runDatabaseId).filter(isDefined);
+    return runs.map(readWorkflowRunId).filter(isDefined);
 }


### PR DESCRIPTION
Packtory now reads the REST Actions workflow run `id` field when matching dispatched release CI runs, while keeping the existing fallback shapes used by older fixtures. This fixes release PR maintenance missing a run that GitHub returned but Packtory could not turn into a usable run id.