### PR TITLE
Create GitHub-signed release PR commits

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,9 +114,11 @@ npx packtory release-pr validate
 npx packtory release-pr authorize-publish
 ```
 
-`release-pr maintain` prepares the changelog commit with the same release planning logic, pushes it to the configured release branch, and creates or updates the release PR. `release-pr validate` checks that release PRs only change configured changelog output files and are not batched with other PRs in a merge queue. `release-pr authorize-publish` lets a publish workflow proceed only when the current commit, or a manually supplied PR number, is a merged valid release PR.
+`release-pr maintain` prepares the changelog commit with the same release planning logic, creates a GitHub-signed commit on the configured release branch, and creates or updates the release PR. `release-pr validate` checks that release PRs only change configured changelog output files and are not batched with other PRs in a merge queue. `release-pr authorize-publish` lets a publish workflow proceed only when the current commit, or a manually supplied PR number, is a merged valid release PR.
 
-The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory dispatches the configured workflow on the release branch, waits for the run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch push already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human push, or another CI system.
+Release PR commits are authored through the GitHub credential from `GH_TOKEN` or `GITHUB_TOKEN`, so GitHub can mark them verified when the credential supports signed API commits. This allows release PRs to merge into branches that require signed commits without local Git signing setup.
+
+The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory dispatches the configured workflow on the release branch, waits for the run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch update already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human update, or another CI system.
 
 For more details about the CLI application have a look at the [full documentation](./source/packages/command-line-interface/readme.md).
 

--- a/source/command-line-interface/runner/github-api-request.ts
+++ b/source/command-line-interface/runner/github-api-request.ts
@@ -1,4 +1,6 @@
-const defaultGitHubApiVersion = '2022-11-28';
+function defaultGitHubApiVersion(): string {
+    return '2022-11-28';
+}
 
 function readReflectedProperty(value: unknown, property: string): unknown {
     return Reflect.get(new Object(value), property) as unknown;
@@ -28,8 +30,16 @@ export function createGitHubJsonRequestHeaders(token: string, userAgent: string)
         accept: 'application/vnd.github+json',
         authorization: `Bearer ${token}`,
         'user-agent': userAgent,
-        'x-github-api-version': defaultGitHubApiVersion
+        'x-github-api-version': defaultGitHubApiVersion()
     };
+}
+
+export async function resolveGitHubResponse<T>(request: Promise<T>): Promise<T> {
+    try {
+        return await request;
+    } catch (error) {
+        throw createGitHubRequestError(error);
+    }
 }
 
 export async function resolveOptionalGitHubResponse<T>(

--- a/source/command-line-interface/runner/release-git-client.test.ts
+++ b/source/command-line-interface/runner/release-git-client.test.ts
@@ -173,6 +173,54 @@ suite('release-git-client', function () {
         });
     });
 
+    suite('readChangedFiles', function () {
+        test('reads added and modified files at the target revision', async function () {
+            const { calls, client } = createGitClientWithRunner(async function (_command, args) {
+                if (args.includes('diff')) {
+                    return { stdout: 'CHANGELOG.md\0packages/pkg-a/CHANGELOG.md\0', stderr: '' };
+                }
+                if (args.includes('target-head:CHANGELOG.md')) {
+                    return { stdout: 'root changelog\n', stderr: '' };
+                }
+                if (args.includes('target-head:packages/pkg-a/CHANGELOG.md')) {
+                    return { stdout: 'package changelog\n', stderr: '' };
+                }
+                throw new Error(`unexpected git args ${args.join(' ')}`);
+            });
+
+            assert.deepStrictEqual(await client.readChangedFiles('base-head', 'target-head'), [
+                {
+                    contentBase64: Buffer.from('root changelog\n', 'utf8').toString('base64'),
+                    kind: 'addition',
+                    path: 'CHANGELOG.md'
+                },
+                {
+                    contentBase64: Buffer.from('package changelog\n', 'utf8').toString('base64'),
+                    kind: 'addition',
+                    path: 'packages/pkg-a/CHANGELOG.md'
+                }
+            ]);
+            assert.deepStrictEqual(calls, [
+                {
+                    command: 'git',
+                    args: [
+                        '-C',
+                        '/repo',
+                        'diff',
+                        '--name-only',
+                        '-z',
+                        '--diff-filter=AM',
+                        'base-head',
+                        'target-head',
+                        '--'
+                    ]
+                },
+                { command: 'git', args: [ '-C', '/repo', 'show', 'target-head:CHANGELOG.md' ] },
+                { command: 'git', args: [ '-C', '/repo', 'show', 'target-head:packages/pkg-a/CHANGELOG.md' ] }
+            ]);
+        });
+    });
+
     suite('remote updates', function () {
         test('pushFollowTags invokes git push with follow-tags', async function () {
             const { calls, client } = createGitClientWithRunner(async function () {

--- a/source/command-line-interface/runner/release-git-client.ts
+++ b/source/command-line-interface/runner/release-git-client.ts
@@ -5,6 +5,12 @@ type ReleaseGitCommandRunner = (
     args: readonly string[]
 ) => Promise<{ readonly stdout: string; readonly stderr: string; }>;
 
+type ReleaseGitFileChange = {
+    readonly contentBase64: string;
+    readonly kind: 'addition';
+    readonly path: string;
+};
+
 export type ReleaseGitClient = {
     readonly commit: (filePaths: readonly string[], message: string) => Promise<void>;
     readonly currentHead: () => Promise<string>;
@@ -13,6 +19,7 @@ export type ReleaseGitClient = {
     readonly ensureTag: (tagName: string, message: string, targetHead: string) => Promise<void>;
     readonly pushHeadToBranch: (branch: string) => Promise<void>;
     readonly pushFollowTags: () => Promise<void>;
+    readonly readChangedFiles: (baseHead: string, targetHead: string) => Promise<readonly ReleaseGitFileChange[]>;
 };
 
 type ReleaseGitClientDependencies = {
@@ -26,6 +33,11 @@ async function runGit(deps: ReleaseGitClientDependencies, args: readonly string[
     return result.stdout.trim();
 }
 
+async function runGitRaw(deps: ReleaseGitClientDependencies, args: readonly string[]): Promise<string> {
+    const result = await deps.runGitCommand('git', [ '-C', deps.repositoryFolder, ...args ]);
+    return result.stdout;
+}
+
 async function readGitOutputResult(
     deps: ReleaseGitClientDependencies,
     args: readonly string[]
@@ -35,6 +47,20 @@ async function readGitOutputResult(
     } catch {
         return { kind: 'missing' };
     }
+}
+
+function splitGitPathOutput(output: string): readonly string[] {
+    return output.split('\0').filter(function (path) {
+        return path.length > 0;
+    });
+}
+
+async function readFileAtRevision(
+    deps: ReleaseGitClientDependencies,
+    revision: string,
+    filePath: string
+): Promise<string> {
+    return runGitRaw(deps, [ 'show', `${revision}:${filePath}` ]);
 }
 
 export function createReleaseGitClient(deps: ReleaseGitClientDependencies): ReleaseGitClient {
@@ -98,6 +124,23 @@ export function createReleaseGitClient(deps: ReleaseGitClientDependencies): Rele
 
         async pushFollowTags() {
             await runGit(deps, [ 'push', '--follow-tags' ]);
+        },
+
+        async readChangedFiles(baseHead, targetHead) {
+            const changedPaths = splitGitPathOutput(
+                await runGit(deps, [ 'diff', '--name-only', '-z', '--diff-filter=AM', baseHead, targetHead, '--' ])
+            );
+            return Promise.all(
+                changedPaths.map(async function (filePath) {
+                    return {
+                        contentBase64: Buffer.from(await readFileAtRevision(deps, targetHead, filePath)).toString(
+                            'base64'
+                        ),
+                        kind: 'addition',
+                        path: filePath
+                    };
+                })
+            );
         }
     };
 }

--- a/source/command-line-interface/runner/release-pr-branch-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import {
+    createReleasePullRequestCommitClient,
+    type CreateCommitOnBranchInput,
+    type ReleasePullRequestCommitClientDependencies
+} from './release-pr-branch-commit.ts';
+
+type GitOperation = {
+    readonly input: Readonly<Record<string, unknown>>;
+    readonly name: string;
+};
+type GraphQLCall = {
+    readonly query: string;
+    readonly variables: Readonly<Record<string, unknown>>;
+};
+type CommitScenarioResult = {
+    readonly graphQLCalls: readonly GraphQLCall[];
+    readonly operations: readonly GitOperation[];
+    readonly releaseHead: string;
+};
+
+const encodedChangelogContent = Buffer.from('updated changelog\n', 'utf8').toString('base64');
+const missingGitHubResourceStatusCode = 404;
+const releaseBranchRef = 'heads/release/packtory';
+
+function createDependencies(
+    currentBranchHead: string | undefined,
+    recordOperation: (operation: GitOperation) => void,
+    recordGraphQLCall: (call: GraphQLCall) => void
+): ReleasePullRequestCommitClientDependencies {
+    return {
+        git: {
+            async createRef(input) {
+                recordOperation({ input, name: 'createRef' });
+                return {};
+            },
+            async getRef(input) {
+                recordOperation({ input, name: 'getRef' });
+                if (currentBranchHead === undefined) {
+                    const error = new Error('Not Found');
+                    Object.assign(error, {
+                        request: {
+                            url: [
+                                'https://api.github.com/repos/owner/repo/git/ref/',
+                                encodeURIComponent(releaseBranchRef)
+                            ]
+                                .join('')
+                        },
+                        status: missingGitHubResourceStatusCode
+                    });
+                    throw error;
+                }
+                return { data: { object: { sha: currentBranchHead } } };
+            },
+            async updateRef(input) {
+                recordOperation({ input, name: 'updateRef' });
+                return {};
+            }
+        },
+        async graphql(query, variables) {
+            recordGraphQLCall({ query, variables });
+            return { createCommitOnBranch: { commit: { oid: 'signed-release-head' } } };
+        },
+        headers: { authorization: 'Bearer token' },
+        owner: 'owner',
+        repo: 'repo',
+        repositoryNameWithOwner: 'owner/repo'
+    };
+}
+
+function createReleaseCommitInput(): CreateCommitOnBranchInput {
+    return {
+        additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
+        branch: 'release/packtory',
+        expectedHeadOid: 'main-head',
+        message: 'Release packages'
+    };
+}
+
+async function createReleaseCommitWithBranchHead(currentBranchHead: string | undefined): Promise<CommitScenarioResult> {
+    const operations: GitOperation[] = [];
+    const graphQLCalls: GraphQLCall[] = [];
+    const client = createReleasePullRequestCommitClient(
+        createDependencies(
+            currentBranchHead,
+            function (operation) {
+                operations.push(operation);
+            },
+            function (call) {
+                graphQLCalls.push(call);
+            }
+        )
+    );
+    return {
+        graphQLCalls,
+        operations,
+        releaseHead: await client.createCommitOnBranch(createReleaseCommitInput())
+    };
+}
+
+suite('release-pr-branch-commit', function () {
+    test('creates GitHub-signed release commits on the release branch', async function () {
+        const { graphQLCalls, operations, releaseHead } = await createReleaseCommitWithBranchHead('old-release-head');
+
+        assert.strictEqual(releaseHead, 'signed-release-head');
+        assert.deepStrictEqual(
+            operations.map(function (operation) {
+                return operation.name;
+            }),
+            [ 'getRef', 'updateRef' ]
+        );
+        assert.deepStrictEqual(operations[0]?.input, {
+            headers: { authorization: 'Bearer token' },
+            owner: 'owner',
+            ref: 'heads/release/packtory',
+            repo: 'repo'
+        });
+        assert.deepStrictEqual(operations[1]?.input, {
+            force: true,
+            headers: { authorization: 'Bearer token' },
+            owner: 'owner',
+            ref: 'heads/release/packtory',
+            repo: 'repo',
+            sha: 'main-head'
+        });
+        assert.deepStrictEqual(graphQLCalls[0]?.variables, {
+            additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
+            branchName: 'release/packtory',
+            expectedHeadOid: 'main-head',
+            headline: 'Release packages',
+            repositoryNameWithOwner: 'owner/repo'
+        });
+        assert.match(graphQLCalls[0].query, /createCommitOnBranch/u);
+    });
+
+    test('creates the release branch before the first GitHub-signed commit', async function () {
+        const { graphQLCalls, operations, releaseHead } = await createReleaseCommitWithBranchHead(undefined);
+
+        assert.strictEqual(releaseHead, 'signed-release-head');
+        assert.deepStrictEqual(
+            operations.map(function (operation) {
+                return operation.name;
+            }),
+            [ 'getRef', 'createRef' ]
+        );
+        assert.deepStrictEqual(operations[1]?.input, {
+            headers: { authorization: 'Bearer token' },
+            owner: 'owner',
+            ref: 'refs/heads/release/packtory',
+            repo: 'repo',
+            sha: 'main-head'
+        });
+        assert.strictEqual(graphQLCalls.length, 1);
+    });
+
+    test('keeps the release branch when it already points at the expected head', async function () {
+        const { graphQLCalls, operations, releaseHead } = await createReleaseCommitWithBranchHead('main-head');
+
+        assert.strictEqual(releaseHead, 'signed-release-head');
+        assert.deepStrictEqual(
+            operations.map(function (operation) {
+                return operation.name;
+            }),
+            [ 'getRef' ]
+        );
+        assert.strictEqual(graphQLCalls.length, 1);
+    });
+
+    test('reports non-missing GitHub ref lookup failures', async function () {
+        const client = createReleasePullRequestCommitClient({
+            ...createDependencies(
+                'main-head',
+                function () {
+                    return undefined;
+                },
+                function () {
+                    return undefined;
+                }
+            ),
+            git: {
+                async createRef() {
+                    return {};
+                },
+                async getRef() {
+                    const error = new Error('Server error');
+                    Object.assign(error, {
+                        request: { url: 'https://api.github.com/repos/owner/repo/git/ref/heads/release%2Fpacktory' },
+                        status: 500
+                    });
+                    throw error;
+                },
+                async updateRef() {
+                    return {};
+                }
+            }
+        });
+
+        await assert.rejects(async function () {
+            await client.createCommitOnBranch(createReleaseCommitInput());
+        }, /GitHub API request failed \(500\) for \/repos\/owner\/repo\/git\/ref\/heads\/release%2Fpacktory/u);
+    });
+});

--- a/source/command-line-interface/runner/release-pr-branch-commit.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.ts
@@ -1,0 +1,139 @@
+import { resolveGitHubResponse, resolveOptionalGitHubResponse } from './github-api-request.ts';
+
+type CreateCommitFileAddition = {
+    readonly contents: string;
+    readonly path: string;
+};
+export type CreateCommitOnBranchInput = {
+    readonly additions: readonly CreateCommitFileAddition[];
+    readonly branch: string;
+    readonly expectedHeadOid: string;
+    readonly message: string;
+};
+export type ReleasePullRequestCommitClient = {
+    readonly createCommitOnBranch: (input: CreateCommitOnBranchInput) => Promise<string>;
+};
+type GitRefInput = {
+    readonly headers: Readonly<Record<string, string>>;
+    readonly owner: string;
+    readonly repo: string;
+    readonly ref: string;
+};
+type CreateRefInput = GitRefInput & {
+    readonly sha: string;
+};
+type UpdateRefInput = CreateRefInput & {
+    readonly force: boolean;
+};
+type GitHubGitApi = {
+    readonly createRef: (input: CreateRefInput) => Promise<unknown>;
+    readonly getRef: (input: GitRefInput) => Promise<{ readonly data: RawGitRef; }>;
+    readonly updateRef: (input: UpdateRefInput) => Promise<unknown>;
+};
+type GitHubGraphQLApi = (
+    query: string,
+    variables: Readonly<Record<string, unknown>>
+) => Promise<CreateCommitOnBranchResponse>;
+export type ReleasePullRequestCommitClientDependencies = {
+    readonly git: GitHubGitApi;
+    readonly graphql: GitHubGraphQLApi;
+    readonly headers: Readonly<Record<string, string>>;
+    readonly owner: string;
+    readonly repo: string;
+    readonly repositoryNameWithOwner: string;
+};
+type RawGitRef = {
+    readonly object: { readonly sha: string; };
+};
+type CreateCommitOnBranchResponse = {
+    readonly createCommitOnBranch: {
+        readonly commit: { readonly oid: string; };
+    };
+};
+
+const missingGitHubResourceStatusCode = 404;
+
+function createCommitOnBranchMutation(): string {
+    return `
+mutation CreateCommitOnBranch(
+  $repositoryNameWithOwner: String!
+  $branchName: String!
+  $expectedHeadOid: GitObjectID!
+  $headline: String!
+  $additions: [FileAddition!]!
+) {
+  createCommitOnBranch(input: {
+    branch: { repositoryNameWithOwner: $repositoryNameWithOwner, branchName: $branchName }
+    message: { headline: $headline }
+    expectedHeadOid: $expectedHeadOid
+    fileChanges: { additions: $additions }
+  }) {
+    commit {
+      oid
+    }
+  }
+}
+`;
+}
+
+export function createReleasePullRequestCommitClient(
+    dependencies: ReleasePullRequestCommitClientDependencies
+): ReleasePullRequestCommitClient {
+    async function readBranchRef(branch: string): Promise<RawGitRef | undefined> {
+        const response = await resolveOptionalGitHubResponse(
+            dependencies.git.getRef({
+                headers: dependencies.headers,
+                owner: dependencies.owner,
+                repo: dependencies.repo,
+                ref: `heads/${branch}`
+            }),
+            missingGitHubResourceStatusCode
+        );
+        return response?.data;
+    }
+
+    async function pointBranchAtHead(branch: string, expectedHeadOid: string): Promise<void> {
+        const branchRef = await readBranchRef(branch);
+        if (branchRef === undefined) {
+            await resolveGitHubResponse(
+                dependencies.git.createRef({
+                    headers: dependencies.headers,
+                    owner: dependencies.owner,
+                    ref: `refs/heads/${branch}`,
+                    repo: dependencies.repo,
+                    sha: expectedHeadOid
+                })
+            );
+            return;
+        }
+        if (branchRef.object.sha === expectedHeadOid) {
+            return;
+        }
+        await resolveGitHubResponse(
+            dependencies.git.updateRef({
+                force: true,
+                headers: dependencies.headers,
+                owner: dependencies.owner,
+                ref: `heads/${branch}`,
+                repo: dependencies.repo,
+                sha: expectedHeadOid
+            })
+        );
+    }
+
+    return {
+        async createCommitOnBranch(input) {
+            await pointBranchAtHead(input.branch, input.expectedHeadOid);
+            const response = await resolveGitHubResponse(
+                dependencies.graphql(createCommitOnBranchMutation(), {
+                    additions: input.additions,
+                    branchName: input.branch,
+                    expectedHeadOid: input.expectedHeadOid,
+                    headline: input.message,
+                    repositoryNameWithOwner: dependencies.repositoryNameWithOwner
+                })
+            );
+            return response.createCommitOnBranch.commit.oid;
+        }
+    };
+}

--- a/source/command-line-interface/runner/release-pr-github-client-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client-commit.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import {
+    captureRequests,
+    createClient,
+    createRecordedRouteFetch,
+    emptyResponse,
+    hasRequestWithBody,
+    jsonResponse,
+    readHeader,
+    routeKey,
+    type RecordedRequest
+} from '../../test-libraries/release-pr-github-client-test-support.ts';
+import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+
+type CommitScenario = {
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly encodedBranchRef: string;
+    readonly encodedContent: string;
+    readonly records: readonly RecordedRequest[];
+};
+
+function createCommitScenario(): CommitScenario {
+    const capturedRequests = captureRequests();
+    const encodedBranchRef = encodeURIComponent('heads/release/packtory');
+    const encodedContent = Buffer.from('changelog\n', 'utf8').toString('base64');
+    const client = createClient(
+        createRecordedRouteFetch(
+            capturedRequests,
+            new Map([
+                [
+                    routeKey('GET', `/repos/owner/repo/git/ref/${encodedBranchRef}`),
+                    function () {
+                        return jsonResponse({ object: { sha: 'old-release-head' } });
+                    }
+                ],
+                [ routeKey('PATCH', `/repos/owner/repo/git/refs/${encodedBranchRef}`), emptyResponse ],
+                [
+                    routeKey('POST', '/graphql'),
+                    function () {
+                        return jsonResponse({
+                            data: { createCommitOnBranch: { commit: { oid: 'signed-release-head' } } }
+                        });
+                    }
+                ]
+            ])
+        )
+    );
+    return { client, encodedBranchRef, encodedContent, records: capturedRequests.records };
+}
+
+suite('release-pr-github-client-commit', function () {
+    test('creates signed release commits through GitHub', async function () {
+        const { client, encodedBranchRef, encodedContent, records } = createCommitScenario();
+        assert.strictEqual(
+            await client.createCommitOnBranch({
+                additions: [ { contents: encodedContent, path: 'CHANGELOG.md' } ],
+                branch: 'release/packtory',
+                expectedHeadOid: 'main-head',
+                message: 'Release packages'
+            }),
+            'signed-release-head'
+        );
+        assert.strictEqual(
+            hasRequestWithBody(records, 'PATCH', `/repos/owner/repo/git/refs/${encodedBranchRef}`, '"sha":"main-head"'),
+            true
+        );
+        assert.strictEqual(
+            hasRequestWithBody(records, 'POST', '/graphql', '"repositoryNameWithOwner":"owner/repo"'),
+            true
+        );
+        assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', `"contents":"${encodedContent}"`), true);
+        assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', 'mutation CreateCommitOnBranch'), true);
+        assert.strictEqual(readHeader(records[0]?.headers, 'accept'), 'application/vnd.github+json');
+        assert.strictEqual(readHeader(records[0]?.headers, 'authorization'), 'Bearer token');
+        assert.strictEqual(readHeader(records[0]?.headers, 'x-github-api-version'), '2022-11-28');
+    });
+});

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -2,7 +2,8 @@ import { isDefined } from 'remeda';
 import { Octokit } from '@octokit/core';
 import { paginateRest } from '@octokit/plugin-paginate-rest';
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
-import { createGitHubJsonRequestHeaders } from './github-api-request.ts';
+import { createGitHubJsonRequestHeaders, resolveGitHubResponse } from './github-api-request.ts';
+import { createReleasePullRequestCommitClient, type CreateCommitOnBranchInput } from './release-pr-branch-commit.ts';
 import {
     findWorkflowRunIdInRuns,
     observedWorkflowRunIds,
@@ -93,6 +94,7 @@ type ReleasePullRequestUpdateInput = {
 };
 export type ReleasePullRequestGitHubClient = {
     readonly closeOpenReleasePullRequests: (input: CloseOpenReleasePullRequestsInput) => Promise<void>;
+    readonly createCommitOnBranch: (input: CreateCommitOnBranchInput) => Promise<string>;
     readonly createOrUpdateReleasePullRequest: (input: CreateOrUpdateReleasePullRequestInput) => Promise<number>;
     readonly createStatus: (input: CreateStatusInput) => Promise<void>;
     readonly deleteActionRequiredPullRequestRuns: (input: DeleteActionRequiredPullRequestRunsInput) => Promise<void>;
@@ -147,6 +149,10 @@ type RequestContext = {
     readonly owner: string;
     readonly repo: string;
 };
+type GitHubRestClientConstructor = ReturnType<
+    typeof Octokit.plugin<typeof Octokit, [typeof restEndpointMethods, typeof paginateRest]>
+>;
+type GitHubRestClientInstance = InstanceType<GitHubRestClientConstructor>;
 
 function labelNames(labels: readonly RawLabel[]): readonly string[] {
     return labels
@@ -168,36 +174,33 @@ function pullRequestIsMerged(pullRequest: RawPullRequest): boolean {
     return pullRequest.merged_at !== undefined && pullRequest.merged_at !== null;
 }
 
-function createGitHubRequestError(error: unknown): Error {
-    const request: unknown = Reflect.get(new Object(error), 'request') as unknown;
-    const requestUrl = String(Reflect.get(new Object(request), 'url') as unknown);
-    const status = String(Reflect.get(new Object(error), 'status') as unknown);
-    const parsedUrl = new URL(requestUrl);
-    const requestPath = `${parsedUrl.pathname}${parsedUrl.search}`;
-    return new Error(`GitHub API request failed (${status}) for ${requestPath}`, { cause: error });
-}
-
-async function resolveGitHubResponse<T>(request: Promise<T>): Promise<T> {
-    try {
-        const response = await request;
-        return response;
-    } catch (error) {
-        throw createGitHubRequestError(error);
-    }
+function createGitHubRestClient(
+    context: GitHubClientContext,
+    requestContext: RequestContext
+): GitHubRestClientInstance {
+    const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
+    return new GitHubRestClient({
+        request: {
+            fetch: context.fetch,
+            headers: requestContext.headers
+        }
+    });
 }
 
 export function createReleasePullRequestGitHubClient(context: GitHubClientContext): ReleasePullRequestGitHubClient {
-    const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
     const requestContext: RequestContext = {
         headers: createGitHubJsonRequestHeaders(context.token, 'packtory-release-pr'),
         owner: context.owner,
         repo: context.repo
     };
-    const octokit = new GitHubRestClient({
-        request: {
-            fetch: context.fetch,
-            headers: requestContext.headers
-        }
+    const octokit = createGitHubRestClient(context, requestContext);
+    const commitClient = createReleasePullRequestCommitClient({
+        git: octokit.rest.git,
+        graphql: octokit.graphql,
+        headers: requestContext.headers,
+        owner: context.owner,
+        repo: context.repo,
+        repositoryNameWithOwner: `${context.owner}/${context.repo}`
     });
 
     async function readPullRequestFiles(pullRequestNumber: number): Promise<readonly string[]> {
@@ -301,6 +304,10 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
                     })
                 );
             }
+        },
+
+        async createCommitOnBranch(input) {
+            return commitClient.createCommitOnBranch(input);
         },
 
         async createOrUpdateReleasePullRequest(input) {

--- a/source/command-line-interface/runner/release-pull-request-handler.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.test.ts
@@ -50,7 +50,8 @@ suite('release-pull-request-handler', function () {
                         ensureClean: fake.resolves(undefined),
                         ensureTag: fake.resolves(undefined),
                         pushHeadToBranch: fake.resolves(undefined),
-                        pushFollowTags: fake.resolves(undefined)
+                        pushFollowTags: fake.resolves(undefined),
+                        readChangedFiles: fake.resolves([])
                     }
                 });
 
@@ -65,23 +66,39 @@ suite('release-pull-request-handler', function () {
 
             test('maintain updates the release PR when changelog content is committed', async function () {
                 const commit = fake.resolves(undefined);
+                const createCommitOnBranch = fake.resolves('signed-release-head');
                 const createOrUpdateReleasePullRequest = fake.resolves(12);
                 const pushHeadToBranch = fake.resolves(undefined);
                 const pushFollowTags = fake.resolves(undefined);
+                const readChangedFiles = fake.resolves([
+                    {
+                        contentBase64: Buffer.from('updated changelog\n', 'utf8').toString('base64'),
+                        kind: 'addition',
+                        path: 'CHANGELOG.md'
+                    }
+                ]);
                 const { dependencies, log } = createReleaseContentDependencies({
                     createReleasePullRequestGitHubClient: fake.returns(
                         createReleasePullRequestClient({
+                            createCommitOnBranch,
                             createOrUpdateReleasePullRequest
                         })
                     ),
-                    gitClient: createChangingReleaseGitClient({ commit, pushFollowTags, pushHeadToBranch })
+                    gitClient: createChangingReleaseGitClient({
+                        commit,
+                        pushFollowTags,
+                        pushHeadToBranch,
+                        readChangedFiles
+                    })
                 });
 
                 assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
                 assertReleasePullRequestWasUpdated({
                     commit,
+                    createCommitOnBranch,
                     createOrUpdateReleasePullRequest,
                     log,
+                    readChangedFiles,
                     pushHeadToBranch,
                     pushFollowTags
                 });
@@ -104,7 +121,7 @@ suite('release-pull-request-handler', function () {
                 });
 
                 assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
-                assert.strictEqual(log.lastCall.args[0], 'Release PR #12 points at release-head');
+                assert.strictEqual(log.lastCall.args[0], 'Release PR #12 points at signed-release-head');
             });
 
             test('maintain reports release preparation failures', async function () {

--- a/source/command-line-interface/runner/release-pull-request-handler.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.ts
@@ -75,6 +75,10 @@ type LoadedReleasePullRequestConfig = {
     readonly config: ReleasePullRequestConfig;
     readonly policyConfig: ReleasePullRequestPolicyConfig;
 };
+type PreparedReleaseCommit = {
+    readonly baseHead: string;
+    readonly localHead: string;
+};
 
 type GitHubMergeGroupEvent = {
     readonly base_sha?: string | undefined;
@@ -224,23 +228,31 @@ async function closeReleaseState(
 
 async function prepareReleasePullRequest(
     dependencies: ReleasePullRequestHandlerDependencies
-): Promise<string | undefined> {
+): Promise<PreparedReleaseCommit | undefined> {
     const originalHead = await dependencies.gitClient.currentHead();
     const releaseExitCode = await runPrepareRelease(dependencies);
     if (releaseExitCode !== 0) {
         throw new Error('Release preparation failed');
     }
     const releaseHead = await dependencies.gitClient.currentHead();
-    return releaseHead === originalHead ? undefined : releaseHead;
+    return releaseHead === originalHead ? undefined : { baseHead: originalHead, localHead: releaseHead };
 }
 
 async function updateReleasePullRequest(
     dependencies: ReleasePullRequestHandlerDependencies,
     client: ReleasePullRequestGitHubClient,
     config: ReleasePullRequestConfig,
-    releaseHead: string
+    releaseCommit: PreparedReleaseCommit
 ): Promise<number> {
-    await dependencies.gitClient.pushHeadToBranch(config.branch);
+    const releaseFiles = await dependencies.gitClient.readChangedFiles(releaseCommit.baseHead, releaseCommit.localHead);
+    const releaseHead = await client.createCommitOnBranch({
+        additions: releaseFiles.map(function (file) {
+            return { contents: file.contentBase64, path: file.path };
+        }),
+        branch: config.branch,
+        expectedHeadOid: releaseCommit.baseHead,
+        message: config.commitSubject
+    });
     const pullRequestNumber = await client.createOrUpdateReleasePullRequest({
         baseBranch: config.defaultBranch,
         body: config.body,
@@ -262,14 +274,14 @@ async function finishReleasePullRequestMaintenance(
     dependencies: ReleasePullRequestHandlerDependencies,
     client: ReleasePullRequestGitHubClient,
     config: ReleasePullRequestConfig,
-    releaseHead: string | undefined
+    releaseCommit: PreparedReleaseCommit | undefined
 ): Promise<number> {
-    if (releaseHead === undefined) {
+    if (releaseCommit === undefined) {
         await closeReleaseState(dependencies, client, config);
         dependencies.log('No release content remains');
         return 0;
     }
-    return updateReleasePullRequest(dependencies, client, config, releaseHead);
+    return updateReleasePullRequest(dependencies, client, config, releaseCommit);
 }
 
 type MaintainReleasePullRequestHandlerDependencies = ReleasePullRequestHandlerDependencies & {
@@ -283,8 +295,8 @@ async function runMaintain(dependencies: MaintainReleasePullRequestHandlerDepend
     }
     const loadedConfig = await loadReleasePullRequestConfig(dependencies);
     const { client } = await createGitHubClient(dependencies);
-    const releaseHead = await prepareReleasePullRequest(dependencies);
-    return finishReleasePullRequestMaintenance(dependencies, client, loadedConfig.config, releaseHead);
+    const releaseCommit = await prepareReleasePullRequest(dependencies);
+    return finishReleasePullRequestMaintenance(dependencies, client, loadedConfig.config, releaseCommit);
 }
 
 function readRequiredEnvironmentVariable(dependencies: ReleasePullRequestHandlerDependencies, name: string): string {

--- a/source/command-line-interface/runner/runner.test.ts
+++ b/source/command-line-interface/runner/runner.test.ts
@@ -118,7 +118,8 @@ suite('runner command routing', function () {
                     ensureClean: fake.resolves(undefined),
                     ensureTag,
                     pushHeadToBranch: fake.resolves(undefined),
-                    pushFollowTags
+                    pushFollowTags,
+                    readChangedFiles: fake.resolves([])
                 }
             });
 

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -39,7 +39,7 @@ packtory <command> [options]
 - **release --tag:** Creates one annotated tag per released package, named `{packageName}@{version}`.
 - **release --push:** Runs `git push --follow-tags`. Requires `--commit` or `--tag`.
 - **release --github-release:** Creates one GitHub Release per package tag. Requires `--tag --push`.
-- **release-pr maintain --no-dry-run:** Writes and commits configured changelogs, pushes the configured release branch, and creates or updates the release PR.
+- **release-pr maintain --no-dry-run:** Writes and commits configured changelogs, creates a GitHub-signed commit on the configured release branch, and creates or updates the release PR.
 - **release-pr validate:** Validates the current GitHub `pull_request` or `merge_group` event against the release PR policy.
 - **release-pr authorize-publish:** Writes `should_publish` and publish target outputs for a workflow that should publish only after a valid release PR merge.
 - **release-pr authorize-publish --release-pull-request &lt;number&gt;:** Authorizes a manual retry from a merged release PR.
@@ -102,14 +102,15 @@ packtory <command> [options]
 
 **Release PR behavior:**
 
-- `release-pr maintain --no-dry-run` runs the changelog commit part of `packtory release`, pushes the result to `releasePullRequest.branch`, creates or updates the release PR, and replaces its labels with `releasePullRequest.label`.
+- `release-pr maintain --no-dry-run` runs the changelog commit part of `packtory release`, creates a GitHub-signed commit on `releasePullRequest.branch` with the GitHub API, creates or updates the release PR, and replaces its labels with `releasePullRequest.label`.
+- Release PR commits are authored through the GitHub credential from `GH_TOKEN` or `GITHUB_TOKEN`, so GitHub can mark them verified when the credential supports signed API commits. This allows release PRs to merge into branches that require signed commits without local Git signing setup.
 - If release planning produces no changelog commit, `maintain` closes the open release PR for that branch and deletes the remote release branch.
 - Release PR settings live in top-level `releasePullRequest`. Defaults are `branch: 'release/packtory'`, `label: 'release'`, `title: 'Prepare release'`, `commitSubject: 'Release packages'`, `defaultBranch: 'main'`, and `automationAuthor: 'github-actions[bot]'`.
 - The release PR policy derives allowed files from `changelog.outputs`. Repository and package changelog files are allowed. GitHub Release outputs are ignored because they do not write repository files.
 - `release-pr validate` accepts normal PRs without a release label. Release-labeled PRs must match the configured branch, title, author, commit subject, base head, and allowed files. Merge groups must not batch release PRs with other PRs.
 - `release-pr authorize-publish` writes GitHub step outputs when `$GITHUB_OUTPUT` exists, otherwise it prints them. Normal commits get `should_publish=false`. A merged valid release PR gets `should_publish=true`, `publish_commit_sha`, `release_commit_sha`, and `release_pull_request_number`.
 - Set `releasePullRequest.githubActionsCi` only for the GitHub Actions `GITHUB_TOKEN` workaround. With `trigger: 'workflow-dispatch'`, `workflowFile`, and `requiredStatusContexts`, `maintain` dispatches CI for the release branch, waits for the exact release commit run, and mirrors the configured job names as commit statuses.
-- Leave `githubActionsCi` unset when the release branch push already triggers normal CI, such as with a GitHub App token, PAT, human push, external automation, or non-GitHub CI.
+- Leave `githubActionsCi` unset when the release branch update already triggers normal CI, such as with a GitHub App token, PAT, human update, external automation, or non-GitHub CI.
 
 **Pack behavior:**
 

--- a/source/test-libraries/release-handler-test-support.ts
+++ b/source/test-libraries/release-handler-test-support.ts
@@ -298,6 +298,9 @@ function createReleaseGitClient(recordReleaseStep: ReleaseStepRecorder): Release
         },
         async pushFollowTags() {
             recordReleaseStep('push');
+        },
+        async readChangedFiles() {
+            return [];
         }
     };
 }

--- a/source/test-libraries/release-pull-request-handler-test-support.ts
+++ b/source/test-libraries/release-pull-request-handler-test-support.ts
@@ -7,6 +7,7 @@ import type { ReleasePullRequestGitHubClient } from '../command-line-interface/r
 import { createBuildReportFixture } from './preview-fixtures.ts';
 import { createFakeFileManager } from './fake-file-manager.ts';
 import {
+    createReleaseGitClientFixture,
     createReleasePullRequestClient,
     createReleasePullRequestConfig
 } from './runner-test-support.ts';
@@ -116,15 +117,7 @@ export function createDependencies(
         },
         fileManager,
         flags: { command: 'authorize-publish', releasePullRequestNumber: undefined },
-        gitClient: {
-            commit: fake.resolves(undefined),
-            currentHead: fake.resolves('head'),
-            deleteRemoteBranch: fake.resolves(undefined),
-            ensureClean: fake.resolves(undefined),
-            ensureTag: fake.resolves(undefined),
-            pushHeadToBranch: fake.resolves(undefined),
-            pushFollowTags: fake.resolves(undefined)
-        },
+        gitClient: createReleaseGitClientFixture({ currentHead: fake.resolves('head') }),
         log(message) {
             log(message);
         },
@@ -155,18 +148,19 @@ export function createChangingReleaseGitClient(
     overrides: Readonly<Partial<ReleasePullRequestHandlerDependencies['gitClient']>> = {}
 ): ReleasePullRequestHandlerDependencies['gitClient'] {
     const heads = [ 'main-head', 'release-head' ];
-    return {
-        commit: fake.resolves(undefined),
+    return createReleaseGitClientFixture({
         async currentHead() {
             return heads.shift() ?? 'release-head';
         },
-        deleteRemoteBranch: fake.resolves(undefined),
-        ensureClean: fake.resolves(undefined),
-        ensureTag: fake.resolves(undefined),
-        pushHeadToBranch: fake.resolves(undefined),
-        pushFollowTags: fake.resolves(undefined),
+        readChangedFiles: fake.resolves([
+            {
+                contentBase64: Buffer.from('updated changelog\n', 'utf8').toString('base64'),
+                kind: 'addition',
+                path: 'CHANGELOG.md'
+            }
+        ]),
         ...overrides
-    };
+    });
 }
 
 export function createReleaseContentDependencies(
@@ -259,15 +253,29 @@ export function createPullRequestHead(
 
 type ReleasePullRequestUpdateAssertion = {
     readonly commit: ReturnType<typeof fake>;
+    readonly createCommitOnBranch: ReturnType<typeof fake>;
     readonly createOrUpdateReleasePullRequest: ReturnType<typeof fake>;
     readonly log: ReturnType<typeof fake>;
+    readonly readChangedFiles: ReturnType<typeof fake>;
     readonly pushHeadToBranch: ReturnType<typeof fake>;
     readonly pushFollowTags: ReturnType<typeof fake>;
 };
 
 export function assertReleasePullRequestWasUpdated(input: ReleasePullRequestUpdateAssertion): void {
     assert.strictEqual(input.commit.callCount, 1);
-    assert.deepStrictEqual(input.pushHeadToBranch.firstCall.args, [ 'release/packtory' ]);
+    assert.deepStrictEqual(input.readChangedFiles.firstCall.args, [ 'main-head', 'release-head' ]);
+    assert.deepStrictEqual(input.createCommitOnBranch.firstCall.args[0], {
+        additions: [
+            {
+                contents: Buffer.from('updated changelog\n', 'utf8').toString('base64'),
+                path: 'CHANGELOG.md'
+            }
+        ],
+        branch: 'release/packtory',
+        expectedHeadOid: 'main-head',
+        message: 'Release packages'
+    });
+    assert.strictEqual(input.pushHeadToBranch.callCount, 0);
     assert.strictEqual(input.pushFollowTags.callCount, 0);
     assert.deepStrictEqual(input.createOrUpdateReleasePullRequest.firstCall.args[0], {
         baseBranch: 'main',
@@ -276,5 +284,5 @@ export function assertReleasePullRequestWasUpdated(input: ReleasePullRequestUpda
         releaseBranch: 'release/packtory',
         title: 'Prepare release'
     });
-    assert.strictEqual(input.log.lastCall.args[0], 'Release PR #12 points at release-head');
+    assert.strictEqual(input.log.lastCall.args[0], 'Release PR #12 points at signed-release-head');
 }

--- a/source/test-libraries/runner-test-support.ts
+++ b/source/test-libraries/runner-test-support.ts
@@ -16,6 +16,7 @@ export const noPublicationOutcome = { type: 'none' } as const;
 type ReleasePullRequestGitHubClientFixture = ReturnType<
     CommandLineInterfaceRunnerDependencies['createReleasePullRequestGitHubClient']
 >;
+type ReleaseGitClientFixture = CommandLineInterfaceRunnerDependencies['releaseGitClient'];
 type RunPreviewOverrides = {
     readonly pageOutput?: SinonSpy;
     readonly log?: SinonSpy;
@@ -105,6 +106,7 @@ function createReleasePullRequestClientFixture(
 ): ReleasePullRequestGitHubClientFixture {
     return {
         closeOpenReleasePullRequests: fake.resolves(undefined),
+        createCommitOnBranch: fake.resolves('signed-release-head'),
         createOrUpdateReleasePullRequest: fake.resolves(1),
         createStatus: fake.resolves(undefined),
         deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
@@ -189,16 +191,24 @@ function readPackageInfo(overrides: Overrides): () => Promise<Readonly<Record<st
         };
 }
 
-function createReleaseGitClient(overrides: Overrides): CommandLineInterfaceRunnerDependencies['releaseGitClient'] {
-    return overrides.releaseGitClient ?? {
+export function createReleaseGitClientFixture(
+    overrides: Readonly<Partial<ReleaseGitClientFixture>> = {}
+): ReleaseGitClientFixture {
+    return {
         commit: fake.resolves(undefined),
         currentHead: fake.resolves('new-head'),
         deleteRemoteBranch: fake.resolves(undefined),
         ensureClean: fake.resolves(undefined),
         ensureTag: fake.resolves(undefined),
         pushHeadToBranch: fake.resolves(undefined),
-        pushFollowTags: fake.resolves(undefined)
+        pushFollowTags: fake.resolves(undefined),
+        readChangedFiles: fake.resolves([]),
+        ...overrides
     };
+}
+
+function createReleaseGitClient(overrides: Overrides): CommandLineInterfaceRunnerDependencies['releaseGitClient'] {
+    return overrides.releaseGitClient ?? createReleaseGitClientFixture();
 }
 
 function createRunnerDependencies(overrides: Overrides): CommandLineInterfaceRunnerDependencies {


### PR DESCRIPTION
This moves release PR branch writes from local `git push` of the prepared commit to GitHub `createCommitOnBranch`. `release-pr maintain` still uses the existing release preparation flow to build the changelog commit, reads its file changes, resets or creates the release branch at the expected base head, and asks GitHub to create the release commit so branch protections that require verified signatures can pass.

It also documents the `GH_TOKEN`/`GITHUB_TOKEN` behavior and expands release PR policy and GitHub client coverage.