### PR TITLE
Speed up mutation testing with full `concurrency` and incremental local runs

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,6 +46,9 @@ test-mutation:
     stryker run
     node --experimental-strip-types --enable-source-maps ./source/build-support/mutation-timeout/check-mutation-timeouts.entry-point.ts
 
+test-mutation-incremental *ARGS:
+    stryker run --incremental {{ARGS}}
+
 test-integration:
     mocha --config mocha.config.integration-tests.json
 

--- a/source/common/code-files.ts
+++ b/source/common/code-files.ts
@@ -8,7 +8,7 @@ export function isDeclarationCodeFile(targetFilePath: string): boolean {
 }
 
 const textDiffablePatterns: readonly RegExp[] = [
-    /(?:\.d\.ts|\.[cm]?[jt]sx?)$/,
+    codeFilePattern,
     /\.json$/,
     /\.md$/,
     /\.txt$/,

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -5,6 +5,7 @@
     "tempDirName": "target/.stryker-tmp",
     "allowConsoleColors": false,
     "concurrency": "100%",
+    "incrementalFile": "target/stryker-incremental.json",
     "mochaOptions": {
         "no-package": true,
         "no-opts": true,

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -4,7 +4,7 @@
     "coverageAnalysis": "perTest",
     "tempDirName": "target/.stryker-tmp",
     "allowConsoleColors": false,
-    "concurrency": "50%",
+    "concurrency": "100%",
     "mochaOptions": {
         "no-package": true,
         "no-opts": true,


### PR DESCRIPTION
Speeds up mutation testing without changing what it verifies (no `ignoreStatic`, no mutate-exclusions, no threshold changes).

The main lever: `concurrency` was `50%`, so on the 4-vCPU CI runner Stryker started only two of the four workers and left half the machine idle. Since the run is dominated by static mutants that each rerun the whole suite and scale with the number of test-runner processes, `100%` roughly halves the CI run (measured ~5m56s at two runners versus ~3m31s at four on a comparable machine).

Alongside that, a local-only `just test-mutation-incremental` recipe lets contributors rerun only the mutants their change touches; CI keeps calling the arg-less `just test-mutation`, which never passes `--incremental` and always does the authoritative full run. Also collapses a regex that was duplicated within `source/common/code-files.ts` into a single definition.
