### PR TITLE
Fix `release-pr maintain` GraphQL authentication

### DIFF
--- a/source/command-line-interface/runner/github-api-request.ts
+++ b/source/command-line-interface/runner/github-api-request.ts
@@ -65,12 +65,21 @@ function createGitHubRequestError(error: unknown): Error {
     );
 }
 
-export function createGitHubJsonRequestHeaders(token: string, userAgent: string): Readonly<Record<string, string>> {
-    return {
+export function createGitHubJsonRequestHeaders(
+    token: string | undefined,
+    userAgent: string
+): Readonly<Record<string, string>> {
+    const headers = {
         accept: 'application/vnd.github+json',
-        authorization: `Bearer ${token}`,
         'user-agent': userAgent,
         'x-github-api-version': defaultGitHubApiVersion()
+    };
+    if (token === undefined) {
+        return headers;
+    }
+    return {
+        ...headers,
+        authorization: `Bearer ${token}`
     };
 }
 

--- a/source/command-line-interface/runner/release-pr-branch-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.test.ts
@@ -11,6 +11,7 @@ type GitOperation = {
     readonly name: string;
 };
 type GraphQLCall = {
+    readonly headers: Readonly<Record<string, string>>;
     readonly query: string;
     readonly variables: Readonly<Record<string, unknown>>;
 };
@@ -40,6 +41,15 @@ function createMissingRefError(ref: string): Error {
         status: missingGitHubResourceStatusCode
     });
     return error;
+}
+
+function createGraphQLCall(query: string, parameters: Readonly<Record<string, unknown>>): GraphQLCall {
+    const { headers, ...variables } = parameters;
+    return {
+        headers: headers as Readonly<Record<string, string>>,
+        query,
+        variables
+    };
 }
 
 function createDependencies(
@@ -74,8 +84,8 @@ function createDependencies(
                 return {};
             }
         },
