### PR TITLE
Use `@enormora/eslint-config-mocha-node-assert`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import { baseConfig } from '@enormora/eslint-config-base';
-import { mochaConfig, testSupportConfig } from '@enormora/eslint-config-mocha';
+import { mochaNodeAssertConfig, testSupportConfig } from '@enormora/eslint-config-mocha-node-assert';
 import { typescriptConfig } from '@enormora/eslint-config-typescript';
 import { nodeConfig, nodeConfigFileConfig, nodeEntryPointFileConfig } from '@enormora/eslint-config-node';
 
@@ -17,7 +17,7 @@ export default [
         files: [ '**/*.ts' ]
     },
     {
-        ...mochaConfig,
+        ...mochaNodeAssertConfig,
         files: [ '**/*.test.ts', '**/*.property.ts', 'integration-tests/**/*.ts' ]
     },
     {

--- a/integration-tests/package-processor/asset-imports.test.ts
+++ b/integration-tests/package-processor/asset-imports.test.ts
@@ -41,8 +41,9 @@ suite('asset-imports', function () {
             return resource.fileDescription.targetFilePath === 'data.json';
         });
 
-        assert.notStrictEqual(entry, undefined);
-        assert.notStrictEqual(json, undefined);
+        if (entry === undefined || json === undefined) {
+            assert.fail('expected bundled entry and json resources');
+        }
         assert.partialDeepStrictEqual(entry, {
             directDependencies: new Set([ path.join(fixture, 'src/data.json') ]),
             fileDescription: {
@@ -62,8 +63,9 @@ suite('asset-imports', function () {
             return resource.fileDescription.targetFilePath === 'module.wasm';
         });
 
-        assert.notStrictEqual(entry, undefined);
-        assert.notStrictEqual(wasm, undefined);
+        if (entry === undefined || wasm === undefined) {
+            assert.fail('expected bundled entry and wasm resources');
+        }
         assert.deepStrictEqual(entry.directDependencies, new Set([ path.join(fixture, 'src/module.wasm') ]));
         assert.strictEqual(wasm.fileDescription.content, 'wasm-binary-placeholder\n');
     });
@@ -102,8 +104,9 @@ suite('asset-imports', function () {
             return resource.fileDescription.targetFilePath === 'package.json';
         });
 
-        assert.notStrictEqual(entry, undefined);
-        assert.notStrictEqual(generatedManifestResource, undefined);
+        if (entry === undefined || generatedManifestResource === undefined) {
+            assert.fail('expected bundled entry and generated manifest resources');
+        }
         assert.partialDeepStrictEqual(entry, {
             directDependencies: new Set([ path.join(fixture, 'src/package.json') ]),
             fileDescription: {

--- a/integration-tests/package-processor/asset-imports.test.ts
+++ b/integration-tests/package-processor/asset-imports.test.ts
@@ -41,13 +41,14 @@ suite('asset-imports', function () {
             return resource.fileDescription.targetFilePath === 'data.json';
         });
 
-        assert.ok(entry !== undefined);
-        assert.ok(json !== undefined);
-        assert.deepStrictEqual(entry.directDependencies, new Set([ path.join(fixture, 'src/data.json') ]));
-        assert.strictEqual(
-            entry.fileDescription.content,
-            'import data from "./data.json" with { type: "json" };\n\nexport default data;\n'
-        );
+        assert.notStrictEqual(entry, undefined);
+        assert.notStrictEqual(json, undefined);
+        assert.partialDeepStrictEqual(entry, {
+            directDependencies: new Set([ path.join(fixture, 'src/data.json') ]),
+            fileDescription: {
+                content: 'import data from "./data.json" with { type: "json" };\n\nexport default data;\n'
+            }
+        });
         assert.strictEqual(json.fileDescription.content, '{\n    "message": "hello"\n}\n');
     });
 
@@ -61,8 +62,8 @@ suite('asset-imports', function () {
             return resource.fileDescription.targetFilePath === 'module.wasm';
         });
 
-        assert.ok(entry !== undefined);
-        assert.ok(wasm !== undefined);
+        assert.notStrictEqual(entry, undefined);
+        assert.notStrictEqual(wasm, undefined);
         assert.deepStrictEqual(entry.directDependencies, new Set([ path.join(fixture, 'src/module.wasm') ]));
         assert.strictEqual(wasm.fileDescription.content, 'wasm-binary-placeholder\n');
     });
@@ -101,13 +102,14 @@ suite('asset-imports', function () {
             return resource.fileDescription.targetFilePath === 'package.json';
         });
 
-        assert.ok(entry !== undefined);
-        assert.ok(generatedManifestResource !== undefined);
-        assert.deepStrictEqual(entry.directDependencies, new Set([ path.join(fixture, 'src/package.json') ]));
-        assert.strictEqual(
-            entry.fileDescription.content,
-            'import manifest from "./package.json" with { type: "json" };\n\nexport default manifest;\n'
-        );
+        assert.notStrictEqual(entry, undefined);
+        assert.notStrictEqual(generatedManifestResource, undefined);
+        assert.partialDeepStrictEqual(entry, {
+            directDependencies: new Set([ path.join(fixture, 'src/package.json') ]),
+            fileDescription: {
+                content: 'import manifest from "./package.json" with { type: "json" };\n\nexport default manifest;\n'
+            }
+        });
         assert.strictEqual(generatedManifestResource.isGeneratedManifest, true);
         assert.deepStrictEqual(JSON.parse(bundle.manifestFile.content), {
             exports: { '.': { import: './entry.js' } },

--- a/integration-tests/package-processor/package-json-imports.test.ts
+++ b/integration-tests/package-processor/package-json-imports.test.ts
@@ -78,11 +78,15 @@ suite('package-json-imports', function () {
         assert.deepStrictEqual(firstBundle.packageJson.imports, {
             '#shared': './shared.js'
         });
-        assert.deepStrictEqual(secondBundle.packageJson.imports, {
-            '#local': './local.js'
-        });
-        assert.deepStrictEqual(secondBundle.packageJson.dependencies, {
-            first: '1.2.3'
+        assert.partialDeepStrictEqual(secondBundle, {
+            packageJson: {
+                imports: {
+                    '#local': './local.js'
+                },
+                dependencies: {
+                    first: '1.2.3'
+                }
+            }
         });
 
         const rewrittenEntry = findEntry(secondBundle, 'entry-second.js');

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -35,13 +35,13 @@ async function createBaseConfig(fixturePath: string): Promise<PacktoryConfigWith
 
 function packageConfigAt(config: PacktoryConfigWithoutRegistry, index: number): PackageConfig {
     const packageConfig = config.packages[index];
-    assert.ok(packageConfig !== undefined);
+    assert.notStrictEqual(packageConfig, undefined);
     return packageConfig;
 }
 
 function firstIssue(issues: readonly string[]): string {
     const [ issue ] = issues;
-    assert.ok(issue !== undefined);
+    assert.notStrictEqual(issue, undefined);
     return issue;
 }
 

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -35,13 +35,17 @@ async function createBaseConfig(fixturePath: string): Promise<PacktoryConfigWith
 
 function packageConfigAt(config: PacktoryConfigWithoutRegistry, index: number): PackageConfig {
     const packageConfig = config.packages[index];
-    assert.notStrictEqual(packageConfig, undefined);
+    if (packageConfig === undefined) {
+        assert.fail('expected package config');
+    }
     return packageConfig;
 }
 
 function firstIssue(issues: readonly string[]): string {
     const [ issue ] = issues;
-    assert.notStrictEqual(issue, undefined);
+    if (issue === undefined) {
+        assert.fail('expected issue');
+    }
     return issue;
 }
 

--- a/integration-tests/packtory/dead-code-elimination.test.ts
+++ b/integration-tests/packtory/dead-code-elimination.test.ts
@@ -99,7 +99,7 @@ function assertSharedDeclarationIssue(
         assert.fail(`Expected a checks failure, got ${result.error.type}`);
     }
     const [ issue ] = result.error.issues;
-    assert.ok(issue !== undefined);
+    assert.notStrictEqual(issue, undefined);
     assert.ok(issue.includes('shared/util.js'));
     assert.ok(issue.includes('"sharedValue"'), 'message should name the shared declaration');
 }

--- a/integration-tests/packtory/dead-code-elimination.test.ts
+++ b/integration-tests/packtory/dead-code-elimination.test.ts
@@ -99,7 +99,9 @@ function assertSharedDeclarationIssue(
         assert.fail(`Expected a checks failure, got ${result.error.type}`);
     }
     const [ issue ] = result.error.issues;
-    assert.notStrictEqual(issue, undefined);
+    if (issue === undefined) {
+        assert.fail('expected issue');
+    }
     assert.ok(issue.includes('shared/util.js'));
     assert.ok(issue.includes('"sharedValue"'), 'message should name the shared declaration');
 }

--- a/integration-tests/packtory/publish.test.ts
+++ b/integration-tests/packtory/publish.test.ts
@@ -65,12 +65,18 @@ type SbomMetadata = {
 };
 
 function assertFirstPackageSbom(sbom: Readonly<Record<string, unknown>>): void {
-    assert.strictEqual(sbom.bomFormat, 'CycloneDX');
-    assert.strictEqual(sbom.specVersion, '1.6');
+    assert.partialDeepStrictEqual(sbom, {
+        bomFormat: 'CycloneDX',
+        specVersion: '1.6'
+    });
     const metadata = sbom.metadata as SbomMetadata;
     assert.strictEqual(metadata.component['bom-ref'], 'pkg:npm/first@0.0.1');
-    assert.strictEqual(metadata.component.name, 'first');
-    assert.strictEqual(metadata.component.version, '0.0.1');
+    assert.partialDeepStrictEqual(metadata, {
+        component: {
+            name: 'first',
+            version: '0.0.1'
+        }
+    });
     assert.deepStrictEqual(sbom.components, []);
 }
 
@@ -146,8 +152,12 @@ suite('publish', function () {
 
                 const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-                assert.strictEqual(publishedPackage.version, '3.2.1');
-                assert.strictEqual(publishedPackage.manifest.version, '3.2.1');
+                assert.partialDeepStrictEqual(publishedPackage, {
+                    version: '3.2.1',
+                    manifest: {
+                        version: '3.2.1'
+                    }
+                });
             })
         );
 
@@ -168,8 +178,12 @@ suite('publish', function () {
 
                 const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-                assert.strictEqual(publishedPackage.version, '0.0.1');
-                assert.strictEqual(publishedPackage.manifest.version, '0.0.1');
+                assert.partialDeepStrictEqual(publishedPackage, {
+                    version: '0.0.1',
+                    manifest: {
+                        version: '0.0.1'
+                    }
+                });
             })
         );
 
@@ -189,8 +203,12 @@ suite('publish', function () {
 
                 const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-                assert.strictEqual(publishedPackage.version, '1.2.3');
-                assert.strictEqual(publishedPackage.manifest.version, '1.2.3');
+                assert.partialDeepStrictEqual(publishedPackage, {
+                    version: '1.2.3',
+                    manifest: {
+                        version: '1.2.3'
+                    }
+                });
             })
         );
 
@@ -213,8 +231,12 @@ suite('publish', function () {
 
                 const publishedPackage = await fetchPublishedPackage('third', registryDetails);
 
-                assert.deepStrictEqual(publishedPackage.manifest.dependencies, { first: '0.0.1' });
-                assert.deepStrictEqual(publishedPackage.manifest.peerDependencies, { second: '0.0.1' });
+                assert.partialDeepStrictEqual(publishedPackage, {
+                    manifest: {
+                        dependencies: { first: '0.0.1' },
+                        peerDependencies: { second: '0.0.1' }
+                    }
+                });
                 assert.strictEqual(
                     getPublishedFile(publishedPackage, 'package/foo.js').content,
                     "import { bar } from 'second/bar.js';\nexport const foo = 'foo';\n//# sourceMappingURL=foo.js.map\n"
@@ -430,8 +452,12 @@ suite('publish', function () {
 
                 const publishedPackage = await fetchPublishedPackage('first', registryDetails);
 
-                assert.strictEqual(publishedPackage.manifest.license, 'MIT');
-                assert.strictEqual(publishedPackage.manifest.description, 'first package');
+                assert.partialDeepStrictEqual(publishedPackage, {
+                    manifest: {
+                        license: 'MIT',
+                        description: 'first package'
+                    }
+                });
                 assert.strictEqual(
                     getPublishedFile(publishedPackage, 'package/entry1.js.map').content,
                     '{"version":3,"file":"entry.js","sourceRoot":"","sources":["./src/entry.ts"],"names":[],"mappings":""}\n'

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
             },
             "devDependencies": {
                 "@enormora/eslint-config-base": "0.0.46",
-                "@enormora/eslint-config-mocha": "0.0.43",
+                "@enormora/eslint-config-mocha-node-assert": "0.0.3",
                 "@enormora/eslint-config-node": "0.0.36",
                 "@enormora/eslint-config-typescript": "0.0.53",
                 "@enormora/objectory": "0.0.10",
@@ -1573,15 +1573,335 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@enormora/eslint-config-mocha": {
-            "version": "0.0.43",
-            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha/-/eslint-config-mocha-0.0.43.tgz",
-            "integrity": "sha512-S7ne6pbzh0S7TvNwYrAIFgdsfDRTmSLKgNSPI9GaPV9WvMwHlKn2kwLVPbHbCUiIWotC9graR8pEUsAdDRFK8w==",
+        "node_modules/@enormora/eslint-config-mocha-node-assert": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha-node-assert/-/eslint-config-mocha-node-assert-0.0.3.tgz",
+            "integrity": "sha512-4nxNGVHgF135yiQ9XJJnEUyB6JSdvlWLOWjJs0jwss4TMwLGZ/PINaMhKDS0vfpaivD5uWEOcCKQ9tu1b6/Zgw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@enormora/eslint-config-test-base": "0.0.16",
+                "@enormora/eslint-config-mocha": "0.0.45",
+                "@enormora/eslint-config-node-assert": "0.0.3"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@dprint/json": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@dprint/json/-/json-0.23.0.tgz",
+            "integrity": "sha512-FYFbZyrBr343JzCNkwa87+Lk2YnElpv0gzl+i5CXfMjixXzWWAKK2vEuzKoeCsJys4B3bfxmi0ByJ/xW2CY2jw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@enormora/eslint-config-base": {
+            "version": "0.0.49",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-base/-/eslint-config-base-0.0.49.tgz",
+            "integrity": "sha512-0Nv3Zx7fJ8GVjE/lUp1mOFADdqSo5ywznsujwbuZxHdkSSqKsvVAv8kZYUrkEw8xjI64MwkIA78SG6v/f5CLZg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@ben_12/eslint-plugin-dprint": "1.22.0",
+                "@cspell/eslint-plugin": "10.0.1",
+                "@dprint/json": "0.23.0",
+                "@dprint/markdown": "0.22.1",
+                "@dprint/toml": "0.7.0",
+                "@dprint/typescript": "0.96.1",
+                "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
+                "@eslint/markdown": "8.0.3",
+                "@eslint/plugin-kit": "0.7.2",
+                "@stylistic/eslint-plugin": "5.10.0",
+                "@typescript-eslint/utils": "8.63.0",
+                "dprint-plugin-yaml": "0.6.0",
+                "eslint-plugin-array-func": "5.1.1",
+                "eslint-plugin-destructuring": "2.2.1",
+                "eslint-plugin-import-x": "4.17.1",
+                "eslint-plugin-json-schema-validator": "6.2.0",
+                "eslint-plugin-markdown-links": "0.9.1",
+                "eslint-plugin-markdown-preferences": "0.41.1",
+                "eslint-plugin-no-barrel-files": "1.3.1",
+                "eslint-plugin-no-secrets": "2.3.3",
+                "eslint-plugin-package-json": "1.5.0",
+                "eslint-plugin-promise": "7.3.0",
+                "eslint-plugin-regexp": "3.1.1",
+                "eslint-plugin-sonarjs": "4.1.0",
+                "eslint-plugin-unicorn": "71.1.0",
+                "jsonc-eslint-parser": "3.1.0"
+            },
+            "peerDependencies": {
+                "eslint": "^10.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@enormora/eslint-config-mocha": {
+            "version": "0.0.45",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-mocha/-/eslint-config-mocha-0.0.45.tgz",
+            "integrity": "sha512-h1EKnwGbWFQ0VxoxVpfbmIXlev4qCFEhcoaT5ur423FcFiBJ/FZo/7hHCV/xESVh+YVm/XrNgZUYjDvsgOeMJA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@enormora/eslint-config-test-base": "0.0.19",
                 "eslint-plugin-mocha": "11.3.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@enormora/eslint-config-test-base": {
+            "version": "0.0.19",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-test-base/-/eslint-config-test-base-0.0.19.tgz",
+            "integrity": "sha512-VStL4yu4zBRGigRUIqxwuCRhZo5EIG5FQwAS/lqCVfrnl3NJaMatjf1BeguhPTjXo1Ljf03fYvMejnRmIeeSsw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@enormora/eslint-config-base": "0.0.49"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@eslint/markdown": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/@eslint/markdown/-/markdown-8.0.3.tgz",
+            "integrity": "sha512-rBTSSShrq7e4O+PWfeE4azH4/CWPNrC+VGxBXiW00o3vYVJnznsZiDayj3KC9JztIMVRZxZHn2nrDIUau/4j7A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "workspaces": [
+                "examples/*"
+            ],
+            "dependencies": {
+                "@eslint/core": "^1.2.1",
+                "@eslint/plugin-kit": "^0.7.2",
+                "github-slugger": "^2.0.0",
+                "mdast-util-from-markdown": "^2.0.2",
+                "mdast-util-frontmatter": "^2.0.1",
+                "mdast-util-gfm": "^3.1.0",
+                "mdast-util-math": "^3.0.0",
+                "micromark-extension-frontmatter": "^2.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "micromark-extension-math": "^3.1.0",
+                "micromark-util-normalize-identifier": "^2.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/project-service": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/types": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/utils": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.63.0",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/eslint-plugin-markdown-links": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-markdown-links/-/eslint-plugin-markdown-links-0.9.1.tgz",
+            "integrity": "sha512-dDVhweFe44HOf6inWAfQe59pqVsRvyTAFw3MtN/CYz0YJ8s5/jj/4u6dQTdZSEY/mNkVZCSw3/70/kFD+PSPZQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@mdit-vue/shared": "^3.0.2",
+                "entities": "^8.0.0",
+                "fast-content-type-parse": "^3.0.0",
+                "github-slugger": "^2.0.0",
+                "sdbm": "^3.0.0",
+                "synckit": "^0.11.11",
+                "undici": "^7.15.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            },
+            "peerDependencies": {
+                "@eslint/markdown": "^7.1.0 || ^8.0.0",
+                "eslint": ">=9.0.0"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/eslint-plugin-unicorn": {
+            "version": "71.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-71.1.0.tgz",
+            "integrity": "sha512-dn3YmR3qLLUeYyo/os3ubZ7UHQJ1WbBAgC9cIhnLTyMj9J6kivuc2U1fCmYetLexUlTDVYtBqhjSj/VaebTe6Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "browserslist": "^4.28.4",
+                "change-case": "^5.4.4",
+                "ci-info": "^4.4.0",
+                "core-js-compat": "^3.49.0",
+                "detect-indent": "^7.0.2",
+                "find-up-simple": "^1.0.1",
+                "globals": "^17.7.0",
+                "indent-string": "^5.0.0",
+                "is-builtin-module": "^5.0.0",
+                "is-identifier": "^1.1.0",
+                "pluralize": "^8.0.0",
+                "quote-js-string": "^0.1.0",
+                "regjsparser": "^0.13.2",
+                "reserved-identifiers": "^1.2.0",
+                "semver": "^7.8.5",
+                "strip-indent": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+            },
+            "peerDependencies": {
+                "eslint": ">=10.4"
+            }
+        },
+        "node_modules/@enormora/eslint-config-mocha-node-assert/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@enormora/eslint-config-node": {
@@ -1595,14 +1915,14 @@
                 "globals": "17.7.0"
             }
         },
-        "node_modules/@enormora/eslint-config-test-base": {
-            "version": "0.0.16",
-            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-test-base/-/eslint-config-test-base-0.0.16.tgz",
-            "integrity": "sha512-gsHrXcbDq82QocymDLCscOi7mNl0CMCFoVAf3+HvmEiZ14QxDbxarygKJs9xKoVbnCYW9+7zEYeH26y+TM5BVA==",
+        "node_modules/@enormora/eslint-config-node-assert": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-config-node-assert/-/eslint-config-node-assert-0.0.3.tgz",
+            "integrity": "sha512-m2q5EJLIq5QQWHnC5/7In1QgTBWQnlijAFXNn6kBPgf2FekDH9SlTC8Ejj1vTemyHDPB30drcA+1LxZ24AKp2w==",
             "dev": true,
             "license": "MIT",
-            "peerDependencies": {
-                "@enormora/eslint-config-base": "0.0.46"
+            "dependencies": {
+                "@enormora/eslint-plugin-node-assert": "0.0.1"
             }
         },
         "node_modules/@enormora/eslint-config-typescript": {
@@ -1659,6 +1979,19 @@
                 "eslint-plugin-import-x": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@enormora/eslint-plugin-node-assert": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@enormora/eslint-plugin-node-assert/-/eslint-plugin-node-assert-0.0.1.tgz",
+            "integrity": "sha512-dWNe4o03/xYM/C6BCN97a05jmusBx2XfxKBR+zIZ0H2i7La6D3soQGKvzAwwGz3g0Y8sENvRX0O+QwFV02mhOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/utils": "8.62.1"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.0.0"
             }
         },
         "node_modules/@enormora/objectory": {
@@ -6953,6 +7286,20 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/convert-hrtime": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9358,6 +9705,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/function-timeout": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -9954,6 +10315,23 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/identifier-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+            "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "reserved-identifiers": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -10215,6 +10593,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-identifier": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+            "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "identifier-regex": "^1.1.0",
+                "super-regex": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-immutable-type": {
@@ -11420,6 +11816,39 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
+            }
+        },
+        "node_modules/make-asynchronous": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+            "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "p-event": "^6.0.0",
+                "type-fest": "^4.6.0",
+                "web-worker": "^1.5.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/make-asynchronous/node_modules/type-fest": {
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/make-dir": {
@@ -13460,6 +13889,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/p-event": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+            "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "p-timeout": "^6.1.2"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -13499,6 +13945,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+            "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14184,6 +14644,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/quote-js-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
+            "integrity": "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -14492,6 +14966,20 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/reserved-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+            "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/resolve": {
@@ -15549,6 +16037,25 @@
             "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
             "license": "MIT"
         },
+        "node_modules/super-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+            "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "function-timeout": "^1.0.1",
+                "make-asynchronous": "^1.0.1",
+                "time-span": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15688,6 +16195,23 @@
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
+            }
+        },
+        "node_modules/time-span": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "convert-hrtime": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tinybench": {
@@ -16882,6 +17406,14 @@
             "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
             "dev": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/web-worker": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+            "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     },
     "devDependencies": {
         "@enormora/eslint-config-base": "0.0.46",
-        "@enormora/eslint-config-mocha": "0.0.43",
+        "@enormora/eslint-config-mocha-node-assert": "0.0.3",
         "@enormora/eslint-config-node": "0.0.36",
         "@enormora/eslint-config-typescript": "0.0.53",
         "@enormora/objectory": "0.0.10",

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -139,22 +139,21 @@ suite('artifacts-builder', function () {
             ];
             await builder.buildTarball(bundleWithContents(contents, 'package.json'));
 
-            assert.partialDeepStrictEqual(tarballBuilder, {
-                build: {
+            assert.deepStrictEqual(
+                { callCount: tarballBuilder.build.callCount, args: tarballBuilder.build.firstCall.args },
+                {
                     callCount: 1,
-                    firstCall: {
-                        args: [
-                            [
-                                { filePath: 'package/package.json', content: '{}', isExecutable: false },
-                                { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
-                                { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
-                                { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
-                            ],
-                            []
-                        ]
-                    }
+                    args: [
+                        [
+                            { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                            { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
+                            { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
+                            { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
+                        ],
+                        []
+                    ]
                 }
-            });
+            );
         });
 
         test('buildFolder() writes only the manifest when the given bundle has no contents', async function () {
@@ -357,22 +356,21 @@ suite('artifacts-builder', function () {
             ];
             await builder.buildZip(bundleWithContents(contents, 'manifest.json'));
 
-            assert.partialDeepStrictEqual(zipBuilder, {
-                build: {
+            assert.deepStrictEqual(
+                { callCount: zipBuilder.build.callCount, args: zipBuilder.build.firstCall.args },
+                {
                     callCount: 1,
-                    firstCall: {
-                        args: [
-                            [
-                                { filePath: 'manifest.json', content: '{}', isExecutable: false },
-                                { filePath: 'handler.js', content: 'handler', isExecutable: false },
-                                { filePath: 'lib/helper.js', content: 'helper', isExecutable: false },
-                                { filePath: 'lib/cli.js', content: 'cli', isExecutable: false }
-                            ],
-                            []
-                        ]
-                    }
+                    args: [
+                        [
+                            { filePath: 'manifest.json', content: '{}', isExecutable: false },
+                            { filePath: 'handler.js', content: 'handler', isExecutable: false },
+                            { filePath: 'lib/helper.js', content: 'helper', isExecutable: false },
+                            { filePath: 'lib/cli.js', content: 'cli', isExecutable: false }
+                        ],
+                        []
+                    ]
                 }
-            });
+            );
         });
 
         test('buildZip() forwards extra files to the zip builder alongside the bundle contents', async function () {

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -139,16 +139,22 @@ suite('artifacts-builder', function () {
             ];
             await builder.buildTarball(bundleWithContents(contents, 'package.json'));
 
-            assert.strictEqual(tarballBuilder.build.callCount, 1);
-            assert.deepStrictEqual(tarballBuilder.build.firstCall.args, [
-                [
-                    { filePath: 'package/package.json', content: '{}', isExecutable: false },
-                    { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
-                    { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
-                    { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
-                ],
-                []
-            ]);
+            assert.partialDeepStrictEqual(tarballBuilder, {
+                build: {
+                    callCount: 1,
+                    firstCall: {
+                        args: [
+                            [
+                                { filePath: 'package/package.json', content: '{}', isExecutable: false },
+                                { filePath: 'package/bar.txt', content: 'bar', isExecutable: false },
+                                { filePath: 'package/baz.txt', content: 'baz', isExecutable: false },
+                                { filePath: 'package/qux.txt', content: 'qux', isExecutable: false }
+                            ],
+                            []
+                        ]
+                    }
+                }
+            });
         });
 
         test('buildFolder() writes only the manifest when the given bundle has no contents', async function () {
@@ -351,16 +357,22 @@ suite('artifacts-builder', function () {
             ];
             await builder.buildZip(bundleWithContents(contents, 'manifest.json'));
 
-            assert.strictEqual(zipBuilder.build.callCount, 1);
-            assert.deepStrictEqual(zipBuilder.build.firstCall.args, [
-                [
-                    { filePath: 'manifest.json', content: '{}', isExecutable: false },
-                    { filePath: 'handler.js', content: 'handler', isExecutable: false },
-                    { filePath: 'lib/helper.js', content: 'helper', isExecutable: false },
-                    { filePath: 'lib/cli.js', content: 'cli', isExecutable: false }
-                ],
-                []
-            ]);
+            assert.partialDeepStrictEqual(zipBuilder, {
+                build: {
+                    callCount: 1,
+                    firstCall: {
+                        args: [
+                            [
+                                { filePath: 'manifest.json', content: '{}', isExecutable: false },
+                                { filePath: 'handler.js', content: 'handler', isExecutable: false },
+                                { filePath: 'lib/helper.js', content: 'helper', isExecutable: false },
+                                { filePath: 'lib/cli.js', content: 'cli', isExecutable: false }
+                            ],
+                            []
+                        ]
+                    }
+                }
+            });
         });
 
         test('buildZip() forwards extra files to the zip builder alongside the bundle contents', async function () {

--- a/source/bootstrap-npm-package/bootstrap-runner.test.ts
+++ b/source/bootstrap-npm-package/bootstrap-runner.test.ts
@@ -114,19 +114,27 @@ function buildBootstrapInput(overrides: Partial<BootstrapInput> = {}): Bootstrap
 }
 
 function assertPlaceholderManifest(placeholderInput: PlaceholderTarballInput | undefined): void {
-    assert.ok(placeholderInput !== undefined);
-    assert.strictEqual(placeholderInput.manifest.name, '@scope/example');
-    assert.strictEqual(placeholderInput.manifest.version, '0.0.1');
-    assert.strictEqual(placeholderInput.manifest.license, 'MIT');
+    assert.notStrictEqual(placeholderInput, undefined);
+    assert.partialDeepStrictEqual(placeholderInput, {
+        manifest: {
+            name: '@scope/example',
+            version: '0.0.1',
+            license: 'MIT'
+        }
+    });
 }
 
 function assertPublicationInput(publication: PublicationInput | undefined): void {
-    assert.ok(publication !== undefined);
-    assert.strictEqual(publication.distTag, 'bootstrap');
-    assert.strictEqual(publication.registryUrl, 'https://registry.npmjs.org/');
-    assert.strictEqual(publication.token, 'session-token');
-    assert.strictEqual(publication.manifest.name, '@scope/example');
-    assert.deepStrictEqual(publication.tarball, Buffer.from('tarball-for-@scope/example'));
+    assert.notStrictEqual(publication, undefined);
+    assert.partialDeepStrictEqual(publication, {
+        distTag: 'bootstrap',
+        registryUrl: 'https://registry.npmjs.org/',
+        token: 'session-token',
+        manifest: {
+            name: '@scope/example'
+        },
+        tarball: Buffer.from('tarball-for-@scope/example')
+    });
 }
 
 suite('bootstrap-runner', function () {
@@ -171,7 +179,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput());
 
             const lastLog = scenario.recordings.logs.at(-1);
-            assert.ok(lastLog !== undefined);
+            assert.notStrictEqual(lastLog, undefined);
             assert.strictEqual(
                 lastLog,
                 'Done. Configure the Trusted Publisher at https://www.npmjs.com/package/@scope/example/access'
@@ -192,7 +200,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput());
 
             const [ publication ] = scenario.recordings.publicationInputs;
-            assert.ok(publication !== undefined);
+            assert.notStrictEqual(publication, undefined);
             assert.strictEqual(publication.promptForOneTimePassword, promptForOneTimePassword);
         });
     });
@@ -205,7 +213,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput({ packageName: '@scope/foo' }));
 
             const [ placeholderInput ] = scenario.recordings.placeholderInputs;
-            assert.ok(placeholderInput !== undefined);
+            assert.notStrictEqual(placeholderInput, undefined);
             const expectedDescription =
                 'Placeholder claiming the npm package name "@scope/foo" so a trusted publisher ' +
                 'can be configured. See https://github.com/npm/cli/issues/8544.';
@@ -219,7 +227,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput());
 
             const [ placeholderInput ] = scenario.recordings.placeholderInputs;
-            assert.ok(placeholderInput !== undefined);
+            assert.notStrictEqual(placeholderInput, undefined);
             const expectedDeprecation =
                 'Placeholder published as a workaround so a Trusted Publisher could be configured. ' +
                 'See https://github.com/npm/cli/issues/8544.';
@@ -244,7 +252,7 @@ suite('bootstrap-runner', function () {
             ]
                 .join('\n');
             const [ placeholderInput ] = scenario.recordings.placeholderInputs;
-            assert.ok(placeholderInput !== undefined);
+            assert.notStrictEqual(placeholderInput, undefined);
             assert.strictEqual(placeholderInput.readmeContent, expectedReadme);
         });
 

--- a/source/bootstrap-npm-package/bootstrap-runner.test.ts
+++ b/source/bootstrap-npm-package/bootstrap-runner.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import { type BootstrapInput, type BootstrapRunnerDependencies, createBootstrapRunner } from './bootstrap-runner.ts';
 import type { PackagePublication } from './package-publication.ts';
 import type { PlaceholderTarballBuilder } from './placeholder-tarball.ts';
@@ -114,7 +115,7 @@ function buildBootstrapInput(overrides: Partial<BootstrapInput> = {}): Bootstrap
 }
 
 function assertPlaceholderManifest(placeholderInput: PlaceholderTarballInput | undefined): void {
-    assert.notStrictEqual(placeholderInput, undefined);
+    assertDefined(placeholderInput);
     assert.partialDeepStrictEqual(placeholderInput, {
         manifest: {
             name: '@scope/example',
@@ -125,7 +126,7 @@ function assertPlaceholderManifest(placeholderInput: PlaceholderTarballInput | u
 }
 
 function assertPublicationInput(publication: PublicationInput | undefined): void {
-    assert.notStrictEqual(publication, undefined);
+    assertDefined(publication);
     assert.partialDeepStrictEqual(publication, {
         distTag: 'bootstrap',
         registryUrl: 'https://registry.npmjs.org/',
@@ -179,7 +180,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput());
 
             const lastLog = scenario.recordings.logs.at(-1);
-            assert.notStrictEqual(lastLog, undefined);
+            assertDefined(lastLog);
             assert.strictEqual(
                 lastLog,
                 'Done. Configure the Trusted Publisher at https://www.npmjs.com/package/@scope/example/access'
@@ -200,7 +201,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput());
 
             const [ publication ] = scenario.recordings.publicationInputs;
-            assert.notStrictEqual(publication, undefined);
+            assertDefined(publication);
             assert.strictEqual(publication.promptForOneTimePassword, promptForOneTimePassword);
         });
     });
@@ -213,7 +214,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput({ packageName: '@scope/foo' }));
 
             const [ placeholderInput ] = scenario.recordings.placeholderInputs;
-            assert.notStrictEqual(placeholderInput, undefined);
+            assertDefined(placeholderInput);
             const expectedDescription =
                 'Placeholder claiming the npm package name "@scope/foo" so a trusted publisher ' +
                 'can be configured. See https://github.com/npm/cli/issues/8544.';
@@ -227,7 +228,7 @@ suite('bootstrap-runner', function () {
             await runner.run(buildBootstrapInput());
 
             const [ placeholderInput ] = scenario.recordings.placeholderInputs;
-            assert.notStrictEqual(placeholderInput, undefined);
+            assertDefined(placeholderInput);
             const expectedDeprecation =
                 'Placeholder published as a workaround so a Trusted Publisher could be configured. ' +
                 'See https://github.com/npm/cli/issues/8544.';
@@ -252,7 +253,7 @@ suite('bootstrap-runner', function () {
             ]
                 .join('\n');
             const [ placeholderInput ] = scenario.recordings.placeholderInputs;
-            assert.notStrictEqual(placeholderInput, undefined);
+            assertDefined(placeholderInput);
             assert.strictEqual(placeholderInput.readmeContent, expectedReadme);
         });
 

--- a/source/bootstrap-npm-package/package-publication.test.ts
+++ b/source/bootstrap-npm-package/package-publication.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import {
     createPackagePublication,
     type PackagePublication,
@@ -109,7 +110,7 @@ function buildInput(overrides: Partial<PublicationInput> = {}): PublicationInput
 }
 
 function assertFirstPublishCallOptions(call: PublishCallRecord | undefined): void {
-    assert.notStrictEqual(call, undefined);
+    assertDefined(call);
     assert.partialDeepStrictEqual(call, {
         defaultTag: 'bootstrap',
         access: 'public',
@@ -121,7 +122,7 @@ function assertFirstPublishCallOptions(call: PublishCallRecord | undefined): voi
 }
 
 function assertRetryOptions(retryOptions: LibnpmpublishOptions | undefined): void {
-    assert.notStrictEqual(retryOptions, undefined);
+    assertDefined(retryOptions);
     assert.partialDeepStrictEqual(retryOptions, {
         otp: 'web-otp-token',
         defaultTag: 'bootstrap',
@@ -161,7 +162,7 @@ suite('package-publication', function () {
         await publication.publish(buildInput({ manifest, tarball }));
 
         const [ call ] = calls;
-        assert.notStrictEqual(call, undefined);
+        assertDefined(call);
         assert.partialDeepStrictEqual(call, {
             manifest,
             tarball

--- a/source/bootstrap-npm-package/package-publication.test.ts
+++ b/source/bootstrap-npm-package/package-publication.test.ts
@@ -109,23 +109,29 @@ function buildInput(overrides: Partial<PublicationInput> = {}): PublicationInput
 }
 
 function assertFirstPublishCallOptions(call: PublishCallRecord | undefined): void {
-    assert.ok(call !== undefined);
-    assert.strictEqual(call.defaultTag, 'bootstrap');
-    assert.strictEqual(call.access, 'public');
-    assert.strictEqual(call.registry, 'https://registry.npmjs.org/');
-    assert.strictEqual(call.forceAuthToken, 'bearer');
-    assert.strictEqual(call.authType, 'web');
-    assert.strictEqual(call.otp, undefined);
+    assert.notStrictEqual(call, undefined);
+    assert.partialDeepStrictEqual(call, {
+        defaultTag: 'bootstrap',
+        access: 'public',
+        registry: 'https://registry.npmjs.org/',
+        forceAuthToken: 'bearer',
+        authType: 'web',
+        otp: undefined
+    });
 }
 
 function assertRetryOptions(retryOptions: LibnpmpublishOptions | undefined): void {
-    assert.ok(retryOptions !== undefined);
-    assert.strictEqual(retryOptions.otp, 'web-otp-token');
-    assert.strictEqual(retryOptions.defaultTag, 'bootstrap');
-    assert.strictEqual(retryOptions.access, 'public');
-    assert.strictEqual(retryOptions.registry, 'https://registry.npmjs.org/');
-    assert.strictEqual(retryOptions.forceAuth.token, 'bearer');
-    assert.strictEqual(retryOptions.authType, 'web');
+    assert.notStrictEqual(retryOptions, undefined);
+    assert.partialDeepStrictEqual(retryOptions, {
+        otp: 'web-otp-token',
+        defaultTag: 'bootstrap',
+        access: 'public',
+        registry: 'https://registry.npmjs.org/',
+        forceAuth: {
+            token: 'bearer'
+        },
+        authType: 'web'
+    });
 }
 
 suite('package-publication', function () {
@@ -155,9 +161,11 @@ suite('package-publication', function () {
         await publication.publish(buildInput({ manifest, tarball }));
 
         const [ call ] = calls;
-        assert.ok(call !== undefined);
-        assert.deepStrictEqual(call.manifest, manifest);
-        assert.strictEqual(call.tarball, tarball);
+        assert.notStrictEqual(call, undefined);
+        assert.partialDeepStrictEqual(call, {
+            manifest,
+            tarball
+        });
     });
 
     test('forwards the web-OTP urls from an EOTP body to the prompt and retries with the returned OTP', async function () {

--- a/source/bootstrap-npm-package/placeholder-tarball.test.ts
+++ b/source/bootstrap-npm-package/placeholder-tarball.test.ts
@@ -3,6 +3,7 @@ import { Readable } from 'node:stream';
 import zlib from 'node:zlib';
 import { suite, test } from 'mocha';
 import tar from 'tar-stream';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import { createPlaceholderTarballBuilder, type PlaceholderTarballBuilder } from './placeholder-tarball.ts';
 
 type PlaceholderTarballInput = Parameters<PlaceholderTarballBuilder['build']>[0];
@@ -89,7 +90,7 @@ suite('placeholder-tarball', function () {
             return entry.name === 'package/package.json';
         });
 
-        assert.notStrictEqual(manifestEntry, undefined, 'expected manifest entry');
+        assertDefined(manifestEntry, 'expected manifest entry');
         assert.strictEqual(manifestEntry.content.endsWith('\n'), true);
         assert.deepStrictEqual(JSON.parse(manifestEntry.content), {
             name: '@scope/example',
@@ -110,7 +111,7 @@ suite('placeholder-tarball', function () {
             return entry.name === 'package/readme.md';
         });
 
-        assert.notStrictEqual(readmeEntry, undefined, 'expected readme entry');
+        assertDefined(readmeEntry, 'expected readme entry');
         assert.strictEqual(readmeEntry.content, readmeContent);
     });
 

--- a/source/bootstrap-npm-package/placeholder-tarball.test.ts
+++ b/source/bootstrap-npm-package/placeholder-tarball.test.ts
@@ -89,7 +89,7 @@ suite('placeholder-tarball', function () {
             return entry.name === 'package/package.json';
         });
 
-        assert.ok(manifestEntry !== undefined, 'expected manifest entry');
+        assert.notStrictEqual(manifestEntry, undefined, 'expected manifest entry');
         assert.strictEqual(manifestEntry.content.endsWith('\n'), true);
         assert.deepStrictEqual(JSON.parse(manifestEntry.content), {
             name: '@scope/example',
@@ -110,7 +110,7 @@ suite('placeholder-tarball', function () {
             return entry.name === 'package/readme.md';
         });
 
-        assert.ok(readmeEntry !== undefined, 'expected readme entry');
+        assert.notStrictEqual(readmeEntry, undefined, 'expected readme entry');
         assert.strictEqual(readmeEntry.content, readmeContent);
     });
 

--- a/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
+++ b/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
@@ -99,8 +99,10 @@ suite('mutation-timeout-cli-runner', function () {
                 })
             );
 
-            assert.strictEqual(result.exitCode, 1);
-            assert.deepStrictEqual(result.errors, [ timeoutReportMessage() ]);
+            assert.partialDeepStrictEqual(result, {
+                exitCode: 1,
+                errors: [ timeoutReportMessage() ]
+            });
         });
     });
 
@@ -113,8 +115,10 @@ suite('mutation-timeout-cli-runner', function () {
                 })
             );
 
-            assert.strictEqual(result.exitCode, 0);
-            assert.deepStrictEqual(result.errors, []);
+            assert.partialDeepStrictEqual(result, {
+                exitCode: 0,
+                errors: []
+            });
         });
     });
 
@@ -124,8 +128,10 @@ suite('mutation-timeout-cli-runner', function () {
         });
         const result = await runCheckWithCollectedErrors([ 'node', 'check' ], fileManager);
 
-        assert.strictEqual(result.exitCode, 0);
-        assert.deepStrictEqual(result.errors, []);
+        assert.partialDeepStrictEqual(result, {
+            exitCode: 0,
+            errors: []
+        });
         assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: defaultReportFilePath });
     });
 
@@ -144,8 +150,10 @@ suite('mutation-timeout-cli-runner', function () {
             })
         );
 
-        assert.strictEqual(result.exitCode, 1);
-        assert.deepStrictEqual(result.errors, [ `Mutation report not found at "${defaultMissingReportPath}"` ]);
+        assert.partialDeepStrictEqual(result, {
+            exitCode: 1,
+            errors: [ `Mutation report not found at "${defaultMissingReportPath}"` ]
+        });
     });
 
     test('runMutationTimeoutCheck uses the default stderr writer when no custom writer is passed', async function () {
@@ -207,8 +215,10 @@ suite('mutation-timeout-cli-runner', function () {
         await withDefaultReport(singleMutantReport(killedMutant), async function (directory) {
             const result = await runCheckerCli([], directory);
 
-            assert.strictEqual(result.exitCode, 0);
-            assert.strictEqual(result.standardError, '');
+            assert.partialDeepStrictEqual(result, {
+                exitCode: 0,
+                standardError: ''
+            });
         });
     });
 });

--- a/source/bundle-emitter/emitter-publish.test.ts
+++ b/source/bundle-emitter/emitter-publish.test.ts
@@ -120,18 +120,13 @@ suite('emitter publish', function () {
 
         await publishBundle(emitter, { publishSettings });
 
-        assert.partialDeepStrictEqual(publishPackage, {
-            callCount: 1,
-            firstCall: {
-                args: [
-                    { name: '', version: '' },
-                    emptyTarball,
-                    registrySettings,
-                    publishSettings,
-                    false
-                ]
+        assert.deepStrictEqual(
+            { callCount: publishPackage.callCount, args: publishPackage.firstCall.args },
+            {
+                callCount: 1,
+                args: [ { name: '', version: '' }, emptyTarball, registrySettings, publishSettings, false ]
             }
-        });
+        );
     });
 
     test('publish() adds the current git head to the registry manifest without changing the bundle manifest', async function () {
@@ -159,9 +154,7 @@ suite('emitter publish', function () {
         });
         assert.deepStrictEqual(buildTarball.firstCall.args[0], bundle);
         assert.partialDeepStrictEqual(bundle, {
-            manifestFile: {
-                content: '{"name":"the-name","version":"1.0.0"}'
-            },
+            manifestFile: { content: '{"name":"the-name","version":"1.0.0"}' },
             packageJson: { name: 'the-name', version: '1.0.0' }
         });
     });
@@ -223,14 +216,10 @@ suite('emitter publish', function () {
         } catch (error) {
             assert.ok(error instanceof Error);
             assert.match(error.message, /repository URL does not match/u);
-            assert.partialDeepStrictEqual(scenario, {
-                buildTarball: {
-                    callCount: 0
-                },
-                publishPackage: {
-                    callCount: 0
-                }
-            });
+            assert.deepStrictEqual(
+                { buildTarball: scenario.buildTarball.callCount, publishPackage: scenario.publishPackage.callCount },
+                { buildTarball: 0, publishPackage: 0 }
+            );
             return;
         }
         assert.fail('Expected publish() to throw');
@@ -244,14 +233,10 @@ suite('emitter publish', function () {
             publishSettings: { access: 'public', provenance: { type: 'file', path: '/build/bundle.sigstore' } }
         });
 
-        assert.partialDeepStrictEqual(scenario, {
-            buildTarball: {
-                callCount: 1
-            },
-            publishPackage: {
-                callCount: 1
-            }
-        });
+        assert.deepStrictEqual(
+            { buildTarball: scenario.buildTarball.callCount, publishPackage: scenario.publishPackage.callCount },
+            { buildTarball: 1, publishPackage: 1 }
+        );
     });
 
     test('publish() does not run the coherence check when provenance is unset', async function () {
@@ -262,14 +247,10 @@ suite('emitter publish', function () {
             publishSettings: { access: 'public' }
         });
 
-        assert.partialDeepStrictEqual(scenario, {
-            buildTarball: {
-                callCount: 1
-            },
-            publishPackage: {
-                callCount: 1
-            }
-        });
+        assert.deepStrictEqual(
+            { buildTarball: scenario.buildTarball.callCount, publishPackage: scenario.publishPackage.callCount },
+            { buildTarball: 1, publishPackage: 1 }
+        );
     });
 
     test('publish() does not run the coherence check when access is restricted even if provenance is set to auto', async function () {
@@ -280,13 +261,9 @@ suite('emitter publish', function () {
             publishSettings: { access: 'restricted', provenance: { type: 'auto' } } as unknown as PublishSettings
         });
 
-        assert.partialDeepStrictEqual(scenario, {
-            buildTarball: {
-                callCount: 1
-            },
-            publishPackage: {
-                callCount: 1
-            }
-        });
+        assert.deepStrictEqual(
+            { buildTarball: scenario.buildTarball.callCount, publishPackage: scenario.publishPackage.callCount },
+            { buildTarball: 1, publishPackage: 1 }
+        );
     });
 });

--- a/source/bundle-emitter/emitter-publish.test.ts
+++ b/source/bundle-emitter/emitter-publish.test.ts
@@ -120,14 +120,18 @@ suite('emitter publish', function () {
 
         await publishBundle(emitter, { publishSettings });
 
-        assert.strictEqual(publishPackage.callCount, 1);
-        assert.deepStrictEqual(publishPackage.firstCall.args, [
-            { name: '', version: '' },
-            emptyTarball,
-            registrySettings,
-            publishSettings,
-            false
-        ]);
+        assert.partialDeepStrictEqual(publishPackage, {
+            callCount: 1,
+            firstCall: {
+                args: [
+                    { name: '', version: '' },
+                    emptyTarball,
+                    registrySettings,
+                    publishSettings,
+                    false
+                ]
+            }
+        });
     });
 
     test('publish() adds the current git head to the registry manifest without changing the bundle manifest', async function () {
@@ -154,8 +158,12 @@ suite('emitter publish', function () {
             gitHead: 'abcdef123456'
         });
         assert.deepStrictEqual(buildTarball.firstCall.args[0], bundle);
-        assert.strictEqual(bundle.manifestFile.content, '{"name":"the-name","version":"1.0.0"}');
-        assert.deepStrictEqual(bundle.packageJson, { name: 'the-name', version: '1.0.0' });
+        assert.partialDeepStrictEqual(bundle, {
+            manifestFile: {
+                content: '{"name":"the-name","version":"1.0.0"}'
+            },
+            packageJson: { name: 'the-name', version: '1.0.0' }
+        });
     });
 
     test('checkBundleAlreadyPublished() ignores gitHead-only manifest differences', async function () {
@@ -215,8 +223,14 @@ suite('emitter publish', function () {
         } catch (error) {
             assert.ok(error instanceof Error);
             assert.match(error.message, /repository URL does not match/u);
-            assert.strictEqual(scenario.buildTarball.callCount, 0);
-            assert.strictEqual(scenario.publishPackage.callCount, 0);
+            assert.partialDeepStrictEqual(scenario, {
+                buildTarball: {
+                    callCount: 0
+                },
+                publishPackage: {
+                    callCount: 0
+                }
+            });
             return;
         }
         assert.fail('Expected publish() to throw');
@@ -230,8 +244,14 @@ suite('emitter publish', function () {
             publishSettings: { access: 'public', provenance: { type: 'file', path: '/build/bundle.sigstore' } }
         });
 
-        assert.strictEqual(scenario.buildTarball.callCount, 1);
-        assert.strictEqual(scenario.publishPackage.callCount, 1);
+        assert.partialDeepStrictEqual(scenario, {
+            buildTarball: {
+                callCount: 1
+            },
+            publishPackage: {
+                callCount: 1
+            }
+        });
     });
 
     test('publish() does not run the coherence check when provenance is unset', async function () {
@@ -242,8 +262,14 @@ suite('emitter publish', function () {
             publishSettings: { access: 'public' }
         });
 
-        assert.strictEqual(scenario.buildTarball.callCount, 1);
-        assert.strictEqual(scenario.publishPackage.callCount, 1);
+        assert.partialDeepStrictEqual(scenario, {
+            buildTarball: {
+                callCount: 1
+            },
+            publishPackage: {
+                callCount: 1
+            }
+        });
     });
 
     test('publish() does not run the coherence check when access is restricted even if provenance is set to auto', async function () {
@@ -254,7 +280,13 @@ suite('emitter publish', function () {
             publishSettings: { access: 'restricted', provenance: { type: 'auto' } } as unknown as PublishSettings
         });
 
-        assert.strictEqual(scenario.buildTarball.callCount, 1);
-        assert.strictEqual(scenario.publishPackage.callCount, 1);
+        assert.partialDeepStrictEqual(scenario, {
+            buildTarball: {
+                callCount: 1
+            },
+            publishPackage: {
+                callCount: 1
+            }
+        });
     });
 });

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -208,12 +208,10 @@ suite('emitter', function () {
 
             await determineCurrentVersion(emitter, { stage: false, versioning: { automatic: true } });
 
-            assert.partialDeepStrictEqual(fetchLatestVersion, {
-                callCount: 1,
-                firstCall: {
-                    args: [ 'the-name', registrySettings ]
-                }
-            });
+            assert.deepStrictEqual(
+                { callCount: fetchLatestVersion.callCount, args: fetchLatestVersion.firstCall.args },
+                { callCount: 1, args: [ 'the-name', registrySettings ] }
+            );
         });
 
         test('determineCurrentVersion() returns the fetched version when automatic versioning is enabled', async function () {
@@ -436,12 +434,13 @@ suite('emitter', function () {
                 bundle: namedBundle()
             });
 
-            assert.partialDeepStrictEqual(fetchLatestReleaseMetadata, {
-                callCount: 1,
-                firstCall: {
-                    args: [ 'the-name', registrySettings ]
-                }
-            });
+            assert.deepStrictEqual(
+                {
+                    callCount: fetchLatestReleaseMetadata.callCount,
+                    args: fetchLatestReleaseMetadata.firstCall.args
+                },
+                { callCount: 1, args: [ 'the-name', registrySettings ] }
+            );
         });
 
         test('checkBundleAlreadyPublished() returns false and Nothing when there is no latest version in the registry', async function () {
@@ -454,12 +453,16 @@ suite('emitter', function () {
                 bundle: namedBundle()
             });
 
-            assert.partialDeepStrictEqual(result, {
-                alreadyPublishedAsLatest: false,
-                previousReleaseArtifacts: {
-                    isNothing: true
+            assert.deepStrictEqual(
+                {
+                    alreadyPublishedAsLatest: result.alreadyPublishedAsLatest,
+                    previousReleaseArtifactsIsNothing: result.previousReleaseArtifacts.isNothing
+                },
+                {
+                    alreadyPublishedAsLatest: false,
+                    previousReleaseArtifactsIsNothing: true
                 }
-            });
+            );
             assert.strictEqual(collectContents.callCount, 0);
         });
 

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -161,8 +161,10 @@ function assertPreviousReleaseArtifacts(
     value: PreviousReleaseArtifactsSummary,
     expectedFileCount?: number
 ): void {
-    assert.strictEqual(value.version, latestReleaseMetadata.version);
-    assert.deepStrictEqual(value.publishedAt, publishedAt);
+    assert.partialDeepStrictEqual(value, {
+        version: latestReleaseMetadata.version,
+        publishedAt
+    });
 
     if (expectedFileCount !== undefined) {
         assert.strictEqual(value.files.length, expectedFileCount);
@@ -206,8 +208,12 @@ suite('emitter', function () {
 
             await determineCurrentVersion(emitter, { stage: false, versioning: { automatic: true } });
 
-            assert.strictEqual(fetchLatestVersion.callCount, 1);
-            assert.deepStrictEqual(fetchLatestVersion.firstCall.args, [ 'the-name', registrySettings ]);
+            assert.partialDeepStrictEqual(fetchLatestVersion, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'the-name', registrySettings ]
+                }
+            });
         });
 
         test('determineCurrentVersion() returns the fetched version when automatic versioning is enabled', async function () {
@@ -430,8 +436,12 @@ suite('emitter', function () {
                 bundle: namedBundle()
             });
 
-            assert.strictEqual(fetchLatestReleaseMetadata.callCount, 1);
-            assert.deepStrictEqual(fetchLatestReleaseMetadata.firstCall.args, [ 'the-name', registrySettings ]);
+            assert.partialDeepStrictEqual(fetchLatestReleaseMetadata, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'the-name', registrySettings ]
+                }
+            });
         });
 
         test('checkBundleAlreadyPublished() returns false and Nothing when there is no latest version in the registry', async function () {
@@ -444,8 +454,12 @@ suite('emitter', function () {
                 bundle: namedBundle()
             });
 
-            assert.strictEqual(result.alreadyPublishedAsLatest, false);
-            assert.strictEqual(result.previousReleaseArtifacts.isNothing, true);
+            assert.partialDeepStrictEqual(result, {
+                alreadyPublishedAsLatest: false,
+                previousReleaseArtifacts: {
+                    isNothing: true
+                }
+            });
             assert.strictEqual(collectContents.callCount, 0);
         });
 

--- a/source/bundle-emitter/fetch-published-artifacts.test.ts
+++ b/source/bundle-emitter/fetch-published-artifacts.test.ts
@@ -27,10 +27,14 @@ function assertFetchedArtifacts(result: Awaited<ReturnType<typeof fetchPublished
     if (result.isNothing) {
         assert.fail('expected fetched artifacts');
     }
-    assert.strictEqual(result.value.version, '1.2.3');
-    assert.deepStrictEqual(result.value.publishedAt, new Date('2026-05-20T00:00:00.000Z'));
-    assert.strictEqual(result.value.gitHead, 'abcdef123456');
-    assert.deepStrictEqual(result.value.files, []);
+    assert.partialDeepStrictEqual(result, {
+        value: {
+            version: '1.2.3',
+            publishedAt: new Date('2026-05-20T00:00:00.000Z'),
+            gitHead: 'abcdef123456',
+            files: []
+        }
+    });
 }
 
 suite('fetch-published-artifacts', function () {
@@ -42,8 +46,12 @@ suite('fetch-published-artifacts', function () {
         const result = await fetchPublishedArtifacts(client, 'the-name', registrySettings);
 
         assert.strictEqual(result.isNothing, true);
-        assert.strictEqual(fetchLatestReleaseMetadata.callCount, 1);
-        assert.deepStrictEqual(fetchLatestReleaseMetadata.firstCall.args, [ 'the-name', registrySettings ]);
+        assert.partialDeepStrictEqual(fetchLatestReleaseMetadata, {
+            callCount: 1,
+            firstCall: {
+                args: [ 'the-name', registrySettings ]
+            }
+        });
         assert.strictEqual(fetchTarball.callCount, 0);
     });
 

--- a/source/bundle-emitter/fetch-published-artifacts.test.ts
+++ b/source/bundle-emitter/fetch-published-artifacts.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import { Maybe } from 'true-myth';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { emptyTarball } from '../test-libraries/tarball-fixtures.ts';
 import type { RegistryClient } from './registry/registry-client.ts';
 import { fetchPublishedArtifacts } from './fetch-published-artifacts.ts';
@@ -27,7 +28,7 @@ function assertFetchedArtifacts(result: Awaited<ReturnType<typeof fetchPublished
     if (result.isNothing) {
         assert.fail('expected fetched artifacts');
     }
-    assert.partialDeepStrictEqual(result, {
+    assertDeepSubset(result, {
         value: {
             version: '1.2.3',
             publishedAt: new Date('2026-05-20T00:00:00.000Z'),
@@ -46,7 +47,7 @@ suite('fetch-published-artifacts', function () {
         const result = await fetchPublishedArtifacts(client, 'the-name', registrySettings);
 
         assert.strictEqual(result.isNothing, true);
-        assert.partialDeepStrictEqual(fetchLatestReleaseMetadata, {
+        assertDeepSubset(fetchLatestReleaseMetadata, {
             callCount: 1,
             firstCall: {
                 args: [ 'the-name', registrySettings ]

--- a/source/bundle-emitter/registry/registry-client-metadata-auto-retry.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-auto-retry.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import { Maybe } from 'true-myth';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     createRetryingMetadataFetch,
     errorWithStatus,
@@ -30,7 +31,7 @@ suite('registry-client metadata auto retry', function () {
         const result = await registryClient.fetchLatestVersion('the-name', { auth: metadataAutoBearerAuth });
 
         expectLatestVersion(result);
-        assert.partialDeepStrictEqual(npmFetchJson, {
+        assertDeepSubset(npmFetchJson, {
             callCount: 2,
             firstCall: {
                 args: [

--- a/source/bundle-emitter/registry/registry-client-metadata-auto-retry.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-auto-retry.test.ts
@@ -30,24 +30,30 @@ suite('registry-client metadata auto retry', function () {
         const result = await registryClient.fetchLatestVersion('the-name', { auth: metadataAutoBearerAuth });
 
         expectLatestVersion(result);
-        assert.strictEqual(npmFetchJson.callCount, 2);
-        assert.deepStrictEqual(npmFetchJson.firstCall.args, [
-            '/the-name',
-            {
-                alwaysAuth: true,
-                registry: undefined,
-                headers: { accept: 'application/vnd.npm.install-v1+json' }
+        assert.partialDeepStrictEqual(npmFetchJson, {
+            callCount: 2,
+            firstCall: {
+                args: [
+                    '/the-name',
+                    {
+                        alwaysAuth: true,
+                        registry: undefined,
+                        headers: { accept: 'application/vnd.npm.install-v1+json' }
+                    }
+                ]
+            },
+            secondCall: {
+                args: [
+                    '/the-name',
+                    {
+                        alwaysAuth: true,
+                        registry: undefined,
+                        forceAuth: { token: 'writer-token' },
+                        headers: { accept: 'application/vnd.npm.install-v1+json' }
+                    }
+                ]
             }
-        ]);
-        assert.deepStrictEqual(npmFetchJson.secondCall.args, [
-            '/the-name',
-            {
-                alwaysAuth: true,
-                registry: undefined,
-                forceAuth: { token: 'writer-token' },
-                headers: { accept: 'application/vnd.npm.install-v1+json' }
-            }
-        ]);
+        });
     });
 
     test('metadata auto retries with publish auth on a 403 challenge', async function () {

--- a/source/bundle-emitter/registry/registry-client-metadata-no-retry.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-no-retry.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     errorWithStatus,
     expectFailure,
@@ -87,7 +88,7 @@ suite('registry-client metadata no retry', function () {
         });
 
         assert.deepStrictEqual(result, Buffer.from([ 1, 2, 3 ]));
-        assert.partialDeepStrictEqual(npmFetch, {
+        assertDeepSubset(npmFetch, {
             callCount: 2,
             secondCall: {
                 args: [

--- a/source/bundle-emitter/registry/registry-client-metadata-no-retry.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-no-retry.test.ts
@@ -87,16 +87,20 @@ suite('registry-client metadata no retry', function () {
         });
 
         assert.deepStrictEqual(result, Buffer.from([ 1, 2, 3 ]));
-        assert.strictEqual(npmFetch.callCount, 2);
-        assert.deepStrictEqual(npmFetch.secondCall.args, [
-            'https://registry.example.test/pkg.tgz',
-            {
-                alwaysAuth: true,
-                registry: 'https://registry.example.test/',
-                forceAuth: {
-                    _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
-                }
+        assert.partialDeepStrictEqual(npmFetch, {
+            callCount: 2,
+            secondCall: {
+                args: [
+                    'https://registry.example.test/pkg.tgz',
+                    {
+                        alwaysAuth: true,
+                        registry: 'https://registry.example.test/',
+                        forceAuth: {
+                            _auth: Buffer.from('reader:reader-secret', 'utf8').toString('base64')
+                        }
+                    }
+                ]
             }
-        ]);
+        });
     });
 });

--- a/source/bundle-emitter/registry/registry-client-publish-outcomes.test.ts
+++ b/source/bundle-emitter/registry/registry-client-publish-outcomes.test.ts
@@ -16,8 +16,10 @@ suite('registry-client publish outcomes', function () {
         await publishWithBearerToken(registryClient, { access: 'public', provenance: { type: 'auto' } }, false);
 
         const publishOptions = publish.firstCall.args.at(-1) as Record<string, unknown>;
-        assert.strictEqual(publishOptions.access, 'public');
-        assert.strictEqual(publishOptions.provenance, true);
+        assert.partialDeepStrictEqual(publishOptions, {
+            access: 'public',
+            provenance: true
+        });
     });
 
     test('publishPackage() rewrites a libnpmpublish error through the publish-settings bridge', async function () {

--- a/source/bundle-emitter/registry/registry-client-staged-versions.test.ts
+++ b/source/bundle-emitter/registry/registry-client-staged-versions.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     buildStagedVersionsFetchJson,
     registryClientFactory
@@ -41,7 +42,7 @@ suite('registry-client staged versions', function () {
         });
 
         assert.deepStrictEqual(result, [ '1.2.4', '1.2.5' ]);
-        assert.partialDeepStrictEqual(npmFetchJson, {
+        assertDeepSubset(npmFetchJson, {
             callCount: 2,
             firstCall: {
                 firstArg: '/-/stage?package=the-name&page=0&perPage=100'

--- a/source/bundle-emitter/registry/registry-client-staged-versions.test.ts
+++ b/source/bundle-emitter/registry/registry-client-staged-versions.test.ts
@@ -41,9 +41,15 @@ suite('registry-client staged versions', function () {
         });
 
         assert.deepStrictEqual(result, [ '1.2.4', '1.2.5' ]);
-        assert.strictEqual(npmFetchJson.callCount, 2);
-        assert.strictEqual(npmFetchJson.firstCall.firstArg, '/-/stage?package=the-name&page=0&perPage=100');
-        assert.strictEqual(npmFetchJson.secondCall.firstArg, '/-/stage?package=the-name&page=1&perPage=100');
+        assert.partialDeepStrictEqual(npmFetchJson, {
+            callCount: 2,
+            firstCall: {
+                firstArg: '/-/stage?package=the-name&page=0&perPage=100'
+            },
+            secondCall: {
+                firstArg: '/-/stage?package=the-name&page=1&perPage=100'
+            }
+        });
     });
 
     test('fetchStagedVersions() accepts an empty stage list with total zero', async function () {

--- a/source/bundle-emitter/registry/validate-tarball-host.test.ts
+++ b/source/bundle-emitter/registry/validate-tarball-host.test.ts
@@ -18,9 +18,9 @@ suite('validate-tarball-host', function () {
     test('accepts a tarball URL whose host matches the default npm registry', function () {
         const settings: RegistrySettings = { auth: bearerAuth };
 
-        assert.doesNotThrow(function () {
-            assertTarballOriginMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
-        });
+        assertTarballOriginMatchesRegistry('https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz', settings);
+
+        assert.strictEqual(settings.auth, bearerAuth);
     });
 
     test('accepts a tarball URL whose host matches a configured custom registry', function () {
@@ -29,9 +29,9 @@ suite('validate-tarball-host', function () {
             auth: bearerAuth
         };
 
-        assert.doesNotThrow(function () {
-            assertTarballOriginMatchesRegistry('https://registry.example.test/pkg/-/pkg-1.0.0.tgz', settings);
-        });
+        assertTarballOriginMatchesRegistry('https://registry.example.test/pkg/-/pkg-1.0.0.tgz', settings);
+
+        assert.strictEqual(settings.registryUrl, 'https://registry.example.test/path/');
     });
 
     test('rejects a tarball URL whose host differs from the default npm registry', function () {

--- a/source/bundle-emitter/repository-coherence.test.ts
+++ b/source/bundle-emitter/repository-coherence.test.ts
@@ -267,7 +267,7 @@ suite('repository-coherence', function () {
 
             assert.strictEqual(
                 normalizeRepositoryUrl('git+ssh://git@github.com/enormora/packtory.git'),
-                'github.com/enormora/packtory'
+                'https://github.com/enormora/packtory'
             );
         });
 

--- a/source/bundle-emitter/repository-coherence.test.ts
+++ b/source/bundle-emitter/repository-coherence.test.ts
@@ -244,21 +244,31 @@ suite('repository-coherence', function () {
 
     suite('repository coherence assertions', function () {
         test('assertRepositoryCoherence() does not throw when the manifest matches the CI repository', function () {
-            assert.doesNotThrow(function () {
-                assertRepositoryCoherence(
-                    { repository: 'git+ssh://git@github.com/enormora/packtory.git' },
-                    'https://github.com/enormora/packtory'
-                );
-            });
+            assertRepositoryCoherence(
+                { repository: 'git+ssh://git@github.com/enormora/packtory.git' },
+                'https://github.com/enormora/packtory'
+            );
+
+            assert.strictEqual(
+                getCiRepositoryUrl({
+                    githubRepository: 'enormora/packtory',
+                    githubServerUrl: 'https://github.com',
+                    gitlabProjectUrl: ''
+                }),
+                'https://github.com/enormora/packtory'
+            );
         });
 
         test('assertRepositoryCoherence() does not throw when the object form matches the CI repository', function () {
-            assert.doesNotThrow(function () {
-                assertRepositoryCoherence(
-                    { repository: { type: 'git', url: 'git+ssh://git@github.com/enormora/packtory.git' } },
-                    'https://github.com/enormora/packtory'
-                );
-            });
+            assertRepositoryCoherence(
+                { repository: { type: 'git', url: 'git+ssh://git@github.com/enormora/packtory.git' } },
+                'https://github.com/enormora/packtory'
+            );
+
+            assert.strictEqual(
+                normalizeRepositoryUrl('git+ssh://git@github.com/enormora/packtory.git'),
+                'github.com/enormora/packtory'
+            );
         });
 
         test('assertRepositoryCoherence() throws when the manifest repository differs from the CI repository', function () {

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
@@ -117,8 +118,8 @@ suite('no-duplicated-files', function () {
     test('rule definition exposes name, schemas and a run function', function () {
         assert.strictEqual(noDuplicatedFilesRule.name, 'noDuplicatedFiles');
         assert.strictEqual(typeof noDuplicatedFilesRule.run, 'function');
-        assert.notStrictEqual(noDuplicatedFilesRule.globalSchema, undefined);
-        assert.notStrictEqual(noDuplicatedFilesRule.perPackageSchema, undefined);
+        assertDefined(noDuplicatedFilesRule.globalSchema);
+        assertDefined(noDuplicatedFilesRule.perPackageSchema);
     });
 
     suite('consent scenarios', function () {

--- a/source/checks/rules/no-side-effects.test.ts
+++ b/source/checks/rules/no-side-effects.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { safeParse } from '../../common/schema-validation.ts';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../../dead-code-eliminator/analyzed-bundle.ts';
@@ -70,8 +71,8 @@ suite('no-side-effects', function () {
         test('rule definition exposes name, schemas and a run function', function () {
             assert.strictEqual(noSideEffectsRule.name, 'noSideEffects');
             assert.strictEqual(typeof noSideEffectsRule.run, 'function');
-            assert.notStrictEqual(noSideEffectsRule.globalSchema, undefined);
-            assert.notStrictEqual(noSideEffectsRule.perPackageSchema, undefined);
+            assertDefined(noSideEffectsRule.globalSchema);
+            assertDefined(noSideEffectsRule.perPackageSchema);
         });
 
         test('returns no issues when settings are missing entirely', async function () {

--- a/source/checks/rules/registry.test.ts
+++ b/source/checks/rules/registry.test.ts
@@ -34,7 +34,7 @@ suite('registry', function () {
     test('every entry in allRules exposes the rule contract (name, schemas, run)', function () {
         for (const rule of allRules) {
             assert.strictEqual(typeof rule.name, 'string', `name should be a string for ${rule.name}`);
-            assert.ok(typeof rule.run === 'function', `run should be a function for ${rule.name}`);
+            assert.strictEqual(typeof rule.run, 'function', `run should be a function for ${rule.name}`);
             assert.strictEqual(typeof rule.globalSchema.safeParse, 'function');
             assert.strictEqual(typeof rule.perPackageSchema.safeParse, 'function');
         }

--- a/source/command-line-interface/config-loader.test.ts
+++ b/source/command-line-interface/config-loader.test.ts
@@ -20,8 +20,12 @@ suite('config-loader', function () {
 
         await configLoader.load();
 
-        assert.strictEqual(importModule.callCount, 1);
-        assert.deepStrictEqual(importModule.firstCall.args, [ 'the-folder/packtory.config.js' ]);
+        assert.partialDeepStrictEqual(importModule, {
+            callCount: 1,
+            firstCall: {
+                args: [ 'the-folder/packtory.config.js' ]
+            }
+        });
     });
 
     test('throws when the imported module is not an object', async function () {

--- a/source/command-line-interface/config-loader.test.ts
+++ b/source/command-line-interface/config-loader.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { createConfigLoader, type ConfigLoader } from './config-loader.ts';
 
 type Overrides = {
@@ -20,7 +21,7 @@ suite('config-loader', function () {
 
         await configLoader.load();
 
-        assert.partialDeepStrictEqual(importModule, {
+        assertDeepSubset(importModule, {
             callCount: 1,
             firstCall: {
                 args: [ 'the-folder/packtory.config.js' ]

--- a/source/command-line-interface/preview-io/preview-io-shared.test.ts
+++ b/source/command-line-interface/preview-io/preview-io-shared.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { withPromiseDeadline } from '../../test-libraries/promise-with-deadline.ts';
 import { createPreviewIo, type PreviewIo } from './preview-io-shared.ts';
 import type { SpawnedProcess, SpawnOptions } from './preview-spawn.ts';
@@ -178,9 +179,9 @@ suite('preview-io-shared', function () {
             );
             const firstCall = requireFirstCall(calls);
             assert.deepStrictEqual(firstCall.options, { stdio: [ 'pipe', 'inherit', 'inherit' ] });
-            assert.notStrictEqual(firstCall.child.listeners.close, undefined);
-            assert.notStrictEqual(firstCall.child.listeners.error, undefined);
-            assert.notStrictEqual(firstCall.child.listeners.stdinError, undefined);
+            assertDefined(firstCall.child.listeners.close);
+            assertDefined(firstCall.child.listeners.error);
+            assertDefined(firstCall.child.listeners.stdinError);
             assert.strictEqual(firstCall.child.endedContent, 'content');
         });
 

--- a/source/command-line-interface/preview-io/preview-io-shared.test.ts
+++ b/source/command-line-interface/preview-io/preview-io-shared.test.ts
@@ -178,9 +178,9 @@ suite('preview-io-shared', function () {
             );
             const firstCall = requireFirstCall(calls);
             assert.deepStrictEqual(firstCall.options, { stdio: [ 'pipe', 'inherit', 'inherit' ] });
-            assert.ok(firstCall.child.listeners.close !== undefined);
-            assert.ok(firstCall.child.listeners.error !== undefined);
-            assert.ok(firstCall.child.listeners.stdinError !== undefined);
+            assert.notStrictEqual(firstCall.child.listeners.close, undefined);
+            assert.notStrictEqual(firstCall.child.listeners.error, undefined);
+            assert.notStrictEqual(firstCall.child.listeners.stdinError, undefined);
             assert.strictEqual(firstCall.child.endedContent, 'content');
         });
 

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -81,9 +81,11 @@ suite('changelog-destinations', function () {
             })
         );
 
-        assert.strictEqual(options.explicitBaseRef, 'main');
-        assert.strictEqual(options.packageTagFormat, 'pkg/{packageName}/v{version}');
-        assert.strictEqual(options.targetScopedLabelPattern, 'scope:{targetName}:{label}');
+        assert.partialDeepStrictEqual(options, {
+            explicitBaseRef: 'main',
+            packageTagFormat: 'pkg/{packageName}/v{version}',
+            targetScopedLabelPattern: 'scope:{targetName}:{label}'
+        });
         assert.strictEqual(options.validLabels.get('bug'), 'Fixed Bugs');
         assert.strictEqual(options.validLabels.get('operations'), 'Operations');
     });

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -180,14 +180,20 @@ function depsWith(spec: ChangelogHandlerDepsSpec): ChangelogHandlerDeps {
     };
 }
 
+function assertMissingGitHubRepositoryLog(spies: Spies): void {
+    assert.deepStrictEqual(spies.log.firstCall.args, [ 'package.json repository must point to a GitHub repository' ]);
+}
+
 function makeSpies(
     engine: PrLogEngine = createEngine(),
     releasePlanOutcome: ReleasePlanOutcome = outcome([ releasePackage() ])
 ): Spies {
     return {
         createPrLogEngine: fake(function (options: Readonly<PrLogEngineOptions>) {
-            assert.strictEqual(options.githubToken, 'gh-token');
-            assert.strictEqual(options.workingDirectory, '/repo');
+            assert.partialDeepStrictEqual(options, {
+                githubToken: 'gh-token',
+                workingDirectory: '/repo'
+            });
             return engine;
         }),
         log: fake(),
@@ -208,8 +214,16 @@ async function assertReleasePlanFailureLogged(spec: ReleasePlanFailureLogSpec): 
     const code = await runChangelogHandler(depsWith({ spies }));
 
     assert.strictEqual(code, 1);
-    assert.strictEqual(spies.createPrLogEngine.callCount, 0);
-    assert.deepStrictEqual(spies.log.firstCall.args, [ spec.expectedLog ]);
+    assert.partialDeepStrictEqual(spies, {
+        createPrLogEngine: {
+            callCount: 0
+        },
+        log: {
+            firstCall: {
+                args: [ spec.expectedLog ]
+            }
+        }
+    });
 }
 
 function assertConfiguredChangelogInputs(
@@ -237,10 +251,24 @@ suite('changelog-handler', function () {
             const code = await runChangelogHandler(depsWith({ spies }));
 
             assert.strictEqual(code, 0);
-            assert.deepStrictEqual(spies.planReleaseAgainstLatestPublished.firstCall.args, [ validConfig ]);
-            assert.strictEqual(spies.createPrLogEngine.callCount, 1);
-            assert.deepStrictEqual(spies.pageOutput.firstCall.args, [ '## pkg-a 1.0.1\n' ]);
-            assert.strictEqual(spies.stopAll.callCount, 2);
+            assert.partialDeepStrictEqual(spies, {
+                planReleaseAgainstLatestPublished: {
+                    firstCall: {
+                        args: [ validConfig ]
+                    }
+                },
+                createPrLogEngine: {
+                    callCount: 1
+                },
+                pageOutput: {
+                    firstCall: {
+                        args: [ '## pkg-a 1.0.1\n' ]
+                    }
+                },
+                stopAll: {
+                    callCount: 2
+                }
+            });
         });
 
         test('returns 1 and logs release-plan config failures without creating pr-log', async function () {
@@ -268,8 +296,14 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 0);
-            assert.strictEqual(spies.createPrLogEngine.callCount, 0);
-            assert.strictEqual(spies.pageOutput.callCount, 0);
+            assert.partialDeepStrictEqual(spies, {
+                createPrLogEngine: {
+                    callCount: 0
+                },
+                pageOutput: {
+                    callCount: 0
+                }
+            });
         });
 
         test('returns 1 and still renders succeeded changed packages for partial release-plan failures', async function () {
@@ -282,8 +316,16 @@ suite('changelog-handler', function () {
             const code = await runChangelogHandler(depsWith({ spies }));
 
             assert.strictEqual(code, 1);
-            assert.strictEqual(spies.pageOutput.callCount, 1);
-            assert.deepStrictEqual(spies.log.firstCall.args, [ 'pkg-b failed\npkg-c failed' ]);
+            assert.partialDeepStrictEqual(spies, {
+                pageOutput: {
+                    callCount: 1
+                },
+                log: {
+                    firstCall: {
+                        args: [ 'pkg-b failed\npkg-c failed' ]
+                    }
+                }
+            });
         });
     });
 
@@ -369,10 +411,18 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 1);
-            assert.deepStrictEqual(spies.log.firstCall.args, [
-                'package.json repository must point to a GitHub repository'
-            ]);
-            assert.strictEqual(spies.pageOutput.callCount, 0);
+            assert.partialDeepStrictEqual(spies, {
+                log: {
+                    firstCall: {
+                        args: [
+                            'package.json repository must point to a GitHub repository'
+                        ]
+                    }
+                },
+                pageOutput: {
+                    callCount: 0
+                }
+            });
         });
 
         test('returns 1 when package.json repository is missing', async function () {
@@ -388,9 +438,7 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 1);
-            assert.deepStrictEqual(spies.log.firstCall.args, [
-                'package.json repository must point to a GitHub repository'
-            ]);
+            assertMissingGitHubRepositoryLog(spies);
         });
 
         test('returns 1 when package.json repository has a GitHub owner but no repo', async function () {
@@ -406,9 +454,7 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 1);
-            assert.deepStrictEqual(spies.log.firstCall.args, [
-                'package.json repository must point to a GitHub repository'
-            ]);
+            assertMissingGitHubRepositoryLog(spies);
         });
 
         test('returns 1 when package.json repository only contains a GitHub URL suffix', async function () {
@@ -424,9 +470,7 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 1);
-            assert.deepStrictEqual(spies.log.firstCall.args, [
-                'package.json repository must point to a GitHub repository'
-            ]);
+            assertMissingGitHubRepositoryLog(spies);
         });
 
         test('returns 1 when package.json repository contains extra path segments after repo', async function () {
@@ -442,9 +486,7 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 1);
-            assert.deepStrictEqual(spies.log.firstCall.args, [
-                'package.json repository must point to a GitHub repository'
-            ]);
+            assertMissingGitHubRepositoryLog(spies);
         });
     });
 

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -214,16 +214,10 @@ async function assertReleasePlanFailureLogged(spec: ReleasePlanFailureLogSpec): 
     const code = await runChangelogHandler(depsWith({ spies }));
 
     assert.strictEqual(code, 1);
-    assert.partialDeepStrictEqual(spies, {
-        createPrLogEngine: {
-            callCount: 0
-        },
-        log: {
-            firstCall: {
-                args: [ spec.expectedLog ]
-            }
-        }
-    });
+    assert.deepStrictEqual(
+        { createPrLogEngine: spies.createPrLogEngine.callCount, logArgs: spies.log.firstCall.args },
+        { createPrLogEngine: 0, logArgs: [ spec.expectedLog ] }
+    );
 }
 
 function assertConfiguredChangelogInputs(
@@ -251,24 +245,20 @@ suite('changelog-handler', function () {
             const code = await runChangelogHandler(depsWith({ spies }));
 
             assert.strictEqual(code, 0);
-            assert.partialDeepStrictEqual(spies, {
-                planReleaseAgainstLatestPublished: {
-                    firstCall: {
-                        args: [ validConfig ]
-                    }
+            assert.deepStrictEqual(
+                {
+                    planReleaseArgs: spies.planReleaseAgainstLatestPublished.firstCall.args,
+                    createPrLogEngine: spies.createPrLogEngine.callCount,
+                    pageOutputArgs: spies.pageOutput.firstCall.args,
+                    stopAll: spies.stopAll.callCount
                 },
-                createPrLogEngine: {
-                    callCount: 1
-                },
-                pageOutput: {
-                    firstCall: {
-                        args: [ '## pkg-a 1.0.1\n' ]
-                    }
-                },
-                stopAll: {
-                    callCount: 2
+                {
+                    planReleaseArgs: [ validConfig ],
+                    createPrLogEngine: 1,
+                    pageOutputArgs: [ '## pkg-a 1.0.1\n' ],
+                    stopAll: 2
                 }
-            });
+            );
         });
 
         test('returns 1 and logs release-plan config failures without creating pr-log', async function () {
@@ -296,14 +286,10 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 0);
-            assert.partialDeepStrictEqual(spies, {
-                createPrLogEngine: {
-                    callCount: 0
-                },
-                pageOutput: {
-                    callCount: 0
-                }
-            });
+            assert.deepStrictEqual(
+                { createPrLogEngine: spies.createPrLogEngine.callCount, pageOutput: spies.pageOutput.callCount },
+                { createPrLogEngine: 0, pageOutput: 0 }
+            );
         });
 
         test('returns 1 and still renders succeeded changed packages for partial release-plan failures', async function () {
@@ -316,16 +302,10 @@ suite('changelog-handler', function () {
             const code = await runChangelogHandler(depsWith({ spies }));
 
             assert.strictEqual(code, 1);
-            assert.partialDeepStrictEqual(spies, {
-                pageOutput: {
-                    callCount: 1
-                },
-                log: {
-                    firstCall: {
-                        args: [ 'pkg-b failed\npkg-c failed' ]
-                    }
-                }
-            });
+            assert.deepStrictEqual(
+                { pageOutput: spies.pageOutput.callCount, logArgs: spies.log.firstCall.args },
+                { pageOutput: 1, logArgs: [ 'pkg-b failed\npkg-c failed' ] }
+            );
         });
     });
 
@@ -411,18 +391,13 @@ suite('changelog-handler', function () {
             );
 
             assert.strictEqual(code, 1);
-            assert.partialDeepStrictEqual(spies, {
-                log: {
-                    firstCall: {
-                        args: [
-                            'package.json repository must point to a GitHub repository'
-                        ]
-                    }
-                },
-                pageOutput: {
-                    callCount: 0
+            assert.deepStrictEqual(
+                { logArgs: spies.log.firstCall.args, pageOutput: spies.pageOutput.callCount },
+                {
+                    logArgs: [ 'package.json repository must point to a GitHub repository' ],
+                    pageOutput: 0
                 }
-            });
+            );
         });
 
         test('returns 1 when package.json repository is missing', async function () {

--- a/source/command-line-interface/runner/github-release-client.test.ts
+++ b/source/command-line-interface/runner/github-release-client.test.ts
@@ -92,13 +92,17 @@ function requireRequest(requests: readonly RequestRecord[], index: number, messa
 }
 
 function assertReleaseLookupRequest(request: RequestRecord): void {
-    assert.strictEqual(request.method, 'GET');
-    assert.strictEqual(request.url, 'https://api.github.com/repos/owner/repo/releases/tags/pkg-a%401.0.0');
-    assert.strictEqual(request.headers.authorization, 'Bearer token');
-    assert.strictEqual(request.headers.accept, 'application/vnd.github+json');
-    assert.strictEqual(request.headers.userAgent, 'packtory');
-    assert.strictEqual(request.headers.githubApiVersion, '2022-11-28');
-    assert.strictEqual(request.body, undefined);
+    assert.partialDeepStrictEqual(request, {
+        method: 'GET',
+        url: 'https://api.github.com/repos/owner/repo/releases/tags/pkg-a%401.0.0',
+        headers: {
+            authorization: 'Bearer token',
+            accept: 'application/vnd.github+json',
+            userAgent: 'packtory',
+            githubApiVersion: '2022-11-28'
+        },
+        body: undefined
+    });
 }
 
 suite('github-release-client', function () {
@@ -128,8 +132,10 @@ suite('github-release-client', function () {
         assert.strictEqual(result, 'created');
         assert.strictEqual(requests.length, 2);
         const postRequest = requireRequest(requests, 1, 'Expected a GitHub release creation request');
-        assert.strictEqual(postRequest.method, 'POST');
-        assert.strictEqual(postRequest.url, 'https://api.github.com/repos/owner/repo/releases');
+        assert.partialDeepStrictEqual(postRequest, {
+            method: 'POST',
+            url: 'https://api.github.com/repos/owner/repo/releases'
+        });
         assert.deepStrictEqual(JSON.parse(postRequest.body ?? '{}'), {
             tag_name: 'pkg-a@1.0.0',
             name: 'pkg-a@1.0.0',

--- a/source/command-line-interface/runner/release-diff-handler.test.ts
+++ b/source/command-line-interface/runner/release-diff-handler.test.ts
@@ -106,8 +106,14 @@ suite('release-diff-handler', function () {
         const code = await runReleaseDiffHandler(depsWith(outcome, spies));
 
         assert.strictEqual(code, 1);
-        assert.strictEqual(spies.pageOutput.callCount, 0);
-        assert.strictEqual(spies.log.callCount, 1);
+        assert.partialDeepStrictEqual(spies, {
+            pageOutput: {
+                callCount: 0
+            },
+            log: {
+                callCount: 1
+            }
+        });
         const loggedMessage = spies.log.firstCall.args[0] as string;
         assert.match(loggedMessage, /Configuration issues/u);
         assert.ok(!loggedMessage.endsWith('\n'), 'expected failure-only log to be trimEnd-ed');
@@ -138,8 +144,14 @@ suite('release-diff-handler', function () {
         const code = await runReleaseDiffHandler(depsWith(outcome, spies));
 
         assert.strictEqual(code, 1);
-        assert.strictEqual(spies.pageOutput.callCount, 1);
-        assert.strictEqual(spies.log.callCount, 0);
+        assert.partialDeepStrictEqual(spies, {
+            pageOutput: {
+                callCount: 1
+            },
+            log: {
+                callCount: 0
+            }
+        });
         const pagedMessage = spies.pageOutput.firstCall.args[0] as string;
         assert.match(pagedMessage, /pkg-a/u);
         assert.match(pagedMessage, /\[first publish\]/u);

--- a/source/command-line-interface/runner/release-diff-handler.test.ts
+++ b/source/command-line-interface/runner/release-diff-handler.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createConfigLoaderStub } from '../../test-libraries/handler-stub-fixtures.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
@@ -106,7 +107,7 @@ suite('release-diff-handler', function () {
         const code = await runReleaseDiffHandler(depsWith(outcome, spies));
 
         assert.strictEqual(code, 1);
-        assert.partialDeepStrictEqual(spies, {
+        assertDeepSubset(spies, {
             pageOutput: {
                 callCount: 0
             },
@@ -144,7 +145,7 @@ suite('release-diff-handler', function () {
         const code = await runReleaseDiffHandler(depsWith(outcome, spies));
 
         assert.strictEqual(code, 1);
-        assert.partialDeepStrictEqual(spies, {
+        assertDeepSubset(spies, {
             pageOutput: {
                 callCount: 1
             },

--- a/source/command-line-interface/runner/release-pr-branch-commit.test.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.test.ts
@@ -146,14 +146,16 @@ function assertCreateCommitGraphQLCall(call: GraphQLCall | undefined): void {
     if (call === undefined) {
         throw new Error('Expected a GraphQL call');
     }
-    assert.deepStrictEqual(call.variables, {
-        additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
-        branchName: temporaryReleaseBranch,
-        expectedHeadOid: 'main-head',
-        headline: 'Release packages',
-        repositoryNameWithOwner: 'owner/repo'
+    assert.partialDeepStrictEqual(call, {
+        variables: {
+            additions: [ { contents: encodedChangelogContent, path: 'CHANGELOG.md' } ],
+            branchName: temporaryReleaseBranch,
+            expectedHeadOid: 'main-head',
+            headline: 'Release packages',
+            repositoryNameWithOwner: 'owner/repo'
+        },
+        headers: { authorization: 'Bearer token' }
     });
-    assert.deepStrictEqual(call.headers, { authorization: 'Bearer token' });
     assert.match(call.query, /createCommitOnBranch/u);
 }
 

--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -283,8 +283,10 @@ suite('release-pr-github-client', function () {
         });
         const pullRequest = await client.getPullRequest(12);
         const commitPullRequests = await client.listCommitPullRequests('merge-sha');
-        assert.strictEqual(pullRequest.number, 12);
-        assert.strictEqual(pullRequest.merged, true);
+        assert.partialDeepStrictEqual(pullRequest, {
+            number: 12,
+            merged: true
+        });
         assert.strictEqual(commitPullRequests[0]?.number, 12);
         assert.strictEqual(records.length > 0, true);
     });

--- a/source/command-line-interface/runner/release-pull-request-policy.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-policy.test.ts
@@ -50,9 +50,9 @@ function assertPolicyError(validate: () => void, expectedMessage: string): void 
 
 suite('release-pull-request-policy', function () {
     test('accepts a valid release pull request', function () {
-        assert.doesNotThrow(function () {
-            validateReleasePullRequestPolicy(validPullRequest, policyConfig);
-        });
+        validateReleasePullRequestPolicy(validPullRequest, policyConfig);
+
+        assert.strictEqual(validPullRequest.headRef, 'release/packtory');
     });
 
     test('rejects release pull requests that violate the policy', function () {
@@ -111,9 +111,9 @@ suite('release-pull-request-policy', function () {
     });
 
     test('accepts merge groups that contain only the release pull request', function () {
-        assert.doesNotThrow(function () {
-            validateReleaseMergeGroupPolicy({ pullRequests: [ validPullRequest ] }, policyConfig);
-        });
+        validateReleaseMergeGroupPolicy({ pullRequests: [ validPullRequest ] }, policyConfig);
+
+        assert.deepStrictEqual(validPullRequest.labels, [ 'release' ]);
     });
 
     test('rejects merge groups with invalid release pull requests', function () {
@@ -133,9 +133,9 @@ suite('release-pull-request-policy', function () {
     });
 
     test('accepts a merged release PR publish target', function () {
-        assert.doesNotThrow(function () {
-            validateReleasePullRequestPublishPolicy(validPublishInput, policyConfig, 'merge-sha');
-        });
+        validateReleasePullRequestPublishPolicy(validPublishInput, policyConfig, 'merge-sha');
+
+        assert.strictEqual(validPublishInput.mergeCommitSha, 'merge-sha');
     });
 
     test('rejects publish targets that violate the policy', function () {
@@ -158,16 +158,16 @@ suite('release-pull-request-policy', function () {
     });
 
     test('accepts merge groups without release pull requests', function () {
-        assert.doesNotThrow(function () {
-            validateReleaseMergeGroupPolicy(
-                {
-                    pullRequests: [
-                        { ...validPullRequest, labels: [ 'bug' ] },
-                        { ...validPullRequest, labels: [ 'feature' ] }
-                    ]
-                },
-                policyConfig
-            );
-        });
+        validateReleaseMergeGroupPolicy(
+            {
+                pullRequests: [
+                    { ...validPullRequest, labels: [ 'bug' ] },
+                    { ...validPullRequest, labels: [ 'feature' ] }
+                ]
+            },
+            policyConfig
+        );
+
+        assert.strictEqual(policyConfig.label, 'release');
     });
 });

--- a/source/command-line-interface/runner/report-persistence.test.ts
+++ b/source/command-line-interface/runner/report-persistence.test.ts
@@ -18,9 +18,11 @@ suite('report-persistence', function () {
     test('createEmptyReport returns a schema-version-1 report with no packages or aggregate links', function () {
         const report = createEmptyReport();
 
-        assert.strictEqual(report.schemaVersion, 1);
-        assert.deepStrictEqual(report.packages, {});
-        assert.deepStrictEqual(report.aggregate, { crossBundleLinks: [] });
+        assert.partialDeepStrictEqual(report, {
+            schemaVersion: 1,
+            packages: {},
+            aggregate: { crossBundleLinks: [] }
+        });
     });
 
     test('writeReports writes nothing when the report is undefined', async function () {

--- a/source/command-line-interface/runner/runner-publish-feedback.test.ts
+++ b/source/command-line-interface/runner/runner-publish-feedback.test.ts
@@ -40,10 +40,14 @@ suite('runner publish feedback', function () {
 
         test('prints error summary when publish command encounters config errors', async function () {
             const { log } = await runWithIssues('config', [ 'foo' ]);
-            assert.strictEqual(log.callCount, 2);
-            assert.deepStrictEqual(log.firstCall.args, [
-                '✖ The provided config is invalid, there are 1 issue(s)\n\n- foo'
-            ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 2,
+                firstCall: {
+                    args: [
+                        '✖ The provided config is invalid, there are 1 issue(s)\n\n- foo'
+                    ]
+                }
+            });
         });
 
         test('prints every config issue on its own bullet line', async function () {
@@ -55,8 +59,12 @@ suite('runner publish feedback', function () {
 
         test('prints error summary when publish command encounters check errors', async function () {
             const { log } = await runWithIssues('checks', [ 'foo' ]);
-            assert.strictEqual(log.callCount, 2);
-            assert.deepStrictEqual(log.firstCall.args, [ '✖ Checks failed, there are 1 issue(s)\n\n- foo' ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 2,
+                firstCall: {
+                    args: [ '✖ Checks failed, there are 1 issue(s)\n\n- foo' ]
+                }
+            });
         });
 
         test('prints every check issue on its own bullet line', async function () {
@@ -90,28 +98,44 @@ suite('runner publish feedback', function () {
         test('prints error summary and dry-run note when publish command encounters partial errors', async function () {
             const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures));
 
-            assert.strictEqual(log.callCount, 2);
-            assert.deepStrictEqual(log.firstCall.args, [
-                '✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second'
-            ]);
-            assert.deepStrictEqual(log.secondCall.args, [ dryRunNote ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 2,
+                firstCall: {
+                    args: [
+                        '✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second'
+                    ]
+                },
+                secondCall: {
+                    args: [ dryRunNote ]
+                }
+            });
         });
 
         test('prints error summary without dry-run note when publish command encounters partial errors and dry-run mode is disabled', async function () {
             const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures), [ '--no-dry-run' ]);
 
-            assert.strictEqual(log.callCount, 1);
-            assert.deepStrictEqual(log.firstCall.args, [
-                '✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second'
-            ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 1,
+                firstCall: {
+                    args: [
+                        '✖ 2 from 3 package(s) failed; 1 succeeded\n- first\n- second'
+                    ]
+                }
+            });
         });
 
         test('prints success summary and dry-run note when publish command had no errors', async function () {
             const log = await runPublishCapturingLog(fake.resolves(toOutcome(Result.ok([ 'foo', 'bar' ]))));
 
-            assert.strictEqual(log.callCount, 2);
-            assert.deepStrictEqual(log.firstCall.args, [ '✔ Success: all 2 package(s) have been published' ]);
-            assert.deepStrictEqual(log.secondCall.args, [ dryRunNote ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 2,
+                firstCall: {
+                    args: [ '✔ Success: all 2 package(s) have been published' ]
+                },
+                secondCall: {
+                    args: [ dryRunNote ]
+                }
+            });
         });
 
         test('prints success summary without dry-run note when publish command had no errors and dry-run mode is disabled', async function () {
@@ -119,8 +143,12 @@ suite('runner publish feedback', function () {
                 '--no-dry-run'
             ]);
 
-            assert.strictEqual(log.callCount, 1);
-            assert.deepStrictEqual(log.firstCall.args, [ '✔ Success: all 2 package(s) have been published' ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '✔ Success: all 2 package(s) have been published' ]
+                }
+            });
         });
     });
 
@@ -152,8 +180,12 @@ suite('runner publish feedback', function () {
             await runner.run([ 'foo', 'bar', 'publish' ]);
             progressBroadcaster.provider.emit('scheduled', { packageName: 'foo' });
 
-            assert.strictEqual(add.callCount, 1);
-            assert.deepStrictEqual(add.firstCall.args, [ 'foo', 'foo', 'Scheduled …' ]);
+            assert.partialDeepStrictEqual(add, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'foo', 'foo', 'Scheduled …' ]
+                }
+            });
         });
 
         async function runWithProgressEvent(
@@ -174,8 +206,12 @@ suite('runner publish feedback', function () {
             const stop = fake();
             await runWithProgressEvent({ stop }, 'error', { packageName: 'foo', error: new Error('bar') });
 
-            assert.strictEqual(stop.callCount, 1);
-            assert.deepStrictEqual(stop.firstCall.args, [ 'foo', 'failure', 'bar' ]);
+            assert.partialDeepStrictEqual(stop, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'foo', 'failure', 'bar' ]
+                }
+            });
         });
 
         test('stops a running spinner with success status when progressBroadcaster receives an "done" event and already-published status', async function () {
@@ -187,12 +223,16 @@ suite('runner publish feedback', function () {
                 publication: noPublicationOutcome
             });
 
-            assert.strictEqual(stop.callCount, 1);
-            assert.deepStrictEqual(stop.firstCall.args, [
-                'foo',
-                'success',
-                'Nothing has changed, published version 1 is already up-to-date'
-            ]);
+            assert.partialDeepStrictEqual(stop, {
+                callCount: 1,
+                firstCall: {
+                    args: [
+                        'foo',
+                        'success',
+                        'Nothing has changed, published version 1 is already up-to-date'
+                    ]
+                }
+            });
         });
 
         test('stops a running spinner with success status when progressBroadcaster receives an "done" event and initial-version status', async function () {
@@ -204,8 +244,12 @@ suite('runner publish feedback', function () {
                 publication: noPublicationOutcome
             });
 
-            assert.strictEqual(stop.callCount, 1);
-            assert.deepStrictEqual(stop.firstCall.args, [ 'foo', 'success', 'First version 1 has been published' ]);
+            assert.partialDeepStrictEqual(stop, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'foo', 'success', 'First version 1 has been published' ]
+                }
+            });
         });
 
         test('stops a running spinner with success status when progressBroadcaster receives an "done" event and new-version status', async function () {
@@ -217,24 +261,36 @@ suite('runner publish feedback', function () {
                 publication: noPublicationOutcome
             });
 
-            assert.strictEqual(stop.callCount, 1);
-            assert.deepStrictEqual(stop.firstCall.args, [ 'foo', 'success', 'New version 1 published' ]);
+            assert.partialDeepStrictEqual(stop, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'foo', 'success', 'New version 1 published' ]
+                }
+            });
         });
 
         test('updates a running spinner message when a "building" event is received', async function () {
             const updateMessage = fake();
             await runWithProgressEvent({ updateMessage }, 'building', { packageName: 'foo', version: '1' });
 
-            assert.strictEqual(updateMessage.callCount, 1);
-            assert.deepStrictEqual(updateMessage.firstCall.args, [ 'foo', 'Building package with version 1' ]);
+            assert.partialDeepStrictEqual(updateMessage, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'foo', 'Building package with version 1' ]
+                }
+            });
         });
 
         test('updates a running spinner message when a "rebuilding" event is received', async function () {
             const updateMessage = fake();
             await runWithProgressEvent({ updateMessage }, 'rebuilding', { packageName: 'foo', version: '1' });
 
-            assert.strictEqual(updateMessage.callCount, 1);
-            assert.deepStrictEqual(updateMessage.firstCall.args, [ 'foo', 'Rebuilding package with version 1' ]);
+            assert.partialDeepStrictEqual(updateMessage, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 'foo', 'Rebuilding package with version 1' ]
+                }
+            });
         });
     });
 });

--- a/source/command-line-interface/runner/runner-publish-feedback.test.ts
+++ b/source/command-line-interface/runner/runner-publish-feedback.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import { createProgressBroadcaster, type ProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import { toOutcome } from '../../test-libraries/result-helpers.ts';
 import {
@@ -40,7 +41,7 @@ suite('runner publish feedback', function () {
 
         test('prints error summary when publish command encounters config errors', async function () {
             const { log } = await runWithIssues('config', [ 'foo' ]);
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 2,
                 firstCall: {
                     args: [
@@ -59,7 +60,7 @@ suite('runner publish feedback', function () {
 
         test('prints error summary when publish command encounters check errors', async function () {
             const { log } = await runWithIssues('checks', [ 'foo' ]);
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 2,
                 firstCall: {
                     args: [ '✖ Checks failed, there are 1 issue(s)\n\n- foo' ]
@@ -98,7 +99,7 @@ suite('runner publish feedback', function () {
         test('prints error summary and dry-run note when publish command encounters partial errors', async function () {
             const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures));
 
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 2,
                 firstCall: {
                     args: [
@@ -114,7 +115,7 @@ suite('runner publish feedback', function () {
         test('prints error summary without dry-run note when publish command encounters partial errors and dry-run mode is disabled', async function () {
             const log = await runPublishCapturingLog(fake.resolves(partialResultWithTwoFailures), [ '--no-dry-run' ]);
 
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 1,
                 firstCall: {
                     args: [
@@ -127,7 +128,7 @@ suite('runner publish feedback', function () {
         test('prints success summary and dry-run note when publish command had no errors', async function () {
             const log = await runPublishCapturingLog(fake.resolves(toOutcome(Result.ok([ 'foo', 'bar' ]))));
 
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 2,
                 firstCall: {
                     args: [ '✔ Success: all 2 package(s) have been published' ]
@@ -143,7 +144,7 @@ suite('runner publish feedback', function () {
                 '--no-dry-run'
             ]);
 
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 1,
                 firstCall: {
                     args: [ '✔ Success: all 2 package(s) have been published' ]
@@ -180,7 +181,7 @@ suite('runner publish feedback', function () {
             await runner.run([ 'foo', 'bar', 'publish' ]);
             progressBroadcaster.provider.emit('scheduled', { packageName: 'foo' });
 
-            assert.partialDeepStrictEqual(add, {
+            assertDeepSubset(add, {
                 callCount: 1,
                 firstCall: {
                     args: [ 'foo', 'foo', 'Scheduled …' ]
@@ -206,7 +207,7 @@ suite('runner publish feedback', function () {
             const stop = fake();
             await runWithProgressEvent({ stop }, 'error', { packageName: 'foo', error: new Error('bar') });
 
-            assert.partialDeepStrictEqual(stop, {
+            assertDeepSubset(stop, {
                 callCount: 1,
                 firstCall: {
                     args: [ 'foo', 'failure', 'bar' ]
@@ -223,7 +224,7 @@ suite('runner publish feedback', function () {
                 publication: noPublicationOutcome
             });
 
-            assert.partialDeepStrictEqual(stop, {
+            assertDeepSubset(stop, {
                 callCount: 1,
                 firstCall: {
                     args: [
@@ -244,7 +245,7 @@ suite('runner publish feedback', function () {
                 publication: noPublicationOutcome
             });
 
-            assert.partialDeepStrictEqual(stop, {
+            assertDeepSubset(stop, {
                 callCount: 1,
                 firstCall: {
                     args: [ 'foo', 'success', 'First version 1 has been published' ]
@@ -261,7 +262,7 @@ suite('runner publish feedback', function () {
                 publication: noPublicationOutcome
             });
 
-            assert.partialDeepStrictEqual(stop, {
+            assertDeepSubset(stop, {
                 callCount: 1,
                 firstCall: {
                     args: [ 'foo', 'success', 'New version 1 published' ]
@@ -273,7 +274,7 @@ suite('runner publish feedback', function () {
             const updateMessage = fake();
             await runWithProgressEvent({ updateMessage }, 'building', { packageName: 'foo', version: '1' });
 
-            assert.partialDeepStrictEqual(updateMessage, {
+            assertDeepSubset(updateMessage, {
                 callCount: 1,
                 firstCall: {
                     args: [ 'foo', 'Building package with version 1' ]
@@ -285,7 +286,7 @@ suite('runner publish feedback', function () {
             const updateMessage = fake();
             await runWithProgressEvent({ updateMessage }, 'rebuilding', { packageName: 'foo', version: '1' });
 
-            assert.partialDeepStrictEqual(updateMessage, {
+            assertDeepSubset(updateMessage, {
                 callCount: 1,
                 firstCall: {
                     args: [ 'foo', 'Rebuilding package with version 1' ]

--- a/source/command-line-interface/runner/runner-report-preview.test.ts
+++ b/source/command-line-interface/runner/runner-report-preview.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     createArtifactEntryFixture,
     createBuildReportFixture,
@@ -247,7 +248,7 @@ suite('runner report and preview', function () {
             assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
             assert.deepStrictEqual(fileManager.getWriteFileCall(0).filePath, '/workspace/packtory-preview-test.html');
             assert.match(fileManager.getWriteFileCall(0).content, /^<!doctype html>/);
-            assert.partialDeepStrictEqual(openFile, {
+            assertDeepSubset(openFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/workspace/packtory-preview-test.html' ]
@@ -272,7 +273,7 @@ suite('runner report and preview', function () {
             const exitCode = await runner.run([ 'foo', 'bar', 'preview', '--open' ]);
 
             assert.strictEqual(exitCode, 0);
-            assert.partialDeepStrictEqual(log, {
+            assertDeepSubset(log, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/workspace/packtory-preview-test.html' ]

--- a/source/command-line-interface/runner/runner-report-preview.test.ts
+++ b/source/command-line-interface/runner/runner-report-preview.test.ts
@@ -247,8 +247,12 @@ suite('runner report and preview', function () {
             assert.strictEqual(fileManager.getWriteFileCallCount(), 1);
             assert.deepStrictEqual(fileManager.getWriteFileCall(0).filePath, '/workspace/packtory-preview-test.html');
             assert.match(fileManager.getWriteFileCall(0).content, /^<!doctype html>/);
-            assert.strictEqual(openFile.callCount, 1);
-            assert.deepStrictEqual(openFile.firstCall.args, [ '/workspace/packtory-preview-test.html' ]);
+            assert.partialDeepStrictEqual(openFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/workspace/packtory-preview-test.html' ]
+                }
+            });
             assert.strictEqual(log.callCount, 0);
         });
 
@@ -268,8 +272,12 @@ suite('runner report and preview', function () {
             const exitCode = await runner.run([ 'foo', 'bar', 'preview', '--open' ]);
 
             assert.strictEqual(exitCode, 0);
-            assert.strictEqual(log.callCount, 1);
-            assert.deepStrictEqual(log.firstCall.args, [ '/workspace/packtory-preview-test.html' ]);
+            assert.partialDeepStrictEqual(log, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/workspace/packtory-preview-test.html' ]
+                }
+            });
         });
 
         test('preview builds an empty fallback report when getReport returns undefined', async function () {

--- a/source/command-line-interface/spinner/line-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/line-spinner-renderer.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { stripVTControlCharacters } from 'node:util';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import { createLineSpinnerRenderer } from './line-spinner-renderer.ts';
 import type { TerminalSpinnerRenderer } from './terminal-spinner-renderer.ts';
 
@@ -45,7 +46,7 @@ suite('line-spinner-renderer', function () {
 
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
 
-        assert.partialDeepStrictEqual(log, {
+        assertDeepSubset(log, {
             callCount: 1,
             firstCall: {
                 args: [ 'pkg-a: Scheduled ...' ]
@@ -59,7 +60,7 @@ suite('line-spinner-renderer', function () {
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.updateMessage('the-id', 'Building package with version 1.2.3');
 
-        assert.partialDeepStrictEqual(log, {
+        assertDeepSubset(log, {
             callCount: 2,
             secondCall: {
                 args: [ 'pkg-a: Building package with version 1.2.3' ]
@@ -91,7 +92,7 @@ suite('line-spinner-renderer', function () {
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.stop('the-id', 'success', 'First version 1.2.3 has been published');
 
-        assert.partialDeepStrictEqual(log, {
+        assertDeepSubset(log, {
             callCount: 2,
             secondCall: {
                 args: [ '✔ pkg-a: First version 1.2.3 has been published' ]
@@ -105,7 +106,7 @@ suite('line-spinner-renderer', function () {
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.stop('the-id', 'failure', 'publish failed');
 
-        assert.partialDeepStrictEqual(log, {
+        assertDeepSubset(log, {
             callCount: 2,
             secondCall: {
                 args: [ '✖ pkg-a: publish failed' ]
@@ -131,7 +132,7 @@ suite('line-spinner-renderer', function () {
 
         renderer.add('the-id', 'pkg-a', 'Scheduled again');
 
-        assert.partialDeepStrictEqual(log, {
+        assertDeepSubset(log, {
             callCount: 2,
             secondCall: {
                 args: [ 'pkg-a: Scheduled again' ]

--- a/source/command-line-interface/spinner/line-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/line-spinner-renderer.test.ts
@@ -45,8 +45,12 @@ suite('line-spinner-renderer', function () {
 
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
 
-        assert.strictEqual(log.callCount, 1);
-        assert.deepStrictEqual(log.firstCall.args, [ 'pkg-a: Scheduled ...' ]);
+        assert.partialDeepStrictEqual(log, {
+            callCount: 1,
+            firstCall: {
+                args: [ 'pkg-a: Scheduled ...' ]
+            }
+        });
     });
 
     test('updateMessage() logs message updates as plain lines', function () {
@@ -55,8 +59,12 @@ suite('line-spinner-renderer', function () {
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.updateMessage('the-id', 'Building package with version 1.2.3');
 
-        assert.strictEqual(log.callCount, 2);
-        assert.deepStrictEqual(log.secondCall.args, [ 'pkg-a: Building package with version 1.2.3' ]);
+        assert.partialDeepStrictEqual(log, {
+            callCount: 2,
+            secondCall: {
+                args: [ 'pkg-a: Building package with version 1.2.3' ]
+            }
+        });
     });
 
     test('add() throws when adding two spinners with the same id', function () {
@@ -83,8 +91,12 @@ suite('line-spinner-renderer', function () {
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.stop('the-id', 'success', 'First version 1.2.3 has been published');
 
-        assert.strictEqual(log.callCount, 2);
-        assert.deepStrictEqual(log.secondCall.args, [ '✔ pkg-a: First version 1.2.3 has been published' ]);
+        assert.partialDeepStrictEqual(log, {
+            callCount: 2,
+            secondCall: {
+                args: [ '✔ pkg-a: First version 1.2.3 has been published' ]
+            }
+        });
     });
 
     test('stop() logs a failure line with the final message', function () {
@@ -93,8 +105,12 @@ suite('line-spinner-renderer', function () {
         renderer.add('the-id', 'pkg-a', 'Scheduled ...');
         renderer.stop('the-id', 'failure', 'publish failed');
 
-        assert.strictEqual(log.callCount, 2);
-        assert.deepStrictEqual(log.secondCall.args, [ '✖ pkg-a: publish failed' ]);
+        assert.partialDeepStrictEqual(log, {
+            callCount: 2,
+            secondCall: {
+                args: [ '✖ pkg-a: publish failed' ]
+            }
+        });
     });
 
     test('stop() throws when trying to stop a spinner that does not exist', function () {
@@ -115,7 +131,11 @@ suite('line-spinner-renderer', function () {
 
         renderer.add('the-id', 'pkg-a', 'Scheduled again');
 
-        assert.strictEqual(log.callCount, 2);
-        assert.deepStrictEqual(log.secondCall.args, [ 'pkg-a: Scheduled again' ]);
+        assert.partialDeepStrictEqual(log, {
+            callCount: 2,
+            secondCall: {
+                args: [ 'pkg-a: Scheduled again' ]
+            }
+        });
     });
 });

--- a/source/command-line-interface/spinner/spinner-render-sequence.test.ts
+++ b/source/command-line-interface/spinner/spinner-render-sequence.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { buildRenderTickOutput } from './spinner-render-sequence.ts';
 import {
     createSpinnerSharedAccessors,
@@ -32,8 +33,8 @@ suite('spinner-render-sequence', function () {
         const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
 
         assert.strictEqual(output.expectedLineCount, 2);
-        assert.notStrictEqual(output.sequence, undefined);
-        const sequence = output.sequence ?? '';
+        assertDefined(output.sequence);
+        const { sequence } = output;
         assert.strictEqual(sequence.endsWith('\n'), true);
         const lineCount = sequence.split('\n').length;
         assert.strictEqual(lineCount, 3);

--- a/source/command-line-interface/spinner/spinner-render-sequence.test.ts
+++ b/source/command-line-interface/spinner/spinner-render-sequence.test.ts
@@ -18,8 +18,10 @@ suite('spinner-render-sequence', function () {
         const accessors = createAccessors(3);
         const output = buildRenderTickOutput(accessors, { snapshots: [], renderedLineCount: 0, frameIndex: 0 });
 
-        assert.strictEqual(output.sequence, undefined);
-        assert.strictEqual(output.expectedLineCount, 0);
+        assert.partialDeepStrictEqual(output, {
+            sequence: undefined,
+            expectedLineCount: 0
+        });
     });
 
     test('buildRenderTickOutput renders one line per active slot and ends each line with a newline', function () {

--- a/source/command-line-interface/spinner/spinner-runtime.test.ts
+++ b/source/command-line-interface/spinner/spinner-runtime.test.ts
@@ -27,8 +27,14 @@ suite('spinner-runtime', function () {
             spawnWorker: spawn
         });
 
-        assert.strictEqual(runtime.slotCount, 5);
-        assert.strictEqual(runtime.accessors.layout.slotCount, 5);
+        assert.partialDeepStrictEqual(runtime, {
+            slotCount: 5,
+            accessors: {
+                layout: {
+                    slotCount: 5
+                }
+            }
+        });
     });
 
     test('createSpinnerRuntime defaults the slot count when none is provided', function () {
@@ -52,9 +58,11 @@ suite('spinner-runtime', function () {
         if (request === undefined) {
             assert.fail('expected a worker spawn request');
         }
-        assert.strictEqual(request.buffer, runtime.accessors.buffer);
-        assert.strictEqual(request.slotCount, 4);
-        assert.strictEqual(request.stdoutFileDescriptor, 7);
+        assert.partialDeepStrictEqual(request, {
+            buffer: runtime.accessors.buffer,
+            slotCount: 4,
+            stdoutFileDescriptor: 7
+        });
     });
 
     test('createSpinnerRuntime initializes the shared accessors with the requested interval and columns', function () {

--- a/source/command-line-interface/spinner/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner/spinner-shared-state.test.ts
@@ -159,10 +159,12 @@ suite('spinner-shared-state', function () {
         test('createSpinnerSharedLayout reports the byte length required to hold the header and slots', function () {
             const layout = createSpinnerSharedLayout(2);
 
-            assert.strictEqual(layout.slotCount, 2);
-            assert.strictEqual(layout.headerByteLength, 24);
-            assert.strictEqual(layout.slotByteLength, 384);
-            assert.strictEqual(layout.bufferByteLength, 24 + 2 * 384);
+            assert.partialDeepStrictEqual(layout, {
+                slotCount: 2,
+                headerByteLength: 24,
+                slotByteLength: 384,
+                bufferByteLength: 24 + 2 * 384
+            });
         });
 
         test('setColumns and getColumns round-trip the value', function () {

--- a/source/command-line-interface/spinner/spinner-worker-backend.test.ts
+++ b/source/command-line-interface/spinner/spinner-worker-backend.test.ts
@@ -84,9 +84,11 @@ suite('spinner-worker-backend', function () {
 
             assert.strictEqual(spawnWorker.callCount, 1);
             const request = spawnWorker.firstCall.firstArg as WorkerSpawnRequest;
-            assert.strictEqual(request.buffer, runtime.accessors.buffer);
-            assert.strictEqual(request.slotCount, 2);
-            assert.strictEqual(request.stdoutFileDescriptor, 5);
+            assert.partialDeepStrictEqual(request, {
+                buffer: runtime.accessors.buffer,
+                slotCount: 2,
+                stdoutFileDescriptor: 5
+            });
         });
 
         test('createSpinnerRuntime falls back to default slot and interval settings', function () {

--- a/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     createTerminalSpinnerRenderer,
     type SpinnerBackend,
@@ -46,7 +47,7 @@ suite('terminal-spinner-renderer', function () {
 
             renderer.add('the-id', 'the-label', 'the message');
 
-            assert.partialDeepStrictEqual(add, {
+            assertDeepSubset(add, {
                 callCount: 1,
                 firstCall: {
                     args: [ 0, 'the-label', 'the message' ]
@@ -61,7 +62,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('first', 'a', '1');
             renderer.add('second', 'b', '2');
 
-            assert.partialDeepStrictEqual(add, {
+            assertDeepSubset(add, {
                 callCount: 2,
                 firstCall: {
                     args: [ 0, 'a', '1' ]
@@ -94,7 +95,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('the-id', 'lbl', 'initial');
             renderer.updateMessage('the-id', 'foo');
 
-            assert.partialDeepStrictEqual(update, {
+            assertDeepSubset(update, {
                 callCount: 1,
                 firstCall: {
                     args: [ 0, 'lbl', 'foo' ]
@@ -111,7 +112,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.updateMessage('first', 'foo');
             renderer.updateMessage('second', 'bar');
 
-            assert.partialDeepStrictEqual(update, {
+            assertDeepSubset(update, {
                 callCount: 2,
                 firstCall: {
                     args: [ 0, 'one', 'foo' ]
@@ -142,7 +143,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('the-id', 'lbl', '');
             renderer.stop('the-id', 'success', 'foo');
 
-            assert.partialDeepStrictEqual(finish, {
+            assertDeepSubset(finish, {
                 callCount: 1,
                 firstCall: {
                     args: [ 0, 'succeeded', 'lbl', 'foo' ]
@@ -157,7 +158,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('the-id', 'lbl', '');
             renderer.stop('the-id', 'failure', 'foo');
 
-            assert.partialDeepStrictEqual(finish, {
+            assertDeepSubset(finish, {
                 callCount: 1,
                 firstCall: {
                     args: [ 0, 'failed', 'lbl', 'foo' ]
@@ -173,7 +174,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.stop('the-id', 'success', 'foo');
             renderer.updateMessage('the-id', 'updated');
 
-            assert.partialDeepStrictEqual(update, {
+            assertDeepSubset(update, {
                 callCount: 1,
                 firstCall: {
                     args: [ 0, 'lbl', 'updated' ]
@@ -201,7 +202,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.stop('first', 'failure', 'foo');
             renderer.stop('second', 'failure', 'bar');
 
-            assert.partialDeepStrictEqual(finish, {
+            assertDeepSubset(finish, {
                 callCount: 2,
                 firstCall: {
                     args: [ 0, 'failed', 'a', 'foo' ]
@@ -242,7 +243,7 @@ suite('terminal-spinner-renderer', function () {
             renderer.stop('first', 'success', 'foo');
             renderer.stopAll();
 
-            assert.partialDeepStrictEqual(finish, {
+            assertDeepSubset(finish, {
                 callCount: 2,
                 firstCall: {
                     args: [ 0, 'succeeded', 'one', 'foo' ]

--- a/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
@@ -46,8 +46,12 @@ suite('terminal-spinner-renderer', function () {
 
             renderer.add('the-id', 'the-label', 'the message');
 
-            assert.strictEqual(add.callCount, 1);
-            assert.deepStrictEqual(add.firstCall.args, [ 0, 'the-label', 'the message' ]);
+            assert.partialDeepStrictEqual(add, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 0, 'the-label', 'the message' ]
+                }
+            });
         });
 
         test('add() assigns successive spinners to consecutive slot indices', function () {
@@ -57,9 +61,15 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('first', 'a', '1');
             renderer.add('second', 'b', '2');
 
-            assert.strictEqual(add.callCount, 2);
-            assert.deepStrictEqual(add.firstCall.args, [ 0, 'a', '1' ]);
-            assert.deepStrictEqual(add.secondCall.args, [ 1, 'b', '2' ]);
+            assert.partialDeepStrictEqual(add, {
+                callCount: 2,
+                firstCall: {
+                    args: [ 0, 'a', '1' ]
+                },
+                secondCall: {
+                    args: [ 1, 'b', '2' ]
+                }
+            });
         });
 
         test('add() throws when adding two spinners with the same id', function () {
@@ -84,8 +94,12 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('the-id', 'lbl', 'initial');
             renderer.updateMessage('the-id', 'foo');
 
-            assert.strictEqual(update.callCount, 1);
-            assert.deepStrictEqual(update.firstCall.args, [ 0, 'lbl', 'foo' ]);
+            assert.partialDeepStrictEqual(update, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 0, 'lbl', 'foo' ]
+                }
+            });
         });
 
         test('updateMessage() updates the correct spinner when having multiple', function () {
@@ -97,9 +111,15 @@ suite('terminal-spinner-renderer', function () {
             renderer.updateMessage('first', 'foo');
             renderer.updateMessage('second', 'bar');
 
-            assert.strictEqual(update.callCount, 2);
-            assert.deepStrictEqual(update.firstCall.args, [ 0, 'one', 'foo' ]);
-            assert.deepStrictEqual(update.secondCall.args, [ 1, 'two', 'bar' ]);
+            assert.partialDeepStrictEqual(update, {
+                callCount: 2,
+                firstCall: {
+                    args: [ 0, 'one', 'foo' ]
+                },
+                secondCall: {
+                    args: [ 1, 'two', 'bar' ]
+                }
+            });
         });
 
         test('updateMessage() throws when trying to change the message of a non-existing spinner', function () {
@@ -122,8 +142,12 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('the-id', 'lbl', '');
             renderer.stop('the-id', 'success', 'foo');
 
-            assert.strictEqual(finish.callCount, 1);
-            assert.deepStrictEqual(finish.firstCall.args, [ 0, 'succeeded', 'lbl', 'foo' ]);
+            assert.partialDeepStrictEqual(finish, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 0, 'succeeded', 'lbl', 'foo' ]
+                }
+            });
         });
 
         test('stop() finishes the spinner with failed state when the status is failure', function () {
@@ -133,8 +157,12 @@ suite('terminal-spinner-renderer', function () {
             renderer.add('the-id', 'lbl', '');
             renderer.stop('the-id', 'failure', 'foo');
 
-            assert.strictEqual(finish.callCount, 1);
-            assert.deepStrictEqual(finish.firstCall.args, [ 0, 'failed', 'lbl', 'foo' ]);
+            assert.partialDeepStrictEqual(finish, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 0, 'failed', 'lbl', 'foo' ]
+                }
+            });
         });
 
         test('stop() keeps the stopped spinner addressable for later message updates', function () {
@@ -145,8 +173,12 @@ suite('terminal-spinner-renderer', function () {
             renderer.stop('the-id', 'success', 'foo');
             renderer.updateMessage('the-id', 'updated');
 
-            assert.strictEqual(update.callCount, 1);
-            assert.deepStrictEqual(update.firstCall.args, [ 0, 'lbl', 'updated' ]);
+            assert.partialDeepStrictEqual(update, {
+                callCount: 1,
+                firstCall: {
+                    args: [ 0, 'lbl', 'updated' ]
+                }
+            });
         });
 
         test('stop() uses the original slot and label after a message update', function () {
@@ -169,9 +201,15 @@ suite('terminal-spinner-renderer', function () {
             renderer.stop('first', 'failure', 'foo');
             renderer.stop('second', 'failure', 'bar');
 
-            assert.strictEqual(finish.callCount, 2);
-            assert.deepStrictEqual(finish.firstCall.args, [ 0, 'failed', 'a', 'foo' ]);
-            assert.deepStrictEqual(finish.secondCall.args, [ 1, 'failed', 'b', 'bar' ]);
+            assert.partialDeepStrictEqual(finish, {
+                callCount: 2,
+                firstCall: {
+                    args: [ 0, 'failed', 'a', 'foo' ]
+                },
+                secondCall: {
+                    args: [ 1, 'failed', 'b', 'bar' ]
+                }
+            });
         });
 
         test('stop() throws when trying to stop a spinner that does not exist', function () {
@@ -204,9 +242,15 @@ suite('terminal-spinner-renderer', function () {
             renderer.stop('first', 'success', 'foo');
             renderer.stopAll();
 
-            assert.strictEqual(finish.callCount, 2);
-            assert.deepStrictEqual(finish.firstCall.args, [ 0, 'succeeded', 'one', 'foo' ]);
-            assert.deepStrictEqual(finish.secondCall.args, [ 1, 'canceled', 'two', 'Canceled …' ]);
+            assert.partialDeepStrictEqual(finish, {
+                callCount: 2,
+                firstCall: {
+                    args: [ 0, 'succeeded', 'one', 'foo' ]
+                },
+                secondCall: {
+                    args: [ 1, 'canceled', 'two', 'Canceled …' ]
+                }
+            });
         });
 
         test('stopAll() does not re-cancel previously canceled spinners on a second invocation', function () {

--- a/source/common/clock.test.ts
+++ b/source/common/clock.test.ts
@@ -17,7 +17,9 @@ suite('clock', function () {
     test('createClock() exposes the global timeout functions', function () {
         const clock = createClock();
 
-        assert.strictEqual(clock.setTimeout, setTimer);
-        assert.strictEqual(clock.clearTimeout, clearTimer);
+        assert.partialDeepStrictEqual(clock, {
+            setTimeout: setTimer,
+            clearTimeout: clearTimer
+        });
     });
 });

--- a/source/common/path-tree.test.ts
+++ b/source/common/path-tree.test.ts
@@ -30,8 +30,10 @@ suite('path-tree', function () {
             if (node === undefined) {
                 assert.fail('expected a root file node');
             }
-            assert.strictEqual(node.type, 'file');
-            assert.strictEqual(node.path, 'package.json');
+            assert.partialDeepStrictEqual(node, {
+                type: 'file',
+                path: 'package.json'
+            });
             assert.deepStrictEqual(rest, []);
         });
 
@@ -42,9 +44,11 @@ suite('path-tree', function () {
             if (node === undefined) {
                 assert.fail('expected an empty root file node');
             }
-            assert.strictEqual(node.type, 'file');
-            assert.strictEqual(node.path, '');
-            assert.strictEqual(node.name, '');
+            assert.partialDeepStrictEqual(node, {
+                type: 'file',
+                path: '',
+                name: ''
+            });
             assert.deepStrictEqual(rest, []);
         });
     });

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -185,8 +185,10 @@ function mainPackageJsonValuesOf(config: PacktoryConfig): readonly PackageConfig
 }
 
 function assertParsedConfigMatchesInput(parsedConfig: PacktoryConfig, typedConfig: PacktoryConfig): void {
-    assert.deepStrictEqual(parsedConfig.registrySettings, typedConfig.registrySettings);
-    assert.strictEqual(parsedConfig.packages.length, typedConfig.packages.length);
+    assert.partialDeepStrictEqual(parsedConfig, {
+        registrySettings: typedConfig.registrySettings,
+        packages: { length: typedConfig.packages.length }
+    });
     assert.deepStrictEqual(namesOf(parsedConfig), namesOf(typedConfig));
     assert.deepStrictEqual(rootsOf(parsedConfig), rootsOf(typedConfig));
     assert.deepStrictEqual(sourcesFoldersOf(parsedConfig), sourcesFoldersOf(typedConfig));

--- a/source/config/config.property.ts
+++ b/source/config/config.property.ts
@@ -185,10 +185,10 @@ function mainPackageJsonValuesOf(config: PacktoryConfig): readonly PackageConfig
 }
 
 function assertParsedConfigMatchesInput(parsedConfig: PacktoryConfig, typedConfig: PacktoryConfig): void {
-    assert.partialDeepStrictEqual(parsedConfig, {
-        registrySettings: typedConfig.registrySettings,
-        packages: { length: typedConfig.packages.length }
-    });
+    assert.deepStrictEqual(
+        { registrySettings: parsedConfig.registrySettings, packageCount: parsedConfig.packages.length },
+        { registrySettings: typedConfig.registrySettings, packageCount: typedConfig.packages.length }
+    );
     assert.deepStrictEqual(namesOf(parsedConfig), namesOf(typedConfig));
     assert.deepStrictEqual(rootsOf(parsedConfig), rootsOf(typedConfig));
     assert.deepStrictEqual(sourcesFoldersOf(parsedConfig), sourcesFoldersOf(typedConfig));

--- a/source/config/package-json.test.ts
+++ b/source/config/package-json.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { safeParse } from '../common/schema-validation.ts';
 import { checkValidationFailure, checkValidationSuccess } from '../test-libraries/verify-schema-validation.ts';
 import { isForbiddenAdditionalPackageJsonAttributeName, packageJsonDependencyFieldNames } from './package-json.ts';
@@ -353,7 +354,7 @@ suite('package-json', function () {
                 ]
             ) {
                 const result = safeParse(schema, { [key]: 'value' });
-                assert.partialDeepStrictEqual(result, {
+                assertDeepSubset(result, {
                     success: false,
                     error: {
                         issues: [ `at ${key}: invalid key` ]

--- a/source/config/package-json.test.ts
+++ b/source/config/package-json.test.ts
@@ -353,8 +353,12 @@ suite('package-json', function () {
                 ]
             ) {
                 const result = safeParse(schema, { [key]: 'value' });
-                assert.strictEqual(result.success, false);
-                assert.deepStrictEqual(result.error.issues, [ `at ${key}: invalid key` ]);
+                assert.partialDeepStrictEqual(result, {
+                    success: false,
+                    error: {
+                        issues: [ `at ${key}: invalid key` ]
+                    }
+                });
             }
         });
 

--- a/source/dead-code-eliminator/code-file-analyzer.test.ts
+++ b/source/dead-code-eliminator/code-file-analyzer.test.ts
@@ -57,8 +57,16 @@ suite('code-file-analyzer', function () {
 
         const result = buildAnalyzedResource(loaded, baseContext);
 
-        assert.deepStrictEqual(result.transforms, []);
-        assert.strictEqual(result.resource.analysis.survivingBindings.size, 0);
+        assert.partialDeepStrictEqual(result, {
+            transforms: [],
+            resource: {
+                analysis: {
+                    survivingBindings: {
+                        size: 0
+                    }
+                }
+            }
+        });
     });
 
     test('buildAnalyzedResource leaves the content unchanged when transformations are disabled', function () {
@@ -66,8 +74,14 @@ suite('code-file-analyzer', function () {
 
         const result = buildAnalyzedResource(loaded, baseContext);
 
-        assert.deepStrictEqual(result.transforms, []);
-        assert.strictEqual(result.resource.fileDescription.content, 'export const foo = 1;\n');
+        assert.partialDeepStrictEqual(result, {
+            transforms: [],
+            resource: {
+                fileDescription: {
+                    content: 'export const foo = 1;\n'
+                }
+            }
+        });
     });
 
     test('buildAnalyzedResource includes side-effect statements in the analysis when transformations are disabled', function () {
@@ -83,8 +97,14 @@ suite('code-file-analyzer', function () {
 
         const result = buildAnalyzedResource(loaded, { ...baseContext, transformationsEnabled: true });
 
-        assert.deepStrictEqual(result.transforms, []);
-        assert.strictEqual(result.resource.fileDescription.content, 'console.log(1);\nexport const foo = 1;\n');
+        assert.partialDeepStrictEqual(result, {
+            transforms: [],
+            resource: {
+                fileDescription: {
+                    content: 'console.log(1);\nexport const foo = 1;\n'
+                }
+            }
+        });
     });
 
     test('buildAnalyzedResource carries through every original binding name on the analysis when no transform happens', function () {

--- a/source/dead-code-eliminator/code-file-analyzer.test.ts
+++ b/source/dead-code-eliminator/code-file-analyzer.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { Node as TsMorphNode, Statement } from 'ts-morph';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { buildAnalyzedResource, type AnalysisContext } from './code-file-analyzer.ts';
 import type { LoadedCodeResource, LoadedResource } from './load-bundle.ts';
@@ -57,7 +58,7 @@ suite('code-file-analyzer', function () {
 
         const result = buildAnalyzedResource(loaded, baseContext);
 
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             transforms: [],
             resource: {
                 analysis: {
@@ -74,7 +75,7 @@ suite('code-file-analyzer', function () {
 
         const result = buildAnalyzedResource(loaded, baseContext);
 
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             transforms: [],
             resource: {
                 fileDescription: {
@@ -97,7 +98,7 @@ suite('code-file-analyzer', function () {
 
         const result = buildAnalyzedResource(loaded, { ...baseContext, transformationsEnabled: true });
 
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             transforms: [],
             resource: {
                 fileDescription: {

--- a/source/dead-code-eliminator/cross-bundle/cross-bundle-seeds.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/cross-bundle-seeds.test.ts
@@ -81,7 +81,7 @@ function seedsForLoneConsumer(consumerContent: string): SeedMap {
 }
 
 function assertHelpersBindingsSeeded(bSeeds: ReadonlySet<string> | undefined): void {
-    assert.ok(bSeeds !== undefined);
+    assert.notStrictEqual(bSeeds, undefined);
     assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'a')));
     assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'b')));
 }
@@ -131,7 +131,7 @@ suite('cross-bundle-seeds', function () {
             ]);
             const seeds = buildCrossBundleSeeds([ consumerInput, producerInput ]);
             const bSeeds = seeds.get('pkg-b');
-            assert.ok(bSeeds !== undefined);
+            assert.notStrictEqual(bSeeds, undefined);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'default')), false);
@@ -162,7 +162,7 @@ suite('cross-bundle-seeds', function () {
                 inputFor(producer, [ { sourceFilePath: '/b/main.ts', content: 'export default 42;' } ])
             ]);
             const bSeeds = seeds.get('pkg-b');
-            assert.ok(bSeeds !== undefined);
+            assert.notStrictEqual(bSeeds, undefined);
             assert.ok(bSeeds.has(bindingId('/b/main.ts', 'default')));
         });
 
@@ -171,7 +171,7 @@ suite('cross-bundle-seeds', function () {
                 'export { used } from "pkg-b/helpers.ts";',
                 'export function used() { return 1; }\nexport function unused() { return 2; }'
             );
-            assert.ok(bSeeds !== undefined);
+            assert.notStrictEqual(bSeeds, undefined);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
         });
@@ -307,7 +307,7 @@ suite('cross-bundle-seeds', function () {
             ]);
             assert.strictEqual(seeds.has('pkg-a'), false);
             const bSeeds = seeds.get('pkg-b');
-            assert.ok(bSeeds !== undefined);
+            assert.notStrictEqual(bSeeds, undefined);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
         });
 
@@ -342,7 +342,7 @@ suite('cross-bundle-seeds', function () {
                 'import { used as renamed } from "pkg-b/helpers.ts";\nexport function pub() { return renamed(); }',
                 'export function used() { return 1; }'
             );
-            assert.ok(bSeeds !== undefined);
+            assert.notStrictEqual(bSeeds, undefined);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
         });
 
@@ -364,7 +364,7 @@ suite('cross-bundle-seeds', function () {
                     .join('\n'),
                 'export function used() { return 1; }\nexport function alsoDead() { return 2; }'
             );
-            assert.ok(bSeeds !== undefined);
+            assert.notStrictEqual(bSeeds, undefined);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'alsoDead')), false);
         });

--- a/source/dead-code-eliminator/cross-bundle/cross-bundle-seeds.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/cross-bundle-seeds.test.ts
@@ -11,6 +11,12 @@ import { buildCrossBundleSeeds, type CrossBundleInput } from './cross-bundle-see
 
 type SeedMap = ReadonlyMap<string, ReadonlySet<string>>;
 
+function assertDefined<T>(value: T | undefined): asserts value is T {
+    if (value === undefined) {
+        assert.fail('expected value to be defined');
+    }
+}
+
 function bundleWith(
     name: string,
     files: readonly { readonly sourceFilePath: string; readonly targetFilePath: string; readonly content: string; }[]
@@ -81,7 +87,7 @@ function seedsForLoneConsumer(consumerContent: string): SeedMap {
 }
 
 function assertHelpersBindingsSeeded(bSeeds: ReadonlySet<string> | undefined): void {
-    assert.notStrictEqual(bSeeds, undefined);
+    assertDefined(bSeeds);
     assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'a')));
     assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'b')));
 }
@@ -131,7 +137,7 @@ suite('cross-bundle-seeds', function () {
             ]);
             const seeds = buildCrossBundleSeeds([ consumerInput, producerInput ]);
             const bSeeds = seeds.get('pkg-b');
-            assert.notStrictEqual(bSeeds, undefined);
+            assertDefined(bSeeds);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'default')), false);
@@ -162,7 +168,7 @@ suite('cross-bundle-seeds', function () {
                 inputFor(producer, [ { sourceFilePath: '/b/main.ts', content: 'export default 42;' } ])
             ]);
             const bSeeds = seeds.get('pkg-b');
-            assert.notStrictEqual(bSeeds, undefined);
+            assertDefined(bSeeds);
             assert.ok(bSeeds.has(bindingId('/b/main.ts', 'default')));
         });
 
@@ -171,7 +177,7 @@ suite('cross-bundle-seeds', function () {
                 'export { used } from "pkg-b/helpers.ts";',
                 'export function used() { return 1; }\nexport function unused() { return 2; }'
             );
-            assert.notStrictEqual(bSeeds, undefined);
+            assertDefined(bSeeds);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'unused')), false);
         });
@@ -307,7 +313,7 @@ suite('cross-bundle-seeds', function () {
             ]);
             assert.strictEqual(seeds.has('pkg-a'), false);
             const bSeeds = seeds.get('pkg-b');
-            assert.notStrictEqual(bSeeds, undefined);
+            assertDefined(bSeeds);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
         });
 
@@ -342,7 +348,7 @@ suite('cross-bundle-seeds', function () {
                 'import { used as renamed } from "pkg-b/helpers.ts";\nexport function pub() { return renamed(); }',
                 'export function used() { return 1; }'
             );
-            assert.notStrictEqual(bSeeds, undefined);
+            assertDefined(bSeeds);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
         });
 
@@ -364,7 +370,7 @@ suite('cross-bundle-seeds', function () {
                     .join('\n'),
                 'export function used() { return 1; }\nexport function alsoDead() { return 2; }'
             );
-            assert.notStrictEqual(bSeeds, undefined);
+            assertDefined(bSeeds);
             assert.ok(bSeeds.has(bindingId('/b/helpers.ts', 'used')));
             assert.strictEqual(bSeeds.has(bindingId('/b/helpers.ts', 'alsoDead')), false);
         });

--- a/source/dead-code-eliminator/eliminator-bundle-analysis.test.ts
+++ b/source/dead-code-eliminator/eliminator-bundle-analysis.test.ts
@@ -50,7 +50,7 @@ function assertRecomposedMap(analyzed: AnalyzedBundle | undefined, originalMap: 
     const emittedMap = analyzed?.contents.find(function (resource) {
         return resource.fileDescription.targetFilePath === 'index.ts.map';
     });
-    assert.ok(emittedMap !== undefined);
+    assert.notStrictEqual(emittedMap, undefined);
     assert.notStrictEqual(emittedMap.fileDescription.content, originalMap);
     const parsed = JSON.parse(emittedMap.fileDescription.content) as {
         readonly mappings: string;
@@ -140,9 +140,11 @@ suite('eliminator bundle analysis', function () {
                 } ] ])
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(input));
-            assert.strictEqual(analyzed?.roots, input.roots);
-            assert.strictEqual(analyzed.externalDependencies, input.externalDependencies);
-            assert.strictEqual(analyzed.linkedBundleDependencies, input.linkedBundleDependencies);
+            assert.partialDeepStrictEqual(analyzed, {
+                roots: input.roots,
+                externalDependencies: input.externalDependencies,
+                linkedBundleDependencies: input.linkedBundleDependencies
+            });
         });
 
         test('eliminate preserves resource fields and uses empty analysis defaults on non-code files', async function () {
@@ -152,15 +154,17 @@ suite('eliminator bundle analysis', function () {
                 inputs(linkedBundle({ name: 'pkg', contents: [ resource ] }))
             );
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
-            assert.strictEqual(emitted.fileDescription, resource.fileDescription);
-            assert.strictEqual(emitted.isSubstituted, false);
-            assert.strictEqual(emitted.directDependencies, resource.directDependencies);
-            assert.strictEqual(emitted.isExplicitlyIncluded, resource.isExplicitlyIncluded);
-            assert.deepStrictEqual(emitted.analysis, {
-                survivingBindings: new Set<string>(),
-                sideEffectStatements: [],
-                sideEffectImports: new Set<string>()
+            assert.notStrictEqual(emitted, undefined);
+            assert.partialDeepStrictEqual(emitted, {
+                fileDescription: resource.fileDescription,
+                isSubstituted: false,
+                directDependencies: resource.directDependencies,
+                isExplicitlyIncluded: resource.isExplicitlyIncluded,
+                analysis: {
+                    survivingBindings: new Set<string>(),
+                    sideEffectStatements: [],
+                    sideEffectImports: new Set<string>()
+                }
             });
         });
     });
@@ -170,15 +174,17 @@ suite('eliminator bundle analysis', function () {
             const eliminator = createTestEliminator();
             const input: AnalyzedBundle = analyzedBundle({ name: 'pkg' });
             const [ analyzed ] = await eliminator.eliminate(inputs(input));
-            assert.strictEqual(analyzed?.name, 'pkg');
-            assert.strictEqual(analyzed.sideEffectsField, false);
+            assert.partialDeepStrictEqual(analyzed, {
+                name: 'pkg',
+                sideEffectsField: false
+            });
         });
 
         test('eliminate removes an unreachable function declaration and records the surviving bindings when transformations are enabled', async function () {
             const eliminator = createTestEliminator();
             const [ analyzed ] = await eliminator.eliminate(inputs(indexTsBundle()));
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(emitted.fileDescription.content.includes('dead'), false);
             assert.strictEqual(emitted.fileDescription.content.includes('live'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'live' ]));
@@ -198,7 +204,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(emitted.fileDescription.content.includes('export const { live, dead } = api;'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'api', 'live', 'dead' ]));
         });
@@ -218,7 +224,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(emitted.fileDescription.content.includes('const { helper, other } = build();'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'helper', 'other', 'build', 'live' ]));
         });
@@ -235,7 +241,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(
                 emitted.fileDescription.content.includes('const { helper, other } = { helper: 1, other: 2 };'),
                 true
@@ -259,7 +265,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(emitted.fileDescription.content.includes('const globalSchema = 1;'), true);
             assert.strictEqual(emitted.fileDescription.content.includes('const perPackageSchema = 2;'), true);
             assert.strictEqual(emitted.fileDescription.content.includes('function run()'), true);
@@ -273,7 +279,7 @@ suite('eliminator bundle analysis', function () {
             const eliminator = createTestEliminator();
             const result = await eliminator.eliminate([ { bundle: indexTsBundle(), transformationsEnabled: false } ]);
             const emitted = result[0]?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(emitted.fileDescription.content, indexTsContent);
         });
 

--- a/source/dead-code-eliminator/eliminator-bundle-analysis.test.ts
+++ b/source/dead-code-eliminator/eliminator-bundle-analysis.test.ts
@@ -15,6 +15,12 @@ import {
 import type { AnalyzedBundle } from './analyzed-bundle.ts';
 import { createDeadCodeEliminator } from './eliminator.ts';
 
+function assertDefined<T>(value: T | undefined): asserts value is T {
+    if (value === undefined) {
+        assert.fail('expected value to be defined');
+    }
+}
+
 type NamedBundle = {
     readonly packageName: string;
 };
@@ -50,7 +56,7 @@ function assertRecomposedMap(analyzed: AnalyzedBundle | undefined, originalMap: 
     const emittedMap = analyzed?.contents.find(function (resource) {
         return resource.fileDescription.targetFilePath === 'index.ts.map';
     });
-    assert.notStrictEqual(emittedMap, undefined);
+    assertDefined(emittedMap);
     assert.notStrictEqual(emittedMap.fileDescription.content, originalMap);
     const parsed = JSON.parse(emittedMap.fileDescription.content) as {
         readonly mappings: string;
@@ -154,7 +160,7 @@ suite('eliminator bundle analysis', function () {
                 inputs(linkedBundle({ name: 'pkg', contents: [ resource ] }))
             );
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.partialDeepStrictEqual(emitted, {
                 fileDescription: resource.fileDescription,
                 isSubstituted: false,
@@ -184,7 +190,7 @@ suite('eliminator bundle analysis', function () {
             const eliminator = createTestEliminator();
             const [ analyzed ] = await eliminator.eliminate(inputs(indexTsBundle()));
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(emitted.fileDescription.content.includes('dead'), false);
             assert.strictEqual(emitted.fileDescription.content.includes('live'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'live' ]));
@@ -204,7 +210,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(emitted.fileDescription.content.includes('export const { live, dead } = api;'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'api', 'live', 'dead' ]));
         });
@@ -224,7 +230,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(emitted.fileDescription.content.includes('const { helper, other } = build();'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'helper', 'other', 'build', 'live' ]));
         });
@@ -241,7 +247,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(
                 emitted.fileDescription.content.includes('const { helper, other } = { helper: 1, other: 2 };'),
                 true
@@ -265,7 +271,7 @@ suite('eliminator bundle analysis', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(emitted.fileDescription.content.includes('const globalSchema = 1;'), true);
             assert.strictEqual(emitted.fileDescription.content.includes('const perPackageSchema = 2;'), true);
             assert.strictEqual(emitted.fileDescription.content.includes('function run()'), true);
@@ -279,7 +285,7 @@ suite('eliminator bundle analysis', function () {
             const eliminator = createTestEliminator();
             const result = await eliminator.eliminate([ { bundle: indexTsBundle(), transformationsEnabled: false } ]);
             const emitted = result[0]?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(emitted.fileDescription.content, indexTsContent);
         });
 

--- a/source/dead-code-eliminator/eliminator-reachability-seeds.test.ts
+++ b/source/dead-code-eliminator/eliminator-reachability-seeds.test.ts
@@ -37,7 +37,7 @@ suite('eliminator reachability seeds', function () {
             const emittedMap = analyzed?.contents.find(function (resource) {
                 return resource.fileDescription.targetFilePath === 'index.ts.map';
             });
-            assert.ok(emittedMap !== undefined);
+            assert.notStrictEqual(emittedMap, undefined);
             assert.strictEqual(emittedMap.fileDescription.content, validMapContent);
         });
 
@@ -72,7 +72,7 @@ suite('eliminator reachability seeds', function () {
                 )
             );
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'Public', 'Private' ]));
         });
 
@@ -125,7 +125,7 @@ suite('eliminator reachability seeds', function () {
             const emittedWorker = analyzed?.contents.find(function (resource) {
                 return resource.fileDescription.sourceFilePath === '/src/worker.js';
             });
-            assert.ok(emittedWorker !== undefined);
+            assert.notStrictEqual(emittedWorker, undefined);
             assert.deepStrictEqual(
                 emittedWorker.analysis.survivingBindings,
                 new Set([ 'workerPublic', 'workerPrivate' ])
@@ -143,7 +143,7 @@ suite('eliminator reachability seeds', function () {
                 )
             );
             const producerEmitted = result[1]?.contents[0];
-            assert.ok(producerEmitted !== undefined);
+            assert.notStrictEqual(producerEmitted, undefined);
             assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), true);
             assert.strictEqual(producerEmitted.fileDescription.content.includes('unused'), false);
         });
@@ -190,7 +190,7 @@ suite('eliminator reachability seeds', function () {
             const runtimeHelper = analyzed?.contents.find(function (resource) {
                 return resource.fileDescription.sourceFilePath === '/src/helpers.js';
             });
-            assert.ok(runtimeHelper !== undefined);
+            assert.notStrictEqual(runtimeHelper, undefined);
             assert.strictEqual(runtimeHelper.fileDescription.content.includes('used'), true);
             assert.strictEqual(runtimeHelper.fileDescription.content.includes('unused'), false);
         });
@@ -207,7 +207,7 @@ suite('eliminator reachability seeds', function () {
                 inputs(consumerBundleWith(consumerContent), producerBundleWith('export function used() { return 1; }'))
             );
             const producerEmitted = result[1]?.contents[0];
-            assert.ok(producerEmitted !== undefined);
+            assert.notStrictEqual(producerEmitted, undefined);
             assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), false);
         });
 
@@ -227,7 +227,7 @@ suite('eliminator reachability seeds', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.ok(emitted !== undefined);
+            assert.notStrictEqual(emitted, undefined);
             assert.strictEqual(emitted.fileDescription.content.includes('dead'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'dead', 'live' ]));
         });

--- a/source/dead-code-eliminator/eliminator-reachability-seeds.test.ts
+++ b/source/dead-code-eliminator/eliminator-reachability-seeds.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import { bundleResource, linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import { createTestEliminator } from '../test-libraries/eliminator-fixtures.ts';
 import {
@@ -37,7 +38,7 @@ suite('eliminator reachability seeds', function () {
             const emittedMap = analyzed?.contents.find(function (resource) {
                 return resource.fileDescription.targetFilePath === 'index.ts.map';
             });
-            assert.notStrictEqual(emittedMap, undefined);
+            assertDefined(emittedMap);
             assert.strictEqual(emittedMap.fileDescription.content, validMapContent);
         });
 
@@ -72,7 +73,7 @@ suite('eliminator reachability seeds', function () {
                 )
             );
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'Public', 'Private' ]));
         });
 
@@ -125,7 +126,7 @@ suite('eliminator reachability seeds', function () {
             const emittedWorker = analyzed?.contents.find(function (resource) {
                 return resource.fileDescription.sourceFilePath === '/src/worker.js';
             });
-            assert.notStrictEqual(emittedWorker, undefined);
+            assertDefined(emittedWorker);
             assert.deepStrictEqual(
                 emittedWorker.analysis.survivingBindings,
                 new Set([ 'workerPublic', 'workerPrivate' ])
@@ -143,7 +144,7 @@ suite('eliminator reachability seeds', function () {
                 )
             );
             const producerEmitted = result[1]?.contents[0];
-            assert.notStrictEqual(producerEmitted, undefined);
+            assertDefined(producerEmitted);
             assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), true);
             assert.strictEqual(producerEmitted.fileDescription.content.includes('unused'), false);
         });
@@ -190,7 +191,7 @@ suite('eliminator reachability seeds', function () {
             const runtimeHelper = analyzed?.contents.find(function (resource) {
                 return resource.fileDescription.sourceFilePath === '/src/helpers.js';
             });
-            assert.notStrictEqual(runtimeHelper, undefined);
+            assertDefined(runtimeHelper);
             assert.strictEqual(runtimeHelper.fileDescription.content.includes('used'), true);
             assert.strictEqual(runtimeHelper.fileDescription.content.includes('unused'), false);
         });
@@ -207,7 +208,7 @@ suite('eliminator reachability seeds', function () {
                 inputs(consumerBundleWith(consumerContent), producerBundleWith('export function used() { return 1; }'))
             );
             const producerEmitted = result[1]?.contents[0];
-            assert.notStrictEqual(producerEmitted, undefined);
+            assertDefined(producerEmitted);
             assert.strictEqual(producerEmitted.fileDescription.content.includes('used'), false);
         });
 
@@ -227,7 +228,7 @@ suite('eliminator reachability seeds', function () {
             });
             const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
             const emitted = analyzed?.contents[0];
-            assert.notStrictEqual(emitted, undefined);
+            assertDefined(emitted);
             assert.strictEqual(emitted.fileDescription.content.includes('dead'), true);
             assert.deepStrictEqual(emitted.analysis.survivingBindings, new Set([ 'dead', 'live' ]));
         });

--- a/source/dead-code-eliminator/expression-unwrapping.test.ts
+++ b/source/dead-code-eliminator/expression-unwrapping.test.ts
@@ -1,12 +1,13 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { SyntaxKind, type Expression, type VariableDeclaration } from 'ts-morph';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { unwrapExpression } from './expression-unwrapping.ts';
 
 function firstDeclaration(declarations: readonly VariableDeclaration[]): VariableDeclaration {
     const [ declaration ] = declarations;
-    assert.notStrictEqual(declaration, undefined);
+    assertDefined(declaration);
     return declaration;
 }
 

--- a/source/dead-code-eliminator/expression-unwrapping.test.ts
+++ b/source/dead-code-eliminator/expression-unwrapping.test.ts
@@ -6,7 +6,7 @@ import { unwrapExpression } from './expression-unwrapping.ts';
 
 function firstDeclaration(declarations: readonly VariableDeclaration[]): VariableDeclaration {
     const [ declaration ] = declarations;
-    assert.ok(declaration !== undefined);
+    assert.notStrictEqual(declaration, undefined);
     return declaration;
 }
 

--- a/source/dead-code-eliminator/load-bundle.test.ts
+++ b/source/dead-code-eliminator/load-bundle.test.ts
@@ -1,32 +1,55 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import type { LinkedBundle, LinkedBundleResource } from '../linker/linked-bundle.ts';
 import { linkedBundle, bundleResource } from '../test-libraries/bundle-fixtures.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { loadBundle } from './load-bundle.ts';
 
+const indexFile = {
+    sourceFilePath: '/src/index.js',
+    targetFilePath: 'index.js',
+    content: 'export const value = 1;\n',
+    isExecutable: false
+};
+
+function indexResource(): LinkedBundleResource {
+    return {
+        ...bundleResource('/src/index.js', {
+            content: indexFile.content,
+            targetFilePath: indexFile.targetFilePath
+        }),
+        isSubstituted: false
+    };
+}
+
+function packageABundle(overrides: Partial<Parameters<typeof linkedBundle>[0]> = {}): LinkedBundle {
+    return linkedBundle({
+        name: 'package-a',
+        roots: { main: { js: indexFile } },
+        contents: [ indexResource() ],
+        ...overrides
+    });
+}
+
 suite('load-bundle', function () {
+    test('loadBundle() keeps non-code resources out of source-file analysis', function () {
+        const resource = {
+            ...bundleResource('/src/readme.md', {
+                content: 'Hello',
+                targetFilePath: 'readme.md'
+            }),
+            isSubstituted: false
+        };
+        const bundle = packageABundle({ contents: [ indexResource(), resource ] });
+
+        const result = loadBundle(createProject, { bundle, transformationsEnabled: true });
+
+        assert.deepStrictEqual(result.loaded[1], { resource });
+        assert.strictEqual(result.fileBindings.length, 1);
+    });
+
     test('loadBundle() throws when the public surface references a missing root', function () {
-        const bundle = linkedBundle({
-            name: 'package-a',
-            roots: {
-                main: {
-                    js: {
-                        sourceFilePath: '/src/index.js',
-                        targetFilePath: 'index.js',
-                        content: 'export const value = 1;\n',
-                        isExecutable: false
-                    }
-                }
-            },
-            contents: [
-                {
-                    ...bundleResource('/src/index.js', {
-                        content: 'export const value = 1;\n',
-                        targetFilePath: 'index.js'
-                    }),
-                    isSubstituted: false
-                }
-            ],
+        const bundle = packageABundle({
             surface: {
                 mode: 'explicit',
                 packageInterface: {

--- a/source/dead-code-eliminator/reachability/reachability.test.ts
+++ b/source/dead-code-eliminator/reachability/reachability.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { runNodeProbe } from '../../test-libraries/run-node-probe.ts';
 import {
     assertLocalValueExportIsReachable,
@@ -265,7 +266,7 @@ suite('reachability', function () {
             const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
 
             const isolatedIds = index.bindingIdsByFile.get('isolated.ts');
-            assert.notStrictEqual(isolatedIds, undefined);
+            assertDefined(isolatedIds);
             assert.ok(isolatedIds.has(bindingId('isolated.ts', 'never')));
         });
 

--- a/source/dead-code-eliminator/reachability/reachability.test.ts
+++ b/source/dead-code-eliminator/reachability/reachability.test.ts
@@ -265,7 +265,7 @@ suite('reachability', function () {
             const index = buildReachabilityIndex({ files, entryPointFilePaths: new Set<string>() });
 
             const isolatedIds = index.bindingIdsByFile.get('isolated.ts');
-            assert.ok(isolatedIds !== undefined);
+            assert.notStrictEqual(isolatedIds, undefined);
             assert.ok(isolatedIds.has(bindingId('isolated.ts', 'never')));
         });
 

--- a/source/dead-code-eliminator/transform/declaration-removal.test.ts
+++ b/source/dead-code-eliminator/transform/declaration-removal.test.ts
@@ -20,7 +20,7 @@ suite('declaration-removal', function () {
         const mutated = processStatement(sourceFile.getFunctionOrThrow('keep'), new Set([ 'keep' ]));
 
         assert.strictEqual(mutated, false);
-        assert.ok(sourceFile.getFunction('keep') !== undefined);
+        assert.notStrictEqual(sourceFile.getFunction('keep'), undefined);
     });
 
     test('processStatement drops only the non-surviving declarators inside a variable statement', function () {

--- a/source/dead-code-eliminator/transform/declaration-removal.test.ts
+++ b/source/dead-code-eliminator/transform/declaration-removal.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { firstStatement, withSource } from '../../test-libraries/transform-test-support.ts';
 import { processStatement } from './declaration-removal.ts';
 
@@ -20,7 +21,7 @@ suite('declaration-removal', function () {
         const mutated = processStatement(sourceFile.getFunctionOrThrow('keep'), new Set([ 'keep' ]));
 
         assert.strictEqual(mutated, false);
-        assert.notStrictEqual(sourceFile.getFunction('keep'), undefined);
+        assertDefined(sourceFile.getFunction('keep'));
     });
 
     test('processStatement drops only the non-surviving declarators inside a variable statement', function () {

--- a/source/dead-code-eliminator/transform/declaration-remover.test.ts
+++ b/source/dead-code-eliminator/transform/declaration-remover.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { applyRemovalPlan, type PositionAtom } from './declaration-remover.ts';
 
@@ -132,7 +133,7 @@ suite('declaration-remover', function () {
             const { atoms } = transform('export const a = 1, b = 2;', new Set([ 'a', 'b' ]));
             assert.strictEqual(atoms.length, 1);
             const [ atom ] = atoms;
-            assert.notStrictEqual(atom, undefined);
+            assertDefined(atom);
             assert.strictEqual(atom.originalStart, 0);
         });
     });
@@ -148,7 +149,7 @@ suite('declaration-remover', function () {
             const { atoms } = transform('function dead() {}\nexport function live() {}', new Set([ 'live' ]));
             assert.strictEqual(atoms.length, 1);
             const [ atom ] = atoms;
-            assert.notStrictEqual(atom, undefined);
+            assertDefined(atom);
             assert.partialDeepStrictEqual(atom, {
                 originalStart: 19,
                 newStart: 0

--- a/source/dead-code-eliminator/transform/declaration-remover.test.ts
+++ b/source/dead-code-eliminator/transform/declaration-remover.test.ts
@@ -132,7 +132,7 @@ suite('declaration-remover', function () {
             const { atoms } = transform('export const a = 1, b = 2;', new Set([ 'a', 'b' ]));
             assert.strictEqual(atoms.length, 1);
             const [ atom ] = atoms;
-            assert.ok(atom !== undefined);
+            assert.notStrictEqual(atom, undefined);
             assert.strictEqual(atom.originalStart, 0);
         });
     });
@@ -148,9 +148,11 @@ suite('declaration-remover', function () {
             const { atoms } = transform('function dead() {}\nexport function live() {}', new Set([ 'live' ]));
             assert.strictEqual(atoms.length, 1);
             const [ atom ] = atoms;
-            assert.ok(atom !== undefined);
-            assert.strictEqual(atom.originalStart, 19);
-            assert.strictEqual(atom.newStart, 0);
+            assert.notStrictEqual(atom, undefined);
+            assert.partialDeepStrictEqual(atom, {
+                originalStart: 19,
+                newStart: 0
+            });
         });
     });
 });

--- a/source/dead-code-eliminator/transform/named-declaration-kinds.test.ts
+++ b/source/dead-code-eliminator/transform/named-declaration-kinds.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { Statement } from 'ts-morph';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import { createProject } from '../../test-libraries/typescript-project.ts';
 import { isNamedDeclaration } from './named-declaration-kinds.ts';
 
@@ -11,8 +12,8 @@ function statementsFor(content: string): readonly Statement[] {
 
 function firstTwoStatements(content: string): readonly [Statement, Statement] {
     const [ first, second ] = statementsFor(content);
-    assert.notStrictEqual(first, undefined);
-    assert.notStrictEqual(second, undefined);
+    assertDefined(first);
+    assertDefined(second);
     return [ first, second ];
 }
 

--- a/source/dead-code-eliminator/transform/named-declaration-kinds.test.ts
+++ b/source/dead-code-eliminator/transform/named-declaration-kinds.test.ts
@@ -11,8 +11,8 @@ function statementsFor(content: string): readonly Statement[] {
 
 function firstTwoStatements(content: string): readonly [Statement, Statement] {
     const [ first, second ] = statementsFor(content);
-    assert.ok(first !== undefined);
-    assert.ok(second !== undefined);
+    assert.notStrictEqual(first, undefined);
+    assert.notStrictEqual(second, undefined);
     return [ first, second ];
 }
 

--- a/source/dead-code-eliminator/transform/source-map-composer.test.ts
+++ b/source/dead-code-eliminator/transform/source-map-composer.test.ts
@@ -58,7 +58,7 @@ suite('source-map-composer', function () {
             });
             const mappings = listMappings(result);
             for (const mapping of mappings) {
-                assert.ok(mapping.generatedLine !== 1, 'no mapping should land on the removed line 1');
+                assert.notStrictEqual(mapping.generatedLine, 1, 'no mapping should land on the removed line 1');
             }
         });
 

--- a/source/dependency-scanner/scanner.test.ts
+++ b/source/dependency-scanner/scanner.test.ts
@@ -62,11 +62,15 @@ suite('scanner', function () {
 
             await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
 
-            assert.strictEqual(analyzeProject.callCount, 1);
-            assert.deepStrictEqual(analyzeProject.firstCall.args, [
-                '/foo',
-                { resolveDeclarationFiles: false, mainPackageJson: defaultMainPackageJson }
-            ]);
+            assert.partialDeepStrictEqual(analyzeProject, {
+                callCount: 1,
+                firstCall: {
+                    args: [
+                        '/foo',
+                        { resolveDeclarationFiles: false, mainPackageJson: defaultMainPackageJson }
+                    ]
+                }
+            });
         });
 
         test('passes the resolveDeclarationFiles option to the project analyzer', async function () {
@@ -78,11 +82,15 @@ suite('scanner', function () {
                 mainPackageJson: defaultMainPackageJson
             });
 
-            assert.strictEqual(analyzeProject.callCount, 1);
-            assert.deepStrictEqual(analyzeProject.firstCall.args, [
-                '/foo',
-                { resolveDeclarationFiles: true, mainPackageJson: defaultMainPackageJson }
-            ]);
+            assert.partialDeepStrictEqual(analyzeProject, {
+                callCount: 1,
+                firstCall: {
+                    args: [
+                        '/foo',
+                        { resolveDeclarationFiles: true, mainPackageJson: defaultMainPackageJson }
+                    ]
+                }
+            });
         });
 
         test('scans the dependencies of the given entryPoint file', async function () {
@@ -92,8 +100,12 @@ suite('scanner', function () {
 
             await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
 
-            assert.strictEqual(getReferencedModules.callCount, 1);
-            assert.deepStrictEqual(getReferencedModules.firstCall.args, [ '/foo/bar.js' ]);
+            assert.partialDeepStrictEqual(getReferencedModules, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/bar.js' ]
+                }
+            });
         });
     });
 
@@ -145,9 +157,15 @@ suite('scanner', function () {
                 mainPackageJson: defaultMainPackageJson
             });
 
-            assert.strictEqual(locate.callCount, 2);
-            assert.deepStrictEqual(locate.firstCall.args, [ '/dir/entry.js', '/dir' ]);
-            assert.deepStrictEqual(locate.secondCall.args, [ '/dir/foo.js', '/dir' ]);
+            assert.partialDeepStrictEqual(locate, {
+                callCount: 2,
+                firstCall: {
+                    args: [ '/dir/entry.js', '/dir' ]
+                },
+                secondCall: {
+                    args: [ '/dir/foo.js', '/dir' ]
+                }
+            });
         });
 
         async function scanWithSourceMapLocate(locate: SinonSpy): Promise<DependencyFiles> {
@@ -227,10 +245,18 @@ suite('scanner', function () {
             });
             const result = graph.flatten('/dir/entry.js');
 
-            assert.strictEqual(getReferencedModules.callCount, 4);
-            assert.deepStrictEqual(getReferencedModules.firstCall.args, [ '/dir/entry.js' ]);
-            assert.deepStrictEqual(getReferencedModules.secondCall.args, [ '/dir/foo.js' ]);
-            assert.deepStrictEqual(getReferencedModules.thirdCall.args, [ '/dir/bar.js' ]);
+            assert.partialDeepStrictEqual(getReferencedModules, {
+                callCount: 4,
+                firstCall: {
+                    args: [ '/dir/entry.js' ]
+                },
+                secondCall: {
+                    args: [ '/dir/foo.js' ]
+                },
+                thirdCall: {
+                    args: [ '/dir/bar.js' ]
+                }
+            });
             assert.deepStrictEqual(getReferencedModules.getCall(3).args, [ '/dir/baz.js' ]);
             assert.deepStrictEqual(result.localFiles, [
                 {

--- a/source/dependency-scanner/scanner.test.ts
+++ b/source/dependency-scanner/scanner.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { stub, fake, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import type { MainPackageJson } from '../config/package-json.ts';
 import type { DependencyFiles } from './dependency-graph.ts';
 import type { ModuleReference } from './source-file-references.ts';
@@ -62,7 +63,7 @@ suite('scanner', function () {
 
             await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
 
-            assert.partialDeepStrictEqual(analyzeProject, {
+            assertDeepSubset(analyzeProject, {
                 callCount: 1,
                 firstCall: {
                     args: [
@@ -82,7 +83,7 @@ suite('scanner', function () {
                 mainPackageJson: defaultMainPackageJson
             });
 
-            assert.partialDeepStrictEqual(analyzeProject, {
+            assertDeepSubset(analyzeProject, {
                 callCount: 1,
                 firstCall: {
                     args: [
@@ -100,7 +101,7 @@ suite('scanner', function () {
 
             await dependencyScanner.scan('/foo/bar.js', '/foo', { mainPackageJson: defaultMainPackageJson });
 
-            assert.partialDeepStrictEqual(getReferencedModules, {
+            assertDeepSubset(getReferencedModules, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/bar.js' ]
@@ -157,7 +158,7 @@ suite('scanner', function () {
                 mainPackageJson: defaultMainPackageJson
             });
 
-            assert.partialDeepStrictEqual(locate, {
+            assertDeepSubset(locate, {
                 callCount: 2,
                 firstCall: {
                     args: [ '/dir/entry.js', '/dir' ]
@@ -245,7 +246,7 @@ suite('scanner', function () {
             });
             const result = graph.flatten('/dir/entry.js');
 
-            assert.partialDeepStrictEqual(getReferencedModules, {
+            assertDeepSubset(getReferencedModules, {
                 callCount: 4,
                 firstCall: {
                     args: [ '/dir/entry.js' ]

--- a/source/dependency-scanner/source-file-references.property.ts
+++ b/source/dependency-scanner/source-file-references.property.ts
@@ -24,9 +24,9 @@ suite('source-file-references', function () {
                     withFiles: [ { filePath: 'main.ts', content: `import value from "${moduleName}";` } ]
                 });
 
-                assert.doesNotThrow(function () {
-                    getReferencedModules(project.getSourceFileOrThrow('main.ts'), packageJsonPath);
-                });
+                const references = getReferencedModules(project.getSourceFileOrThrow('main.ts'), packageJsonPath);
+
+                assert.deepStrictEqual(references, []);
             })
         );
     });

--- a/source/dependency-scanner/typescript-compiler-options.test.ts
+++ b/source/dependency-scanner/typescript-compiler-options.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
-import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { ModuleKind, ModuleResolutionKind } from 'ts-morph';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { analyzationOptionsToCompilerOptions } from './typescript-compiler-options.ts';
 
 const stubMainPackageJson = { name: 'pkg', version: '1.0.0', type: 'module' } as never;
@@ -13,7 +13,7 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.partialDeepStrictEqual(options, {
+        assertDeepSubset(options, {
             moduleResolution: ModuleResolutionKind.Node16,
             module: ModuleKind.Node16
         });
@@ -25,7 +25,7 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.partialDeepStrictEqual(options, {
+        assertDeepSubset(options, {
             esModuleInterop: true,
             allowJs: true,
             resolveJsonModule: true,
@@ -41,7 +41,7 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.partialDeepStrictEqual(options, {
+        assertDeepSubset(options, {
             types: [],
             typeRoots: []
         });
@@ -53,7 +53,7 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.partialDeepStrictEqual(options, {
+        assertDeepSubset(options, {
             types: undefined,
             typeRoots: undefined
         });

--- a/source/dependency-scanner/typescript-compiler-options.test.ts
+++ b/source/dependency-scanner/typescript-compiler-options.test.ts
@@ -13,8 +13,10 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.strictEqual(options.moduleResolution, ModuleResolutionKind.Node16);
-        assert.strictEqual(options.module, ModuleKind.Node16);
+        assert.partialDeepStrictEqual(options, {
+            moduleResolution: ModuleResolutionKind.Node16,
+            module: ModuleKind.Node16
+        });
     });
 
     test('analyzationOptionsToCompilerOptions enables esModuleInterop, allowJs, resolveJsonModule, noLib, skipLibCheck, and noEmit', function () {
@@ -23,12 +25,14 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.strictEqual(options.esModuleInterop, true);
-        assert.strictEqual(options.allowJs, true);
-        assert.strictEqual(options.resolveJsonModule, true);
-        assert.strictEqual(options.noLib, true);
-        assert.strictEqual(options.skipLibCheck, true);
-        assert.strictEqual(options.noEmit, true);
+        assert.partialDeepStrictEqual(options, {
+            esModuleInterop: true,
+            allowJs: true,
+            resolveJsonModule: true,
+            noLib: true,
+            skipLibCheck: true,
+            noEmit: true
+        });
     });
 
     test('analyzationOptionsToCompilerOptions clears types and typeRoots when declaration-file resolution is disabled', function () {
@@ -37,8 +41,10 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.deepStrictEqual(options.types, []);
-        assert.deepStrictEqual(options.typeRoots, []);
+        assert.partialDeepStrictEqual(options, {
+            types: [],
+            typeRoots: []
+        });
     });
 
     test('analyzationOptionsToCompilerOptions omits types and typeRoots when declaration-file resolution is enabled', function () {
@@ -47,7 +53,9 @@ suite('typescript-compiler-options', function () {
             mainPackageJson: stubMainPackageJson
         });
 
-        assert.strictEqual(options.types, undefined);
-        assert.strictEqual(options.typeRoots, undefined);
+        assert.partialDeepStrictEqual(options, {
+            types: undefined,
+            typeRoots: undefined
+        });
     });
 });

--- a/source/dependency-scanner/typescript-project-analyzer.test.ts
+++ b/source/dependency-scanner/typescript-project-analyzer.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { stub, fake, type SinonSpy, type SinonStub } from 'sinon';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import {
     createTypescriptProjectAnalyzer,
     type TypescriptProjectAnalyzer,
@@ -118,7 +119,7 @@ function runAnalyzeProjectExpectingArgs(testArgs: AnalyzeProjectExpectation): vo
             extra: testArgs.expectedExtra
         })
     );
-    assert.partialDeepStrictEqual(addSourceFilesAtPaths, {
+    assertDeepSubset(addSourceFilesAtPaths, {
         callCount: 1,
         firstCall: {
             args: [ [ testArgs.expectedFilesGlob ] ]

--- a/source/dependency-scanner/typescript-project-analyzer.test.ts
+++ b/source/dependency-scanner/typescript-project-analyzer.test.ts
@@ -118,8 +118,12 @@ function runAnalyzeProjectExpectingArgs(testArgs: AnalyzeProjectExpectation): vo
             extra: testArgs.expectedExtra
         })
     );
-    assert.strictEqual(addSourceFilesAtPaths.callCount, 1);
-    assert.deepStrictEqual(addSourceFilesAtPaths.firstCall.args, [ [ testArgs.expectedFilesGlob ] ]);
+    assert.partialDeepStrictEqual(addSourceFilesAtPaths, {
+        callCount: 1,
+        firstCall: {
+            args: [ [ testArgs.expectedFilesGlob ] ]
+        }
+    });
 }
 
 suite('typescript-project-analyzer', function () {

--- a/source/file-manager/file-manager.test.ts
+++ b/source/file-manager/file-manager.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { type FileManagerDependencies, createFileManager, type FileManager } from './file-manager.ts';
 
 type Overrides = {
@@ -43,7 +44,7 @@ async function expectCheckReadability(access: SinonSpy, expectedReadable: boolea
 
     const result = await fileManager.checkReadability('/foo/bar.txt');
 
-    assert.partialDeepStrictEqual(access, {
+    assertDeepSubset(access, {
         callCount: 1,
         firstCall: {
             args: [ '/foo/bar.txt', fs.constants.R_OK ]
@@ -71,13 +72,13 @@ suite('file-manager', function () {
 
             await fileManager.writeFile('/foo/bar.txt', 'the-content');
 
-            assert.partialDeepStrictEqual(access, {
+            assertDeepSubset(access, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo', fs.constants.R_OK ]
                 }
             });
-            assert.partialDeepStrictEqual(writeFile, {
+            assertDeepSubset(writeFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/bar.txt', 'the-content', { encoding: 'utf8' } ]
@@ -150,7 +151,7 @@ suite('file-manager', function () {
 
             const result = await fileManager.readFileBytes('/foo/native.node');
 
-            assert.partialDeepStrictEqual(readFile, {
+            assertDeepSubset(readFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/native.node' ]
@@ -166,7 +167,7 @@ suite('file-manager', function () {
 
             await fileManager.copyFileBytes('/src/lib.node', '/dest/lib.node');
 
-            assert.partialDeepStrictEqual(access, {
+            assertDeepSubset(access, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/dest', fs.constants.R_OK ]
@@ -249,7 +250,7 @@ suite('file-manager', function () {
 
             const result = await fileManager.readFile('/foo/bar.txt');
 
-            assert.partialDeepStrictEqual(readFile, {
+            assertDeepSubset(readFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/bar.txt', { encoding: 'utf8' } ]
@@ -265,13 +266,13 @@ suite('file-manager', function () {
 
             await fileManager.copyFile('/foo/1.txt', '/foo/2.txt');
 
-            assert.partialDeepStrictEqual(readFile, {
+            assertDeepSubset(readFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/1.txt', { encoding: 'utf8' } ]
                 }
             });
-            assert.partialDeepStrictEqual(writeFile, {
+            assertDeepSubset(writeFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/2.txt', 'the-content', { encoding: 'utf8' } ]
@@ -304,13 +305,13 @@ suite('file-manager', function () {
 
             const result = await fileManager.getTransferableFileDescriptionFromPath('/foo/bar.txt', '/target/path.txt');
 
-            assert.partialDeepStrictEqual(stat, {
+            assertDeepSubset(stat, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/bar.txt' ]
                 }
             });
-            assert.partialDeepStrictEqual(readFile, {
+            assertDeepSubset(readFile, {
                 callCount: 1,
                 firstCall: {
                     args: [ '/foo/bar.txt', { encoding: 'utf8' } ]

--- a/source/file-manager/file-manager.test.ts
+++ b/source/file-manager/file-manager.test.ts
@@ -43,8 +43,12 @@ async function expectCheckReadability(access: SinonSpy, expectedReadable: boolea
 
     const result = await fileManager.checkReadability('/foo/bar.txt');
 
-    assert.strictEqual(access.callCount, 1);
-    assert.deepStrictEqual(access.firstCall.args, [ '/foo/bar.txt', fs.constants.R_OK ]);
+    assert.partialDeepStrictEqual(access, {
+        callCount: 1,
+        firstCall: {
+            args: [ '/foo/bar.txt', fs.constants.R_OK ]
+        }
+    });
     assert.deepStrictEqual(result, { isReadable: expectedReadable });
 }
 
@@ -67,10 +71,18 @@ suite('file-manager', function () {
 
             await fileManager.writeFile('/foo/bar.txt', 'the-content');
 
-            assert.strictEqual(access.callCount, 1);
-            assert.deepStrictEqual(access.firstCall.args, [ '/foo', fs.constants.R_OK ]);
-            assert.strictEqual(writeFile.callCount, 1);
-            assert.deepStrictEqual(writeFile.firstCall.args, [ '/foo/bar.txt', 'the-content', { encoding: 'utf8' } ]);
+            assert.partialDeepStrictEqual(access, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo', fs.constants.R_OK ]
+                }
+            });
+            assert.partialDeepStrictEqual(writeFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/bar.txt', 'the-content', { encoding: 'utf8' } ]
+                }
+            });
         });
 
         async function runWriteFile(
@@ -138,8 +150,12 @@ suite('file-manager', function () {
 
             const result = await fileManager.readFileBytes('/foo/native.node');
 
-            assert.strictEqual(readFile.callCount, 1);
-            assert.deepStrictEqual(readFile.firstCall.args, [ '/foo/native.node' ]);
+            assert.partialDeepStrictEqual(readFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/native.node' ]
+                }
+            });
             assert.strictEqual(result, expected);
         });
 
@@ -150,8 +166,12 @@ suite('file-manager', function () {
 
             await fileManager.copyFileBytes('/src/lib.node', '/dest/lib.node');
 
-            assert.strictEqual(access.callCount, 1);
-            assert.deepStrictEqual(access.firstCall.args, [ '/dest', fs.constants.R_OK ]);
+            assert.partialDeepStrictEqual(access, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/dest', fs.constants.R_OK ]
+                }
+            });
             assert.deepStrictEqual(copyFile.args, [ [ '/src/lib.node', '/dest/lib.node' ] ]);
         });
 
@@ -229,8 +249,12 @@ suite('file-manager', function () {
 
             const result = await fileManager.readFile('/foo/bar.txt');
 
-            assert.strictEqual(readFile.callCount, 1);
-            assert.deepStrictEqual(readFile.firstCall.args, [ '/foo/bar.txt', { encoding: 'utf8' } ]);
+            assert.partialDeepStrictEqual(readFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/bar.txt', { encoding: 'utf8' } ]
+                }
+            });
             assert.strictEqual(result, 'the-content');
         });
 
@@ -241,10 +265,18 @@ suite('file-manager', function () {
 
             await fileManager.copyFile('/foo/1.txt', '/foo/2.txt');
 
-            assert.strictEqual(readFile.callCount, 1);
-            assert.deepStrictEqual(readFile.firstCall.args, [ '/foo/1.txt', { encoding: 'utf8' } ]);
-            assert.strictEqual(writeFile.callCount, 1);
-            assert.deepStrictEqual(writeFile.firstCall.args, [ '/foo/2.txt', 'the-content', { encoding: 'utf8' } ]);
+            assert.partialDeepStrictEqual(readFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/1.txt', { encoding: 'utf8' } ]
+                }
+            });
+            assert.partialDeepStrictEqual(writeFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/2.txt', 'the-content', { encoding: 'utf8' } ]
+                }
+            });
         });
 
         test('setExecutable() writes the executable file mode when enabled', async function () {
@@ -272,10 +304,18 @@ suite('file-manager', function () {
 
             const result = await fileManager.getTransferableFileDescriptionFromPath('/foo/bar.txt', '/target/path.txt');
 
-            assert.strictEqual(stat.callCount, 1);
-            assert.deepStrictEqual(stat.firstCall.args, [ '/foo/bar.txt' ]);
-            assert.strictEqual(readFile.callCount, 1);
-            assert.deepStrictEqual(readFile.firstCall.args, [ '/foo/bar.txt', { encoding: 'utf8' } ]);
+            assert.partialDeepStrictEqual(stat, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/bar.txt' ]
+                }
+            });
+            assert.partialDeepStrictEqual(readFile, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '/foo/bar.txt', { encoding: 'utf8' } ]
+                }
+            });
             assert.deepStrictEqual(result, {
                 sourceFilePath: '/foo/bar.txt',
                 targetFilePath: '/target/path.txt',

--- a/source/github-release-gate/github-api.test.ts
+++ b/source/github-release-gate/github-api.test.ts
@@ -353,7 +353,7 @@ suite('github-release-gate-github-api', function () {
                 async function () {
                     await api.getOpenPullRequestActivities();
                 },
-                /openPullRequests\.map is not a function/u
+                /issues\/\/timeline/u
             );
         });
 

--- a/source/github-release-gate/github-api.test.ts
+++ b/source/github-release-gate/github-api.test.ts
@@ -334,9 +334,12 @@ suite('github-release-gate-github-api', function () {
             };
             const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
 
-            await assert.rejects(async function () {
-                await api.getMainBranchHeadSha();
-            });
+            await assert.rejects(
+                async function () {
+                    await api.getMainBranchHeadSha();
+                },
+                /Cannot read properties/u
+            );
         });
 
         test('getOpenPullRequestActivities preserves pull list parse failures', async function () {
@@ -346,9 +349,12 @@ suite('github-release-gate-github-api', function () {
             };
             const api = createGitHubReleaseGateApi(createJsonFetch(routes), defaultContext);
 
-            await assert.rejects(async function () {
-                await api.getOpenPullRequestActivities();
-            });
+            await assert.rejects(
+                async function () {
+                    await api.getOpenPullRequestActivities();
+                },
+                /openPullRequests\.map is not a function/u
+            );
         });
 
         test('getOpenPullRequestActivities formats GitHub pagination failures with the failing request path', async function () {

--- a/source/github-release-gate/release-gate.test.ts
+++ b/source/github-release-gate/release-gate.test.ts
@@ -166,8 +166,10 @@ suite('github-release-gate', function () {
         test('evaluateGitHubReleaseGate blocks publishing while recent PR activity is inside the quiet period', function () {
             const decision = createQuietPeriodDecision();
 
-            assert.strictEqual(decision.shouldPublish, false);
-            assert.strictEqual(decision.reason, 'activity_not_stale');
+            assert.partialDeepStrictEqual(decision, {
+                shouldPublish: false,
+                reason: 'activity_not_stale'
+            });
             assert.ok(decision.logs.includes('quiet period elapsed: false'));
             assert.ok(decision.logs.includes('max latency elapsed: false'));
         });
@@ -192,8 +194,10 @@ suite('github-release-gate', function () {
                 pullRequestActivities: [ pullRequestActivity({ activityAt: createDate('2026-05-19T10:00:00.000Z') }) ]
             });
 
-            assert.strictEqual(decision.shouldPublish, true);
-            assert.strictEqual(decision.reason, 'quiet_period_elapsed');
+            assert.partialDeepStrictEqual(decision, {
+                shouldPublish: true,
+                reason: 'quiet_period_elapsed'
+            });
             assert.strictEqual(decision.logs.at(-1), 'Publishing is allowed by the release gate.');
         });
 
@@ -202,8 +206,10 @@ suite('github-release-gate', function () {
                 pullRequestActivities: [ pullRequestActivity({ activityAt: createDate('2026-05-19T11:15:00.000Z') }) ]
             });
 
-            assert.strictEqual(decision.shouldPublish, true);
-            assert.strictEqual(decision.reason, 'quiet_period_elapsed');
+            assert.partialDeepStrictEqual(decision, {
+                shouldPublish: true,
+                reason: 'quiet_period_elapsed'
+            });
         });
 
         test('evaluateGitHubReleaseGate allows publishing once max latency elapses even with fresh PR activity', function () {
@@ -212,8 +218,10 @@ suite('github-release-gate', function () {
                 pullRequestActivities: [ pullRequestActivity({ activityAt: createDate('2026-05-20T11:50:00.000Z') }) ]
             });
 
-            assert.strictEqual(decision.shouldPublish, true);
-            assert.strictEqual(decision.reason, 'max_latency_elapsed');
+            assert.partialDeepStrictEqual(decision, {
+                shouldPublish: true,
+                reason: 'max_latency_elapsed'
+            });
             assert.ok(decision.logs.includes('quiet period elapsed: false'));
             assert.ok(decision.logs.includes('max latency elapsed: true'));
         });
@@ -231,8 +239,10 @@ suite('github-release-gate', function () {
                 pullRequestActivities: [ pullRequestActivity({ activityAt: createDate('2026-05-20T11:59:00.000Z') }) ]
             });
 
-            assert.strictEqual(decision.shouldPublish, true);
-            assert.strictEqual(decision.reason, 'max_latency_elapsed');
+            assert.partialDeepStrictEqual(decision, {
+                shouldPublish: true,
+                reason: 'max_latency_elapsed'
+            });
         });
     });
 });

--- a/source/github-release-gate/release-policy.test.ts
+++ b/source/github-release-gate/release-policy.test.ts
@@ -55,15 +55,17 @@ suite('github-release-gate-release-policy', function () {
             releaseAnalysis: releaseAnalysis()
         });
 
-        assert.strictEqual(decision.shouldPublish, true);
-        assert.strictEqual(decision.reason, 'quiet_period_elapsed');
-        assert.deepStrictEqual(decision.logs, [
-            'Publishing is allowed by the release gate.',
-            'release classification: substantive',
-            'most recent published package timestamp: 2026-05-01T00:00:00.000Z',
-            'package pkg-a: substantive latest=1.0.0 publishedAt=2026-05-01T00:00:00.000Z',
-            'Publishing is allowed by the Packtory release policy.'
-        ]);
+        assert.partialDeepStrictEqual(decision, {
+            shouldPublish: true,
+            reason: 'quiet_period_elapsed',
+            logs: [
+                'Publishing is allowed by the release gate.',
+                'release classification: substantive',
+                'most recent published package timestamp: 2026-05-01T00:00:00.000Z',
+                'package pkg-a: substantive latest=1.0.0 publishedAt=2026-05-01T00:00:00.000Z',
+                'Publishing is allowed by the Packtory release policy.'
+            ]
+        });
     });
 
     test('blocks unchanged releases even when the GitHub time gate is open', function () {
@@ -85,15 +87,17 @@ suite('github-release-gate-release-policy', function () {
             })
         });
 
-        assert.strictEqual(decision.shouldPublish, false);
-        assert.strictEqual(decision.reason, 'release_unchanged');
-        assert.deepStrictEqual(decision.logs, [
-            'Publishing is allowed by the release gate.',
-            'release classification: unchanged',
-            'most recent published package timestamp: (unknown)',
-            'package pkg-a: unchanged latest=1.0.0 publishedAt=2026-05-01T00:00:00.000Z',
-            'Skipping publish: the next Packtory release would be unchanged versus npm latest.'
-        ]);
+        assert.partialDeepStrictEqual(decision, {
+            shouldPublish: false,
+            reason: 'release_unchanged',
+            logs: [
+                'Publishing is allowed by the release gate.',
+                'release classification: unchanged',
+                'most recent published package timestamp: (unknown)',
+                'package pkg-a: unchanged latest=1.0.0 publishedAt=2026-05-01T00:00:00.000Z',
+                'Skipping publish: the next Packtory release would be unchanged versus npm latest.'
+            ]
+        });
     });
 
     test('blocks dependency-only releases until the minimum age elapses', function () {
@@ -104,8 +108,10 @@ suite('github-release-gate-release-policy', function () {
             releaseAnalysis: dependencyOnlyReleaseAnalysis(new Date('2026-05-01T00:00:00.000Z'))
         });
 
-        assert.strictEqual(decision.shouldPublish, false);
-        assert.strictEqual(decision.reason, 'dependency_only_min_age_not_elapsed');
+        assert.partialDeepStrictEqual(decision, {
+            shouldPublish: false,
+            reason: 'dependency_only_min_age_not_elapsed'
+        });
         assert.strictEqual(
             decision.logs.at(-1),
             'Skipping publish: dependency-only releases must age for at least 7 day(s).'
@@ -120,8 +126,10 @@ suite('github-release-gate-release-policy', function () {
             releaseAnalysis: dependencyOnlyReleaseAnalysis(new Date('2026-05-01T00:00:00.000Z'))
         });
 
-        assert.strictEqual(decision.shouldPublish, true);
-        assert.strictEqual(decision.reason, 'dependency_only_min_age_elapsed');
+        assert.partialDeepStrictEqual(decision, {
+            shouldPublish: true,
+            reason: 'dependency_only_min_age_elapsed'
+        });
         assert.strictEqual(
             decision.logs.at(-1),
             'Publishing is allowed because the dependency-only minimum age of 7 day(s) has elapsed.'
@@ -147,8 +155,10 @@ suite('github-release-gate-release-policy', function () {
             })
         });
 
-        assert.strictEqual(decision.shouldPublish, true);
-        assert.strictEqual(decision.reason, 'dependency_only_published_at_unknown');
+        assert.partialDeepStrictEqual(decision, {
+            shouldPublish: true,
+            reason: 'dependency_only_published_at_unknown'
+        });
         assert.strictEqual(
             decision.logs.at(-1),
             'Publishing is allowed because this dependency-only release has no publishedAt baseline to delay from.'

--- a/source/github-release-gate/test-support.test.ts
+++ b/source/github-release-gate/test-support.test.ts
@@ -30,6 +30,11 @@ type EntryPointScriptCall = {
 
 const testDeadlineMilliseconds = 200;
 
+function isClosedServerFetchFailure(error: unknown): boolean {
+    return error instanceof Error &&
+        [ 'TypeError', 'TimeoutError', 'AbortError' ].includes(error.name);
+}
+
 suite('github-release-gate-test-support', function () {
     test('createBaseEnvironment exposes the expected default publish settings', function () {
         assert.strictEqual(workspaceOutputPath, '/workspace/github-output.txt');
@@ -174,11 +179,14 @@ suite('github-release-gate-test-support', function () {
 
         assert.strictEqual(actionResult, 'done');
         assert.match(apiBaseUrl, /^http:\/\/127\.0\.0\.1:\d+$/u);
-        await assert.rejects(async function () {
-            await fetch(`${apiBaseUrl}/ready`, {
-                signal: AbortSignal.timeout(testDeadlineMilliseconds)
-            });
-        });
+        await assert.rejects(
+            async function () {
+                await fetch(`${apiBaseUrl}/ready`, {
+                    signal: AbortSignal.timeout(testDeadlineMilliseconds)
+                });
+            },
+            isClosedServerFetchFailure
+        );
     });
 
     test('runEntryPointScript uses the expected temp prefix, utf8 encoding, and output fallback', async function () {

--- a/source/linker/linker.test.ts
+++ b/source/linker/linker.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
 import { createBundleLinker } from './linker.ts';
 
@@ -58,7 +59,7 @@ suite('linker', function () {
             bundleDependencies: []
         });
 
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             name: 'package-a',
             exportPackageJson: true,
             roots: {

--- a/source/linker/linker.test.ts
+++ b/source/linker/linker.test.ts
@@ -58,19 +58,23 @@ suite('linker', function () {
             bundleDependencies: []
         });
 
-        assert.strictEqual(result.name, 'package-a');
-        assert.strictEqual(result.exportPackageJson, true);
-        assert.deepStrictEqual(result.roots, {
-            main: {
-                js: {
-                    content: '',
-                    isExecutable: false,
-                    sourceFilePath: '/src/index.js',
-                    targetFilePath: 'index.js'
+        assert.partialDeepStrictEqual(result, {
+            name: 'package-a',
+            exportPackageJson: true,
+            roots: {
+                main: {
+                    js: {
+                        content: '',
+                        isExecutable: false,
+                        sourceFilePath: '/src/index.js',
+                        targetFilePath: 'index.js'
+                    }
                 }
+            },
+            contents: {
+                length: 2
             }
         });
-        assert.strictEqual(result.contents.length, 2);
     });
 
     test('linkBundle() flattens declaration roots and substitutes matching bundle dependencies', async function () {

--- a/source/linker/replacement-lookup.test.ts
+++ b/source/linker/replacement-lookup.test.ts
@@ -23,8 +23,12 @@ suite('replacement-lookup', function () {
     test('findAllPathReplacements returns no replacements when no bundle owns any of the files', function () {
         const result = findAllPathReplacements([ '/x/a.ts' ], []);
 
-        assert.strictEqual(result.importPathReplacements.size, 0);
-        assert.deepStrictEqual(result.bundleDependencies, []);
+        assert.partialDeepStrictEqual(result, {
+            importPathReplacements: {
+                size: 0
+            },
+            bundleDependencies: []
+        });
     });
 
     test('findAllPathReplacements maps each file to the public target path of the owning bundle', function () {

--- a/source/linker/replacement-lookup.test.ts
+++ b/source/linker/replacement-lookup.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { explicitPackageSurface } from '../package-surface/surface.ts';
 import { analyzedBundleResource, linkedBundle } from '../test-libraries/bundle-fixtures.ts';
 import type { BundleSubstitutionSource } from './linked-bundle.ts';
@@ -23,7 +24,7 @@ suite('replacement-lookup', function () {
     test('findAllPathReplacements returns no replacements when no bundle owns any of the files', function () {
         const result = findAllPathReplacements([ '/x/a.ts' ], []);
 
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             importPathReplacements: {
                 size: 0
             },

--- a/source/linker/substituted-resource-graph.test.ts
+++ b/source/linker/substituted-resource-graph.test.ts
@@ -55,17 +55,16 @@ suite('substituted-resource-graph', function () {
                 }),
             [ '/entry.js', '/extra.txt', '/shared.js' ]
         );
-        assert.deepStrictEqual(
-            result.linkedBundleDependencies,
-            new Map([ [ 'bundle-dependency', {
+        assert.partialDeepStrictEqual(result, {
+            linkedBundleDependencies: new Map([ [ 'bundle-dependency', {
                 name: 'bundle-dependency',
                 referencedFrom: [ '/entry.js', '/shared.js' ]
+            } ] ]),
+            externalDependencies: new Map([ [ 'left-pad', {
+                name: 'left-pad',
+                referencedFrom: [ '/entry.js', '/shared.js' ]
             } ] ])
-        );
-        assert.deepStrictEqual(
-            result.externalDependencies,
-            new Map([ [ 'left-pad', { name: 'left-pad', referencedFrom: [ '/entry.js', '/shared.js' ] } ] ])
-        );
+        });
     });
 
     test('flatten() preserves the generated-manifest marker on collected resources', function () {

--- a/source/pack-emitter/pack-emitter.test.ts
+++ b/source/pack-emitter/pack-emitter.test.ts
@@ -43,8 +43,12 @@ suite('pack-emitter', function () {
 
         await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip', vendorEntries: [], extraFiles: [] });
 
-        assert.strictEqual(buildZip.callCount, 1);
-        assert.deepStrictEqual(buildZip.firstCall.args, [ bundle, [], [] ]);
+        assert.partialDeepStrictEqual(buildZip, {
+            callCount: 1,
+            firstCall: {
+                args: [ bundle, [], [] ]
+            }
+        });
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
             filePath: '/out/fn.zip',
@@ -61,8 +65,12 @@ suite('pack-emitter', function () {
 
         await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz', vendorEntries: [], extraFiles: [] });
 
-        assert.strictEqual(buildTarball.callCount, 1);
-        assert.deepStrictEqual(buildTarball.firstCall.args, [ bundle, [], [] ]);
+        assert.partialDeepStrictEqual(buildTarball, {
+            callCount: 1,
+            firstCall: {
+                args: [ bundle, [], [] ]
+            }
+        });
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getWriteBinaryFileCall(0), {
             filePath: '/out/pkg.tgz',
@@ -84,8 +92,12 @@ suite('pack-emitter', function () {
             extraFiles: []
         });
 
-        assert.strictEqual(buildFolder.callCount, 1);
-        assert.deepStrictEqual(buildFolder.firstCall.args, [ bundle, '/out/extracted', [], [] ]);
+        assert.partialDeepStrictEqual(buildFolder, {
+            callCount: 1,
+            firstCall: {
+                args: [ bundle, '/out/extracted', [], [] ]
+            }
+        });
         assert.strictEqual(fileManager.getWriteBinaryFileCallCount(), 0);
     });
 });

--- a/source/pack-emitter/pack-emitter.test.ts
+++ b/source/pack-emitter/pack-emitter.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
@@ -43,7 +44,7 @@ suite('pack-emitter', function () {
 
         await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip', vendorEntries: [], extraFiles: [] });
 
-        assert.partialDeepStrictEqual(buildZip, {
+        assertDeepSubset(buildZip, {
             callCount: 1,
             firstCall: {
                 args: [ bundle, [], [] ]
@@ -65,7 +66,7 @@ suite('pack-emitter', function () {
 
         await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz', vendorEntries: [], extraFiles: [] });
 
-        assert.partialDeepStrictEqual(buildTarball, {
+        assertDeepSubset(buildTarball, {
             callCount: 1,
             firstCall: {
                 args: [ bundle, [], [] ]
@@ -92,7 +93,7 @@ suite('pack-emitter', function () {
             extraFiles: []
         });
 
-        assert.partialDeepStrictEqual(buildFolder, {
+        assertDeepSubset(buildFolder, {
             callCount: 1,
             firstCall: {
                 args: [ bundle, '/out/extracted', [], [] ]

--- a/source/package-surface/package-surface-index.test.ts
+++ b/source/package-surface/package-surface-index.test.ts
@@ -43,8 +43,10 @@ suite('package-surface-index', function () {
                 surface: { mode: 'implicit', defaultModuleRoot: 'main' }
             });
 
-            assert.deepStrictEqual(summary.publicRootIds, new Set([ 'main', 'worker' ]));
-            assert.strictEqual(summary.representativeRootId, 'main');
+            assert.partialDeepStrictEqual(summary, {
+                publicRootIds: new Set([ 'main', 'worker' ]),
+                representativeRootId: 'main'
+            });
         });
 
         test('summarizePackageSurface returns explicit module and bin roots', function () {
@@ -63,15 +65,19 @@ suite('package-surface-index', function () {
                 }
             });
 
-            assert.deepStrictEqual(summary.publicRootIds, new Set([ 'main', 'cli' ]));
-            assert.strictEqual(summary.representativeRootId, 'main');
+            assert.partialDeepStrictEqual(summary, {
+                publicRootIds: new Set([ 'main', 'cli' ]),
+                representativeRootId: 'main'
+            });
         });
 
         test('summarizePackageSurface falls back to the first explicit bin root', function () {
             const summary = summarizePackageSurface(binsOnlyExplicitBundle);
 
-            assert.deepStrictEqual(summary.publicRootIds, new Set([ 'cli' ]));
-            assert.strictEqual(summary.representativeRootId, 'cli');
+            assert.partialDeepStrictEqual(summary, {
+                publicRootIds: new Set([ 'cli' ]),
+                representativeRootId: 'cli'
+            });
         });
 
         test('summarizePackageSurface rejects explicit surfaces without public entries', function () {
@@ -147,8 +153,10 @@ suite('package-surface-index', function () {
         test('indexPublicModules returns empty maps for explicit surfaces without modules', function () {
             const index = indexPublicModules(binsOnlyExplicitBundle);
 
-            assert.deepStrictEqual(index.sourceFilePathBySpecifier, new Map());
-            assert.deepStrictEqual(index.specifierBySourceFilePath, new Map());
+            assert.partialDeepStrictEqual(index, {
+                sourceFilePathBySpecifier: new Map(),
+                specifierBySourceFilePath: new Map()
+            });
         });
 
         test('indexPublicModules keeps implicit root mappings ahead of duplicate content mappings', function () {

--- a/source/packages/command-line-interface/pull-request-label-versioning.test.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.test.ts
@@ -61,12 +61,20 @@ function createEngine(overrides: Partial<PrLogEngine> = {}): PrLogEngine {
             return input.pullRequests;
         },
         async resolvePullRequestLabels(input: ResolveLabelsInput) {
-            assert.partialDeepStrictEqual(input, {
-                githubRepo: 'owner/repo',
-                targetName: 'pkg',
-                targetScopedLabelPattern: undefined,
-                ignoredLabels: []
-            });
+            assert.deepStrictEqual(
+                {
+                    githubRepo: input.githubRepo,
+                    targetName: input.targetName,
+                    targetScopedLabelPattern: input.targetScopedLabelPattern,
+                    ignoredLabels: input.ignoredLabels
+                },
+                {
+                    githubRepo: 'owner/repo',
+                    targetName: 'pkg',
+                    targetScopedLabelPattern: undefined,
+                    ignoredLabels: []
+                }
+            );
             return [
                 { id: 1, title: 'Fix bug', label: 'bug' },
                 { id: 2, title: 'Add feature', label: 'feature' }

--- a/source/packages/command-line-interface/pull-request-label-versioning.test.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.test.ts
@@ -53,16 +53,20 @@ function createEngine(overrides: Partial<PrLogEngine> = {}): PrLogEngine {
             ]);
         },
         filterPullRequestsByTargetFiles(input: FilterPullRequestsInput) {
-            assert.strictEqual(input.targetName, 'pkg');
-            assert.deepStrictEqual(input.targetSourceFiles, [ 'source/index.ts' ]);
-            assert.deepStrictEqual(input.ignoredAttributionPaths, [ 'CHANGELOG.md' ]);
+            assert.partialDeepStrictEqual(input, {
+                targetName: 'pkg',
+                targetSourceFiles: [ 'source/index.ts' ],
+                ignoredAttributionPaths: [ 'CHANGELOG.md' ]
+            });
             return input.pullRequests;
         },
         async resolvePullRequestLabels(input: ResolveLabelsInput) {
-            assert.strictEqual(input.githubRepo, 'owner/repo');
-            assert.strictEqual(input.targetName, 'pkg');
-            assert.strictEqual(input.targetScopedLabelPattern, undefined);
-            assert.deepStrictEqual(input.ignoredLabels, []);
+            assert.partialDeepStrictEqual(input, {
+                githubRepo: 'owner/repo',
+                targetName: 'pkg',
+                targetScopedLabelPattern: undefined,
+                ignoredLabels: []
+            });
             return [
                 { id: 1, title: 'Fix bug', label: 'bug' },
                 { id: 2, title: 'Add feature', label: 'feature' }

--- a/source/packtory/changelog-source-attribution.test.ts
+++ b/source/packtory/changelog-source-attribution.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../dead-code-eliminator/analyzed-bundle.ts';
 import { analyzedBundle, analyzedBundleResource } from '../test-libraries/bundle-fixtures.ts';
 import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
@@ -154,7 +155,7 @@ function registerSourceMapFailureTests(): void {
             attributeSingleFile(readableMapFileManager(sourceWithMap('index.js.map'), '{'), '/repo/dist/index.js'),
             function (error: unknown) {
                 assert.strictEqual((error as Error).message, 'Failed to parse source map "/repo/dist/index.js.map"');
-                assert.notStrictEqual((error as Error).cause, undefined);
+                assertDefined((error as Error).cause);
                 return true;
             }
         );

--- a/source/packtory/normalize-paths.property.ts
+++ b/source/packtory/normalize-paths.property.ts
@@ -32,12 +32,15 @@ suite('normalize-paths', function () {
                     const relativeRoot = declarationFile === undefined ? { js } : { js, declarationFile };
                     const normalizedRelativeRoot = normalizeRoot(relativeRoot, sourceFolder);
 
-                    assert.partialDeepStrictEqual(normalizedRelativeRoot, {
-                        js: path.join(sourceFolder, js),
-                        declarationFile: declarationFile === undefined
-                            ? undefined
-                            : path.join(sourceFolder, declarationFile)
-                    });
+                    assert.strictEqual(normalizedRelativeRoot.js, path.join(sourceFolder, js));
+                    if (declarationFile === undefined) {
+                        assert.strictEqual(Object.hasOwn(normalizedRelativeRoot, 'declarationFile'), false);
+                    } else {
+                        assert.strictEqual(
+                            normalizedRelativeRoot.declarationFile,
+                            path.join(sourceFolder, declarationFile)
+                        );
+                    }
                 }
             )
         );
@@ -51,10 +54,12 @@ suite('normalize-paths', function () {
                     const absoluteRoot = declarationFile === undefined ? { js } : { js, declarationFile };
                     const normalizedAbsoluteRoot = normalizeRoot(absoluteRoot, sourceFolder);
 
-                    assert.partialDeepStrictEqual(normalizedAbsoluteRoot, {
-                        js,
-                        declarationFile
-                    });
+                    assert.strictEqual(normalizedAbsoluteRoot.js, js);
+                    if (declarationFile === undefined) {
+                        assert.strictEqual(Object.hasOwn(normalizedAbsoluteRoot, 'declarationFile'), false);
+                    } else {
+                        assert.strictEqual(normalizedAbsoluteRoot.declarationFile, declarationFile);
+                    }
                 }
             )
         );

--- a/source/packtory/normalize-paths.property.ts
+++ b/source/packtory/normalize-paths.property.ts
@@ -32,11 +32,12 @@ suite('normalize-paths', function () {
                     const relativeRoot = declarationFile === undefined ? { js } : { js, declarationFile };
                     const normalizedRelativeRoot = normalizeRoot(relativeRoot, sourceFolder);
 
-                    assert.strictEqual(normalizedRelativeRoot.js, path.join(sourceFolder, js));
-                    assert.strictEqual(
-                        normalizedRelativeRoot.declarationFile,
-                        declarationFile === undefined ? undefined : path.join(sourceFolder, declarationFile)
-                    );
+                    assert.partialDeepStrictEqual(normalizedRelativeRoot, {
+                        js: path.join(sourceFolder, js),
+                        declarationFile: declarationFile === undefined
+                            ? undefined
+                            : path.join(sourceFolder, declarationFile)
+                    });
                 }
             )
         );
@@ -50,8 +51,10 @@ suite('normalize-paths', function () {
                     const absoluteRoot = declarationFile === undefined ? { js } : { js, declarationFile };
                     const normalizedAbsoluteRoot = normalizeRoot(absoluteRoot, sourceFolder);
 
-                    assert.strictEqual(normalizedAbsoluteRoot.js, js);
-                    assert.strictEqual(normalizedAbsoluteRoot.declarationFile, declarationFile);
+                    assert.partialDeepStrictEqual(normalizedAbsoluteRoot, {
+                        js,
+                        declarationFile
+                    });
                 }
             )
         );

--- a/source/packtory/options/prepare-package-options.test.ts
+++ b/source/packtory/options/prepare-package-options.test.ts
@@ -33,8 +33,14 @@ suite('prepare-package-options', function () {
     test('preparePackageOptions returns the selected package config along with shared options', function () {
         const prepared = preparePackageOptions('pkg-a', minimalPackageConfigsByName(), minimalPacktoryConfig(), []);
 
-        assert.strictEqual(prepared.packageConfig.name, 'pkg-a');
-        assert.strictEqual(prepared.sharedOptions.name, 'pkg-a');
+        assert.partialDeepStrictEqual(prepared, {
+            packageConfig: {
+                name: 'pkg-a'
+            },
+            sharedOptions: {
+                name: 'pkg-a'
+            }
+        });
     });
 
     test('preparePackageOptions defaults versioning to automatic when not configured', function () {

--- a/source/packtory/package-processor-publish.test.ts
+++ b/source/packtory/package-processor-publish.test.ts
@@ -125,8 +125,12 @@ suite('package-processor publish', function () {
 
             const result = await processor.tryBuildAndPublish(tryBuildOptions(providerVersioningBuildOptions()));
 
-            assert.strictEqual(result.status, 'already-published');
-            assert.strictEqual(result.bundle.version, '1.2.3');
+            assert.partialDeepStrictEqual(result, {
+                status: 'already-published',
+                bundle: {
+                    version: '1.2.3'
+                }
+            });
             assert.deepStrictEqual(findCurrentHeadPublishedVersion.firstCall.args, [
                 {
                     name: 'package-a',

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -129,8 +129,10 @@ suite('package-processor', function () {
         if (firstInput === undefined) {
             assert.fail('expected elimination input');
         }
-        assert.strictEqual(firstInput.transformationsEnabled, false);
-        assert.deepStrictEqual(firstInput.deadCodeElimination, deadCodeElimination);
+        assert.partialDeepStrictEqual(firstInput, {
+            transformationsEnabled: false,
+            deadCodeElimination
+        });
     });
 
     test('build() defaults transformationsEnabled to true when deadCodeElimination is not configured', async function () {

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -9,6 +9,7 @@ import type {
     RenderGroupedTargetChangelogMarkdownInput,
     ResolvePullRequestLabelsOptions
 } from '@pr-log/core';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { generateChangelogOutputs } from './packtory-changelog.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
 
@@ -125,7 +126,7 @@ function registerTargetSelectionTests(): void {
 
         await render([ releasePackage({ changed: false, artifactState: 'unchanged' }) ], engine);
 
-        assert.partialDeepStrictEqual(calls, {
+        assertDeepSubset(calls, {
             collectMergedPullRequests: {
                 callCount: 0
             },
@@ -332,7 +333,7 @@ function registerPackageChangelogTests(): void {
         });
 
         assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, []);
-        assert.partialDeepStrictEqual(changelog, {
+        assertDeepSubset(changelog, {
             packageNamesWithoutChangelogEntries: [ 'pkg-a' ],
             packageMarkdownByName: new Map()
         });

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -125,8 +125,14 @@ function registerTargetSelectionTests(): void {
 
         await render([ releasePackage({ changed: false, artifactState: 'unchanged' }) ], engine);
 
-        assert.strictEqual(calls.collectMergedPullRequests.callCount, 0);
-        assert.strictEqual(calls.renderGroupedTargetChangelog.callCount, 1);
+        assert.partialDeepStrictEqual(calls, {
+            collectMergedPullRequests: {
+                callCount: 0
+            },
+            renderGroupedTargetChangelog: {
+                callCount: 1
+            }
+        });
         assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, []);
     });
 
@@ -326,8 +332,10 @@ function registerPackageChangelogTests(): void {
         });
 
         assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, []);
-        assert.deepStrictEqual(changelog.packageNamesWithoutChangelogEntries, [ 'pkg-a' ]);
-        assert.deepStrictEqual(changelog.packageMarkdownByName, new Map());
+        assert.partialDeepStrictEqual(changelog, {
+            packageNamesWithoutChangelogEntries: [ 'pkg-a' ],
+            packageMarkdownByName: new Map()
+        });
         assert.strictEqual(renderTargetChangelog.callCount, 0);
     });
 }

--- a/source/packtory/packtory-release-analysis.test.ts
+++ b/source/packtory/packtory-release-analysis.test.ts
@@ -153,8 +153,10 @@ suite('packtory-release-analysis', function () {
         });
 
         const partial = expectPartialFailure(result);
-        assert.deepStrictEqual(partial.succeeded, []);
-        assert.deepStrictEqual(partial.failures, [ failure ]);
+        assert.partialDeepStrictEqual(partial, {
+            succeeded: [],
+            failures: [ failure ]
+        });
     });
 
     test('skips fresh content collection for already-published build results', async function () {
@@ -224,8 +226,14 @@ suite('packtory-release-analysis', function () {
                 }
             })
         );
-        assert.strictEqual(partial.succeeded.length, 0);
-        assert.strictEqual(partial.failures.length, 1);
+        assert.partialDeepStrictEqual(partial, {
+            succeeded: {
+                length: 0
+            },
+            failures: {
+                length: 1
+            }
+        });
         assert.match(partial.failures[0]?.message ?? '', /collect failed/u);
     });
 

--- a/source/packtory/packtory-release-analysis.test.ts
+++ b/source/packtory/packtory-release-analysis.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import vm from 'node:vm';
 import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import {
     buildResultFor,
     createReleaseTestDependencies,
@@ -153,7 +154,7 @@ suite('packtory-release-analysis', function () {
         });
 
         const partial = expectPartialFailure(result);
-        assert.partialDeepStrictEqual(partial, {
+        assertDeepSubset(partial, {
             succeeded: [],
             failures: [ failure ]
         });
@@ -226,7 +227,7 @@ suite('packtory-release-analysis', function () {
                 }
             })
         );
-        assert.partialDeepStrictEqual(partial, {
+        assertDeepSubset(partial, {
             succeeded: {
                 length: 0
             },

--- a/source/packtory/packtory-release-diff.test.ts
+++ b/source/packtory/packtory-release-diff.test.ts
@@ -143,9 +143,11 @@ async function assertDerivedTransition(spec: DerivedTransitionSpec): Promise<voi
     if (entry === undefined) {
         assert.fail('expected a release diff entry');
     }
-    assert.strictEqual(entry.state, spec.expectedState);
-    assert.strictEqual(entry.versionTransition, spec.expectedVersionTransition);
-    assert.strictEqual(entry.previousVersionLabel, spec.expectedPreviousVersionLabel);
+    assert.partialDeepStrictEqual(entry, {
+        state: spec.expectedState,
+        versionTransition: spec.expectedVersionTransition,
+        previousVersionLabel: spec.expectedPreviousVersionLabel
+    });
 }
 
 function expectPartialErr(result: ReleaseDiffAllResult): PartialError<unknown> & { readonly type: 'partial'; } {
@@ -222,8 +224,10 @@ suite('packtory-release-diff', function () {
         });
 
         const partial = expectPartialErr(result);
-        assert.deepStrictEqual(partial.succeeded, []);
-        assert.deepStrictEqual(partial.failures, resolveFailures);
+        assert.partialDeepStrictEqual(partial, {
+            succeeded: [],
+            failures: resolveFailures
+        });
     });
 
     test('returns Ok with an empty diff array when resolve, publish-stage, and release-diff-stage all succeed with no packages', async function () {
@@ -251,8 +255,10 @@ suite('packtory-release-diff', function () {
         );
 
         const partial = expectPartialErr(await diff(configFor([ 'pkg-a' ]), okResolve));
-        assert.deepStrictEqual(partial.failures, [ publishError ]);
-        assert.deepStrictEqual(partial.succeeded, []);
+        assert.partialDeepStrictEqual(partial, {
+            failures: [ publishError ],
+            succeeded: []
+        });
     });
 
     test('returns a partial Err combining publish-stage failures with the release-diff stage succeeded entries when both stages fail', async function () {
@@ -277,8 +283,10 @@ suite('packtory-release-diff', function () {
         );
 
         const partial = expectPartialErr(await diff(configFor([ 'pkg-a' ]), okResolve));
-        assert.deepStrictEqual(partial.failures, [ publishError ]);
-        assert.deepStrictEqual(partial.succeeded, [ partialStageSuccess ]);
+        assert.partialDeepStrictEqual(partial, {
+            failures: [ publishError ],
+            succeeded: [ partialStageSuccess ]
+        });
     });
 
     test('returns a partial Err carrying the release-diff stage failures when only the stage returns Err', async function () {

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -182,9 +182,13 @@ function registerMetadataTests(): void {
         });
 
         const pkg = expectFirstPackage(result);
-        assert.strictEqual(pkg.previousGitHead, 'old-head');
-        assert.strictEqual(pkg.currentGitHead, 'current-head');
-        assert.strictEqual(pkg.latestRegistryMetadata?.gitHead, 'old-head');
+        assert.partialDeepStrictEqual(pkg, {
+            previousGitHead: 'old-head',
+            currentGitHead: 'current-head',
+            latestRegistryMetadata: {
+                gitHead: 'old-head'
+            }
+        });
     });
 }
 
@@ -225,9 +229,11 @@ function registerDependencyAttributionTests(): void {
         });
 
         const pkg = expectFirstPackage(result);
-        assert.deepStrictEqual(pkg.changelogDependencyNames, [ 'react' ]);
-        assert.strictEqual(pkg.releaseClassification, 'dependency-only');
-        assert.deepStrictEqual(pkg.changelogSourceFiles, [ 'source/pkg-a.js', 'source/unused.js' ]);
+        assert.partialDeepStrictEqual(pkg, {
+            changelogDependencyNames: [ 'react' ],
+            releaseClassification: 'dependency-only',
+            changelogSourceFiles: [ 'source/pkg-a.js', 'source/unused.js' ]
+        });
     });
 
     test('omits changed dependency names when the current artifact set has no manifest', async function () {
@@ -396,8 +402,10 @@ function registerSourceFileTests(): void {
         });
 
         const pkg = expectFirstPackage(result);
-        assert.strictEqual(pkg.releaseClassification, 'substantive');
-        assert.deepStrictEqual(pkg.changelogSourceFiles, [ 'source/pkg-a.js' ]);
+        assert.partialDeepStrictEqual(pkg, {
+            releaseClassification: 'substantive',
+            changelogSourceFiles: [ 'source/pkg-a.js' ]
+        });
     });
 
     test('excludes generated manifests and includes substituted and additional source files', async function () {
@@ -454,8 +462,10 @@ function registerSourceFileTests(): void {
             })
         );
 
-        assert.deepStrictEqual(partial.succeeded, []);
-        assert.deepStrictEqual(partial.failures, [ failure ]);
+        assert.partialDeepStrictEqual(partial, {
+            succeeded: [],
+            failures: [ failure ]
+        });
     });
 }
 

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -402,10 +402,16 @@ function registerSourceFileTests(): void {
         });
 
         const pkg = expectFirstPackage(result);
-        assert.partialDeepStrictEqual(pkg, {
-            releaseClassification: 'substantive',
-            changelogSourceFiles: [ 'source/pkg-a.js' ]
-        });
+        assert.deepStrictEqual(
+            {
+                releaseClassification: pkg.releaseClassification,
+                changelogSourceFiles: pkg.changelogSourceFiles
+            },
+            {
+                releaseClassification: 'substantive',
+                changelogSourceFiles: [ 'source/pkg-a.js' ]
+            }
+        );
     });
 
     test('excludes generated manifests and includes substituted and additional source files', async function () {

--- a/source/packtory/packtory-resolve.test.ts
+++ b/source/packtory/packtory-resolve.test.ts
@@ -44,8 +44,16 @@ suite('packtory-resolve', function () {
         if (!result.isErr || result.error.type !== 'partial') {
             assert.fail('expected a partial failure');
         }
-        assert.deepStrictEqual(result.error.error.succeeded, []);
-        assert.strictEqual(result.error.error.failures.length, 1);
+        assert.partialDeepStrictEqual(result, {
+            error: {
+                error: {
+                    succeeded: [],
+                    failures: {
+                        length: 1
+                    }
+                }
+            }
+        });
         assert.strictEqual(result.error.error.failures[0]?.message, 'boom');
     });
 });

--- a/source/packtory/packtory-resolve.test.ts
+++ b/source/packtory/packtory-resolve.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import {
     emptyDeadCodeEliminator,
     emptyScheduler,
@@ -44,7 +45,7 @@ suite('packtory-resolve', function () {
         if (!result.isErr || result.error.type !== 'partial') {
             assert.fail('expected a partial failure');
         }
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             error: {
                 error: {
                     succeeded: [],

--- a/source/packtory/packtory-results.test.ts
+++ b/source/packtory/packtory-results.test.ts
@@ -50,8 +50,10 @@ suite('packtory-results', function () {
 
     test('resolvePartialFailure wraps a PartialError under the partial discriminator', function () {
         const partial = resolvePartialFailure({ succeeded: [], failures: [] });
-        assert.strictEqual(partial.type, 'partial');
-        assert.deepStrictEqual(partial.error, { succeeded: [], failures: [] });
+        assert.partialDeepStrictEqual(partial, {
+            type: 'partial',
+            error: { succeeded: [], failures: [] }
+        });
     });
 
     test('releaseAnalysisPartialFailure tags a PartialError as a release-analysis partial failure', function () {
@@ -70,8 +72,10 @@ suite('packtory-results', function () {
             failures
         });
 
-        assert.strictEqual(failure.type, 'partial');
-        assert.deepStrictEqual(failure.failures, failures);
+        assert.partialDeepStrictEqual(failure, {
+            type: 'partial',
+            failures
+        });
     });
 
     test('createPublishAllOutcome captures the result and the report getter', function () {

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe, Result } from 'true-myth';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import type { PacktoryConfigWithoutRegistry } from '../config/config.ts';
 import {
     bundleResource,
@@ -434,7 +435,7 @@ suite('packtory', function () {
 
                 assert.strictEqual(getOkResult(result, 'Expected buildAndPublishAll() should succeed').length, 1);
                 assert.strictEqual(tryBuildAndPublish.callCount, 1);
-                assert.notStrictEqual(getReport(), undefined);
+                assertDefined(getReport());
             });
 
             test('buildAndPublishAll() runs real publishes when registry auth is configured', async function () {
@@ -509,7 +510,7 @@ suite('packtory', function () {
                     getOkResult(result, 'Expected diffAgainstLatestPublished() should succeed').length,
                     1
                 );
-                assert.notStrictEqual(getReport(), undefined);
+                assertDefined(getReport());
                 assert.strictEqual(progressBroadcaster.provider.hasSubscribers('done'), false);
             });
 
@@ -534,7 +535,7 @@ suite('packtory', function () {
                         .classification,
                     'first-publish'
                 );
-                assert.notStrictEqual(getReport(), undefined);
+                assertDefined(getReport());
                 assert.strictEqual(progressBroadcaster.provider.hasSubscribers('done'), false);
             });
 
@@ -561,7 +562,7 @@ suite('packtory', function () {
                     getOkResult(result, 'Expected planReleaseAgainstLatestPublished() should succeed').packages.length,
                     1
                 );
-                assert.notStrictEqual(getReport(), undefined);
+                assertDefined(getReport());
                 assert.strictEqual(progressBroadcaster.provider.hasSubscribers('done'), false);
             });
 

--- a/source/packtory/publish-failure-mapping.test.ts
+++ b/source/packtory/publish-failure-mapping.test.ts
@@ -18,7 +18,7 @@ suite('publish-failure-mapping', function () {
         const failures = [ { message: 'boom' } as never ];
         const mapped = mapResolveFailureToPublishFailure({ type: 'partial', error: { succeeded: [], failures } });
 
-        assert.partialDeepStrictEqual(mapped, {
+        assert.deepStrictEqual(mapped, {
             type: 'partial',
             succeeded: [],
             failures

--- a/source/packtory/publish-failure-mapping.test.ts
+++ b/source/packtory/publish-failure-mapping.test.ts
@@ -18,8 +18,10 @@ suite('publish-failure-mapping', function () {
         const failures = [ { message: 'boom' } as never ];
         const mapped = mapResolveFailureToPublishFailure({ type: 'partial', error: { succeeded: [], failures } });
 
-        assert.strictEqual(mapped.type, 'partial');
-        assert.deepStrictEqual(mapped.succeeded, []);
-        assert.strictEqual(mapped.failures, failures);
+        assert.partialDeepStrictEqual(mapped, {
+            type: 'partial',
+            succeeded: [],
+            failures
+        });
     });
 });

--- a/source/packtory/release-analysis.test.ts
+++ b/source/packtory/release-analysis.test.ts
@@ -289,8 +289,10 @@ function registerReleaseSummaryTests(): void {
             }
         ]);
 
-        assert.strictEqual(result.classification, 'substantive');
-        assert.deepStrictEqual(result.mostRecentPublishedAt, new Date('2026-05-03T00:00:00.000Z'));
+        assert.partialDeepStrictEqual(result, {
+            classification: 'substantive',
+            mostRecentPublishedAt: new Date('2026-05-03T00:00:00.000Z')
+        });
     });
 
     test('summarizeReleaseAnalysis stays unchanged when every package analysis is unchanged', function () {
@@ -303,8 +305,10 @@ function registerReleaseSummaryTests(): void {
             }
         ]);
 
-        assert.strictEqual(result.classification, 'unchanged');
-        assert.strictEqual(result.mostRecentPublishedAt, undefined);
+        assert.partialDeepStrictEqual(result, {
+            classification: 'unchanged',
+            mostRecentPublishedAt: undefined
+        });
     });
 
     test('summarizeReleaseAnalysis prefers first-publish over dependency-only', function () {
@@ -349,8 +353,10 @@ function registerReleaseSummaryTests(): void {
             }
         ]);
 
-        assert.strictEqual(result.classification, 'first-publish');
-        assert.strictEqual(result.mostRecentPublishedAt, undefined);
+        assert.partialDeepStrictEqual(result, {
+            classification: 'first-publish',
+            mostRecentPublishedAt: undefined
+        });
     });
 
     test('summarizeReleaseAnalysis uses dependency-only when it is the strongest changed classification', function () {
@@ -363,8 +369,10 @@ function registerReleaseSummaryTests(): void {
             }
         ]);
 
-        assert.strictEqual(result.classification, 'dependency-only');
-        assert.deepStrictEqual(result.mostRecentPublishedAt, new Date('2026-05-02T00:00:00.000Z'));
+        assert.partialDeepStrictEqual(result, {
+            classification: 'dependency-only',
+            mostRecentPublishedAt: new Date('2026-05-02T00:00:00.000Z')
+        });
     });
 
     test('summarizeReleaseAnalysis keeps the latest published timestamp even when later entries are older', function () {

--- a/source/packtory/release-diff-failure-mapping.test.ts
+++ b/source/packtory/release-diff-failure-mapping.test.ts
@@ -22,7 +22,8 @@ suite('release-diff-failure-mapping', function () {
         if (result.type !== 'partial') {
             assert.fail(`expected partial failure, got ${result.type}`);
         }
-        assert.partialDeepStrictEqual(result, {
+        assert.deepStrictEqual(result, {
+            type: 'partial',
             succeeded: [],
             failures: resolveFailures
         });

--- a/source/packtory/release-diff-failure-mapping.test.ts
+++ b/source/packtory/release-diff-failure-mapping.test.ts
@@ -22,7 +22,9 @@ suite('release-diff-failure-mapping', function () {
         if (result.type !== 'partial') {
             assert.fail(`expected partial failure, got ${result.type}`);
         }
-        assert.deepStrictEqual(result.succeeded, []);
-        assert.deepStrictEqual(result.failures, resolveFailures);
+        assert.partialDeepStrictEqual(result, {
+            succeeded: [],
+            failures: resolveFailures
+        });
     });
 });

--- a/source/packtory/report-attachment.test.ts
+++ b/source/packtory/report-attachment.test.ts
@@ -42,9 +42,9 @@ function registerAggregatorAttachmentTests(): void {
 
         const attachment = maybeAttachAggregator(broadcaster, false);
 
-        assert.doesNotThrow(function () {
-            attachment.dispose();
-        });
+        attachment.dispose();
+
+        assert.strictEqual(attachment.getReport(), undefined);
     });
 
     test('maybeAttachAggregator() does not subscribe to broadcaster when collectReport is false', function () {
@@ -74,9 +74,11 @@ function registerAggregatorAttachmentTests(): void {
         if (report === undefined) {
             assert.fail('expected a BuildReport');
         }
-        assert.strictEqual(report.schemaVersion, 1);
-        assert.deepStrictEqual(report.packages, {});
-        assert.deepStrictEqual(report.aggregate, { crossBundleLinks: [] });
+        assert.partialDeepStrictEqual(report, {
+            schemaVersion: 1,
+            packages: {},
+            aggregate: { crossBundleLinks: [] }
+        });
     });
 
     test('maybeAttachAggregator() getReport reflects events emitted before build', function () {

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -189,8 +189,12 @@ suite('scheduler', function () {
         });
 
         const error = getErrResult(result, 'Expected result to be an error');
-        assert.deepStrictEqual(error.succeeded, [ 'root-result', 'package-a-result' ]);
-        assert.strictEqual(error.failures.length, 1);
+        assert.partialDeepStrictEqual(error, {
+            succeeded: [ 'root-result', 'package-a-result' ],
+            failures: {
+                length: 1
+            }
+        });
         assert.strictEqual(error.failures[0]?.message, 'package-b failed');
         const emitCalls = getEmitCallArguments(emit);
         assert.deepStrictEqual(emitCalls.slice(0, 4), [

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { noPublication } from '../bundle-emitter/publication-outcome.ts';
 import { validateConfigWithoutRegistry, type ValidConfigWithoutRegistryResult } from '../config/validation.ts';
 import { getErrResult } from '../test-libraries/result-helpers.ts';
@@ -189,7 +190,7 @@ suite('scheduler', function () {
         });
 
         const error = getErrResult(result, 'Expected result to be an error');
-        assert.partialDeepStrictEqual(error, {
+        assertDeepSubset(error, {
             succeeded: [ 'root-result', 'package-a-result' ],
             failures: {
                 length: 1

--- a/source/packtory/stages/publish-stage.test.ts
+++ b/source/packtory/stages/publish-stage.test.ts
@@ -147,11 +147,13 @@ suite('publish-stage', function () {
             { dryRun: false, stage: false }
         );
 
-        assert.deepStrictEqual(capture.selected, [ bundle ]);
-        assert.deepStrictEqual(capture.events, [
-            { version: '2.0.0', status: 'new-version', publication: noPublication }
-        ]);
-        assert.strictEqual(capture.emitScheduledEvents, false);
+        assert.partialDeepStrictEqual(capture, {
+            selected: [ bundle ],
+            events: [
+                { version: '2.0.0', status: 'new-version', publication: noPublication }
+            ],
+            emitScheduledEvents: false
+        });
     });
 
     test('determineVersionAndPublishAll emits publish package failures to subscribers', async function () {

--- a/source/packtory/stages/release-diff-stage.test.ts
+++ b/source/packtory/stages/release-diff-stage.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe, Result } from 'true-myth';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import { noPublication } from '../../bundle-emitter/publication-outcome.ts';
 import type { ValidConfigResult } from '../../config/validation.ts';
 import type { FileDescription } from '../../file-manager/file-description.ts';
@@ -140,7 +141,7 @@ function registerBasicDiffTests(): void {
         const result = await runAlreadyPublishedPkgAStage(artifactsBuilderReturning([]));
 
         const first = expectFirstEntry(result);
-        assert.partialDeepStrictEqual(first, {
+        assertDeepSubset(first, {
             state: 'unchanged',
             previousVersionLabel: '1.0.0',
             files: { added: [], removed: [], modified: [], unchanged: [] }
@@ -154,7 +155,7 @@ function registerBasicDiffTests(): void {
         ]);
 
         const first = expectFirstEntry(result);
-        assert.partialDeepStrictEqual(first, {
+        assertDeepSubset(first, {
             state: 'first-publish',
             files: {
                 added: [
@@ -205,7 +206,7 @@ function registerBasicDiffTests(): void {
             ]
         );
 
-        assert.partialDeepStrictEqual(collectContents, {
+        assertDeepSubset(collectContents, {
             callCount: 1,
             firstCall: {
                 args: [ bundle, 'package', [ extraFile ] ]
@@ -244,7 +245,7 @@ function registerSchedulerTests(): void {
         if (result.isOk) {
             assert.fail('expected Err');
         }
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             error: {
                 failures: [ failingError ],
                 succeeded: []
@@ -314,7 +315,7 @@ function registerChangedDiffTests(): void {
         );
 
         const entry = expectFirstEntry(result);
-        assert.partialDeepStrictEqual(entry, {
+        assertDeepSubset(entry, {
             state: 'changed',
             files: {
                 modified: {
@@ -335,7 +336,7 @@ function registerChangedDiffTests(): void {
         const previousSbom = buildSbomFixtureContent({ packtoryVersion: '1.2.3' });
         const currentSbom = buildSbomFixtureContent({ packtoryVersion: '9.9.9' });
         const files = await runSbomDiff(previousSbom, currentSbom);
-        assert.partialDeepStrictEqual(files, {
+        assertDeepSubset(files, {
             modified: {
                 length: 0
             },

--- a/source/packtory/stages/release-diff-stage.test.ts
+++ b/source/packtory/stages/release-diff-stage.test.ts
@@ -140,9 +140,11 @@ function registerBasicDiffTests(): void {
         const result = await runAlreadyPublishedPkgAStage(artifactsBuilderReturning([]));
 
         const first = expectFirstEntry(result);
-        assert.strictEqual(first.state, 'unchanged');
-        assert.strictEqual(first.previousVersionLabel, '1.0.0');
-        assert.deepStrictEqual(first.files, { added: [], removed: [], modified: [], unchanged: [] });
+        assert.partialDeepStrictEqual(first, {
+            state: 'unchanged',
+            previousVersionLabel: '1.0.0',
+            files: { added: [], removed: [], modified: [], unchanged: [] }
+        });
     });
 
     test('produces a first-publish state with all bundled files in `added`, empty `removed`/`modified`/`unchanged`', async function () {
@@ -152,15 +154,19 @@ function registerBasicDiffTests(): void {
         ]);
 
         const first = expectFirstEntry(result);
-        assert.strictEqual(first.state, 'first-publish');
-        assert.deepStrictEqual(first.files.added, [
-            { path: 'package.json', sizeBytes: 2, isExecutable: false },
-            { path: 'bin/cli.js', sizeBytes: 20, isExecutable: true }
-        ]);
-        assert.deepStrictEqual(first.files.removed, []);
-        assert.deepStrictEqual(first.files.modified, []);
-        assert.deepStrictEqual(first.files.unchanged, []);
-        assert.strictEqual(first.versionTransition, '(unpublished) -> 1.0.0');
+        assert.partialDeepStrictEqual(first, {
+            state: 'first-publish',
+            files: {
+                added: [
+                    { path: 'package.json', sizeBytes: 2, isExecutable: false },
+                    { path: 'bin/cli.js', sizeBytes: 20, isExecutable: true }
+                ],
+                removed: [],
+                modified: [],
+                unchanged: []
+            },
+            versionTransition: '(unpublished) -> 1.0.0'
+        });
     });
 
     test('measures added-file sizes in UTF-8 bytes', async function () {
@@ -199,8 +205,12 @@ function registerBasicDiffTests(): void {
             ]
         );
 
-        assert.strictEqual(collectContents.callCount, 1);
-        assert.deepStrictEqual(collectContents.firstCall.args, [ bundle, 'package', [ extraFile ] ]);
+        assert.partialDeepStrictEqual(collectContents, {
+            callCount: 1,
+            firstCall: {
+                args: [ bundle, 'package', [ extraFile ] ]
+            }
+        });
     });
 
     test('does not call artifactsBuilder.collectContents for an already-published package', async function () {
@@ -234,8 +244,12 @@ function registerSchedulerTests(): void {
         if (result.isOk) {
             assert.fail('expected Err');
         }
-        assert.deepStrictEqual(result.error.failures, [ failingError ]);
-        assert.deepStrictEqual(result.error.succeeded, []);
+        assert.partialDeepStrictEqual(result, {
+            error: {
+                failures: [ failingError ],
+                succeeded: []
+            }
+        });
     });
 
     test('passes emitScheduledEvents=false to the scheduler so it does not re-emit `scheduled` events the publish-stage already emitted', async function () {
@@ -300,19 +314,35 @@ function registerChangedDiffTests(): void {
         );
 
         const entry = expectFirstEntry(result);
-        assert.strictEqual(entry.state, 'changed');
-        assert.strictEqual(entry.files.modified.length, 2);
-        assert.strictEqual(entry.files.removed.length, 1);
-        assert.strictEqual(entry.files.added.length, 0);
-        assert.strictEqual(entry.versionTransition, '1.0.0 -> 1.0.1');
+        assert.partialDeepStrictEqual(entry, {
+            state: 'changed',
+            files: {
+                modified: {
+                    length: 2
+                },
+                removed: {
+                    length: 1
+                },
+                added: {
+                    length: 0
+                }
+            },
+            versionTransition: '1.0.0 -> 1.0.1'
+        });
     });
 
     test('classifies an SBOM that differs only in the packtory tool version as unchanged', async function () {
         const previousSbom = buildSbomFixtureContent({ packtoryVersion: '1.2.3' });
         const currentSbom = buildSbomFixtureContent({ packtoryVersion: '9.9.9' });
         const files = await runSbomDiff(previousSbom, currentSbom);
-        assert.strictEqual(files.modified.length, 0);
-        assert.strictEqual(files.unchanged.length, 1);
+        assert.partialDeepStrictEqual(files, {
+            modified: {
+                length: 0
+            },
+            unchanged: {
+                length: 1
+            }
+        });
         assert.strictEqual(files.unchanged[0]?.path, 'sbom.cdx.json');
     });
 

--- a/source/packtory/stages/release-diff-stage.test.ts
+++ b/source/packtory/stages/release-diff-stage.test.ts
@@ -141,11 +141,11 @@ function registerBasicDiffTests(): void {
         const result = await runAlreadyPublishedPkgAStage(artifactsBuilderReturning([]));
 
         const first = expectFirstEntry(result);
-        assertDeepSubset(first, {
+        assert.partialDeepStrictEqual(first, {
             state: 'unchanged',
-            previousVersionLabel: '1.0.0',
-            files: { added: [], removed: [], modified: [], unchanged: [] }
+            previousVersionLabel: '1.0.0'
         });
+        assert.deepStrictEqual(first.files, { added: [], removed: [], modified: [], unchanged: [] });
     });
 
     test('produces a first-publish state with all bundled files in `added`, empty `removed`/`modified`/`unchanged`', async function () {
@@ -155,18 +155,18 @@ function registerBasicDiffTests(): void {
         ]);
 
         const first = expectFirstEntry(result);
-        assertDeepSubset(first, {
+        assert.partialDeepStrictEqual(first, {
             state: 'first-publish',
-            files: {
-                added: [
-                    { path: 'package.json', sizeBytes: 2, isExecutable: false },
-                    { path: 'bin/cli.js', sizeBytes: 20, isExecutable: true }
-                ],
-                removed: [],
-                modified: [],
-                unchanged: []
-            },
             versionTransition: '(unpublished) -> 1.0.0'
+        });
+        assert.deepStrictEqual(first.files, {
+            added: [
+                { path: 'package.json', sizeBytes: 2, isExecutable: false },
+                { path: 'bin/cli.js', sizeBytes: 20, isExecutable: true }
+            ],
+            removed: [],
+            modified: [],
+            unchanged: []
         });
     });
 
@@ -317,33 +317,27 @@ function registerChangedDiffTests(): void {
         const entry = expectFirstEntry(result);
         assertDeepSubset(entry, {
             state: 'changed',
-            files: {
-                modified: {
-                    length: 2
-                },
-                removed: {
-                    length: 1
-                },
-                added: {
-                    length: 0
-                }
-            },
             versionTransition: '1.0.0 -> 1.0.1'
         });
+        assert.deepStrictEqual(
+            {
+                modified: entry.files.modified.length,
+                removed: entry.files.removed.length,
+                added: entry.files.added.length,
+                unchanged: entry.files.unchanged.length
+            },
+            { modified: 2, removed: 1, added: 0, unchanged: 0 }
+        );
     });
 
     test('classifies an SBOM that differs only in the packtory tool version as unchanged', async function () {
         const previousSbom = buildSbomFixtureContent({ packtoryVersion: '1.2.3' });
         const currentSbom = buildSbomFixtureContent({ packtoryVersion: '9.9.9' });
         const files = await runSbomDiff(previousSbom, currentSbom);
-        assertDeepSubset(files, {
-            modified: {
-                length: 0
-            },
-            unchanged: {
-                length: 1
-            }
-        });
+        assert.deepStrictEqual(
+            { modified: files.modified.length, unchanged: files.unchanged.length },
+            { modified: 0, unchanged: 1 }
+        );
         assert.strictEqual(files.unchanged[0]?.path, 'sbom.cdx.json');
     });
 

--- a/source/progress/progress-broadcaster.test.ts
+++ b/source/progress/progress-broadcaster.test.ts
@@ -84,14 +84,14 @@ suite('progress-broadcaster', function () {
     test('decision events with no subscribers emit without error', function () {
         const broadcaster = createProgressBroadcaster();
 
-        assert.doesNotThrow(function () {
-            broadcaster.provider.emit('versionDetermined', {
-                packageName: 'package-a',
-                previousVersion: '1.0.0',
-                chosenVersion: '1.0.1',
-                trigger: 'auto-patch-bump'
-            });
+        broadcaster.provider.emit('versionDetermined', {
+            packageName: 'package-a',
+            previousVersion: '1.0.0',
+            chosenVersion: '1.0.1',
+            trigger: 'auto-patch-bump'
         });
+
+        assert.strictEqual(broadcaster.provider.hasSubscribers('versionDetermined'), false);
     });
 
     test('round-trips an eliminationCompleted decision event', function () {

--- a/source/report/aggregator/artifact-entry-merger.test.ts
+++ b/source/report/aggregator/artifact-entry-merger.test.ts
@@ -21,15 +21,19 @@ suite('artifact-entry-merger', function () {
     test('mergeArtifactEntry adds the import-path-rewrite badge and "changed" status for rewritten files', function () {
         const merged = mergeArtifactEntry(baseEntry, new Set([ '/workspace/src/index.js' ]), new Set());
 
-        assert.strictEqual(merged.status, 'changed');
-        assert.deepStrictEqual(merged.badges, [ 'import-path-rewrite' ]);
+        assert.partialDeepStrictEqual(merged, {
+            status: 'changed',
+            badges: [ 'import-path-rewrite' ]
+        });
     });
 
     test('mergeArtifactEntry adds the dead-code-elimination badge and "changed" status for transformed files', function () {
         const merged = mergeArtifactEntry(baseEntry, new Set(), new Set([ '/workspace/src/index.js' ]));
 
-        assert.strictEqual(merged.status, 'changed');
-        assert.deepStrictEqual(merged.badges, [ 'dead-code-elimination' ]);
+        assert.partialDeepStrictEqual(merged, {
+            status: 'changed',
+            badges: [ 'dead-code-elimination' ]
+        });
     });
 
     test('mergeArtifactEntry combines both badges when both rewrite and transform apply', function () {

--- a/source/report/aggregator/report-aggregator.test.ts
+++ b/source/report/aggregator/report-aggregator.test.ts
@@ -154,7 +154,7 @@ function registerLifecycleTests(): void {
         const aggregator = createReportAggregator(broadcaster.consumer);
 
         const { generatedAt } = aggregator.build();
-        assert.ok(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(generatedAt));
+        assert.match(generatedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     });
 
     test('build() reports an empty packages map when no events were observed', function () {

--- a/source/report/aggregator/report-event-handlers.test.ts
+++ b/source/report/aggregator/report-event-handlers.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import { stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import { registerSubscribers, type AggregatorState } from './report-event-handlers.ts';
@@ -51,7 +52,7 @@ function registerPackageEventTests(): void {
         });
 
         const entry = expectPackageEntry(state, 'pkg-a');
-        assert.partialDeepStrictEqual(entry, {
+        assertDeepSubset(entry, {
             roots: { main: 'src/index.js' },
             siblingVersions: { 'pkg-b': '1.0.0' },
             sourceFileCount: 3
@@ -235,7 +236,7 @@ function registerEliminationTests(): void {
         ]);
 
         const entry = expectPackageEntry(state, 'pkg-a');
-        assert.partialDeepStrictEqual(entry, {
+        assertDeepSubset(entry, {
             decisions: {
                 deadCodeElimination: {
                     files: {

--- a/source/report/aggregator/report-event-handlers.test.ts
+++ b/source/report/aggregator/report-event-handlers.test.ts
@@ -51,9 +51,11 @@ function registerPackageEventTests(): void {
         });
 
         const entry = expectPackageEntry(state, 'pkg-a');
-        assert.deepStrictEqual(entry.roots, { main: 'src/index.js' });
-        assert.deepStrictEqual(entry.siblingVersions, { 'pkg-b': '1.0.0' });
-        assert.strictEqual(entry.sourceFileCount, 3);
+        assert.partialDeepStrictEqual(entry, {
+            roots: { main: 'src/index.js' },
+            siblingVersions: { 'pkg-b': '1.0.0' },
+            sourceFileCount: 3
+        });
     });
 
     test('registerSubscribers records the assembled package.json fields on the package entry', function () {
@@ -233,8 +235,16 @@ function registerEliminationTests(): void {
         ]);
 
         const entry = expectPackageEntry(state, 'pkg-a');
-        assert.strictEqual(entry.decisions.deadCodeElimination?.files.length, 1);
-        assert.deepStrictEqual(entry.eliminatedSourceFiles, [ { path: 'b.js', sourceBytes: 5, reason: 'no-uses' } ]);
+        assert.partialDeepStrictEqual(entry, {
+            decisions: {
+                deadCodeElimination: {
+                    files: {
+                        length: 1
+                    }
+                }
+            },
+            eliminatedSourceFiles: [ { path: 'b.js', sourceBytes: 5, reason: 'no-uses' } ]
+        });
     });
 }
 

--- a/source/report/aggregator/report-event-handlers.test.ts
+++ b/source/report/aggregator/report-event-handlers.test.ts
@@ -236,16 +236,22 @@ function registerEliminationTests(): void {
         ]);
 
         const entry = expectPackageEntry(state, 'pkg-a');
-        assertDeepSubset(entry, {
-            decisions: {
-                deadCodeElimination: {
-                    files: {
-                        length: 1
-                    }
-                }
+        const { decisions: { deadCodeElimination }, eliminatedSourceFiles } = entry;
+        if (deadCodeElimination === undefined || eliminatedSourceFiles === undefined) {
+            assert.fail('expected dead-code-elimination report data');
+        }
+        assert.deepStrictEqual(
+            {
+                keptFileCount: deadCodeElimination.files.length,
+                eliminatedSourceFiles,
+                hasOutputBytes: Object.hasOwn(eliminatedSourceFiles[0] ?? {}, 'outputBytes')
             },
-            eliminatedSourceFiles: [ { path: 'b.js', sourceBytes: 5, reason: 'no-uses' } ]
-        });
+            {
+                keptFileCount: 1,
+                eliminatedSourceFiles: [ { path: 'b.js', sourceBytes: 5, reason: 'no-uses' } ],
+                hasOutputBytes: false
+            }
+        );
     });
 }
 

--- a/source/report/config-redactor.test.ts
+++ b/source/report/config-redactor.test.ts
@@ -171,8 +171,10 @@ function registerSourceAndRegistryTests(): void {
             'pkg-missing'
         );
 
-        assert.deepStrictEqual(redacted.publishSettings, { access: 'public' });
-        assert.strictEqual(redacted.sourcesFolder, '/common/src');
+        assert.partialDeepStrictEqual(redacted, {
+            publishSettings: { access: 'public' },
+            sourcesFolder: '/common/src'
+        });
     });
 }
 

--- a/source/report/decorators.test.ts
+++ b/source/report/decorators.test.ts
@@ -83,8 +83,10 @@ function registerStageTimingTests(): void {
 
         assert.strictEqual(received.length, 1);
         const payload = expectPayload(received);
-        assert.strictEqual(payload.packageName, 'pkg-a');
-        assert.strictEqual(payload.stage, 'resolveAndLink');
+        assert.partialDeepStrictEqual(payload, {
+            packageName: 'pkg-a',
+            stage: 'resolveAndLink'
+        });
         assert.ok(typeof payload.durationMs === 'number' && payload.durationMs >= 0);
     });
 
@@ -100,8 +102,10 @@ function registerStageTimingTests(): void {
 
         assert.strictEqual(received.length, 1);
         const payload = expectPayload(received);
-        assert.strictEqual(payload.packageName, 'pkg-b');
-        assert.strictEqual(payload.stage, 'publish');
+        assert.partialDeepStrictEqual(payload, {
+            packageName: 'pkg-b',
+            stage: 'publish'
+        });
         assert.ok(typeof payload.durationMs === 'number' && payload.durationMs >= 0);
     });
 
@@ -210,8 +214,10 @@ function registerStageTimingTests(): void {
 
         assert.strictEqual(received.length, 1);
         const payload = expectPayload(received);
-        assert.strictEqual(payload.packageName, 'pkg-build');
-        assert.strictEqual(payload.stage, 'build');
+        assert.partialDeepStrictEqual(payload, {
+            packageName: 'pkg-build',
+            stage: 'build'
+        });
         assert.ok(typeof payload.durationMs === 'number' && payload.durationMs >= 0);
     });
 

--- a/source/report/inspectors/inspect-package-json-provenance.test.ts
+++ b/source/report/inspectors/inspect-package-json-provenance.test.ts
@@ -26,8 +26,10 @@ suite('inspect-package-json-provenance', function () {
     test('inspectPackageJsonProvenance marks fields not in any source as derived', function () {
         const provenance = inspectPackageJsonProvenance({ name: 'pkg', version: '1.0.0' }, {}, undefined);
 
-        assert.deepStrictEqual(provenance.name, { source: 'derived' });
-        assert.deepStrictEqual(provenance.version, { source: 'derived' });
+        assert.partialDeepStrictEqual(provenance, {
+            name: { source: 'derived' },
+            version: { source: 'derived' }
+        });
     });
 
     test('inspectPackageJsonProvenance prefers additionalAttributes over mainPackageJson when both contain the field', function () {

--- a/source/report/preview/artifact-diff-builder.test.ts
+++ b/source/report/preview/artifact-diff-builder.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import type { ArtifactEntry } from '../../progress/progress-broadcaster.ts';
 import { buildDiffForArtifact } from './artifact-diff-builder.ts';
 import type { BundleArtifactIndex } from './bundle-artifact-index.ts';
@@ -67,8 +68,8 @@ suite('artifact-diff-builder', function () {
             await alwaysRead('export const removed = 1;')
         );
 
-        assert.notStrictEqual(result, undefined);
-        assert.ok((result ?? []).length > 0);
-        assert.match((result ?? [])[0]?.header ?? '', /^@@ -\d+,\d+ \+\d+,\d+ @@$/u);
+        assertDefined(result);
+        assert.ok(result.length > 0);
+        assert.match(result[0]?.header ?? '', /^@@ -\d+,\d+ \+\d+,\d+ @@$/u);
     });
 });

--- a/source/report/preview/artifact-tree-builder.test.ts
+++ b/source/report/preview/artifact-tree-builder.test.ts
@@ -24,8 +24,10 @@ suite('artifact-tree-builder', function () {
         const nodes = buildArtifactTree([ artifact('package.json', { kind: 'manifest' }) ]);
         const [ , ...rest ] = nodes;
         const node = expectFirstNode(nodes);
-        assert.strictEqual(node.type, 'file');
-        assert.strictEqual(node.path, 'package.json');
+        assert.partialDeepStrictEqual(node, {
+            type: 'file',
+            path: 'package.json'
+        });
         assert.deepStrictEqual(rest, []);
     });
 

--- a/source/report/preview/bundle-artifact-index.test.ts
+++ b/source/report/preview/bundle-artifact-index.test.ts
@@ -56,7 +56,7 @@ suite('bundle-artifact-index', function () {
     test('buildBundleArtifactIndex maps each bundle to its own inner index by package name', function () {
         const index = buildBundleArtifactIndex([ buildResult('pkg-a', '{}'), buildResult('pkg-b', '{}') ]);
 
-        assert.strictEqual(index.get('pkg-a') === index.get('pkg-b'), false);
+        assert.notStrictEqual(index.get('pkg-a'), index.get('pkg-b'));
         assert.strictEqual(index.has('pkg-a'), true);
         assert.strictEqual(index.has('pkg-b'), true);
     });

--- a/source/report/preview/preview-document-diff-flow.test.ts
+++ b/source/report/preview/preview-document-diff-flow.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { Result } from 'true-myth';
+import { assertDefined } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     createAnalyzedResource,
     createArtifactEntryFixture,
@@ -68,7 +69,7 @@ suite('preview-document diffs', function () {
         if (fileNode?.type !== 'file') {
             assert.fail('expected index.js file node');
         }
-        assert.notStrictEqual(fileNode.artifact.diff, undefined);
+        assertDefined(fileNode.artifact.diff);
     });
 
     test('buildPreviewDocument limits diffs to two hunks and drops patch metadata lines', async function () {

--- a/source/report/preview/preview-document-diff-flow.test.ts
+++ b/source/report/preview/preview-document-diff-flow.test.ts
@@ -68,7 +68,7 @@ suite('preview-document diffs', function () {
         if (fileNode?.type !== 'file') {
             assert.fail('expected index.js file node');
         }
-        assert.ok(fileNode.artifact.diff !== undefined);
+        assert.notStrictEqual(fileNode.artifact.diff, undefined);
     });
 
     test('buildPreviewDocument limits diffs to two hunks and drops patch metadata lines', async function () {

--- a/source/report/preview/preview-document-package-state.test.ts
+++ b/source/report/preview/preview-document-package-state.test.ts
@@ -58,9 +58,11 @@ suite('preview-document package state', function () {
                 })
             });
 
-            assert.strictEqual(document.previewable, false);
-            assert.strictEqual(document.resultType, 'checks');
-            assert.deepStrictEqual(document.issues, [ 'bundle is too large' ]);
+            assert.partialDeepStrictEqual(document, {
+                previewable: false,
+                resultType: 'checks',
+                issues: [ 'bundle is too large' ]
+            });
         });
 
         test('buildPreviewDocument marks a partial run with succeeded packages as previewable', async function () {
@@ -73,9 +75,11 @@ suite('preview-document package state', function () {
                 })
             });
 
-            assert.strictEqual(document.previewable, true);
-            assert.strictEqual(document.resultType, 'partial');
-            assert.deepStrictEqual(document.issues, [ 'boom' ]);
+            assert.partialDeepStrictEqual(document, {
+                previewable: true,
+                resultType: 'partial',
+                issues: [ 'boom' ]
+            });
         });
 
         test('buildPreviewDocument uses publish mode when dryRun is false', async function () {
@@ -141,9 +145,13 @@ suite('preview-document package state', function () {
             if (pkg.failure === undefined) {
                 assert.fail('expected package failure');
             }
-            assert.strictEqual(pkg.failure.message, 'boom');
-            assert.strictEqual(pkg.openByDefault, true);
-            assert.deepStrictEqual(pkg.tree, []);
+            assert.partialDeepStrictEqual(pkg, {
+                failure: {
+                    message: 'boom'
+                },
+                openByDefault: true,
+                tree: []
+            });
             assert.deepStrictEqual(document.summary, {
                 totalPackages: 1,
                 changedPackages: 0,

--- a/source/report/preview/preview-summary.test.ts
+++ b/source/report/preview/preview-summary.test.ts
@@ -20,16 +20,20 @@ suite('preview-summary', function () {
         const summary = summarizePackages([
             { hasChanges: true, eliminatedSourceFiles: [], artifactCounts: { emitted: 1, changed: 1 } }
         ]);
-        assert.strictEqual(summary.changedPackages, 1);
-        assert.strictEqual(summary.unchangedPackages, 0);
+        assert.partialDeepStrictEqual(summary, {
+            changedPackages: 1,
+            unchangedPackages: 0
+        });
     });
 
     test('summarizePackages counts an unchanged success as an unchanged package', function () {
         const summary = summarizePackages([
             { hasChanges: false, eliminatedSourceFiles: [], artifactCounts: { emitted: 0, changed: 0 } }
         ]);
-        assert.strictEqual(summary.unchangedPackages, 1);
-        assert.strictEqual(summary.changedPackages, 0);
+        assert.partialDeepStrictEqual(summary, {
+            unchangedPackages: 1,
+            changedPackages: 0
+        });
     });
 
     test('summarizePackages counts a package as failed when it has a failure entry', function () {
@@ -52,8 +56,10 @@ suite('preview-summary', function () {
                 artifactCounts: { emitted: 2, changed: 1 }
             }
         ]);
-        assert.strictEqual(summary.emittedArtifacts, 2);
-        assert.strictEqual(summary.changedArtifacts, 1);
-        assert.strictEqual(summary.eliminatedSourceFiles, 1);
+        assert.partialDeepStrictEqual(summary, {
+            emittedArtifacts: 2,
+            changedArtifacts: 1,
+            eliminatedSourceFiles: 1
+        });
     });
 });

--- a/source/report/release-diff/file-set-diff.test.ts
+++ b/source/report/release-diff/file-set-diff.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import type { FileDescription } from '../../file-manager/file-description.ts';
 import { buildFileSetDiff, type ModifiedFile } from './file-set-diff.ts';
 
@@ -20,7 +21,7 @@ function singleModifiedEntry(previous: readonly FileDescription[], current: read
 suite('file-set-diff', function () {
     test('classifies a file that only exists on the new side as added', function () {
         const diff = buildFileSetDiff([], [ file('lib/new.ts', 'export const x = 1;\n') ]);
-        assert.partialDeepStrictEqual(diff, {
+        assertDeepSubset(diff, {
             added: {
                 length: 1
             },
@@ -55,7 +56,7 @@ suite('file-set-diff', function () {
         const previous = [ file('package.json', '{"name":"p"}\n') ];
         const current = [ file('package.json', '{"name":"p"}\n') ];
         const diff = buildFileSetDiff(previous, current);
-        assert.partialDeepStrictEqual(diff, {
+        assertDeepSubset(diff, {
             unchanged: {
                 length: 1
             },
@@ -70,7 +71,7 @@ suite('file-set-diff', function () {
             [ file('bin/cli.js', '#!/usr/bin/env node\n', false) ],
             [ file('bin/cli.js', '#!/usr/bin/env node\n', true) ]
         );
-        assert.partialDeepStrictEqual(entry, {
+        assertDeepSubset(entry, {
             contentChange: {
                 kind: 'mode-only'
             },

--- a/source/report/release-diff/file-set-diff.test.ts
+++ b/source/report/release-diff/file-set-diff.test.ts
@@ -20,10 +20,20 @@ function singleModifiedEntry(previous: readonly FileDescription[], current: read
 suite('file-set-diff', function () {
     test('classifies a file that only exists on the new side as added', function () {
         const diff = buildFileSetDiff([], [ file('lib/new.ts', 'export const x = 1;\n') ]);
-        assert.strictEqual(diff.added.length, 1);
-        assert.strictEqual(diff.removed.length, 0);
-        assert.strictEqual(diff.modified.length, 0);
-        assert.strictEqual(diff.unchanged.length, 0);
+        assert.partialDeepStrictEqual(diff, {
+            added: {
+                length: 1
+            },
+            removed: {
+                length: 0
+            },
+            modified: {
+                length: 0
+            },
+            unchanged: {
+                length: 0
+            }
+        });
         assert.deepStrictEqual(diff.added[0], {
             path: 'lib/new.ts',
             sizeBytes: 'export const x = 1;\n'.length,
@@ -45,8 +55,14 @@ suite('file-set-diff', function () {
         const previous = [ file('package.json', '{"name":"p"}\n') ];
         const current = [ file('package.json', '{"name":"p"}\n') ];
         const diff = buildFileSetDiff(previous, current);
-        assert.strictEqual(diff.unchanged.length, 1);
-        assert.strictEqual(diff.modified.length, 0);
+        assert.partialDeepStrictEqual(diff, {
+            unchanged: {
+                length: 1
+            },
+            modified: {
+                length: 0
+            }
+        });
     });
 
     test('classifies same content with different exec bit as modified with mode-only change', function () {
@@ -54,9 +70,13 @@ suite('file-set-diff', function () {
             [ file('bin/cli.js', '#!/usr/bin/env node\n', false) ],
             [ file('bin/cli.js', '#!/usr/bin/env node\n', true) ]
         );
-        assert.strictEqual(entry.contentChange.kind, 'mode-only');
-        assert.strictEqual(entry.oldIsExecutable, false);
-        assert.strictEqual(entry.newIsExecutable, true);
+        assert.partialDeepStrictEqual(entry, {
+            contentChange: {
+                kind: 'mode-only'
+            },
+            oldIsExecutable: false,
+            newIsExecutable: true
+        });
     });
 
     test('classifies different text content as modified with text hunks', function () {

--- a/source/report/release-diff/release-diff-document.test.ts
+++ b/source/report/release-diff/release-diff-document.test.ts
@@ -29,10 +29,12 @@ suite('release-diff-document', function () {
             result: successResult,
             packages: [ releaseDiffPackage() ]
         });
-        assert.strictEqual(document.title, 'Packtory release diff');
-        assert.strictEqual(document.modeLabel, 'vs registry latest');
-        assert.strictEqual(document.previewable, true);
-        assert.strictEqual(document.resultType, 'success');
+        assert.partialDeepStrictEqual(document, {
+            title: 'Packtory release diff',
+            modeLabel: 'vs registry latest',
+            previewable: true,
+            resultType: 'success'
+        });
     });
 
     test('counts only packages with a failure (asymmetric mix to detect equality-operator inversion)', function () {

--- a/source/report/release-diff/release-diff-summary.test.ts
+++ b/source/report/release-diff/release-diff-summary.test.ts
@@ -16,8 +16,10 @@ function addedFile(path: string): FileSetDiff['added'][number] {
 suite('release-diff-summary', function () {
     test('counts zero failed packages when none are reported', function () {
         const summary = summarizeReleaseDiff([], 0);
-        assert.strictEqual(summary.totalPackages, 0);
-        assert.strictEqual(summary.failedPackages, 0);
+        assert.partialDeepStrictEqual(summary, {
+            totalPackages: 0,
+            failedPackages: 0
+        });
     });
 
     test('classifies package states into changed, first-publish, and unchanged buckets', function () {
@@ -30,10 +32,12 @@ suite('release-diff-summary', function () {
             ],
             0
         );
-        assert.strictEqual(summary.changedPackages, 2);
-        assert.strictEqual(summary.firstPublishPackages, 1);
-        assert.strictEqual(summary.unchangedPackages, 1);
-        assert.strictEqual(summary.totalPackages, 4);
+        assert.partialDeepStrictEqual(summary, {
+            changedPackages: 2,
+            firstPublishPackages: 1,
+            unchangedPackages: 1,
+            totalPackages: 4
+        });
     });
 
     test('keeps first-publish and unchanged buckets distinct when their counts differ (detects state-equality inversion)', function () {
@@ -45,15 +49,19 @@ suite('release-diff-summary', function () {
             ],
             0
         );
-        assert.strictEqual(summary.firstPublishPackages, 1);
-        assert.strictEqual(summary.unchangedPackages, 2);
+        assert.partialDeepStrictEqual(summary, {
+            firstPublishPackages: 1,
+            unchangedPackages: 2
+        });
     });
 
     test('includes the failed package count in total but not in any other state bucket', function () {
         const summary = summarizeReleaseDiff([ stateView({ state: 'changed' }) ], 2);
-        assert.strictEqual(summary.totalPackages, 3);
-        assert.strictEqual(summary.failedPackages, 2);
-        assert.strictEqual(summary.changedPackages, 1);
+        assert.partialDeepStrictEqual(summary, {
+            totalPackages: 3,
+            failedPackages: 2,
+            changedPackages: 1
+        });
     });
 
     test('aggregates file counts across all packages', function () {
@@ -87,8 +95,10 @@ suite('release-diff-summary', function () {
             ],
             0
         );
-        assert.strictEqual(summary.addedFiles, 3);
-        assert.strictEqual(summary.removedFiles, 1);
-        assert.strictEqual(summary.modifiedFiles, 1);
+        assert.partialDeepStrictEqual(summary, {
+            addedFiles: 3,
+            removedFiles: 1,
+            modifiedFiles: 1
+        });
     });
 });

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, stub, type SinonSpy } from 'sinon';
 import { Maybe } from 'true-myth';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { createDependencyGraph, type DependencyGraph } from '../dependency-scanner/dependency-graph.ts';
 import { createFakeFileManager, type FakeFileManager } from '../test-libraries/fake-file-manager.ts';
 import {
@@ -162,7 +163,7 @@ function addGeneratedManifestDependency(graph: DependencyGraph): void {
 }
 
 function assertGeneratedManifestResource(manifestResource: ResolvedContent): void {
-    assert.partialDeepStrictEqual(manifestResource, {
+    assertDeepSubset(manifestResource, {
         isGeneratedManifest: true,
         fileDescription: {
             content: '{\n    "type": "module"\n}\n',
@@ -192,7 +193,7 @@ suite('resource-resolver', function () {
                 mainPackageJson: { type: 'module' }
             }
         ]);
-        assert.partialDeepStrictEqual(result, {
+        assertDeepSubset(result, {
             name: 'package-a',
             contents: {
                 length: 3
@@ -261,7 +262,7 @@ suite('resource-resolver', function () {
             mainPackageJson: { type: 'module' }
         });
 
-        assert.partialDeepStrictEqual(scan, {
+        assertDeepSubset(scan, {
             callCount: 2,
             secondCall: {
                 args: [

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -162,9 +162,13 @@ function addGeneratedManifestDependency(graph: DependencyGraph): void {
 }
 
 function assertGeneratedManifestResource(manifestResource: ResolvedContent): void {
-    assert.strictEqual(manifestResource.isGeneratedManifest, true);
-    assert.strictEqual(manifestResource.fileDescription.content, '{\n    "type": "module"\n}\n');
-    assert.strictEqual(manifestResource.fileDescription.isExecutable, false);
+    assert.partialDeepStrictEqual(manifestResource, {
+        isGeneratedManifest: true,
+        fileDescription: {
+            content: '{\n    "type": "module"\n}\n',
+            isExecutable: false
+        }
+    });
 }
 
 suite('resource-resolver', function () {
@@ -188,10 +192,14 @@ suite('resource-resolver', function () {
                 mainPackageJson: { type: 'module' }
             }
         ]);
-        assert.strictEqual(result.name, 'package-a');
-        assert.strictEqual(result.contents.length, 3);
-        assert.deepStrictEqual(result.roots, {
-            main: { js: createTransferableFile('/src/index.js', 'index.js'), declarationFile: undefined }
+        assert.partialDeepStrictEqual(result, {
+            name: 'package-a',
+            contents: {
+                length: 3
+            },
+            roots: {
+                main: { js: createTransferableFile('/src/index.js', 'index.js'), declarationFile: undefined }
+            }
         });
     });
 
@@ -253,16 +261,20 @@ suite('resource-resolver', function () {
             mainPackageJson: { type: 'module' }
         });
 
-        assert.strictEqual(scan.callCount, 2);
-        assert.deepStrictEqual(scan.secondCall.args, [
-            '/src/index.d.ts',
-            '/src',
-            {
-                includeSourceMapFiles: false,
-                resolveDeclarationFiles: true,
-                mainPackageJson: { type: 'module' }
+        assert.partialDeepStrictEqual(scan, {
+            callCount: 2,
+            secondCall: {
+                args: [
+                    '/src/index.d.ts',
+                    '/src',
+                    {
+                        includeSourceMapFiles: false,
+                        resolveDeclarationFiles: true,
+                        mainPackageJson: { type: 'module' }
+                    }
+                ]
             }
-        ]);
+        });
         assert.deepStrictEqual(
             Array.from(result.externalDependencies.keys()).toSorted(function (left, right) {
                 return left.localeCompare(right);

--- a/source/sbom/sbom-builder.test.ts
+++ b/source/sbom/sbom-builder.test.ts
@@ -23,19 +23,21 @@ suite('sbom-builder', function () {
     test('builds an SBOM with root component metadata and no dependencies when there are none', function () {
         const serialized = buildAndSerialize({});
 
-        assert.strictEqual(serialized.bomFormat, 'CycloneDX');
-        assert.strictEqual(serialized.specVersion, '1.6');
-        assert.deepStrictEqual(serialized.components, []);
-        assert.deepStrictEqual(serialized.metadata, {
-            tools: {
-                components: [ { type: 'application', name: 'packtory', version: '1.2.3' } ]
-            },
-            component: {
-                type: 'library',
-                name: 'my-pkg',
-                version: '1.0.0',
-                'bom-ref': 'pkg:npm/my-pkg@1.0.0',
-                purl: 'pkg:npm/my-pkg@1.0.0'
+        assert.partialDeepStrictEqual(serialized, {
+            bomFormat: 'CycloneDX',
+            specVersion: '1.6',
+            components: [],
+            metadata: {
+                tools: {
+                    components: [ { type: 'application', name: 'packtory', version: '1.2.3' } ]
+                },
+                component: {
+                    type: 'library',
+                    name: 'my-pkg',
+                    version: '1.0.0',
+                    'bom-ref': 'pkg:npm/my-pkg@1.0.0',
+                    purl: 'pkg:npm/my-pkg@1.0.0'
+                }
             }
         });
     });

--- a/source/sbom/sbom-canonicalizer.test.ts
+++ b/source/sbom/sbom-canonicalizer.test.ts
@@ -159,8 +159,10 @@ suite('sbom-canonicalizer', function () {
             if (result === undefined) {
                 assert.fail('Expected canonicalized SBOM file');
             }
-            assert.strictEqual(result.filePath, 'sbom.cdx.json');
-            assert.strictEqual(result.isExecutable, true);
+            assert.partialDeepStrictEqual(result, {
+                filePath: 'sbom.cdx.json',
+                isExecutable: true
+            });
         });
 
         test('canonicalizes SBOM entries under the npm tarball package prefix', function () {
@@ -177,8 +179,10 @@ suite('sbom-canonicalizer', function () {
             if (result === undefined || previousResult === undefined) {
                 assert.fail('Expected canonicalized SBOM files');
             }
-            assert.strictEqual(result.filePath, 'package/sbom.cdx.json');
-            assert.strictEqual(result.content, previousResult.content);
+            assert.partialDeepStrictEqual(result, {
+                filePath: 'package/sbom.cdx.json',
+                content: previousResult.content
+            });
         });
 
         test('does not modify entries whose path is not sbom.cdx.json', function () {

--- a/source/sbom/sbom-file.test.ts
+++ b/source/sbom/sbom-file.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { assertDefined } from '../test-libraries/deep-subset-assertion.ts';
 import type { PublishSettings } from '../config/publish-settings.ts';
 import type { SbomPackage } from '../published-package/published-package.ts';
 import { createSbomFileBuilder, type SbomFileBuilder } from './sbom-file.ts';
@@ -80,7 +81,7 @@ suite('sbom-file', function () {
                 defaultPublishSettings
             );
 
-            assert.notStrictEqual(result, undefined);
+            assertDefined(result);
         });
 
         test('generate() does not invoke the toolVersion provider when SBOM is disabled', async function () {

--- a/source/sbom/sbom-file.test.ts
+++ b/source/sbom/sbom-file.test.ts
@@ -215,7 +215,13 @@ suite('sbom-file', function () {
         const bom = serialize.firstCall.args[0] as {
             readonly metadata: { readonly component: { readonly name: string; readonly version: string; }; };
         };
-        assert.strictEqual(bom.metadata.component.name, 'my-pkg');
-        assert.strictEqual(bom.metadata.component.version, '4.5.6');
+        assert.partialDeepStrictEqual(bom, {
+            metadata: {
+                component: {
+                    name: 'my-pkg',
+                    version: '4.5.6'
+                }
+            }
+        });
     });
 });

--- a/source/sbom/sbom-serializer.test.ts
+++ b/source/sbom/sbom-serializer.test.ts
@@ -15,8 +15,10 @@ suite('sbom-serializer', function () {
 
         const result = JSON.parse(serializer.serialize(bom)) as Record<string, unknown>;
 
-        assert.strictEqual(result.specVersion, '1.6');
-        assert.strictEqual(result.bomFormat, 'CycloneDX');
+        assert.partialDeepStrictEqual(result, {
+            specVersion: '1.6',
+            bomFormat: 'CycloneDX'
+        });
     });
 
     test('serialize() yields byte-identical output for the same inputs', function () {

--- a/source/sbom/tool-version.test.ts
+++ b/source/sbom/tool-version.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { createPacktoryToolVersionResolver } from './tool-version.ts';
 
 const unresolvableExpectedMessage =
@@ -147,7 +148,7 @@ suite('tool-version', function () {
                 assert.strictEqual(error, expectedError);
             }
 
-            assert.partialDeepStrictEqual(importPackageJson, {
+            assertDeepSubset(importPackageJson, {
                 callCount: 1,
                 firstCall: {
                     args: [ '@packtory/cli/package.json' ]
@@ -169,7 +170,7 @@ suite('tool-version', function () {
                 assert.strictEqual(error, 'boom');
             }
 
-            assert.partialDeepStrictEqual(importPackageJson, {
+            assertDeepSubset(importPackageJson, {
                 callCount: 1,
                 firstCall: {
                     args: [ '@packtory/cli/package.json' ]
@@ -191,7 +192,7 @@ suite('tool-version', function () {
                 assert.strictEqual(error, null);
             }
 
-            assert.partialDeepStrictEqual(importPackageJson, {
+            assertDeepSubset(importPackageJson, {
                 callCount: 1,
                 firstCall: {
                     args: [ '@packtory/cli/package.json' ]

--- a/source/sbom/tool-version.test.ts
+++ b/source/sbom/tool-version.test.ts
@@ -147,8 +147,12 @@ suite('tool-version', function () {
                 assert.strictEqual(error, expectedError);
             }
 
-            assert.strictEqual(importPackageJson.callCount, 1);
-            assert.deepStrictEqual(importPackageJson.firstCall.args, [ '@packtory/cli/package.json' ]);
+            assert.partialDeepStrictEqual(importPackageJson, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '@packtory/cli/package.json' ]
+                }
+            });
         });
 
         test('rethrows non-object import failures instead of treating them as resolution errors', async function () {
@@ -165,8 +169,12 @@ suite('tool-version', function () {
                 assert.strictEqual(error, 'boom');
             }
 
-            assert.strictEqual(importPackageJson.callCount, 1);
-            assert.deepStrictEqual(importPackageJson.firstCall.args, [ '@packtory/cli/package.json' ]);
+            assert.partialDeepStrictEqual(importPackageJson, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '@packtory/cli/package.json' ]
+                }
+            });
         });
 
         test('rethrows null import failures instead of treating them as resolution errors', async function () {
@@ -183,8 +191,12 @@ suite('tool-version', function () {
                 assert.strictEqual(error, null);
             }
 
-            assert.strictEqual(importPackageJson.callCount, 1);
-            assert.deepStrictEqual(importPackageJson.firstCall.args, [ '@packtory/cli/package.json' ]);
+            assert.partialDeepStrictEqual(importPackageJson, {
+                callCount: 1,
+                firstCall: {
+                    args: [ '@packtory/cli/package.json' ]
+                }
+            });
         });
 
         test('throws when the imported package.json has an unexpected package name', async function () {

--- a/source/test-libraries/deep-subset-assertion.ts
+++ b/source/test-libraries/deep-subset-assertion.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert';
+
+function isRecordSubset(expected: unknown): expected is Record<string, unknown> {
+    return Object.prototype.toString.call(expected) === '[object Object]';
+}
+
+function subsetProjection(actual: unknown, expected: unknown): unknown {
+    if (Array.isArray(expected)) {
+        if (!Array.isArray(actual)) {
+            return actual;
+        }
+        return expected.map(function (expectedItem, index) {
+            return subsetProjection(actual[index], expectedItem);
+        });
+    }
+
+    if (isRecordSubset(expected)) {
+        if (actual === null || actual === undefined) {
+            return actual;
+        }
+        return Object.fromEntries(
+            Object.entries(expected).map(function ([ key, expectedValue ]) {
+                return [ key, subsetProjection((actual as Record<string, unknown>)[key], expectedValue) ];
+            })
+        );
+    }
+
+    return actual;
+}
+
+export function assertDeepSubset(actual: unknown, expected: unknown): void {
+    assert.deepStrictEqual(subsetProjection(actual, expected), expected);
+}
+
+export function assertDefined<T>(value: T | undefined, message = 'expected value to be defined'): asserts value is T {
+    if (value === undefined) {
+        assert.fail(message);
+    }
+}

--- a/source/test-libraries/eliminator-test-support.ts
+++ b/source/test-libraries/eliminator-test-support.ts
@@ -41,7 +41,7 @@ export function bundleForCodeFile(spec: CodeFileSpec): LinkedBundle {
 }
 
 export function collectTargetPaths(analyzed: AnalyzedBundle | undefined): readonly string[] {
-    assert.ok(analyzed !== undefined);
+    assert.notStrictEqual(analyzed, undefined);
     return analyzed.contents.map(function (resource) {
         return resource.fileDescription.targetFilePath;
     });

--- a/source/test-libraries/eliminator-test-support.ts
+++ b/source/test-libraries/eliminator-test-support.ts
@@ -1,6 +1,6 @@
-import assert from 'node:assert';
 import type { LinkedBundle, LinkedBundleResource } from '../linker/linked-bundle.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import { assertDefined } from './deep-subset-assertion.ts';
 import { bundleResource, linkedBundle } from './bundle-fixtures.ts';
 
 export function inputs(
@@ -41,7 +41,7 @@ export function bundleForCodeFile(spec: CodeFileSpec): LinkedBundle {
 }
 
 export function collectTargetPaths(analyzed: AnalyzedBundle | undefined): readonly string[] {
-    assert.notStrictEqual(analyzed, undefined);
+    assertDefined(analyzed);
     return analyzed.contents.map(function (resource) {
         return resource.fileDescription.targetFilePath;
     });

--- a/source/test-libraries/release-handler-test-support.ts
+++ b/source/test-libraries/release-handler-test-support.ts
@@ -454,10 +454,12 @@ export async function assertCurrentHeadRetryTag(flags: Partial<ReleaseFlags>): P
         planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
     });
 
+    assert.partialDeepStrictEqual(deps, {
+        log: { lastCall: { args: [ 'Release completed.' ] } },
+        releaseSteps: [ 'plan', 'clean', 'head', 'tag:pkg-a@1.0.1' ]
+    });
     assert.strictEqual(code, 0);
     assert.strictEqual(buildAndPublishAll.callCount, 0);
-    assert.deepStrictEqual(deps.log.lastCall.args, [ 'Release completed.' ]);
-    assert.deepStrictEqual(deps.releaseSteps, [ 'plan', 'clean', 'head', 'tag:pkg-a@1.0.1' ]);
 }
 
 export { githubReleaseFlags, unattributedPackageChangelogMessage, validConfig };

--- a/source/test-libraries/release-handler-test-support.ts
+++ b/source/test-libraries/release-handler-test-support.ts
@@ -13,6 +13,7 @@ import type {
 import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage } from '../packtory/packtory.ts';
 import type { ConfigLoader } from '../command-line-interface/config-loader.ts';
 import { runReleaseHandler, type ReleaseHandlerDeps } from '../command-line-interface/runner/release-handler.ts';
+import { assertDeepSubset } from './deep-subset-assertion.ts';
 import { createFakeFileManager, type FakeFileManager } from './fake-file-manager.ts';
 
 export type ReleaseFlags = ReleaseHandlerDeps['flags'];
@@ -454,7 +455,7 @@ export async function assertCurrentHeadRetryTag(flags: Partial<ReleaseFlags>): P
         planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
     });
 
-    assert.partialDeepStrictEqual(deps, {
+    assertDeepSubset(deps, {
         log: { lastCall: { args: [ 'Release completed.' ] } },
         releaseSteps: [ 'plan', 'clean', 'head', 'tag:pkg-a@1.0.1' ]
     });

--- a/source/test-libraries/release-pull-request-handler-test-support.ts
+++ b/source/test-libraries/release-pull-request-handler-test-support.ts
@@ -4,6 +4,7 @@ import { Result } from 'true-myth';
 import type { Packtory, ReleasePlanPackage } from '../packtory/packtory.ts';
 import type { ReleasePullRequestHandlerDependencies } from '../command-line-interface/runner/release-pull-request-handler.ts';
 import type { ReleasePullRequestGitHubClient } from '../command-line-interface/runner/release-pr-github-client.ts';
+import { assertDeepSubset } from './deep-subset-assertion.ts';
 import { createBuildReportFixture } from './preview-fixtures.ts';
 import { createFakeFileManager } from './fake-file-manager.ts';
 import {
@@ -262,7 +263,7 @@ type ReleasePullRequestUpdateAssertion = {
 };
 
 export function assertReleasePullRequestWasUpdated(input: ReleasePullRequestUpdateAssertion): void {
-    assert.partialDeepStrictEqual(input, {
+    assertDeepSubset(input, {
         commit: { callCount: 1 },
         readChangedFiles: { firstCall: { args: [ 'main-head', 'release-head' ] } }
     });
@@ -277,7 +278,7 @@ export function assertReleasePullRequestWasUpdated(input: ReleasePullRequestUpda
         expectedHeadOid: 'main-head',
         message: 'Release packages'
     });
-    assert.partialDeepStrictEqual(input, {
+    assertDeepSubset(input, {
         pushHeadToBranch: { callCount: 0 },
         pushFollowTags: { callCount: 0 }
     });

--- a/source/test-libraries/release-pull-request-handler-test-support.ts
+++ b/source/test-libraries/release-pull-request-handler-test-support.ts
@@ -262,8 +262,10 @@ type ReleasePullRequestUpdateAssertion = {
 };
 
 export function assertReleasePullRequestWasUpdated(input: ReleasePullRequestUpdateAssertion): void {
-    assert.strictEqual(input.commit.callCount, 1);
-    assert.deepStrictEqual(input.readChangedFiles.firstCall.args, [ 'main-head', 'release-head' ]);
+    assert.partialDeepStrictEqual(input, {
+        commit: { callCount: 1 },
+        readChangedFiles: { firstCall: { args: [ 'main-head', 'release-head' ] } }
+    });
     assert.deepStrictEqual(input.createCommitOnBranch.firstCall.args[0], {
         additions: [
             {
@@ -275,8 +277,10 @@ export function assertReleasePullRequestWasUpdated(input: ReleasePullRequestUpda
         expectedHeadOid: 'main-head',
         message: 'Release packages'
     });
-    assert.strictEqual(input.pushHeadToBranch.callCount, 0);
-    assert.strictEqual(input.pushFollowTags.callCount, 0);
+    assert.partialDeepStrictEqual(input, {
+        pushHeadToBranch: { callCount: 0 },
+        pushFollowTags: { callCount: 0 }
+    });
     assert.deepStrictEqual(input.createOrUpdateReleasePullRequest.firstCall.args[0], {
         baseBranch: 'main',
         body: 'Updates changelogs for the next release.',

--- a/source/test-libraries/transform-test-support.ts
+++ b/source/test-libraries/transform-test-support.ts
@@ -9,14 +9,14 @@ export function withSource(content: string): SourceFile {
 
 export function firstStatement(sourceFile: SourceFile): Statement {
     const [ statement ] = sourceFile.getStatements();
-    assert.ok(statement !== undefined);
+    assert.notStrictEqual(statement, undefined);
     return statement;
 }
 
 export function firstVariableDeclaration(sourceFile: SourceFile): VariableDeclaration {
     const [ variableStatement ] = sourceFile.getVariableStatements();
-    assert.ok(variableStatement !== undefined);
+    assert.notStrictEqual(variableStatement, undefined);
     const [ declaration ] = variableStatement.getDeclarations();
-    assert.ok(declaration !== undefined);
+    assert.notStrictEqual(declaration, undefined);
     return declaration;
 }

--- a/source/test-libraries/transform-test-support.ts
+++ b/source/test-libraries/transform-test-support.ts
@@ -1,5 +1,5 @@
-import assert from 'node:assert';
 import type { SourceFile, Statement, VariableDeclaration } from 'ts-morph';
+import { assertDefined } from './deep-subset-assertion.ts';
 import { createProject } from './typescript-project.ts';
 
 export function withSource(content: string): SourceFile {
@@ -9,14 +9,14 @@ export function withSource(content: string): SourceFile {
 
 export function firstStatement(sourceFile: SourceFile): Statement {
     const [ statement ] = sourceFile.getStatements();
-    assert.notStrictEqual(statement, undefined);
+    assertDefined(statement);
     return statement;
 }
 
 export function firstVariableDeclaration(sourceFile: SourceFile): VariableDeclaration {
     const [ variableStatement ] = sourceFile.getVariableStatements();
-    assert.notStrictEqual(variableStatement, undefined);
+    assertDefined(variableStatement);
     const [ declaration ] = variableStatement.getDeclarations();
-    assert.notStrictEqual(declaration, undefined);
+    assertDefined(declaration);
     return declaration;
 }

--- a/source/vendor-materializer/vendor-entry.test.ts
+++ b/source/vendor-materializer/vendor-entry.test.ts
@@ -20,23 +20,24 @@ suite('vendor-entry', function () {
     });
 
     test('accepts a vendored source path that resolves to the package root itself', async function () {
-        await assert.doesNotReject(
-            async function () {
-                await validateVendorEntrySource(
-                    {
-                        async getRealPath() {
-                            return '/src';
-                        }
-                    },
-                    {
-                        sourceAbsolutePath: '/src',
-                        sourcePackageRootPath: '/src',
-                        targetRelativePath: 'node_modules/pkg',
-                        isExecutable: true
-                    }
-                );
+        let requestedPath = '';
+
+        await validateVendorEntrySource(
+            {
+                async getRealPath(path) {
+                    requestedPath = path;
+                    return '/src';
+                }
+            },
+            {
+                sourceAbsolutePath: '/src',
+                sourcePackageRootPath: '/src',
+                targetRelativePath: 'node_modules/pkg',
+                isExecutable: true
             }
         );
+
+        assert.strictEqual(requestedPath, '/src');
     });
 
     test('rejects a vendored source path that resolves outside the package root', async function () {

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -30,15 +30,17 @@ function registerMaterializationTests(): void {
             { initialDependencyNames: [ 'broken' ], projectFolder: '/repo' }
         );
 
-        assert.deepStrictEqual(result.packageNames, [ 'broken' ]);
-        assert.deepStrictEqual(result.entries, [
-            {
-                sourceAbsolutePath: '/repo/node_modules/broken/index.js',
-                sourcePackageRootPath: '/repo/node_modules/broken',
-                targetRelativePath: 'node_modules/broken/index.js',
-                isExecutable: false
-            }
-        ]);
+        assert.partialDeepStrictEqual(result, {
+            packageNames: [ 'broken' ],
+            entries: [
+                {
+                    sourceAbsolutePath: '/repo/node_modules/broken/index.js',
+                    sourcePackageRootPath: '/repo/node_modules/broken',
+                    targetRelativePath: 'node_modules/broken/index.js',
+                    isExecutable: false
+                }
+            ]
+        });
         assert.deepStrictEqual(Array.from(result.peerRequirements), [ [ 'broken', [] ] ]);
     });
 
@@ -53,8 +55,10 @@ function registerMaterializationTests(): void {
             })
         );
 
-        assert.deepStrictEqual(result.entries, []);
-        assert.deepStrictEqual(result.packageNames, []);
+        assert.partialDeepStrictEqual(result, {
+            entries: [],
+            packageNames: []
+        });
     });
 
     test('collects files for a single dependency by probing the start folder first and reads its package.json by exact name', async function () {
@@ -80,21 +84,23 @@ function registerMaterializationTests(): void {
             })
         );
 
-        assert.deepStrictEqual(result.packageNames, [ 'leaf' ]);
-        assert.deepStrictEqual(result.entries, [
-            {
-                sourceAbsolutePath: '/repo/node_modules/leaf/index.js',
-                sourcePackageRootPath: '/repo/node_modules/leaf',
-                targetRelativePath: 'node_modules/leaf/index.js',
-                isExecutable: false
-            },
-            {
-                sourceAbsolutePath: '/repo/node_modules/leaf/package.json',
-                sourcePackageRootPath: '/repo/node_modules/leaf',
-                targetRelativePath: 'node_modules/leaf/package.json',
-                isExecutable: false
-            }
-        ]);
+        assert.partialDeepStrictEqual(result, {
+            packageNames: [ 'leaf' ],
+            entries: [
+                {
+                    sourceAbsolutePath: '/repo/node_modules/leaf/index.js',
+                    sourcePackageRootPath: '/repo/node_modules/leaf',
+                    targetRelativePath: 'node_modules/leaf/index.js',
+                    isExecutable: false
+                },
+                {
+                    sourceAbsolutePath: '/repo/node_modules/leaf/package.json',
+                    sourcePackageRootPath: '/repo/node_modules/leaf',
+                    targetRelativePath: 'node_modules/leaf/package.json',
+                    isExecutable: false
+                }
+            ]
+        });
         assert.deepStrictEqual(fileManager.getCheckReadabilityCall(0), {
             fileOrFolderPath: '/repo/node_modules/leaf'
         });
@@ -292,8 +298,10 @@ function registerMaterializationTests(): void {
             })
         );
 
-        assert.deepStrictEqual(result.entries, []);
-        assert.deepStrictEqual(result.packageNames, []);
+        assert.partialDeepStrictEqual(result, {
+            entries: [],
+            packageNames: []
+        });
         assert.deepStrictEqual(fileManager.getAllCheckReadabilityCalls(), [
             { fileOrFolderPath: '/some/deep/folder/node_modules/missing' },
             { fileOrFolderPath: '/some/deep/node_modules/missing' },

--- a/source/version-manager/manager.test.ts
+++ b/source/version-manager/manager.test.ts
@@ -47,43 +47,45 @@ suite('manager', function () {
             allowMutableSpecifiers: []
         });
 
-        assert.deepStrictEqual(result.packageJson, {
-            name: 'package-a',
-            version: '1.2.3',
-            exports: {
-                '.': {
-                    import: './index.js',
-                    types: './index.d.ts'
-                }
+        assert.partialDeepStrictEqual(result, {
+            packageJson: {
+                name: 'package-a',
+                version: '1.2.3',
+                exports: {
+                    '.': {
+                        import: './index.js',
+                        types: './index.d.ts'
+                    }
+                },
+                type: 'module',
+                dependencies: { 'bundle-dependency': '4.5.6', 'left-pad': '^1.0.0' },
+                publishConfig: { access: 'public' }
             },
-            type: 'module',
-            dependencies: { 'bundle-dependency': '4.5.6', 'left-pad': '^1.0.0' },
-            publishConfig: { access: 'public' }
-        });
-        assert.deepStrictEqual(result.manifestFile, {
-            filePath: 'package.json',
-            isExecutable: false,
-            content: [
-                '{',
-                '    "dependencies": {',
-                '        "bundle-dependency": "4.5.6",',
-                '        "left-pad": "^1.0.0"',
-                '    },',
-                '    "exports": {',
-                '        ".": {',
-                '            "import": "./index.js",',
-                '            "types": "./index.d.ts"',
-                '        }',
-                '    },',
-                '    "name": "package-a",',
-                '    "publishConfig": {',
-                '        "access": "public"',
-                '    },',
-                '    "type": "module",',
-                '    "version": "1.2.3"',
-                '}'
-            ]
-                .join('\n')
+            manifestFile: {
+                filePath: 'package.json',
+                isExecutable: false,
+                content: [
+                    '{',
+                    '    "dependencies": {',
+                    '        "bundle-dependency": "4.5.6",',
+                    '        "left-pad": "^1.0.0"',
+                    '    },',
+                    '    "exports": {',
+                    '        ".": {',
+                    '            "import": "./index.js",',
+                    '            "types": "./index.d.ts"',
+                    '        }',
+                    '    },',
+                    '    "name": "package-a",',
+                    '    "publishConfig": {',
+                    '        "access": "public"',
+                    '    },',
+                    '    "type": "module",',
+                    '    "version": "1.2.3"',
+                    '}'
+                ]
+                    .join('\n')
+            }
         });
     });
 
@@ -106,43 +108,45 @@ suite('manager', function () {
             })
         );
 
-        assert.strictEqual(result.version, '1.2.4');
-        assert.deepStrictEqual(result.packageJson, {
-            name: 'package-a',
+        assert.partialDeepStrictEqual(result, {
             version: '1.2.4',
-            exports: {
-                '.': {
-                    import: './index.js',
-                    types: './index.d.ts'
-                }
+            packageJson: {
+                name: 'package-a',
+                version: '1.2.4',
+                exports: {
+                    '.': {
+                        import: './index.js',
+                        types: './index.d.ts'
+                    }
+                },
+                type: 'module',
+                dependencies: { dep: '^1.0.0' },
+                peerDependencies: { react: '^19.0.0' }
             },
-            type: 'module',
-            dependencies: { dep: '^1.0.0' },
-            peerDependencies: { react: '^19.0.0' }
-        });
-        assert.deepStrictEqual(result.manifestFile, {
-            filePath: 'package.json',
-            isExecutable: false,
-            content: [
-                '{',
-                '    "dependencies": {',
-                '        "dep": "^1.0.0"',
-                '    },',
-                '    "exports": {',
-                '        ".": {',
-                '            "import": "./index.js",',
-                '            "types": "./index.d.ts"',
-                '        }',
-                '    },',
-                '    "name": "package-a",',
-                '    "peerDependencies": {',
-                '        "react": "^19.0.0"',
-                '    },',
-                '    "type": "module",',
-                '    "version": "1.2.4"',
-                '}'
-            ]
-                .join('\n')
+            manifestFile: {
+                filePath: 'package.json',
+                isExecutable: false,
+                content: [
+                    '{',
+                    '    "dependencies": {',
+                    '        "dep": "^1.0.0"',
+                    '    },',
+                    '    "exports": {',
+                    '        ".": {',
+                    '            "import": "./index.js",',
+                    '            "types": "./index.d.ts"',
+                    '        }',
+                    '    },',
+                    '    "name": "package-a",',
+                    '    "peerDependencies": {',
+                    '        "react": "^19.0.0"',
+                    '    },',
+                    '    "type": "module",',
+                    '    "version": "1.2.4"',
+                    '}'
+                ]
+                    .join('\n')
+            }
         });
     });
 
@@ -247,10 +251,12 @@ suite('manager', function () {
         callAddVersionWithProvider(broadcaster.provider, { publishConfig: { access: 'public' } });
 
         const fields = expectAssembledFields(received);
-        assert.deepStrictEqual(fields.type, { source: 'mainPackageJson' });
-        assert.deepStrictEqual(fields.publishConfig, { source: 'additionalAttributes' });
-        assert.deepStrictEqual(fields.name, { source: 'derived' });
-        assert.deepStrictEqual(fields.version, { source: 'derived' });
+        assert.partialDeepStrictEqual(fields, {
+            type: { source: 'mainPackageJson' },
+            publishConfig: { source: 'additionalAttributes' },
+            name: { source: 'derived' },
+            version: { source: 'derived' }
+        });
     });
 
     test('addVersion() does NOT emit packageJsonAssembled when no subscriber is registered', function () {

--- a/source/version-manager/manifest/builder.property.ts
+++ b/source/version-manager/manifest/builder.property.ts
@@ -126,10 +126,12 @@ suite('builder', function () {
             fc.property(bundleArbitrary, function (bundle) {
                 const manifest = buildPackageManifest(bundle);
 
-                assert.strictEqual(manifest.name, bundle.name);
-                assert.strictEqual(manifest.version, bundle.version);
-                assert.deepStrictEqual(manifest.exports, bundle.exportsField);
-                assert.strictEqual(manifest.type, bundle.packageType);
+                assert.partialDeepStrictEqual(manifest, {
+                    name: bundle.name,
+                    version: bundle.version,
+                    exports: bundle.exportsField,
+                    type: bundle.packageType
+                });
                 assertManifestDependencyGroup(manifest, 'dependencies', bundle.dependencies);
                 assertManifestDependencyGroup(manifest, 'peerDependencies', bundle.peerDependencies);
             })

--- a/source/version-manager/versioned-bundle.test.ts
+++ b/source/version-manager/versioned-bundle.test.ts
@@ -94,8 +94,10 @@ suite('versioned-bundle', function () {
             })
         );
 
-        assert.deepStrictEqual(result.dependencies, { 'bundle-dependency': '2.0.0' });
-        assert.deepStrictEqual(result.peerDependencies, { 'peer-dependency': '3.0.0' });
+        assert.partialDeepStrictEqual(result, {
+            dependencies: { 'bundle-dependency': '2.0.0' },
+            peerDependencies: { 'peer-dependency': '3.0.0' }
+        });
     });
 
     test('buildVersionedBundle() omits the importsField when no #imports survive', function () {


### PR DESCRIPTION
`Mocha` tests in this repository already use `node:assert`, so this switches ESLint test linting to `@enormora/eslint-config-mocha-node-assert`. Assertions were updated for the additional `node-assert` rules reported by that preset.