### PR TITLE
Make `release-pr maintain` update release branches atomically

### DIFF
--- a/source/command-line-interface/runner/github-api-request.test.ts
+++ b/source/command-line-interface/runner/github-api-request.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { resolveGitHubResponse } from './github-api-request.ts';
+
+function createGitHubError(overrides: Readonly<Record<string, unknown>>): Error {
+    return Object.assign(new Error('GitHub request failed'), {
+        request: { url: 'https://api.github.com/graphql' },
+        status: 403,
+        ...overrides
+    });
+}
+
+async function rejectWith(error: Error): Promise<unknown> {
+    async function fail(): Promise<never> {
+        throw error;
+    }
+    return resolveGitHubResponse(fail());
+}
+
+async function assertRejectedMessage(error: Error, message: string): Promise<void> {
+    await assert.rejects(rejectWith(error), { message });
+}
+
+suite('github-api-request', function () {
+    test('formats failed GitHub API requests without details when none are available', async function () {
+        await assertRejectedMessage(
+            createGitHubError({ message: '' }),
+            'GitHub API request failed (403) for /graphql'
+        );
+    });
+
+    test('ignores empty and non-string GitHub API error details', async function () {
+        await assertRejectedMessage(
+            createGitHubError({
+                errors: [ { message: '' }, { message: 123 }, {} ],
+                message: '',
+                response: {
+                    data: { errors: [ { message: undefined } ], message: 456 },
+                    errors: [ { message: null } ]
+                }
+            }),
+            'GitHub API request failed (403) for /graphql'
+        );
+    });
+
+    test('appends unique GitHub API error details from GraphQL error shapes', async function () {
+        await assertRejectedMessage(
+            createGitHubError({
+                errors: [ { message: 'ruleset rejected the update' }, {} ],
+                message: 'Resource not accessible by integration',
+                response: {
+                    data: {
+                        errors: [ { message: 'branch requires signed commits' } ],
+                        message: 'GraphQL request failed'
+                    },
+                    errors: [ { message: 'secondary GraphQL error' } ]
+                }
+            }),
+            [
+                'GitHub API request failed (403) for /graphql: Resource not accessible by integration',
+                'GraphQL request failed',
+                'ruleset rejected the update',
+                'secondary GraphQL error',
+                'branch requires signed commits'
+            ]
+                .join('; ')
+        );
+    });
+});

--- a/source/command-line-interface/runner/github-api-request.ts
+++ b/source/command-line-interface/runner/github-api-request.ts
@@ -16,9 +16,49 @@ function readGitHubErrorPath(error: unknown): string {
     return `${parsedUrl.pathname}${parsedUrl.search}`;
 }
 