-        async graphql(query, variables) {
-            recordGraphQLCall({ query, variables });
+        async graphql(query, parameters) {
+            recordGraphQLCall(createGraphQLCall(query, parameters));
             if (graphQLBehavior === 'fail') {
                 const error = new Error('Resource not accessible by integration');
                 Object.assign(error, {
@@ -132,6 +142,21 @@ async function createReleaseCommitWithBranchHead(currentBranchHead: string | und
     };
 }
 
+function assertCreateCommitGraphQLCall(call: GraphQLCall | undefined): void {
+    if (call === undefined) {
+        throw new Error('Expected a GraphQL call');
+    }
+    assert.deepStrictEqual(call.variables, {
+        additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
+        branchName: temporaryReleaseBranch,
+        expectedHeadOid: 'main-head',
+        headline: 'Release packages',
+        repositoryNameWithOwner: 'owner/repo'
+    });
+    assert.deepStrictEqual(call.headers, { authorization: 'Bearer token' });
+    assert.match(call.query, /createCommitOnBranch/u);
+}
+
 suite('release-pr-branch-commit', function () {
     test('creates GitHub-signed release commits on the release branch', async function () {
         const { graphQLCalls, operations, releaseHead } = await createReleaseCommitWithBranchHead('old-release-head');
@@ -171,14 +196,7 @@ suite('release-pr-branch-commit', function () {
             ref: temporaryReleaseBranchRef,
             repo: 'repo'
         });
-        assert.deepStrictEqual(graphQLCalls[0]?.variables, {
-            additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
-            branchName: temporaryReleaseBranch,
-            expectedHeadOid: 'main-head',
-            headline: 'Release packages',
-            repositoryNameWithOwner: 'owner/repo'
-        });
-        assert.match(graphQLCalls[0].query, /createCommitOnBranch/u);
+        assertCreateCommitGraphQLCall(graphQLCalls[0]);
     });
 
     test('creates the release branch before the first GitHub-signed commit', async function () {
@@ -321,8 +339,8 @@ suite('release-pr-branch-commit', function () {
                     return {};
                 }
             },
-            async graphql(query, variables) {
-                events.push(`graphql:${String(variables.branchName)}`);
+            async graphql(query, parameters) {
+                events.push(`graphql:${String(parameters.branchName)}`);
                 assert.match(query, /createCommitOnBranch/u);
                 return { createCommitOnBranch: { commit: { oid: 'signed-release-head' } } };
             }

--- a/source/command-line-interface/runner/release-pr-branch-commit.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.ts
@@ -34,7 +34,7 @@ type GitHubGitApi = {
 };
 type GitHubGraphQLApi = (
     query: string,
-    variables: Readonly<Record<string, unknown>>
+    parameters: Readonly<Record<string, unknown>>
 ) => Promise<CreateCommitOnBranchResponse>;
 export type ReleasePullRequestCommitClientDependencies = {
     readonly git: GitHubGitApi;
@@ -165,6 +165,7 @@ export function createReleasePullRequestCommitClient(
                         additions: input.additions,
                         branchName: temporaryBranch,
                         expectedHeadOid: input.expectedHeadOid,
+                        headers: dependencies.headers,
                         headline: input.message,
                         repositoryNameWithOwner: dependencies.repositoryNameWithOwner
                     })

--- a/source/command-line-interface/runner/release-pr-github-client-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client-commit.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import {
     captureRequests,
-    createClient,
+    createClientWithToken,
     createRecordedRouteFetch,
     emptyResponse,
     hasRequestWithBody,
@@ -21,14 +21,14 @@ type CommitScenario = {
     readonly records: readonly RecordedRequest[];
 };
 
-function createCommitScenario(): CommitScenario {
+function createCommitScenarioWithToken(token: string | undefined): CommitScenario {
     const capturedRequests = captureRequests();
     const encodedBranchRef = encodeURIComponent('heads/release/packtory');
     const encodedTemporaryBranchRef = encodeURIComponent(
         'heads/packtory-release-pr-staging-release-packtory-ebb84e32ba80-main-head'
     );
     const encodedContent = Buffer.from('changelog\n', 'utf8').toString('base64');
-    const client = createClient(
+    const client = createClientWithToken(
         createRecordedRouteFetch(
             capturedRequests,
             new Map([
@@ -56,9 +56,14 @@ function createCommitScenario(): CommitScenario {
                     }
                 ]
             ])
-        )
+        ),
+        token
     );
     return { client, encodedBranchRef, encodedContent, encodedTemporaryBranchRef, records: capturedRequests.records };
+}
+
+function createCommitScenario(): CommitScenario {
+    return createCommitScenarioWithToken('token');
 }
 
 function assertBranchWasMoved(records: readonly RecordedRequest[], encodedBranchRef: string, sha: string): void {
@@ -83,10 +88,21 @@ function assertGraphQLCommitRequest(records: readonly RecordedRequest[], encoded
     assert.strictEqual(hasRequestWithBody(records, 'POST', '/graphql', 'mutation CreateCommitOnBranch'), true);
 }
 
+function findGraphQLRequest(records: readonly RecordedRequest[]): RecordedRequest {
+    const request = records.find(function (record) {
+        return record.method === 'POST' && record.path === '/graphql';
+    });
+    if (request === undefined) {
+        throw new Error('Expected a GraphQL request');
+    }
+    return request;
+}
+
 function assertGitHubHeaders(records: readonly RecordedRequest[]): void {
     assert.strictEqual(readHeader(records[0]?.headers, 'accept'), 'application/vnd.github+json');
     assert.strictEqual(readHeader(records[0]?.headers, 'authorization'), 'Bearer token');
     assert.strictEqual(readHeader(records[0]?.headers, 'x-github-api-version'), '2022-11-28');
+    assert.strictEqual(readHeader(findGraphQLRequest(records).headers, 'authorization'), 'Bearer token');
 }
 
 suite('release-pr-github-client-commit', function () {
@@ -106,5 +122,21 @@ suite('release-pr-github-client-commit', function () {
         assertBranchWasDeleted(records, encodedTemporaryBranchRef);
         assertGraphQLCommitRequest(records, encodedContent);
         assertGitHubHeaders(records);
+    });
+
+    test('creates signed release commits without authentication when no token is set', async function () {
+        const { client, encodedContent, records } = createCommitScenarioWithToken(undefined);
+
+        assert.strictEqual(
+            await client.createCommitOnBranch({
+                additions: [ { contents: encodedContent, path: 'CHANGELOG.md' } ],
+                branch: 'release/packtory',
+                expectedHeadOid: 'main-head',
+                message: 'Release packages'
+            }),
+            'signed-release-head'
+        );
+        assert.strictEqual(readHeader(records[0]?.headers, 'authorization'), undefined);
+        assert.strictEqual(readHeader(findGraphQLRequest(records).headers, 'authorization'), undefined);
     });
 });

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -111,7 +111,7 @@ type GitHubClientContext = {
     readonly fetch: typeof globalThis.fetch;
     readonly owner: string;
     readonly repo: string;
-    readonly token: string;
+    readonly token: string | undefined;
 };
 
 type RawLabel = { readonly name?: string | null | undefined; };

--- a/source/command-line-interface/runner/release-pull-request-handler.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.test.ts
@@ -174,9 +174,9 @@ suite('release-pull-request-handler', function () {
                 assert.strictEqual(log.lastCall.args[0], 'The loaded config is invalid for release PR management');
             });
 
-            test('maintain rejects missing GitHub tokens before creating a client', async function () {
-                const createReleasePullRequestGitHubClient = fake();
-                const { dependencies, log } = createDependencies({
+            test('maintain creates an unauthenticated GitHub client when no token is set', async function () {
+                const createReleasePullRequestGitHubClient = fake.returns(createReleasePullRequestClient({}));
+                const { dependencies } = createDependencies({
                     createReleasePullRequestGitHubClient,
                     flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined },
                     readEnvironmentVariable(name) {
@@ -184,9 +184,12 @@ suite('release-pull-request-handler', function () {
                     }
                 });
 
-                assert.strictEqual(await runReleasePullRequestHandler(dependencies), 1);
-                assert.strictEqual(log.lastCall.args[0], 'GH_TOKEN or GITHUB_TOKEN must be set');
-                assert.strictEqual(createReleasePullRequestGitHubClient.callCount, 0);
+                assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+                assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+                    owner: 'owner',
+                    repo: 'repo',
+                    token: undefined
+                });
             });
 
             test('maintain uses GITHUB_TOKEN and package repository when GitHub repository env is absent', async function () {

--- a/source/command-line-interface/runner/release-pull-request-handler.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.ts
@@ -47,7 +47,7 @@ type ReleasePullRequestFlags = ReleasePullRequestWriteFlags | ValidateReleasePul
 type GitHubClientContext = {
     readonly owner: string;
     readonly repo: string;
-    readonly token: string;
+    readonly token: string | undefined;
 };
 
 export type ReleasePullRequestHandlerDependencies = {
@@ -106,13 +106,11 @@ function formatHandlerError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
 
-function readGitHubToken(dependencies: Pick<ReleasePullRequestHandlerDependencies, 'readEnvironmentVariable'>): string {
-    const token = dependencies.readEnvironmentVariable('GH_TOKEN') ??
+function readGitHubToken(
+    dependencies: Pick<ReleasePullRequestHandlerDependencies, 'readEnvironmentVariable'>
+): string | undefined {
+    return dependencies.readEnvironmentVariable('GH_TOKEN') ??
         dependencies.readEnvironmentVariable('GITHUB_TOKEN');
-    if (token === undefined) {
-        throw new Error('GH_TOKEN or GITHUB_TOKEN must be set');
-    }
-    return token;
 }
 
 function parseGitHubRepositoryName(repositoryName: string): GitHubRepositoryNameParts {

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -30,16 +30,23 @@ import { runReleaseHandler } from './release-handler.ts';
 import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
 import { runReleasePullRequestHandler } from './release-pull-request-handler.ts';
 
-type GitHubClientContext = {
+type GitHubReleaseClientContext = {
     readonly owner: string;
     readonly repo: string;
     readonly token: string;
 };
+type ReleasePullRequestGitHubClientContext = {
+    readonly owner: string;
+    readonly repo: string;
+    readonly token: string | undefined;
+};
 
 export type CommandLineInterfaceRunnerDependencies = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
-    readonly createGitHubReleaseClient: (context: GitHubClientContext) => GitHubReleaseClient;
-    readonly createReleasePullRequestGitHubClient: (context: GitHubClientContext) => ReleasePullRequestGitHubClient;
+    readonly createGitHubReleaseClient: (context: GitHubReleaseClientContext) => GitHubReleaseClient;
+    readonly createReleasePullRequestGitHubClient: (
+        context: ReleasePullRequestGitHubClientContext
+    ) => ReleasePullRequestGitHubClient;
     readonly currentDate: () => Date;
     readonly packtory: Packtory;
     readonly progressBroadcaster: ProgressBroadcastConsumer;

--- a/source/test-libraries/release-pr-github-client-test-support.ts
+++ b/source/test-libraries/release-pr-github-client-test-support.ts
@@ -80,13 +80,20 @@ export function requestHasSearchParameter(record: RecordedRequest, name: string,
     return searchParameters.get(name) === value;
 }
 
-export function createClient(fetchImplementation: typeof globalThis.fetch): ReleasePullRequestGitHubClient {
+export function createClientWithToken(
+    fetchImplementation: typeof globalThis.fetch,
+    token: string | undefined
+): ReleasePullRequestGitHubClient {
     return createReleasePullRequestGitHubClient({
         fetch: fetchImplementation,
         owner: 'owner',
         repo: 'repo',
-        token: 'token'
+        token
     });
+}
+
+export function createClient(fetchImplementation: typeof globalThis.fetch): ReleasePullRequestGitHubClient {
+    return createClientWithToken(fetchImplementation, 'token');
 }
 
 export function hasRequestWithBody(


### PR DESCRIPTION
This routes the release PR GitHub request headers into the `createCommitOnBranch` GraphQL mutation, so `GH_TOKEN` and `GITHUB_TOKEN` authenticate the signed release commit request. Release PR maintenance can still run without either token, in which case REST and GraphQL requests are sent without authorization headers.