### PR TITLE
Make `release` retry finalized npm publishes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,8 @@ npx packtory release --write-changelog --commit --publish --tag --push --github-
 
 `release` writes changelogs, commits them, recomputes the final plan, publishes directly to npm, creates annotated `{packageName}@{version}` tags, pushes with `git push --follow-tags`, and creates GitHub Releases. It requires a clean Git index and worktree before writing. Commit identity and push credentials come from normal Git config and environment, such as `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, and your configured Git credential helper or CI checkout credentials.
 
+If npm publish succeeds but a later tag, push, or GitHub Release step fails, rerun the same `release` command. When npm metadata says the latest package version has `gitHead` equal to the current Git HEAD and Packtory regenerates matching package contents for that version, Packtory treats the publish as complete and finishes any missing git tags, tag pushes, and GitHub Releases without publishing the package again.
+
 For a reviewed release PR flow, use `release-pr`:
 
 ```bash

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -50,6 +50,7 @@ type Overrides = {
     readonly fetchLatestReleaseMetadata?: SinonSpy;
     readonly collectContents?: SinonSpy;
     readonly fetchTarball?: SinonSpy;
+    readonly currentGitHead?: string | undefined;
 };
 
 function createSpy<TSpy extends Readonly<SinonSpy>>(spy: TSpy | undefined, fallback: () => TSpy): TSpy {
@@ -86,7 +87,7 @@ function emitterFactory(overrides: Overrides = {}): BundleEmitter {
         },
         ciRepositoryUrl: undefined,
         async readCurrentGitHead() {
-            return undefined;
+            return overrides.currentGitHead;
         }
     };
 
@@ -260,6 +261,52 @@ suite('emitter', function () {
 
             assert.deepStrictEqual(result, Maybe.just('1.2.3'));
             assert.deepStrictEqual(fetchLatestVersion.firstCall.args, [ 'the-name', registrySettings ]);
+        });
+    });
+
+    suite('current-head published version lookup', function () {
+        test('findCurrentHeadPublishedVersion() returns the latest version when gitHead matches current HEAD', async function () {
+            const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3', gitHead: 'current-head' }));
+            const emitter = emitterFactory({ fetchLatestVersion, currentGitHead: 'current-head' });
+
+            const result = await emitter.findCurrentHeadPublishedVersion({
+                name: 'the-name',
+                registrySettings
+            });
+
+            assert.deepStrictEqual(result, { version: '1.2.3', gitHead: 'current-head' });
+            assert.deepStrictEqual(fetchLatestVersion.firstCall.args, [ 'the-name', registrySettings ]);
+        });
+
+        test('findCurrentHeadPublishedVersion() returns undefined when no current HEAD is available', async function () {
+            const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3', gitHead: 'current-head' }));
+            const emitter = emitterFactory({ fetchLatestVersion, currentGitHead: undefined });
+
+            assert.strictEqual(
+                await emitter.findCurrentHeadPublishedVersion({ name: 'the-name', registrySettings }),
+                undefined
+            );
+            assert.strictEqual(fetchLatestVersion.callCount, 0);
+        });
+
+        test('findCurrentHeadPublishedVersion() returns undefined when the registry has no latest version', async function () {
+            const fetchLatestVersion = fake.resolves(Maybe.nothing());
+            const emitter = emitterFactory({ fetchLatestVersion, currentGitHead: 'current-head' });
+
+            assert.strictEqual(
+                await emitter.findCurrentHeadPublishedVersion({ name: 'the-name', registrySettings }),
+                undefined
+            );
+        });
+
+        test('findCurrentHeadPublishedVersion() returns undefined when gitHead differs', async function () {
+            const fetchLatestVersion = fake.resolves(Maybe.just({ version: '1.2.3', gitHead: 'other-head' }));
+            const emitter = emitterFactory({ fetchLatestVersion, currentGitHead: 'current-head' });
+
+            assert.strictEqual(
+                await emitter.findCurrentHeadPublishedVersion({ name: 'the-name', registrySettings }),
+                undefined
+            );
         });
     });
 

--- a/source/bundle-emitter/emitter.ts
+++ b/source/bundle-emitter/emitter.ts
@@ -62,6 +62,22 @@ type CurrentVersionLookupOptions = {
     readonly versioning: VersioningSettings;
 };
 
