### PR TITLE
Fix `release --github-release` notes for finalized retries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,7 @@ npx packtory release --write-changelog --commit --publish --tag --push --github-
 
 `release` writes changelogs, commits them, recomputes the final plan, publishes directly to npm, creates annotated `{packageName}@{version}` tags, pushes with `git push --follow-tags`, and creates GitHub Releases. It requires a clean Git index and worktree before writing. Commit identity and push credentials come from normal Git config and environment, such as `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, and your configured Git credential helper or CI checkout credentials.
 
-If npm publish succeeds but a later tag, push, or GitHub Release step fails, rerun the same `release` command. When npm metadata says the latest package version has `gitHead` equal to the current Git HEAD and Packtory regenerates matching package contents for that version, Packtory treats the publish as complete and finishes any missing git tags, tag pushes, and GitHub Releases without publishing the package again.
+If npm publish succeeds but a later tag, push, or GitHub Release step fails, rerun the same `release` command. When npm metadata says the latest package version has `gitHead` equal to the current Git HEAD and Packtory regenerates matching package contents for that version, Packtory treats the publish as complete and finishes any missing git tags, tag pushes, and GitHub Releases without publishing the package again. GitHub Release creation requires non-empty release notes; retry runs recover them from configured package changelog outputs when the publish is already complete.
 
 For a reviewed release PR flow, use `release-pr`:
 

--- a/source/command-line-interface/runner/github-release-notes.test.ts
+++ b/source/command-line-interface/runner/github-release-notes.test.ts
@@ -1,0 +1,327 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
+import {
+    collectGitHubReleaseNotes,
+    type GitHubReleaseNotesDeps,
+    type ReleaseNotesTarget
+} from './github-release-notes.ts';
+import type { ChangelogConfig } from './changelog-destinations.ts';
+
+const target: ReleaseNotesTarget = {
+    name: '@scope/pkg-a',
+    tagName: '@scope/pkg-a@1.0.1',
+    version: '1.0.1'
+};
+
+const config: ChangelogConfig = {
+    packages: [
+        { name: 'pkg-b', sourcesFolder: 'packages/pkg-b' },
+        { name: '@scope/pkg-a', sourcesFolder: 'packages/pkg-a' }
+    ],
+    changelog: {
+        outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ]
+    }
+};
+
+function changelog(markdownByName: ReadonlyMap<string, string> = new Map()): GeneratedChangelog {
+    return {
+        groupedMarkdown: '',
+        packageNamesWithoutChangelogEntries: [],
+        packageMarkdownByName: markdownByName
+    };
+}
+
+function readFileDeps(contentByPath: ReadonlyMap<string, string>): GitHubReleaseNotesDeps {
+    return {
+        workingDirectory: '/repo',
+        fileManager: {
+            async readFile(filePath: string): Promise<string> {
+                const content = contentByPath.get(filePath);
+                if (content === undefined) {
+                    const error = new Error(`Missing file ${filePath}`);
+                    Object.assign(error, { code: 'ENOENT' });
+                    throw error;
+                }
+                return content;
+            }
+        }
+    };
+}
+
+function markdown(...lines: readonly string[]): string {
+    return lines.join('\n');
+}
+
+function registerGeneratedNotesTests(): void {
+    test('keeps generated release notes without reading changelog files', async function () {
+        let readCount = 0;
+        const result = await collectGitHubReleaseNotes(
+            {
+                workingDirectory: '/repo',
+                fileManager: {
+                    async readFile(): Promise<string> {
+                        readCount += 1;
+                        return 'unused';
+                    }
+                }
+            },
+            config,
+            [ target ],
+            changelog(new Map([ [ target.name, '## @scope/pkg-a 1.0.1\n\n* Fix package' ] ]))
+        );
+
+        assert.strictEqual(result.get(target.name), '## @scope/pkg-a 1.0.1\n\n* Fix package');
+        assert.strictEqual(readCount, 0);
+    });
+
+    test('recovers when generated release notes are whitespace only', async function () {
+        const result = await collectGitHubReleaseNotes(
+            readFileDeps(
+                new Map([
+                    [
+                        '/repo/packages/pkg-a/CHANGELOG.md',
+                        markdown('## @scope/pkg-a 1.0.1 (June 13, 2026)', '', '* Recovered package notes')
+                    ]
+                ])
+            ),
+            config,
+            [ target ],
+            changelog(new Map([ [ target.name, ' '.repeat(3) ] ]))
+        );
+
+        assert.strictEqual(
+            result.get(target.name),
+            markdown('## @scope/pkg-a 1.0.1 (June 13, 2026)', '', '* Recovered package notes')
+        );
+    });
+}
+
+function registerRecoveryTests(): void {
+    test('recovers scoped package release notes from the configured package changelog', async function () {
+        const result = await collectGitHubReleaseNotes(
+            readFileDeps(
+                new Map([
+                    [
+                        '/repo/packages/pkg-a/CHANGELOG.md',
+                        markdown(
+                            '## @scope/pkg-a 1.0.1 (June 13, 2026)',
+                            '',
+                            '* Fix package',
+                            '* Keep multiline notes',
+                            '',
+                            '## @scope/pkg-a 1.0.0 (June 1, 2026)',
+                            '',
+                            '* Previous release'
+                        )
+                    ]
+                ])
+            ),
+            config,
+            [ target ],
+            changelog()
+        );
+
+        assert.strictEqual(
+            result.get(target.name),
+            markdown('## @scope/pkg-a 1.0.1 (June 13, 2026)', '', '* Fix package', '* Keep multiline notes')
+        );
+    });
+
+    test('recovers release notes from a changelog section at end of file', async function () {
+        const result = await collectGitHubReleaseNotes(
+            readFileDeps(
+                new Map([
+                    [
+                        '/repo/packages/pkg-a/CHANGELOG.md',
+                        markdown(
+                            '## @scope/pkg-a 1.0.2 (June 14, 2026)',
+                            '',
+                            '* Newer release',
+                            '',
+                            '## @scope/pkg-a 1.0.1 (June 13, 2026)',
+                            '',
+                            '* Last release'
+                        )
+                    ]
+                ])
+            ),
+            config,
+            [ target ],
+            changelog()
+        );
+
+        assert.strictEqual(
+            result.get(target.name),
+            markdown('## @scope/pkg-a 1.0.1 (June 13, 2026)', '', '* Last release')
+        );
+    });
+
+    test('recovers unscoped release notes from an explicit package changelog path', async function () {
+        const unscopedTarget = { name: 'pkg-a', tagName: 'pkg-a@1.0.1', version: '1.0.1' };
+        const result = await collectGitHubReleaseNotes(
+            readFileDeps(
+                new Map([
+                    [
+                        '/repo/changelogs/pkg-a.md',
+                        markdown(
+                            '## 1.0.1 (June 13, 2026)',
+                            '',
+                            '* Fix package',
+                            '',
+                            '## 1.0.0 (June 1, 2026)',
+                            '',
+                            '* Previous release'
+                        )
+                    ]
+                ])
+            ),
+            {
+                packages: [ { name: 'pkg-a', sourcesFolder: 'packages/pkg-a' } ],
+                changelog: { outputs: [ { kind: 'package-file', paths: { 'pkg-a': 'changelogs/pkg-a.md' } } ] }
+            },
+            [ unscopedTarget ],
+            changelog()
+        );
+
+        assert.strictEqual(result.get('pkg-a'), markdown('## 1.0.1 (June 13, 2026)', '', '* Fix package'));
+    });
+}
+
+function registerFailureTests(): void {
+    test('does not recover notes from another package changelog path', async function () {
+        await assert.rejects(
+            collectGitHubReleaseNotes(
+                readFileDeps(
+                    new Map([
+                        [
+                            '/repo/packages/pkg-b/CHANGELOG.md',
+                            markdown('## @scope/pkg-a 1.0.1 (June 13, 2026)', '', '* Wrong file')
+                        ]
+                    ])
+                ),
+                config,
+                [ target ],
+                changelog()
+            ),
+            /GitHub release notes for "@scope\/pkg-a@1\.0\.1" could not be generated/u
+        );
+    });
+
+    test('rejects when the configured changelog has no matching release section', async function () {
+        await assert.rejects(
+            collectGitHubReleaseNotes(
+                readFileDeps(
+                    new Map([
+                        [
+                            '/repo/packages/pkg-a/CHANGELOG.md',
+                            markdown('## @scope/pkg-a 1.0.2 (June 14, 2026)', '', '* Newer release')
+                        ]
+                    ])
+                ),
+                config,
+                [ target ],
+                changelog()
+            ),
+            /GitHub release notes for "@scope\/pkg-a@1\.0\.1" could not be generated/u
+        );
+    });
+
+    test('rejects when the configured changelog has no release headings', async function () {
+        await assert.rejects(
+            collectGitHubReleaseNotes(
+                readFileDeps(
+                    new Map([
+                        [
+                            '/repo/packages/pkg-a/CHANGELOG.md',
+                            markdown('Changelog', '', '* No release heading')
+                        ]
+                    ])
+                ),
+                config,
+                [ target ],
+                changelog()
+            ),
+            /GitHub release notes for "@scope\/pkg-a@1\.0\.1" could not be generated/u
+        );
+    });
+
+    test('rejects when no package changelog output is configured', async function () {
+        let readCount = 0;
+        await assert.rejects(
+            collectGitHubReleaseNotes(
+                {
+                    workingDirectory: '/repo',
+                    fileManager: {
+                        async readFile(): Promise<string> {
+                            readCount += 1;
+                            throw new Error('unexpected read');
+                        }
+                    }
+                },
+                {
+                    packages: [ { name: '@scope/pkg-a', sourcesFolder: 'packages/pkg-a' } ],
+                    changelog: { outputs: [ { kind: 'repository-file', path: 'CHANGELOG.md' } ] }
+                },
+                [ target ],
+                changelog()
+            ),
+            /GitHub release notes for "@scope\/pkg-a@1\.0\.1" could not be generated/u
+        );
+        assert.strictEqual(readCount, 0);
+    });
+
+    test('rejects missing and whitespace-only release sections', async function () {
+        await assert.rejects(
+            collectGitHubReleaseNotes(
+                readFileDeps(
+                    new Map([
+                        [
+                            '/repo/packages/pkg-a/CHANGELOG.md',
+                            markdown(
+                                '## @scope/pkg-a 1.0.2 (June 14, 2026)',
+                                '',
+                                '* Newer release',
+                                '',
+                                '## @scope/pkg-a 1.0.1 (June 13, 2026)',
+                                ' '.repeat(3),
+                                '## @scope/pkg-a 1.0.0 (June 1, 2026)',
+                                '',
+                                '* Previous release'
+                            )
+                        ]
+                    ])
+                ),
+                config,
+                [ target ],
+                changelog()
+            ),
+            /GitHub release notes for "@scope\/pkg-a@1\.0\.1" could not be generated/u
+        );
+    });
+
+    test('propagates unexpected changelog read failures', async function () {
+        await assert.rejects(
+            collectGitHubReleaseNotes(
+                {
+                    workingDirectory: '/repo',
+                    fileManager: {
+                        async readFile(): Promise<string> {
+                            throw new Error('permission denied');
+                        }
+                    }
+                },
+                config,
+                [ target ],
+                changelog()
+            ),
+            /permission denied/u
+        );
+    });
+}
+
+suite('github-release-notes', function () {
+    registerGeneratedNotesTests();
+    registerRecoveryTests();
+    registerFailureTests();
+});

--- a/source/command-line-interface/runner/github-release-notes.ts
+++ b/source/command-line-interface/runner/github-release-notes.ts
@@ -1,0 +1,116 @@
+import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
+import { collectChangelogOutputFilePaths, type ChangelogConfig } from './changelog-destinations.ts';
+
+type FileReader = {
+    readonly readFile: (filePath: string) => Promise<string>;
+};
+
+export type GitHubReleaseNotesDeps = {
+    readonly fileManager: FileReader;
+    readonly workingDirectory: string;
+};
+
+export type ReleaseNotesTarget = {
+    readonly name: string;
+    readonly tagName: string;
+    readonly version: string;
+};
+
+export function missingGitHubReleaseNotes(target: ReleaseNotesTarget): never {
+    throw new Error(`GitHub release notes for "${target.tagName}" could not be generated`);
+}
+
+function hasReleaseNotes(value: string | undefined): value is string {
+    return value !== undefined && value.trim().length > 0;
+}
+
+function escapeRegExp(value: string): string {
+    return value.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function releaseNotesHeadingPattern(target: ReleaseNotesTarget): RegExp {
+    const packageName = escapeRegExp(target.name);
+    const version = escapeRegExp(target.version);
+    return new RegExp(`^##\\s+(?:${packageName}\\s+)?${version}(?:\\s|\\(|$)`);
+}
+
+function extractReleaseNotes(markdown: string, target: ReleaseNotesTarget): string | undefined {
+    const lines = markdown.split(/\r?\n/u);
+    const headingPattern = releaseNotesHeadingPattern(target);
+    const start = lines.findIndex(function (line) {
+        return headingPattern.test(line);
+    });
+    if (start === -1) {
+        return undefined;
+    }
+    const next = lines.findIndex(function (line, index) {
+        return index > start && line.startsWith('## ');
+    });
+    const end = next === -1 ? lines.length : next;
+    const releaseNotes = lines.slice(start, end).join('\n').trim();
+    const hasBody = lines.slice(start + 1, end).some(function (line) {
+        return line.trim().length > 0;
+    });
+    return hasBody ? releaseNotes : undefined;
+}
+
+function isMissingFileError(error: unknown): boolean {
+    return Reflect.get(new Object(error), 'code') === 'ENOENT';
+}
+
+function packageChangelogPathFor(
+    deps: Pick<GitHubReleaseNotesDeps, 'workingDirectory'>,
+    config: ChangelogConfig,
+    packageName: string
+): string | undefined {
+    const outputPath = collectChangelogOutputFilePaths(deps, config).find(function (entry) {
+        return entry.packageName === packageName;
+    });
+    return outputPath?.filePath;
+}
+
+async function readConfiguredReleaseNotes(
+    deps: GitHubReleaseNotesDeps,
+    config: ChangelogConfig,
+    target: ReleaseNotesTarget
+): Promise<string | undefined> {
+    const changelogPath = packageChangelogPathFor(deps, config, target.name);
+    if (changelogPath === undefined) {
+        return undefined;
+    }
+    try {
+        return extractReleaseNotes(await deps.fileManager.readFile(changelogPath), target);
+    } catch (error: unknown) {
+        if (isMissingFileError(error)) {
+            return undefined;
+        }
+        throw error;
+    }
+}
+
+async function recoverMissingReleaseNotes(
+    deps: GitHubReleaseNotesDeps,
+    config: ChangelogConfig,
+    target: ReleaseNotesTarget
+): Promise<string> {
+    const releaseNotes = await readConfiguredReleaseNotes(deps, config, target);
+    if (!hasReleaseNotes(releaseNotes)) {
+        missingGitHubReleaseNotes(target);
+    }
+    return releaseNotes;
+}
+
+export async function collectGitHubReleaseNotes(
+    deps: GitHubReleaseNotesDeps,
+    config: ChangelogConfig,
+    targets: readonly ReleaseNotesTarget[],
+    changelog: GeneratedChangelog
+): Promise<ReadonlyMap<string, string>> {
+    const releaseNotesByPackageName = new Map(changelog.packageMarkdownByName);
+    for (const target of targets) {
+        if (!hasReleaseNotes(releaseNotesByPackageName.get(target.name))) {
+            releaseNotesByPackageName.set(target.name, await recoverMissingReleaseNotes(deps, config, target));
+        }
+    }
+    return releaseNotesByPackageName;
+}