+function readStringProperty(value: unknown, property: string): string | undefined {
+    const propertyValue = readReflectedProperty(value, property);
+    return typeof propertyValue === 'string' && propertyValue.length > 0 ? propertyValue : undefined;
+}
+
+function readGitHubErrorMessages(value: unknown): readonly (string | undefined)[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.map(function (item) {
+        return readStringProperty(item, 'message');
+    });
+}
+
+function uniqueMessages(messages: readonly (string | undefined)[]): readonly string[] {
+    return Array.from(
+        new Set(
+            messages.filter(function (message): message is string {
+                return message !== undefined;
+            })
+        )
+    );
+}
+
+function readGitHubErrorDetails(error: unknown): readonly string[] {
+    const response = readReflectedProperty(error, 'response');
+    const responseData = readReflectedProperty(response, 'data');
+    return uniqueMessages([
+        readStringProperty(error, 'message'),
+        readStringProperty(responseData, 'message'),
+        ...readGitHubErrorMessages(readReflectedProperty(error, 'errors')),
+        ...readGitHubErrorMessages(readReflectedProperty(response, 'errors')),
+        ...readGitHubErrorMessages(readReflectedProperty(responseData, 'errors'))
+    ]);
+}
+
 function createGitHubRequestError(error: unknown): Error {
+    const details = readGitHubErrorDetails(error);
+    const detailText = details.length === 0 ? '' : `: ${details.join('; ')}`;
     return new Error(
-        `GitHub API request failed (${String(readGitHubErrorStatus(error))}) for ${readGitHubErrorPath(error)}`,
+        `GitHub API request failed (${String(readGitHubErrorStatus(error))}) for ${
+            readGitHubErrorPath(error)
+        }${detailText}`,
         {
             cause: error
         }

--- a/source/command-line-interface/runner/release-pr-branch-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.test.ts
@@ -19,37 +19,53 @@ type CommitScenarioResult = {
     readonly operations: readonly GitOperation[];
     readonly releaseHead: string;
 };
+type GraphQLBehavior = 'fail' | 'succeed';
 
 const encodedChangelogContent = Buffer.from('updated changelog\n', 'utf8').toString('base64');
 const missingGitHubResourceStatusCode = 404;
 const releaseBranchRef = 'heads/release/packtory';
+const temporaryReleaseBranch = 'release/packtory/packtory-staging-main-head';
+const temporaryReleaseBranchRef = `heads/${temporaryReleaseBranch}`;
 
 function createDependencies(
     currentBranchHead: string | undefined,
+    graphQLBehavior: GraphQLBehavior,
     recordOperation: (operation: GitOperation) => void,
     recordGraphQLCall: (call: GraphQLCall) => void
 ): ReleasePullRequestCommitClientDependencies {
+    function createMissingRefError(): Error {
+        const error = new Error('Not Found');
+        Object.assign(error, {
+            request: {
+                url: [
+                    'https://api.github.com/repos/owner/repo/git/ref/',
+                    encodeURIComponent(releaseBranchRef)
+                ]
+                    .join('')
+            },
+            status: missingGitHubResourceStatusCode
+        });
+        return error;
+    }
+
     return {
         git: {
             async createRef(input) {
                 recordOperation({ input, name: 'createRef' });
                 return {};
             },
+            async deleteRef(input) {
+                recordOperation({ input, name: 'deleteRef' });
+                return {};
+            },
             async getRef(input) {
                 recordOperation({ input, name: 'getRef' });
+                const { ref } = input;
                 if (currentBranchHead === undefined) {
-                    const error = new Error('Not Found');
-                    Object.assign(error, {
-                        request: {
-                            url: [
-                                'https://api.github.com/repos/owner/repo/git/ref/',
-                                encodeURIComponent(releaseBranchRef)
-                            ]
-                                .join('')
-                        },
-                        status: missingGitHubResourceStatusCode
-                    });
-                    throw error;
+                    throw createMissingRefError();
+                }
+                if (ref === temporaryReleaseBranchRef) {
+                    return { data: { object: { sha: currentBranchHead } } };
                 }
                 return { data: { object: { sha: currentBranchHead } } };
             },
@@ -60,6 +76,15 @@ function createDependencies(
         },
         async graphql(query, variables) {
             recordGraphQLCall({ query, variables });
+            if (graphQLBehavior === 'fail') {
+                const error = new Error('Resource not accessible by integration');
+                Object.assign(error, {
+                    errors: [ { message: 'ref update failed because the token cannot bypass a ruleset' } ],
+                    request: { url: 'https://api.github.com/graphql' },
+                    status: 403
+                });
+                throw error;
+            }
             return { createCommitOnBranch: { commit: { oid: 'signed-release-head' } } };
         },
         headers: { authorization: 'Bearer token' },
@@ -78,12 +103,20 @@ function createReleaseCommitInput(): CreateCommitOnBranchInput {
     };
 }
 
+function createReleaseCommitInputWithHead(expectedHeadOid: string): CreateCommitOnBranchInput {
+    return {
+        ...createReleaseCommitInput(),
+        expectedHeadOid
+    };
+}
+
 async function createReleaseCommitWithBranchHead(currentBranchHead: string | undefined): Promise<CommitScenarioResult> {
     const operations: GitOperation[] = [];
     const graphQLCalls: GraphQLCall[] = [];
     const client = createReleasePullRequestCommitClient(
         createDependencies(
             currentBranchHead,
+            'succeed',
             function (operation) {
                 operations.push(operation);
             },
@@ -108,25 +141,39 @@ suite('release-pr-branch-commit', function () {
             operations.map(function (operation) {
                 return operation.name;
             }),
-            [ 'getRef', 'updateRef' ]
+            [ 'getRef', 'updateRef', 'getRef', 'updateRef', 'deleteRef' ]
         );
         assert.deepStrictEqual(operations[0]?.input, {
             headers: { authorization: 'Bearer token' },
             owner: 'owner',
-            ref: 'heads/release/packtory',
+            ref: temporaryReleaseBranchRef,
             repo: 'repo'
         });
         assert.deepStrictEqual(operations[1]?.input, {
             force: true,
             headers: { authorization: 'Bearer token' },
             owner: 'owner',
-            ref: 'heads/release/packtory',
+            ref: temporaryReleaseBranchRef,
             repo: 'repo',
             sha: 'main-head'
         });
+        assert.deepStrictEqual(operations[3]?.input, {
+            force: true,
+            headers: { authorization: 'Bearer token' },
+            owner: 'owner',
+            ref: releaseBranchRef,
+            repo: 'repo',
+            sha: 'signed-release-head'
+        });
+        assert.deepStrictEqual(operations[4]?.input, {
+            headers: { authorization: 'Bearer token' },
+            owner: 'owner',
+            ref: temporaryReleaseBranchRef,
+            repo: 'repo'
+        });
         assert.deepStrictEqual(graphQLCalls[0]?.variables, {
             additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
-            branchName: 'release/packtory',
+            branchName: temporaryReleaseBranch,
             expectedHeadOid: 'main-head',
             headline: 'Release packages',
             repositoryNameWithOwner: 'owner/repo'
@@ -142,14 +189,21 @@ suite('release-pr-branch-commit', function () {
             operations.map(function (operation) {
                 return operation.name;
             }),
-            [ 'getRef', 'createRef' ]
+            [ 'getRef', 'createRef', 'getRef', 'createRef', 'deleteRef' ]
         );
         assert.deepStrictEqual(operations[1]?.input, {
             headers: { authorization: 'Bearer token' },
             owner: 'owner',
-            ref: 'refs/heads/release/packtory',
+            ref: `refs/heads/${temporaryReleaseBranch}`,
             repo: 'repo',
             sha: 'main-head'
+        });
+        assert.deepStrictEqual(operations[3]?.input, {
+            headers: { authorization: 'Bearer token' },
+            owner: 'owner',
+            ref: 'refs/heads/release/packtory',
+            repo: 'repo',
+            sha: 'signed-release-head'
         });
         assert.strictEqual(graphQLCalls.length, 1);
     });
@@ -162,15 +216,84 @@ suite('release-pr-branch-commit', function () {
             operations.map(function (operation) {
                 return operation.name;
             }),
-            [ 'getRef' ]
+            [ 'getRef', 'getRef', 'updateRef', 'deleteRef' ]
         );
         assert.strictEqual(graphQLCalls.length, 1);
+    });
+
+    test('uses a stable prefix of the expected head in the temporary branch name', async function () {
+        const graphQLCalls: GraphQLCall[] = [];
+        const client = createReleasePullRequestCommitClient(
+            createDependencies(
+                'old-release-head',
+                'succeed',
+                function () {
+                    return undefined;
+                },
+                function (call) {
+                    graphQLCalls.push(call);
+                }
+            )
+        );
+
+        assert.strictEqual(
+            await client.createCommitOnBranch(createReleaseCommitInputWithHead('0123456789abcdef')),
+            'signed-release-head'
+        );
+        assert.strictEqual(
+            graphQLCalls[0]?.variables.branchName,
+            'release/packtory/packtory-staging-0123456789ab'
+        );
+    });
+
+    test('does not move the release branch when GitHub commit creation fails', async function () {
+        const operations: GitOperation[] = [];
+        const graphQLCalls: GraphQLCall[] = [];
+        const client = createReleasePullRequestCommitClient(
+            createDependencies(
+                'old-release-head',
+                'fail',
+                function (operation) {
+                    operations.push(operation);
+                },
+                function (call) {
+                    graphQLCalls.push(call);
+                }
+            )
+        );
+
+        await assert.rejects(
+            async function () {
+                await client.createCommitOnBranch(createReleaseCommitInput());
+            },
+            /GitHub API request failed \(403\) for \/graphql: Resource not accessible by integration; ref update failed because the token cannot bypass a ruleset/u
+        );
+        assert.deepStrictEqual(graphQLCalls[0]?.variables.branchName, temporaryReleaseBranch);
+        assert.deepStrictEqual(
+            operations.map(function (operation) {
+                return operation.name;
+            }),
+            [ 'getRef', 'updateRef', 'deleteRef' ]
+        );
+        assert.strictEqual(
+            operations.some(function (operation) {
+                return operation.name === 'updateRef' && operation.input.ref === releaseBranchRef;
+            }),
+            false
+        );
+        assert.strictEqual(
+            operations.some(function (operation) {
+                return operation.name === 'createRef' && operation.input.ref === 'refs/heads/release/packtory';
+            }),
+            false
+        );
     });
 
     test('reports non-missing GitHub ref lookup failures', async function () {
         const client = createReleasePullRequestCommitClient({
             ...createDependencies(
                 'main-head',
+                'succeed',
                 function () {
                     return undefined;
                 },
@@ -180,6 +303,9 @@ suite('release-pr-branch-commit', function () {
             ),
             git: {
                 async createRef() {
+                    return {};
+                },
+                async deleteRef() {
                     return {};
                 },
                 async getRef() {

--- a/source/command-line-interface/runner/release-pr-branch-commit.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.ts
@@ -27,6 +27,7 @@ type UpdateRefInput = CreateRefInput & {
 };
 type GitHubGitApi = {
     readonly createRef: (input: CreateRefInput) => Promise<unknown>;
+    readonly deleteRef: (input: GitRefInput) => Promise<unknown>;
     readonly getRef: (input: GitRefInput) => Promise<{ readonly data: RawGitRef; }>;
     readonly updateRef: (input: UpdateRefInput) => Promise<unknown>;
 };
@@ -52,6 +53,11 @@ type CreateCommitOnBranchResponse = {
 };
 
 const missingGitHubResourceStatusCode = 404;
+const temporaryBranchHeadLength = 12;
+
+function temporaryBranchName(branch: string, expectedHeadOid: string): string {
+    return `${branch}/packtory-staging-${expectedHeadOid.slice(0, temporaryBranchHeadLength)}`;
+}
 
 function createCommitOnBranchMutation(): string {
     return `
@@ -92,7 +98,7 @@ export function createReleasePullRequestCommitClient(
         return response?.data;
     }
 
-    async function pointBranchAtHead(branch: string, expectedHeadOid: string): Promise<void> {
+    async function pointBranchAtHead(branch: string, targetHeadOid: string): Promise<void> {
         const branchRef = await readBranchRef(branch);
         if (branchRef === undefined) {
             await resolveGitHubResponse(
@@ -101,12 +107,12 @@ export function createReleasePullRequestCommitClient(
                     owner: dependencies.owner,
                     ref: `refs/heads/${branch}`,
                     repo: dependencies.repo,
-                    sha: expectedHeadOid
+                    sha: targetHeadOid
                 })
             );
             return;
         }
-        if (branchRef.object.sha === expectedHeadOid) {
+        if (branchRef.object.sha === targetHeadOid) {
             return;
         }
         await resolveGitHubResponse(
@@ -116,24 +122,43 @@ export function createReleasePullRequestCommitClient(
                 owner: dependencies.owner,
                 ref: `heads/${branch}`,
                 repo: dependencies.repo,
-                sha: expectedHeadOid
+                sha: targetHeadOid
             })
+        );
+    }
+
+    async function deleteBranchRef(branch: string): Promise<void> {
+        await resolveOptionalGitHubResponse(
+            dependencies.git.deleteRef({
+                headers: dependencies.headers,
+                owner: dependencies.owner,
+                repo: dependencies.repo,
+                ref: `heads/${branch}`
+            }),
+            missingGitHubResourceStatusCode
         );
     }
 
     return {
         async createCommitOnBranch(input) {
-            await pointBranchAtHead(input.branch, input.expectedHeadOid);
-            const response = await resolveGitHubResponse(
-                dependencies.graphql(createCommitOnBranchMutation(), {
-                    additions: input.additions,
-                    branchName: input.branch,
-                    expectedHeadOid: input.expectedHeadOid,
-                    headline: input.message,
-                    repositoryNameWithOwner: dependencies.repositoryNameWithOwner
-                })
-            );
-            return response.createCommitOnBranch.commit.oid;
+            const temporaryBranch = temporaryBranchName(input.branch, input.expectedHeadOid);
+            await pointBranchAtHead(temporaryBranch, input.expectedHeadOid);
+            try {
+                const response = await resolveGitHubResponse(
+                    dependencies.graphql(createCommitOnBranchMutation(), {
+                        additions: input.additions,
+                        branchName: temporaryBranch,
+                        expectedHeadOid: input.expectedHeadOid,
+                        headline: input.message,
+                        repositoryNameWithOwner: dependencies.repositoryNameWithOwner
+                    })
+                );
+                const releaseHead = response.createCommitOnBranch.commit.oid;
+                await pointBranchAtHead(input.branch, releaseHead);
+                return releaseHead;
+            } finally {
+                await deleteBranchRef(temporaryBranch);
+            }
         }
     };
 }

--- a/source/command-line-interface/runner/release-pr-github-client-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client-commit.test.ts
@@ -17,24 +17,34 @@ type CommitScenario = {
     readonly client: ReleasePullRequestGitHubClient;
     readonly encodedBranchRef: string;
     readonly encodedContent: string;
+    readonly encodedTemporaryBranchRef: string;
     readonly records: readonly RecordedRequest[];
 };
 
 function createCommitScenario(): CommitScenario {
     const capturedRequests = captureRequests();
     const encodedBranchRef = encodeURIComponent('heads/release/packtory');
+    const encodedTemporaryBranchRef = encodeURIComponent('heads/release/packtory/packtory-staging-main-head');
     const encodedContent = Buffer.from('changelog\n', 'utf8').toString('base64');
     const client = createClient(
         createRecordedRouteFetch(
             capturedRequests,
             new Map([
                 [
+                    routeKey('GET', `/repos/owner/repo/git/ref/${encodedTemporaryBranchRef}`),
+                    function () {
+                        return jsonResponse({ object: { sha: 'old-temporary-head' } });
+                    }
+                ],
+                [ routeKey('PATCH', `/repos/owner/repo/git/refs/${encodedTemporaryBranchRef}`), emptyResponse ],
+                [ routeKey('PATCH', `/repos/owner/repo/git/refs/${encodedBranchRef}`), emptyResponse ],
+                [
                     routeKey('GET', `/repos/owner/repo/git/ref/${encodedBranchRef}`),
                     function () {
                         return jsonResponse({ object: { sha: 'old-release-head' } });
                     }
                 ],
-                [ routeKey('PATCH', `/repos/owner/repo/git/refs/${encodedBranchRef}`), emptyResponse ],
+                [ routeKey('DELETE', `/repos/owner/repo/git/refs/${encodedTemporaryBranchRef}`), emptyResponse ],
                 [
                     routeKey('POST', '/graphql'),
                     function () {
@@ -46,12 +56,40 @@ function createCommitScenario(): CommitScenario {
             ])
         )
     );
-    return { client, encodedBranchRef, encodedContent, records: capturedRequests.records };
+    return { client, encodedBranchRef, encodedContent, encodedTemporaryBranchRef, records: capturedRequests.records };
+}
+
+function assertBranchWasMoved(records: readonly RecordedRequest[], encodedBranchRef: string, sha: string): void {
+    assert.strictEqual(
+        hasRequestWithBody(records, 'PATCH', `/repos/owner/repo/git/refs/${encodedBranchRef}`, `"sha":"${sha}"`),
+        true
+    );
+}
+
+function assertBranchWasDeleted(records: readonly RecordedRequest[], encodedBranchRef: string): void {
+    assert.strictEqual(
+        records.some(function (record) {
+            return record.method === 'DELETE' && record.path === `/repos/owner/repo/git/refs/${encodedBranchRef}`;
+        }),
+        true
+    );
+}
+
+function assertGraphQLCommitRequest(records: readonly RecordedRequest[], encodedContent: string): void {
+    assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', '"repositoryNameWithOwner":"owner/repo"'), true);
+    assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', `"contents":"${encodedContent}"`), true);
+    assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', 'mutation CreateCommitOnBranch'), true);
+}
+
+function assertGitHubHeaders(records: readonly RecordedRequest[]): void {
+    assert.strictEqual(readHeader(records[0]?.headers, 'accept'), 'application/vnd.github+json');
+    assert.strictEqual(readHeader(records[0]?.headers, 'authorization'), 'Bearer token');
+    assert.strictEqual(readHeader(records[0]?.headers, 'x-github-api-version'), '2022-11-28');
 }
 
 suite('release-pr-github-client-commit', function () {
     test('creates signed release commits through GitHub', async function () {
-        const { client, encodedBranchRef, encodedContent, records } = createCommitScenario();
+        const { client, encodedBranchRef, encodedContent, encodedTemporaryBranchRef, records } = createCommitScenario();
         assert.strictEqual(
             await client.createCommitOnBranch({
                 additions: [ { contents: encodedContent, path: 'CHANGELOG.md' } ],
@@ -61,18 +99,10 @@ suite('release-pr-github-client-commit', function () {
             }),
             'signed-release-head'
         );
-        assert.strictEqual(
-            hasRequestWithBody(records, 'PATCH', `/repos/owner/repo/git/refs/${encodedBranchRef}`, '"sha":"main-head"'),
-            true
-        );
-        assert.strictEqual(
-            hasRequestWithBody(records, 'POST', '/graphql', '"repositoryNameWithOwner":"owner/repo"'),
-            true
-        );
-        assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', `"contents":"${encodedContent}"`), true);
-        assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', 'mutation CreateCommitOnBranch'), true);
-        assert.strictEqual(readHeader(records[0]?.headers, 'accept'), 'application/vnd.github+json');
-        assert.strictEqual(readHeader(records[0]?.headers, 'authorization'), 'Bearer token');
-        assert.strictEqual(readHeader(records[0]?.headers, 'x-github-api-version'), '2022-11-28');
+        assertBranchWasMoved(records, encodedTemporaryBranchRef, 'main-head');
+        assertBranchWasMoved(records, encodedBranchRef, 'signed-release-head');
+        assertBranchWasDeleted(records, encodedTemporaryBranchRef);
+        assertGraphQLCommitRequest(records, encodedContent);
+        assertGitHubHeaders(records);
     });
 });

--- a/source/command-line-interface/runner/release-pr-github-client-responses.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client-responses.test.ts
@@ -66,7 +66,7 @@ suite('release-pr-github-client responses', function () {
                 assert.ok(error instanceof Error);
                 assert.strictEqual(
                     error.message,
-                    'GitHub API request failed (401) for /repos/owner/repo/branches/main'
+                    'GitHub API request failed (401) for /repos/owner/repo/branches/main: Bad credentials'
                 );
                 assert.ok(error.cause instanceof Error);
                 return true;


### PR DESCRIPTION
`release-pr maintain` now creates the GitHub signed commit on a temporary branch and only moves the configured release branch after the mutation succeeds. GitHub API errors now include response details, so `/graphql` failures expose permission, ruleset, or token messages instead of only the status and path.