+type CurrentHeadPublishedVersionLookupOptions = {
+    readonly name: string;
+    readonly registrySettings: RegistrySettings;
+};
+
+type CurrentHeadPublishedVersion = {
+    readonly version: string;
+    readonly gitHead: string;
+};
+type PackageVersionGitHead = {
+    readonly gitHead: string | undefined;
+};
+type PackageVersionWithGitHead = {
+    readonly gitHead: string;
+};
+
 type BundlePublishedCheckResult = {
     readonly alreadyPublishedAsLatest: boolean;
     readonly previousReleaseArtifacts: PreviousReleaseArtifacts;
@@ -70,6 +86,9 @@ type BundlePublishedCheckResult = {
 export type BundleEmitter = {
     publish: (options: PublishOptions) => Promise<PublicationOutcome>;
     determineCurrentVersion: (options: CurrentVersionLookupOptions) => Promise<Maybe<string>>;
+    findCurrentHeadPublishedVersion: (
+        options: CurrentHeadPublishedVersionLookupOptions
+    ) => Promise<CurrentHeadPublishedVersion | undefined>;
     checkBundleAlreadyPublished: (options: AlreadyPublishedCheckOptions) => Promise<BundlePublishedCheckResult>;
 };
 
@@ -108,6 +127,13 @@ function hasVersionProvider(
     versioning: VersioningSettings
 ): versioning is Extract<VersioningSettings, { readonly provideVersion: unknown; }> {
     return Object.hasOwn(versioning, 'provideVersion');
+}
+
+function isCurrentHeadPackageVersion(
+    versionDetails: PackageVersionGitHead,
+    currentGitHead: string
+): versionDetails is PackageVersionWithGitHead {
+    return versionDetails.gitHead === currentGitHead;
 }
 
 export function createBundleEmitter(dependencies: BundleEmitterDependencies): BundleEmitter {
@@ -151,6 +177,21 @@ export function createBundleEmitter(dependencies: BundleEmitterDependencies): Bu
             }
 
             return Maybe.just(versioning.version);
+        },
+
+        async findCurrentHeadPublishedVersion(options) {
+            const currentGitHead = await readCurrentGitHead();
+            if (currentGitHead === undefined) {
+                return undefined;
+            }
+            const latestVersion = await registryClient.fetchLatestVersion(options.name, options.registrySettings);
+            if (latestVersion.isNothing || !isCurrentHeadPackageVersion(latestVersion.value, currentGitHead)) {
+                return undefined;
+            }
+            return {
+                version: latestVersion.value.version,
+                gitHead: latestVersion.value.gitHead
+            };
         },
 
         async checkBundleAlreadyPublished(options) {

--- a/source/command-line-interface/runner/release-handler-mutation-flow.test.ts
+++ b/source/command-line-interface/runner/release-handler-mutation-flow.test.ts
@@ -60,6 +60,27 @@ suite('release-handler mutation flow', function () {
         await assertCurrentHeadRetryTag({ publish: true, tag: true, noDryRun: true });
     });
 
+    test('finishes tags, pushes, and GitHub releases for current-head retry packages with publish enabled', async function () {
+        const buildAndPublishAll = fake();
+        const deps = createReleaseHandlerDeps({
+            buildAndPublishAll,
+            flags: { publish: true, tag: true, push: true, githubRelease: true, noDryRun: true },
+            planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+        });
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 0);
+        assert.strictEqual(buildAndPublishAll.callCount, 0);
+        assert.deepStrictEqual(deps.releaseSteps, [
+            'plan',
+            'clean',
+            'head',
+            'tag:pkg-a@1.0.1',
+            'push',
+            'github-release'
+        ]);
+    });
+
     test('creates GitHub releases with empty notes for current-head retry packages', async function () {
         const createReleaseIfMissing = fake.resolves('created');
         const createGitHubReleaseClient = fake(function () {

--- a/source/packtory/package-processor-publish.test.ts
+++ b/source/packtory/package-processor-publish.test.ts
@@ -12,6 +12,7 @@ import {
     createTransferableFile,
     createVersionedBundle,
     getCallArgs,
+    type ProcessorContext,
     type TransferableFile
 } from '../test-libraries/package-processor-test-support.ts';
 import type { BuildAndPublishOptions } from './map-config.ts';
@@ -30,9 +31,62 @@ type SbomScenario = {
     readonly checkBundleAlreadyPublished: SinonSpy;
     readonly processor: PackageProcessor;
 };
+type CurrentHeadRetryScenario = {
+    readonly alreadyPublishedAsLatest: boolean;
+    readonly artifactGitHead: string;
+    readonly artifactVersion: string;
+};
 
 function nonEsmMainPackageJson(): BuildAndPublishOptions['mainPackageJson'] {
     return JSON.parse('{"type":"commonjs"}') as BuildAndPublishOptions['mainPackageJson'];
+}
+
+function publishedArtifacts(version: string, gitHead: string): BuildAndPublishResult['previousReleaseArtifacts'] {
+    return Maybe.just({
+        version,
+        publishedAt: undefined,
+        gitHead,
+        files: []
+    });
+}
+
+function providerVersioningBuildOptions(): BuildAndPublishOptions {
+    return {
+        ...createBuildAndPublishOptions(),
+        versioning: {
+            automatic: false,
+            provideVersion() {
+                throw new Error('missing package tag');
+            }
+        }
+    };
+}
+
+function tryBuildOptions(buildOptions: BuildAndPublishOptions): DetermineVersionAndPublishOptions {
+    return {
+        analyzedBundle: createAnalyzedBundle(),
+        buildOptions,
+        stage: false
+    };
+}
+
+async function expectMissingTagFailure(processor: PackageProcessor): Promise<void> {
+    await assert.rejects(
+        processor.tryBuildAndPublish(tryBuildOptions(providerVersioningBuildOptions())),
+        { message: 'missing package tag' }
+    );
+}
+
+function createCurrentHeadRetryProcessor(scenario: CurrentHeadRetryScenario): ProcessorContext {
+    return createProcessor({
+        determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+        findCurrentHeadPublishedVersion: fake.resolves({ version: '1.2.3', gitHead: 'current-head' }),
+        addVersion: fake.returns(createVersionedBundle()),
+        checkBundleAlreadyPublished: fake.resolves({
+            alreadyPublishedAsLatest: scenario.alreadyPublishedAsLatest,
+            previousReleaseArtifacts: publishedArtifacts(scenario.artifactVersion, scenario.artifactGitHead)
+        })
+    });
 }
 
 suite('package-processor publish', function () {
@@ -50,6 +104,92 @@ suite('package-processor publish', function () {
                 { message: 'mainPackageJson.type must be "module"' }
             );
             assert.strictEqual(determineCurrentVersion.callCount, 0);
+        });
+    });
+
+    suite('current-head retry publishing', function () {
+        test('tryBuildAndPublish() finalizes current-head registry packages before provider versioning', async function () {
+            const publish = fake.resolves(undefined);
+            const determineCurrentVersion = fake.rejects(new Error('version provider should not run'));
+            const findCurrentHeadPublishedVersion = fake.resolves({ version: '1.2.3', gitHead: 'current-head' });
+            const { processor } = createProcessor({
+                determineCurrentVersion,
+                findCurrentHeadPublishedVersion,
+                addVersion: fake.returns(createVersionedBundle()),
+                checkBundleAlreadyPublished: fake.resolves({
+                    alreadyPublishedAsLatest: true,
+                    previousReleaseArtifacts: publishedArtifacts('1.2.3', 'current-head')
+                }),
+                publish
+            });
+
+            const result = await processor.tryBuildAndPublish(tryBuildOptions(providerVersioningBuildOptions()));
+
+            assert.strictEqual(result.status, 'already-published');
+            assert.strictEqual(result.bundle.version, '1.2.3');
+            assert.deepStrictEqual(findCurrentHeadPublishedVersion.firstCall.args, [
+                {
+                    name: 'package-a',
+                    registrySettings: { auth: { type: 'bearer-token', token: 'token' } }
+                }
+            ]);
+            assert.strictEqual(determineCurrentVersion.callCount, 0);
+            assert.strictEqual(publish.callCount, 0);
+        });
+
+        test('tryBuildAndPublish() falls back when current-head registry contents differ', async function () {
+            const { processor, determineCurrentVersion } = createCurrentHeadRetryProcessor({
+                alreadyPublishedAsLatest: false,
+                artifactVersion: '1.2.3',
+                artifactGitHead: 'current-head'
+            });
+
+            await expectMissingTagFailure(processor);
+
+            assert.strictEqual(determineCurrentVersion.callCount, 1);
+        });
+
+        for (
+            const scenario of [
+                { name: 'versions', artifactVersion: '1.2.4', artifactGitHead: 'current-head' },
+                { name: 'git heads', artifactVersion: '1.2.3', artifactGitHead: 'other-head' }
+            ] as const
+        ) {
+            test(
+                `tryBuildAndPublish() falls back when current-head registry metadata changes ${scenario.name}`,
+                async function () {
+                    const { processor } = createCurrentHeadRetryProcessor({
+                        alreadyPublishedAsLatest: true,
+                        ...scenario
+                    });
+
+                    await expectMissingTagFailure(processor);
+                }
+            );
+        }
+
+        test('tryBuildAndPublish() skips current-head retry detection in stage mode', async function () {
+            const findCurrentHeadPublishedVersion = fake.resolves({ version: '1.2.3', gitHead: 'current-head' });
+            const { processor } = createProcessor({
+                determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+                findCurrentHeadPublishedVersion,
+                addVersion: fake.returns(createVersionedBundle()),
+                checkBundleAlreadyPublished: fake.resolves({
+                    alreadyPublishedAsLatest: true,
+                    previousReleaseArtifacts: publishedArtifacts('1.2.3', 'current-head')
+                })
+            });
+
+            await processor.tryBuildAndPublish({
+                analyzedBundle: createAnalyzedBundle(),
+                buildOptions: {
+                    ...createBuildAndPublishOptions(),
+                    versioning: { automatic: false, version: '1.2.3' }
+                },
+                stage: true
+            });
+
+            assert.strictEqual(findCurrentHeadPublishedVersion.callCount, 0);
         });
     });
 

--- a/source/packtory/package-processor-publish.ts
+++ b/source/packtory/package-processor-publish.ts
@@ -25,6 +25,9 @@ type VersionedBundleWithManifest = Awaited<ReturnType<PublishDependencies['versi
 type CurrentVersion = Awaited<ReturnType<PublishDependencies['bundleEmitter']['determineCurrentVersion']>>;
 type PublicationOutcome = Awaited<ReturnType<PublishDependencies['bundleEmitter']['publish']>>;
 type PublishedCheckResult = Awaited<ReturnType<PublishDependencies['bundleEmitter']['checkBundleAlreadyPublished']>>;
+type CurrentHeadPublishedVersion = Awaited<
+    ReturnType<PublishDependencies['bundleEmitter']['findCurrentHeadPublishedVersion']>
+>;
 type PreviousReleaseArtifacts = Readonly<PublishedCheckResult['previousReleaseArtifacts']>;
 type ExtraFiles = Exclude<Awaited<ReturnType<PublishDependencies['sbomFileBuilder']['generate']>>, undefined>;
 type SiblingPackage = Parameters<PublishDependencies['sbomFileBuilder']['generate']>[1][number];
@@ -44,6 +47,13 @@ type VersionDeterminedInput = {
 type FinalizeWithoutBumpExtras = {
     readonly extraFiles: ExtraFiles;
     readonly previousReleaseArtifacts: PreviousReleaseArtifacts;
+};
+type BuildVersionedBundleForVersionInput = {
+    readonly dependencies: PublishDependencies;
+    readonly analyzedBundle: AnalyzedBundle;
+    readonly options: BuildAndPublishOptions;
+    readonly version: string;
+    readonly substitutionPublicModuleSourcePaths: ReadonlySet<string> | undefined;
 };
 
 export type BuildAndPublishResult = {
@@ -71,6 +81,111 @@ function siblingsFromOptions(buildOptions: BuildAndPublishOptions): readonly Sib
     return [ ...buildOptions.bundleDependencies, ...buildOptions.bundlePeerDependencies ];
 }
 
+function buildVersionedBundleForVersion(input: BuildVersionedBundleForVersionInput): VersionedBundleWithManifest {
+    const { dependencies, analyzedBundle, options, version, substitutionPublicModuleSourcePaths } = input;
+    dependencies.progressBroadcaster.emit('building', { packageName: options.name, version });
+    return dependencies.versionManager.addVersion({
+        bundle: analyzedBundle,
+        ...options,
+        version,
+        substitutionPublicModuleSourcePaths
+    });
+}
+
+async function generateExtraFiles(
+    dependencies: PublishDependencies,
+    versionedBundle: VersionedBundleWithManifest,
+    buildOptions: BuildAndPublishOptions
+): Promise<ExtraFiles> {
+    const result = await dependencies.sbomFileBuilder.generate(
+        versionedBundle,
+        siblingsFromOptions(buildOptions),
+        buildOptions.publishSettings
+    );
+    return result ?? [];
+}
+
+function checkAlreadyPublishedOptions(
+    versionedBundle: VersionedBundleWithManifest,
+    buildOptions: BuildAndPublishOptions,
+    extraFiles: ExtraFiles
+): Parameters<BundleEmitter['checkBundleAlreadyPublished']>[0] {
+    return pickBy(
+        {
+            bundle: versionedBundle,
+            registrySettings: buildOptions.registrySettings,
+            extraFiles: extraFiles.length === 0 ? undefined : extraFiles
+        },
+        isDefined
+    );
+}
+
+async function checkBundleAlreadyPublished(
+    dependencies: PublishDependencies,
+    versionedBundle: VersionedBundleWithManifest,
+    buildOptions: BuildAndPublishOptions,
+    extraFiles: ExtraFiles
+): Promise<PublishedCheckResult> {
+    return dependencies.bundleEmitter.checkBundleAlreadyPublished(
+        checkAlreadyPublishedOptions(versionedBundle, buildOptions, extraFiles)
+    );
+}
+
+function isVerifiedFinalizedPublish(
+    candidate: Exclude<CurrentHeadPublishedVersion, undefined>,
+    result: PublishedCheckResult
+): boolean {
+    if (!result.alreadyPublishedAsLatest || result.previousReleaseArtifacts.isNothing) {
+        return false;
+    }
+    return (
+        result.previousReleaseArtifacts.value.version === candidate.version &&
+        result.previousReleaseArtifacts.value.gitHead === candidate.gitHead
+    );
+}
+
+async function tryFinalizePublishedCurrentHead(
+    dependencies: PublishDependencies,
+    options: DetermineVersionAndPublishOptions
+): Promise<BuildAndPublishResult | undefined> {
+    const candidate = options.stage
+        ? undefined
+        : await dependencies.bundleEmitter.findCurrentHeadPublishedVersion({
+            name: options.buildOptions.name,
+            registrySettings: options.buildOptions.registrySettings
+        });
+    if (candidate === undefined) {
+        return undefined;
+    }
+
+    const versionedBundle = buildVersionedBundleForVersion({
+        dependencies,
+        analyzedBundle: options.analyzedBundle,
+        options: options.buildOptions,
+        version: candidate.version,
+        substitutionPublicModuleSourcePaths: options.substitutionPublicModuleSourcePaths
+    });
+    const extraFiles = await generateExtraFiles(dependencies, versionedBundle, options.buildOptions);
+    const alreadyPublished = await checkBundleAlreadyPublished(
+        dependencies,
+        versionedBundle,
+        options.buildOptions,
+        extraFiles
+    );
+
+    if (!isVerifiedFinalizedPublish(candidate, alreadyPublished)) {
+        return undefined;
+    }
+
+    return {
+        bundle: versionedBundle,
+        status: publishedReleaseStatus.alreadyPublished,
+        publication: noPublication,
+        extraFiles,
+        previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts
+    };
+}
+
 export type PublishOperations = {
     readonly buildAndPublish: (options: DetermineVersionAndPublishOptions) => Promise<BuildAndPublishResult>;
     readonly tryBuildAndPublish: (options: DetermineVersionAndPublishOptions) => Promise<BuildAndPublishResult>;
@@ -95,10 +210,10 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
             options,
             await createVersionProviderContext(dependencies, analyzedBundle, options, stage)
         );
-        dependencies.progressBroadcaster.emit('building', { packageName: options.name, version });
-        const versionedBundle = dependencies.versionManager.addVersion({
-            bundle: analyzedBundle,
-            ...options,
+        const versionedBundle = buildVersionedBundleForVersion({
+            dependencies,
+            analyzedBundle,
+            options,
             version,
             substitutionPublicModuleSourcePaths
         });
@@ -156,58 +271,59 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
         return newVersionedBundle;
     }
 
-    async function generateExtraFiles(
-        versionedBundle: VersionedBundleWithManifest,
-        buildOptions: BuildAndPublishOptions
-    ): Promise<ExtraFiles> {
-        const result = await dependencies.sbomFileBuilder.generate(
-            versionedBundle,
-            siblingsFromOptions(buildOptions),
-            buildOptions.publishSettings
-        );
-        return result ?? [];
+    function tryFinalizeWithoutBump(
+        buildContext: VersionedBundleBuildContext,
+        options: BuildAndPublishOptions,
+        alreadyPublished: PublishedCheckResult,
+        extraFiles: ExtraFiles
+    ): BuildAndPublishResult | undefined {
+        const extras = { extraFiles, previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts };
+        if (alreadyPublished.alreadyPublishedAsLatest) {
+            return finalizeWithoutBump(buildContext, options, publishedReleaseStatus.alreadyPublished, extras);
+        }
+        if (!shouldIncreaseVersion(buildContext.currentVersion, options)) {
+            return finalizeWithoutBump(
+                buildContext,
+                options,
+                buildContext.currentVersion.isJust
+                    ? publishedReleaseStatus.newVersion
+                    : publishedReleaseStatus.initialVersion,
+                extras
+            );
+        }
+        return undefined;
     }
 
-    async function tryBuildAndPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {
+    async function buildPendingPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {
         const buildContext = await buildVersionedBundle(
             options.analyzedBundle,
             options.buildOptions,
             options.stage,
             options.substitutionPublicModuleSourcePaths
         );
-        const preBumpExtraFiles = await generateExtraFiles(buildContext.versionedBundle, options.buildOptions);
-        const alreadyPublished = await dependencies.bundleEmitter.checkBundleAlreadyPublished(
-            pickBy(
-                {
-                    bundle: buildContext.versionedBundle,
-                    registrySettings: options.buildOptions.registrySettings,
-                    extraFiles: preBumpExtraFiles.length === 0 ? undefined : preBumpExtraFiles
-                },
-                isDefined
-            )
+        const preBumpExtraFiles = await generateExtraFiles(
+            dependencies,
+            buildContext.versionedBundle,
+            options.buildOptions
+        );
+        const alreadyPublished = await checkBundleAlreadyPublished(
+            dependencies,
+            buildContext.versionedBundle,
+            options.buildOptions,
+            preBumpExtraFiles
+        );
+        const finalizedWithoutBump = tryFinalizeWithoutBump(
+            buildContext,
+            options.buildOptions,
+            alreadyPublished,
+            preBumpExtraFiles
         );
 
-        if (alreadyPublished.alreadyPublishedAsLatest) {
-            return finalizeWithoutBump(buildContext, options.buildOptions, publishedReleaseStatus.alreadyPublished, {
-                extraFiles: preBumpExtraFiles,
-                previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts
-            });
-        }
-        if (!shouldIncreaseVersion(buildContext.currentVersion, options.buildOptions)) {
-            return finalizeWithoutBump(
-                buildContext,
-                options.buildOptions,
-                buildContext.currentVersion.isJust
-                    ? publishedReleaseStatus.newVersion
-                    : publishedReleaseStatus.initialVersion,
-                {
-                    extraFiles: preBumpExtraFiles,
-                    previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts
-                }
-            );
+        if (finalizedWithoutBump !== undefined) {
+            return finalizedWithoutBump;
         }
         const newVersionedBundle = await bumpVersion(buildContext, options.buildOptions);
-        const extraFiles = await generateExtraFiles(newVersionedBundle, options.buildOptions);
+        const extraFiles = await generateExtraFiles(dependencies, newVersionedBundle, options.buildOptions);
         return {
             bundle: newVersionedBundle,
             status: buildContext.currentVersion.isJust
@@ -217,6 +333,11 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
             extraFiles,
             previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts
         };
+    }
+
+    async function tryBuildAndPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {
+        const finalizedPublish = await tryFinalizePublishedCurrentHead(dependencies, options);
+        return finalizedPublish ?? await buildPendingPublish(options);
     }
 
     async function buildAndPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {

--- a/source/test-libraries/package-processor-test-support.ts
+++ b/source/test-libraries/package-processor-test-support.ts
@@ -82,6 +82,7 @@ export type ProcessorOverrides = {
     readonly resolve?: SinonSpy;
     readonly linkBundle?: SinonSpy;
     readonly determineCurrentVersion?: SinonSpy;
+    readonly findCurrentHeadPublishedVersion?: SinonSpy;
     readonly addVersion?: SinonSpy;
     readonly increaseVersion?: SinonSpy;
     readonly checkBundleAlreadyPublished?: SinonSpy;
@@ -97,6 +98,7 @@ export type ProcessorContext = {
     readonly resolve: SinonSpy;
     readonly linkBundle: SinonSpy;
     readonly determineCurrentVersion: SinonSpy;
+    readonly findCurrentHeadPublishedVersion: SinonSpy;
     readonly addVersion: SinonSpy;
     readonly increaseVersion: SinonSpy;
     readonly checkBundleAlreadyPublished: SinonSpy;
@@ -110,6 +112,7 @@ type ProcessorSpies = {
     readonly resolve: SinonSpy;
     readonly linkBundle: SinonSpy;
     readonly determineCurrentVersion: SinonSpy;
+    readonly findCurrentHeadPublishedVersion: SinonSpy;
     readonly addVersion: SinonSpy;
     readonly increaseVersion: SinonSpy;
     readonly checkBundleAlreadyPublished: SinonSpy;
@@ -129,6 +132,7 @@ function createDefaultProcessorSpies(): ProcessorSpies {
         resolve: fake.resolves(createLinkedBundle()),
         linkBundle: fake.resolves(createLinkedBundle()),
         determineCurrentVersion: fake.resolves(Maybe.nothing()),
+        findCurrentHeadPublishedVersion: fake.resolves(undefined),
         addVersion: fake.returns(createVersionedBundle()),
         increaseVersion: fake.returns(createVersionedBundle('package-a', '1.2.4')),
         checkBundleAlreadyPublished: fake.resolves({
@@ -154,6 +158,10 @@ function createProcessorSpies(overrides: ProcessorOverrides): ProcessorSpies {
         resolve: providedSpy(overrides.resolve, defaults.resolve),
         linkBundle: providedSpy(overrides.linkBundle, defaults.linkBundle),
         determineCurrentVersion: providedSpy(overrides.determineCurrentVersion, defaults.determineCurrentVersion),
+        findCurrentHeadPublishedVersion: providedSpy(
+            overrides.findCurrentHeadPublishedVersion,
+            defaults.findCurrentHeadPublishedVersion
+        ),
         addVersion: providedSpy(overrides.addVersion, defaults.addVersion),
         increaseVersion: providedSpy(overrides.increaseVersion, defaults.increaseVersion),
         checkBundleAlreadyPublished: providedSpy(
@@ -174,6 +182,7 @@ export function createProcessor(overrides: ProcessorOverrides = {}): ProcessorCo
         linker: { linkBundle: spies.linkBundle },
         bundleEmitter: {
             determineCurrentVersion: spies.determineCurrentVersion,
+            findCurrentHeadPublishedVersion: spies.findCurrentHeadPublishedVersion,
             checkBundleAlreadyPublished: spies.checkBundleAlreadyPublished,
             publish: spies.publish
         },
@@ -197,6 +206,7 @@ export function createProcessor(overrides: ProcessorOverrides = {}): ProcessorCo
         resolve: spies.resolve,
         linkBundle: spies.linkBundle,
         determineCurrentVersion: spies.determineCurrentVersion,
+        findCurrentHeadPublishedVersion: spies.findCurrentHeadPublishedVersion,
         addVersion: spies.addVersion,
         increaseVersion: spies.increaseVersion,
         checkBundleAlreadyPublished: spies.checkBundleAlreadyPublished,


### PR DESCRIPTION
Allows `release --publish --tag --push --github-release` to recover after npm publish succeeds but a later git or GitHub Release step fails. Packtory now recognizes a latest registry version whose `gitHead` matches the current HEAD, rebuilds that exact version, verifies the generated contents against the published tarball, and then finishes the missing tag, push, and GitHub Release work without republishing.