--- a/source/command-line-interface/runner/release-handler-mutation-flow.test.ts
+++ b/source/command-line-interface/runner/release-handler-mutation-flow.test.ts
@@ -10,9 +10,37 @@ import {
     createReleasePlanOutcome,
     createReleasePlanOutcomesForPackage,
     createReleaseStepRecorder,
-    githubReleaseFlags
+    githubReleaseFlags,
+    validConfig
 } from '../../test-libraries/release-handler-test-support.ts';
+import { createFakeFileManager, type FakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import { runReleaseHandler } from './release-handler.ts';
+
+const currentHeadRetryChangelog = [
+    '## 1.0.1 (June 13, 2026)',
+    '',
+    '### Bug Fixes',
+    '',
+    '* Fix package (#1)',
+    '',
+    '## 1.0.0 (June 1, 2026)',
+    '',
+    '* Previous release'
+]
+    .join('\n');
+
+function packageChangelogConfig(): unknown {
+    return {
+        ...validConfig,
+        changelog: { outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ] }
+    };
+}
+
+function packageChangelogFileManager(): FakeFileManager {
+    return createFakeFileManager({
+        simulatedReadFileResponses: [ { value: currentHeadRetryChangelog } ]
+    });
+}
 
 suite('release-handler mutation flow', function () {
     test('writes changelog, commits, replans, publishes, tags, pushes, and creates GitHub releases in order', async function () {
@@ -64,6 +92,8 @@ suite('release-handler mutation flow', function () {
         const buildAndPublishAll = fake();
         const deps = createReleaseHandlerDeps({
             buildAndPublishAll,
+            config: packageChangelogConfig(),
+            fileManager: packageChangelogFileManager(),
             flags: { publish: true, tag: true, push: true, githubRelease: true, noDryRun: true },
             planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
         });
@@ -81,15 +111,18 @@ suite('release-handler mutation flow', function () {
         ]);
     });
 
-    test('creates GitHub releases with empty notes for current-head retry packages', async function () {
+    test('recovers GitHub release notes from package changelogs for current-head retry packages', async function () {
         const createReleaseIfMissing = fake.resolves('created');
         const createGitHubReleaseClient = fake(function () {
             return { createReleaseIfMissing };
         });
+        const fileManager = packageChangelogFileManager();
 
         const code = await runReleaseHandler(
             createReleaseHandlerDeps({
+                config: packageChangelogConfig(),
                 createGitHubReleaseClient,
+                fileManager,
                 flags: githubReleaseFlags,
                 planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
             })
@@ -100,7 +133,40 @@ suite('release-handler mutation flow', function () {
             { owner: 'enormora', repo: 'packtory', token: 'gh-token' }
         ]);
         assert.deepStrictEqual(createReleaseIfMissing.firstCall.args, [
-            { tagName: 'pkg-a@1.0.1', name: 'pkg-a@1.0.1', body: '' }
+            {
+                tagName: 'pkg-a@1.0.1',
+                name: 'pkg-a@1.0.1',
+                body: [
+                    '## 1.0.1 (June 13, 2026)',
+                    '',
+                    '### Bug Fixes',
+                    '',
+                    '* Fix package (#1)'
+                ]
+                    .join('\n')
+            }
+        ]);
+        assert.deepStrictEqual(fileManager.getAllReadFileCalls(), [ { filePath: '/repo/src/pkg-a/CHANGELOG.md' } ]);
+    });
+
+    test('fails GitHub release creation when release notes cannot be generated', async function () {
+        const createReleaseIfMissing = fake.resolves('created');
+        const createGitHubReleaseClient = fake(function () {
+            return { createReleaseIfMissing };
+        });
+
+        const deps = createReleaseHandlerDeps({
+            createGitHubReleaseClient,
+            flags: githubReleaseFlags,
+            planOutcomes: createReleasePlanOutcomesForPackage(createCurrentHeadRetryPackage())
+        });
+
+        const code = await runReleaseHandler(deps);
+
+        assert.strictEqual(code, 1);
+        assert.strictEqual(createReleaseIfMissing.callCount, 0);
+        assert.deepStrictEqual(deps.log.firstCall.args, [
+            'GitHub release notes for "pkg-a@1.0.1" could not be generated'
         ]);
     });
 
@@ -111,7 +177,9 @@ suite('release-handler mutation flow', function () {
 
         const code = await runReleaseHandler(
             createReleaseHandlerDeps({
+                config: packageChangelogConfig(),
                 createGitHubReleaseClient,
+                fileManager: packageChangelogFileManager(),
                 readEnvironmentVariable(name) {
                     return name === 'GITHUB_TOKEN' ? 'github-token' : undefined;
                 },

--- a/source/command-line-interface/runner/release-handler.ts
+++ b/source/command-line-interface/runner/release-handler.ts
@@ -9,6 +9,7 @@ import {
 } from './changelog-destinations.ts';
 import { printPublishFailure } from './failure-printing.ts';
 import type { GitHubReleaseClient } from './github-release-client.ts';
+import { collectGitHubReleaseNotes, missingGitHubReleaseNotes } from './github-release-notes.ts';
 import { formatGitHubRepositoryName, parseGitHubRepositoryParts } from './github-repository.ts';
 import type { ReleaseGitClient } from './release-git-client.ts';
 import { printReleasePlanFailure } from './release-plan-result-printing.ts';
@@ -297,6 +298,7 @@ async function ensureTags(deps: ReleaseHandlerDeps, targets: readonly ReleaseTar
 
 async function createGitHubReleases(
     deps: ReleaseHandlerDeps,
+    config: ValidChangelogConfig,
     targets: readonly ReleaseTarget[],
     changelog: GeneratedChangelog
 ): Promise<void> {
@@ -306,11 +308,12 @@ async function createGitHubReleases(
     }
     const repository = parseGitHubRepositoryParts(await deps.readPackageInfo());
     const client = deps.createGitHubReleaseClient({ ...repository, token });
+    const releaseNotesByPackageName = await collectGitHubReleaseNotes(deps, config, targets, changelog);
     for (const target of targets) {
         await client.createReleaseIfMissing({
             tagName: target.tagName,
             name: target.tagName,
-            body: changelog.packageMarkdownByName.get(target.name) ?? ''
+            body: releaseNotesByPackageName.get(target.name) ?? missingGitHubReleaseNotes(target)
         });
     }
 }
@@ -443,7 +446,7 @@ async function finishReleaseActions(
         await deps.gitClient.pushFollowTags();
     }
     if (state.githubRelease) {
-        await createGitHubReleases(deps, releaseTargets, state.changelog.changelog);
+        await createGitHubReleases(deps, state.changelog.config, releaseTargets, state.changelog.changelog);
     }
 }
 

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -97,6 +97,7 @@ packtory <command> [options]
 - The write order is changelog files, commit, final release-plan recomputation, direct npm publish, annotated tags, `git push --follow-tags`, then GitHub Releases.
 - Existing package tags at the current head are accepted. Existing tags at another head fail.
 - Existing GitHub Releases for verified package tags are accepted and their notes are not rewritten.
+- GitHub Release creation requires non-empty release notes. Retry runs recover notes from configured package changelog outputs when npm already has the package version for the current Git head.
 - Packtory uses inherited Git configuration, environment, and credentials. In CI, configure commit identity with standard variables such as `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and `GIT_COMMITTER_EMAIL`, and configure push credentials outside Packtory.
 - GitHub Release creation reads `GH_TOKEN` first, then `GITHUB_TOKEN`.
 

--- a/source/test-libraries/release-handler-test-support.ts
+++ b/source/test-libraries/release-handler-test-support.ts
@@ -223,6 +223,7 @@ export type Scenario = {
     readonly configLoader?: ConfigLoader;
     readonly createGitHubReleaseClient?: SinonSpy;
     readonly engine?: PrLogEngine;
+    readonly fileManager?: FakeFileManager;
     readonly flags?: Partial<ReleaseFlags>;
     readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
     readonly readPackageInfo?: () => Promise<Readonly<Record<string, unknown>>>;
@@ -362,7 +363,7 @@ export function createReleaseHandlerDeps(scenario: Scenario = {}): ReleaseHandle
         currentDate() {
             return new Date('2026-06-13T00:00:00.000Z');
         },
-        fileManager: createFakeFileManager(),
+        fileManager: scenario.fileManager ?? createFakeFileManager(),
         flags: { ...defaultFlags, ...scenario.flags },
         gitClient: createReleaseGitClient(recordReleaseStep),
         log: fake(),


### PR DESCRIPTION
Recover GitHub Release notes for retry runs that finalize packages already published at the current `gitHead`. When generated changelog output no longer includes a current-head package, Packtory reads the configured package changelog entry and fails instead of creating an empty release body.