### PR TITLE
Expose `changelog.prLog` config for `@pr-log/core`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@octokit/core": "7.0.6",
                 "@octokit/plugin-paginate-rest": "14.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-                "@pr-log/core": "0.0.2",
+                "@pr-log/core": "0.0.3",
                 "@schema-hub/zod-error-formatter": "0.0.12",
                 "@ts-morph/common": "0.29.0",
                 "@types/common-tags": "1.8.4",
@@ -3834,6 +3834,38 @@
                 "node": "^24 || ^26"
             }
         },
+        "node_modules/@packtory/cli/node_modules/@pr-log/core": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.2.tgz",
+            "integrity": "sha512-M+RhqKvyH1wwO8+dch3Pk6hK5Z1F8bAxmxD/1qoWp9+OX1PhUFvDsZTpQYQ04ygvDGK7bAho7MpKscd50LnIXA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@sindresorhus/is": "8.1.0",
+                "common-tags": "1.8.2",
+                "date-fns": "4.4.0",
+                "execa": "9.6.1",
+                "semver": "7.8.2",
+                "true-myth": "9.4.0"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
+        "node_modules/@packtory/cli/node_modules/@pr-log/core/node_modules/semver": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@packtory/github-release-gate": {
             "version": "0.0.26",
             "resolved": "https://registry.npmjs.org/@packtory/github-release-gate/-/github-release-gate-0.0.26.tgz",
@@ -3927,9 +3959,9 @@
             }
         },
         "node_modules/@pr-log/core": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.2.tgz",
-            "integrity": "sha512-M+RhqKvyH1wwO8+dch3Pk6hK5Z1F8bAxmxD/1qoWp9+OX1PhUFvDsZTpQYQ04ygvDGK7bAho7MpKscd50LnIXA==",
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-zzMVv+AL5KwuDIpjxyu6jRs9qLLbEcgQYAzg6+o+mQCBuvyzL5J1e8st2xocA87WSD1DeY1lewvXXrorubFyFg==",
             "license": "MIT",
             "dependencies": {
                 "@octokit/rest": "22.0.1",
@@ -3937,23 +3969,11 @@
                 "common-tags": "1.8.2",
                 "date-fns": "4.4.0",
                 "execa": "9.6.1",
-                "semver": "7.8.2",
+                "semver": "7.8.5",
                 "true-myth": "9.4.0"
             },
             "engines": {
                 "node": "^24.0.0 || ^26.0.0"
-            }
-        },
-        "node_modules/@pr-log/core/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@schema-hub/zod-error-formatter": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@octokit/core": "7.0.6",
         "@octokit/plugin-paginate-rest": "14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-        "@pr-log/core": "0.0.2",
+        "@pr-log/core": "0.0.3",
         "@schema-hub/zod-error-formatter": "0.0.12",
         "@ts-morph/common": "0.29.0",
         "@types/common-tags": "1.8.4",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -54,7 +54,7 @@ export async function buildConfig() {
         checks: {
             noDuplicatedFiles: { enabled: true, allowList: [ sharedLicensePath ] },
             requiredFiles: { enabled: true, files: [ 'LICENSE', 'readme.md' ] },
-            maxBundleSize: { enabled: true, bytes: 1_000_000 },
+            maxBundleSize: { enabled: true, bytes: 1_050_000 },
             noUnusedBundleDependencies: { enabled: true },
             noDevDependencyImports: { enabled: true },
             uniqueTargetPaths: { enabled: true },

--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ versioning: {
 }
 ```
 
-This source uses the same pull request attribution files as changelog generation. It inspects merged pull request labels since the package's current version tag, bumps `major` for `breaking`, `minor` for `feature`, and `patch` for other configured changelog labels. If no attributed pull request has a matching label, it returns the current version.
+This source uses the same pull request attribution files as changelog generation. It inspects merged pull request labels since the package's current version tag and applies `changelog.prLog.versionBumps`. If no attributed pull request has a matching label, it returns the current version.
 
 ### Pack (on-disk artifacts)
 
@@ -244,7 +244,13 @@ The configuration for `packtory` is an object with the following properties:
 4. **`changelog`** (Optional, Object):
    - Configures changelog generation and outputs for `packtory changelog` and `packtory release --write-changelog`.
    - If omitted, `packtory changelog` prints grouped Markdown to the pager and writes no files.
-   - `labels` extends or overrides the default pull request label to changelog section mapping.
+   - `prLog` passes changelog behavior into `@pr-log/core`.
+   - `prLog.validLabels` extends or overrides the default pull request label to changelog section mapping.
+   - `prLog.ignoredLabels` skips pull request labels during changelog attribution.
+   - `prLog.versionBumps` configures the `major`, `minor`, and `patch` label groups used by `versioning.source: 'pull-request-labels'`.
+   - `prLog.dateFormat` customizes rendered changelog dates.
+   - `prLog.collapseRules` groups repeated pull request entries with a configured label, regular expression, replacement, and optional capture group names.
+   - `prLog.labelLookupIntervalMilliseconds` and `prLog.maximumRateLimitRetryCount` tune GitHub label lookup timing and retry behavior.
    - `targetScopedLabelPattern` customizes package-specific labels. It must contain `{targetName}` and `{label}`.
    - `packageTagFormat` customizes package tag lookup for changelog base refs. `explicitBaseRef` uses one fixed base ref instead.
    - `outputs` is a non-empty array of:
@@ -252,7 +258,7 @@ The configuration for `packtory` is an object with the following properties:
      - `{ kind: 'package-file', path: 'CHANGELOG.md' }`: writes one package-specific changelog below each changed package's effective `sourcesFolder`.
      - `{ kind: 'package-file', paths: { 'pkg-a': 'packages/pkg-a/CHANGELOG.md' } }`: writes package-specific changelogs to explicit repository-relative paths. Every changed package must have a configured path.
      - `{ kind: 'github-release' }`: prints grouped release-body Markdown to the pager. Remote GitHub release creation is not implemented by `packtory changelog`.
-   - `outputs` can be omitted when only label or base-ref settings are configured.
+   - `outputs` can be omitted when only `prLog` or base-ref settings are configured.
    - Output paths must be safe relative paths. Absolute paths and parent-traversing paths are rejected.
    - Duplicate `github-release` outputs, duplicate repository-file paths, and package-file destinations that resolve to the same file are rejected.
    - Generated changelog files are ignored during pull request source attribution.

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -48,6 +48,21 @@ function createGeneratedChangelog(overrides: GeneratedChangelogOverrides = {}): 
     };
 }
 
+function createPacktoryConfigWithPrLog(prLog: unknown): unknown {
+    return {
+        changelog: { prLog },
+        packages: [
+            {
+                mainPackageJson: { type: 'module' },
+                name: 'pkg-a',
+                publishSettings: { access: 'public' },
+                roots: { main: { js: 'index.js' } },
+                sourcesFolder: 'source'
+            }
+        ]
+    };
+}
+
 async function assertRepositoryReadFailureRethrown(error: Error, messagePattern: RegExp): Promise<void> {
     const fileManager = createFakeFileManager({
         simulatedReadFileResponses: [ { error } ]
@@ -69,12 +84,24 @@ suite('changelog-destinations', function () {
         assert.strictEqual(parseValidConfig({ packages: [] }), undefined);
     });
 
+    test('parseValidConfig returns undefined for non-object pr-log settings', function () {
+        assert.strictEqual(parseValidConfig(createPacktoryConfigWithPrLog(null)), undefined);
+        assert.strictEqual(parseValidConfig(createPacktoryConfigWithPrLog('invalid')), undefined);
+    });
+
+    test('parseValidConfig accepts object pr-log settings', function () {
+        assert.notStrictEqual(
+            parseValidConfig(createPacktoryConfigWithPrLog({ validLabels: { bug: 'Bugs' } })),
+            undefined
+        );
+    });
+
     test('createChangelogGenerationOptions combines defaults with configured settings', function () {
         const options = createChangelogGenerationOptions(
             createChangelogConfig({
                 changelog: {
                     explicitBaseRef: 'main',
-                    labels: { bug: 'Fixed Bugs', operations: 'Operations' },
+                    prLog: { validLabels: { bug: 'Fixed Bugs', operations: 'Operations' } },
                     packageTagFormat: 'pkg/{packageName}/v{version}',
                     targetScopedLabelPattern: 'scope:{targetName}:{label}'
                 }
@@ -86,8 +113,8 @@ suite('changelog-destinations', function () {
             packageTagFormat: 'pkg/{packageName}/v{version}',
             targetScopedLabelPattern: 'scope:{targetName}:{label}'
         });
-        assert.strictEqual(options.validLabels.get('bug'), 'Fixed Bugs');
-        assert.strictEqual(options.validLabels.get('operations'), 'Operations');
+        assert.strictEqual(options.prLogConfig.validLabels.get('bug'), 'Fixed Bugs');
+        assert.strictEqual(options.prLogConfig.validLabels.get('operations'), 'Operations');
     });
 
     suite('collectGeneratedAttributionPaths', function () {
@@ -99,7 +126,7 @@ suite('changelog-destinations', function () {
             assert.deepStrictEqual(
                 collectGeneratedAttributionPaths(
                     deps,
-                    createChangelogConfig({ changelog: { labels: { operations: 'Operations' } } })
+                    createChangelogConfig({ changelog: { prLog: { validLabels: { operations: 'Operations' } } } })
                 ),
                 []
             );
@@ -206,7 +233,7 @@ suite('changelog-destinations', function () {
 
             const writtenPaths = await writeConfiguredChangelogs(
                 { ...deps, fileManager },
-                createChangelogConfig({ changelog: { labels: { operations: 'Operations' } } }),
+                createChangelogConfig({ changelog: { prLog: { validLabels: { operations: 'Operations' } } } }),
                 { updateChangelog: fake.returns('updated') },
                 createGeneratedChangelog()
             );

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -1,27 +1,23 @@
 import path from 'node:path';
-import { defaultValidLabels, type PrLogEngine } from '@pr-log/core';
+import type { PrLogConfig, PrLogEngine } from '@pr-log/core';
+import type { z } from 'zod/mini';
 import { safeParse } from '../../common/schema-validation.ts';
-import type { ChangelogOutput } from '../../config/changelog-settings.ts';
+import type { ChangelogOutput, ChangelogSettings } from '../../config/changelog-settings.ts';
 import { packtoryConfigSchema } from '../../config/packtory-config-schema.ts';
 import type { FileManager } from '../../file-manager/file-manager.ts';
 import * as generatedAttributionPaths from '../../packtory/generated-attribution-paths.ts';
 import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
+import { createPrLogConfig } from './changelog-pr-log-config.ts';
 
 type PackagePathConfig = {
     readonly name: string;
     readonly sourcesFolder?: string | undefined;
 };
 
-type ChangelogSettingsConfig = {
-    readonly explicitBaseRef?: string | undefined;
-    readonly labels?: Readonly<Record<string, string>> | undefined;
-    readonly outputs?: readonly ChangelogOutput[] | undefined;
-    readonly packageTagFormat?: string | undefined;
-    readonly targetScopedLabelPattern?: string | undefined;
-};
+type ParsedPacktoryConfig = Readonly<z.infer<typeof packtoryConfigSchema>>;
 
 export type ChangelogConfig = {
-    readonly changelog?: ChangelogSettingsConfig | undefined;
+    readonly changelog?: ChangelogSettings | undefined;
     readonly commonPackageSettings?: { readonly sourcesFolder?: string | undefined; } | undefined;
     readonly packages: readonly PackagePathConfig[];
 };
@@ -48,21 +44,36 @@ type PackageChangelogOutputWithExplicitPaths = PackageChangelogOutput & {
 export type ChangelogGenerationOptions = {
     readonly explicitBaseRef: string | undefined;
     readonly packageTagFormat: string | undefined;
+    readonly prLogConfig: PrLogConfig;
     readonly targetScopedLabelPattern: string | undefined;
-    readonly validLabels: ReadonlyMap<string, string>;
 };
+
+function isPassThroughObject(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isChangelogSettings(changelog: ParsedPacktoryConfig['changelog']): changelog is ChangelogSettings | undefined {
+    return changelog?.prLog === undefined || isPassThroughObject(changelog.prLog);
+}
 
 export function parseValidConfig(config: unknown): ChangelogConfig | undefined {
     const result = safeParse(packtoryConfigSchema, config);
-    return result.success ? result.data : undefined;
+    if (!result.success || !isChangelogSettings(result.data.changelog)) {
+        return undefined;
+    }
+    return {
+        changelog: result.data.changelog,
+        commonPackageSettings: result.data.commonPackageSettings,
+        packages: result.data.packages
+    };
 }
 
 export function createChangelogGenerationOptions(config: ChangelogConfig): ChangelogGenerationOptions {
     return {
         explicitBaseRef: config.changelog?.explicitBaseRef,
         packageTagFormat: config.changelog?.packageTagFormat,
-        targetScopedLabelPattern: config.changelog?.targetScopedLabelPattern,
-        validLabels: new Map([ ...defaultValidLabels, ...Object.entries(config.changelog?.labels ?? {}) ])
+        prLogConfig: createPrLogConfig(config.changelog),
+        targetScopedLabelPattern: config.changelog?.targetScopedLabelPattern
     };
 }
 

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -93,7 +93,7 @@ type ChangelogUpdateInput = {
 };
 type ChangelogLabelInput = {
     readonly targetScopedLabelPattern: string;
-    readonly validLabels: ReadonlyMap<string, string>;
+    readonly config: { readonly validLabels: ReadonlyMap<string, string>; };
 };
 
 type EngineOverrides = {
@@ -117,6 +117,7 @@ function createEngine(overrides: EngineOverrides = {}): PrLogEngine {
             return input.pullRequests;
         }),
         resolvePullRequestLabels: overrides.resolvePullRequestLabels ?? fake.resolves(labeledPullRequests),
+        resolveVersionNumber: fake.returns('1.0.1'),
         renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
         renderTargetChangelog: fake(function (input: TargetChangelogInput) {
             return `## ${input.targetName} 1.0.1\n`;
@@ -194,6 +195,7 @@ function makeSpies(
                 githubToken: 'gh-token',
                 workingDirectory: '/repo'
             });
+            assert.strictEqual(options.config.maximumRateLimitRetryCount, 3);
             return engine;
         }),
         log: fake(),
@@ -233,8 +235,8 @@ function assertConfiguredChangelogInputs(
     });
     const labelInput = resolvePullRequestLabels.firstCall.args[0] as ChangelogLabelInput;
     assert.strictEqual(labelInput.targetScopedLabelPattern, 'scope:{targetName}:{label}');
-    assert.strictEqual(labelInput.validLabels.get('bug'), 'Bug Fixes');
-    assert.strictEqual(labelInput.validLabels.get('operations'), 'Operations');
+    assert.strictEqual(labelInput.config.validLabels.get('bug'), 'Bug Fixes');
+    assert.strictEqual(labelInput.config.validLabels.get('operations'), 'Operations');
 }
 
 suite('changelog-handler', function () {
@@ -364,7 +366,7 @@ suite('changelog-handler', function () {
                         ...validConfig,
                         changelog: {
                             explicitBaseRef: 'main',
-                            labels: { operations: 'Operations' },
+                            prLog: { validLabels: { operations: 'Operations' } },
                             packageTagFormat: 'pkg/{packageName}/v{version}',
                             targetScopedLabelPattern: 'scope:{targetName}:{label}'
                         }

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -1,4 +1,4 @@
-import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
+import type { PrLogConfig, PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { FileManager } from '../../file-manager/file-manager.ts';
 import type { Packtory, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
 import { generateChangelogOutputs } from '../../packtory/packtory-changelog.ts';
@@ -32,9 +32,6 @@ export type ChangelogHandlerDeps = {
     readonly workingDirectory: string;
 };
 
-const labelLookupIntervalMilliseconds = 250;
-const maximumRateLimitRetryCount = 3;
-
 function formatChangelogHandlerError(error: unknown): string {
     return String(error).replace(/^[A-Za-z]*Error: /u, '');
 }
@@ -43,12 +40,11 @@ function readGitHubToken(deps: Pick<ChangelogHandlerDeps, 'readEnvironmentVariab
     return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
-function createEngine(deps: ChangelogHandlerDeps): PrLogEngine {
+function createEngine(deps: ChangelogHandlerDeps, config: PrLogConfig): PrLogEngine {
     return deps.createPrLogEngine({
         githubToken: readGitHubToken(deps),
         workingDirectory: deps.workingDirectory,
-        labelLookupIntervalMilliseconds,
-        maximumRateLimitRetryCount
+        config
     });
 }
 
@@ -61,19 +57,18 @@ async function renderChangelog(
         return;
     }
     const packageInfo = await deps.readPackageInfo();
-    const prLogEngine = createEngine(deps);
     const generationOptions = createChangelogGenerationOptions(config);
+    const prLogEngine = createEngine(deps, generationOptions.prLogConfig);
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine,
         explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
         ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
-        packageInfo,
         packageTagFormat: generationOptions.packageTagFormat,
         currentDate: deps.currentDate(),
-        targetScopedLabelPattern: generationOptions.targetScopedLabelPattern,
-        validLabels: generationOptions.validLabels
+        prLogConfig: generationOptions.prLogConfig,
+        targetScopedLabelPattern: generationOptions.targetScopedLabelPattern
     });
     if (shouldPageGroupedChangelog(config.changelog?.outputs) && changelog.groupedMarkdown.length > 0) {
         await deps.pageOutput(changelog.groupedMarkdown);

--- a/source/command-line-interface/runner/changelog-pr-log-config.test.ts
+++ b/source/command-line-interface/runner/changelog-pr-log-config.test.ts
@@ -1,0 +1,215 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import type { ChangelogSettings } from '../../config/changelog-settings.ts';
+import { createPrLogConfig } from './changelog-pr-log-config.ts';
+
+function collectPrLogSettingIssues(settings: ChangelogSettings['prLog']): readonly string[] {
+    try {
+        createPrLogConfig({ prLog: settings });
+        return [];
+    } catch (error) {
+        assert.ok(error instanceof Error);
+        return error.message.split('\n');
+    }
+}
+
+suite('changelog-pr-log-config', function () {
+    test('creates pr-log config from defaults and configured settings', function () {
+        const prLogConfig = createPrLogConfig({
+            prLog: {
+                validLabels: { operations: 'Operations' },
+                ignoredLabels: [ 'skip-changelog' ],
+                versionBumps: { minor: [ 'operations' ] },
+                dateFormat: 'yyyy-MM-dd',
+                collapseRules: [
+                    {
+                        label: 'operations',
+                        pattern: '^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                        replace: 'Update $<dependency> from $<from> to $<to>'
+                    }
+                ],
+                labelLookupIntervalMilliseconds: 500,
+                maximumRateLimitRetryCount: 5
+            }
+        });
+
+        assert.deepStrictEqual(
+            {
+                bugLabel: prLogConfig.validLabels.get('bug'),
+                operationsLabel: prLogConfig.validLabels.get('operations'),
+                ignoredLabels: prLogConfig.ignoredLabels,
+                versionBumps: prLogConfig.versionBumps,
+                dateFormat: prLogConfig.dateFormat,
+                collapseRulePatternMatches: prLogConfig.collapseRules[0]?.pattern.test('Update foo from 1 to 2'),
+                collapseRuleKeyGroup: prLogConfig.collapseRules[0]?.keyGroup,
+                collapseRuleFromGroup: prLogConfig.collapseRules[0]?.fromGroup,
+                collapseRuleToGroup: prLogConfig.collapseRules[0]?.toGroup,
+                labelLookupIntervalMilliseconds: prLogConfig.labelLookupIntervalMilliseconds,
+                maximumRateLimitRetryCount: prLogConfig.maximumRateLimitRetryCount
+            },
+            {
+                bugLabel: 'Bug Fixes',
+                operationsLabel: 'Operations',
+                ignoredLabels: [ 'skip-changelog' ],
+                versionBumps: { major: [], minor: [ 'operations' ], patch: [] },
+                dateFormat: 'yyyy-MM-dd',
+                collapseRulePatternMatches: true,
+                collapseRuleKeyGroup: 'dependency',
+                collapseRuleFromGroup: 'from',
+                collapseRuleToGroup: 'to',
+                labelLookupIntervalMilliseconds: 500,
+                maximumRateLimitRetryCount: 5
+            }
+        );
+    });
+
+    test('creates default version bumps without duplicating major or minor labels into patch', function () {
+        const prLogConfig = createPrLogConfig({
+            prLog: {
+                validLabels: { operations: 'Operations' }
+            }
+        });
+
+        assert.deepStrictEqual(prLogConfig.versionBumps, {
+            major: [ 'breaking' ],
+            minor: [ 'feature' ],
+            patch: [ 'bug', 'enhancement', 'documentation', 'upgrade', 'refactor', 'build', 'operations' ]
+        });
+    });
+
+    test('creates empty arrays for omitted configured version bump levels', function () {
+        const prLogConfig = createPrLogConfig({
+            prLog: {
+                versionBumps: { major: [ 'breaking' ] }
+            }
+        });
+
+        assert.deepStrictEqual(prLogConfig.versionBumps, {
+            major: [ 'breaking' ],
+            minor: [],
+            patch: []
+        });
+    });
+
+    test('creates default settings when pr-log config is omitted', function () {
+        const prLogConfig = createPrLogConfig(undefined);
+
+        assert.deepStrictEqual(
+            {
+                ignoredLabels: prLogConfig.ignoredLabels,
+                dateFormat: prLogConfig.dateFormat,
+                collapseRules: prLogConfig.collapseRules,
+                labelLookupIntervalMilliseconds: prLogConfig.labelLookupIntervalMilliseconds,
+                maximumRateLimitRetryCount: prLogConfig.maximumRateLimitRetryCount
+            },
+            {
+                ignoredLabels: [],
+                dateFormat: undefined,
+                collapseRules: [],
+                labelLookupIntervalMilliseconds: 250,
+                maximumRateLimitRetryCount: 3
+            }
+        );
+    });
+
+    test('creates collapse rules with custom groups and unicode matching', function () {
+        const prLogConfig = createPrLogConfig({
+            prLog: {
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '^(?<name>\\u{E9}) (?<before>.+) (?<after>.+)$',
+                        replace: '$<name>',
+                        keyGroup: 'name',
+                        fromGroup: 'before',
+                        toGroup: 'after'
+                    }
+                ]
+            }
+        });
+
+        assert.deepStrictEqual(
+            {
+                flags: prLogConfig.collapseRules[0]?.pattern.flags,
+                matchesUnicode: prLogConfig.collapseRules[0]?.pattern.test('\u{E9} 1 2'),
+                keyGroup: prLogConfig.collapseRules[0]?.keyGroup,
+                fromGroup: prLogConfig.collapseRules[0]?.fromGroup,
+                toGroup: prLogConfig.collapseRules[0]?.toGroup
+            },
+            {
+                flags: 'u',
+                matchesUnicode: true,
+                keyGroup: 'name',
+                fromGroup: 'before',
+                toGroup: 'after'
+            }
+        );
+    });
+
+    test('accepts omitted and zero numeric settings', function () {
+        assert.deepStrictEqual(collectPrLogSettingIssues(undefined), []);
+        assert.deepStrictEqual(collectPrLogSettingIssues({}), []);
+        assert.deepStrictEqual(
+            collectPrLogSettingIssues({
+                collapseRules: undefined,
+                labelLookupIntervalMilliseconds: 0,
+                maximumRateLimitRetryCount: 0
+            }),
+            []
+        );
+    });
+
+    test('reports invalid settings before creating config', function () {
+        const settings = {
+            validLabels: { operations: 'Operations' },
+            versionBumps: { major: [ 'operations' ], minor: [ 'operations' ], patch: [ 'unknown' ] },
+            collapseRules: [ { label: 'operations', pattern: '[', replace: 'Update' } ],
+            labelLookupIntervalMilliseconds: -1,
+            maximumRateLimitRetryCount: 1.5
+        } as const;
+
+        const issues = [
+            'changelog.prLog.labelLookupIntervalMilliseconds must be a non-negative integer',
+            'changelog.prLog.maximumRateLimitRetryCount must be a non-negative integer',
+            'changelog.prLog.collapseRules[0].pattern must be a valid regular expression',
+            'changelog.prLog.versionBumps.patch label "unknown" must be configured in validLabels',
+            'changelog.prLog.versionBumps label "operations" must be unique'
+        ];
+
+        assert.deepStrictEqual(collectPrLogSettingIssues(settings), issues);
+        assert.throws(function () {
+            createPrLogConfig({ prLog: settings });
+        }, { message: issues.join('\n') });
+    });
+
+    test('reports duplicate version bump labels once in sorted order', function () {
+        const issues = collectPrLogSettingIssues({
+            versionBumps: {
+                major: [ 'feature', 'breaking' ],
+                minor: [ 'feature', 'breaking' ],
+                patch: [ 'bug', 'bug' ]
+            }
+        });
+
+        assert.deepStrictEqual(issues, [
+            'changelog.prLog.versionBumps label "breaking" must be unique',
+            'changelog.prLog.versionBumps label "bug" must be unique',
+            'changelog.prLog.versionBumps label "feature" must be unique'
+        ]);
+    });
+
+    test('reports unicode-only invalid regular expressions', function () {
+        assert.deepStrictEqual(
+            collectPrLogSettingIssues({
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '\\u{110000}',
+                        replace: 'upgrade'
+                    }
+                ]
+            }),
+            [ 'changelog.prLog.collapseRules[0].pattern must be a valid regular expression' ]
+        );
+    });
+});

--- a/source/command-line-interface/runner/changelog-pr-log-config.ts
+++ b/source/command-line-interface/runner/changelog-pr-log-config.ts
@@ -1,0 +1,187 @@
+import { defaultPrLogConfig, type CollapseRule, type PrLogConfig } from '@pr-log/core';
+import type { ChangelogSettings } from '../../config/changelog-settings.ts';
+
+type PrLogSettings = NonNullable<ChangelogSettings['prLog']>;
+type ConfiguredCollapseRule = NonNullable<PrLogSettings['collapseRules']>[number];
+type VersionBumpLevel = keyof PrLogConfig['versionBumps'];
+
+const versionBumpLevels: readonly VersionBumpLevel[] = [ 'major', 'minor', 'patch' ];
+
+function createDefaultVersionBumps(validLabels: ReadonlyMap<string, string>): PrLogConfig['versionBumps'] {
+    const customPatchLabels = Array
+        .from(validLabels.keys())
+        .filter(function (label) {
+            return !defaultPrLogConfig.validLabels.has(label);
+        });
+    return {
+        major: defaultPrLogConfig.versionBumps.major,
+        minor: defaultPrLogConfig.versionBumps.minor,
+        patch: [ ...defaultPrLogConfig.versionBumps.patch, ...customPatchLabels ]
+    };
+}
+
+function createValidLabels(settings: PrLogSettings | undefined): ReadonlyMap<string, string> {
+    return new Map([ ...defaultPrLogConfig.validLabels, ...Object.entries(settings?.validLabels ?? {}) ]);
+}
+
+function createVersionBumps(
+    settings: PrLogSettings | undefined,
+    validLabels: ReadonlyMap<string, string>
+): PrLogConfig['versionBumps'] {
+    if (settings?.versionBumps === undefined) {
+        return createDefaultVersionBumps(validLabels);
+    }
+    return {
+        major: settings.versionBumps.major ?? [],
+        minor: settings.versionBumps.minor ?? [],
+        patch: settings.versionBumps.patch ?? []
+    };
+}
+
+function createCollapseRule(rule: ConfiguredCollapseRule): CollapseRule {
+    return {
+        label: rule.label,
+        pattern: new RegExp(rule.pattern, 'u'),
+        replace: rule.replace,
+        keyGroup: rule.keyGroup ?? 'dependency',
+        fromGroup: rule.fromGroup ?? 'from',
+        toGroup: rule.toGroup ?? 'to'
+    };
+}
+
+function resolveIgnoredLabels(settings: PrLogSettings | undefined): readonly string[] {
+    return settings?.ignoredLabels ?? defaultPrLogConfig.ignoredLabels;
+}
+
+function resolveDateFormat(settings: PrLogSettings | undefined): string | undefined {
+    return settings?.dateFormat ?? defaultPrLogConfig.dateFormat;
+}
+
+function resolveCollapseRules(settings: PrLogSettings | undefined): readonly CollapseRule[] {
+    return settings?.collapseRules?.map(createCollapseRule) ?? defaultPrLogConfig.collapseRules;
+}
+
+function resolveLabelLookupIntervalMilliseconds(settings: PrLogSettings | undefined): number {
+    return settings?.labelLookupIntervalMilliseconds ?? defaultPrLogConfig.labelLookupIntervalMilliseconds;
+}
+
+function resolveMaximumRateLimitRetryCount(settings: PrLogSettings | undefined): number {
+    return settings?.maximumRateLimitRetryCount ?? defaultPrLogConfig.maximumRateLimitRetryCount;
+}
+
+function validateNonNegativeInteger(value: number | undefined, settingName: string): readonly string[] {
+    if (value === undefined) {
+        return [];
+    }
+    return Number.isSafeInteger(value) && value >= 0 ? [] : [ `${settingName} must be a non-negative integer` ];
+}
+
+function isValidRegularExpression(pattern: string): boolean | undefined {
+    try {
+        const expression = new RegExp(pattern, 'u');
+        return expression instanceof RegExp;
+    } catch {
+        return false;
+    }
+}
+
+function collectInvalidCollapseRuleIssues(rules: PrLogSettings['collapseRules']): readonly string[] {
+    if (rules === undefined) {
+        return [];
+    }
+    return rules.flatMap(function (rule, index) {
+        const issue = `changelog.prLog.collapseRules[${index}].pattern must be a valid regular expression`;
+        return isValidRegularExpression(rule.pattern) === false ? [ issue ] : [];
+    });
+}
+
+function collectDuplicateValueIssues(values: readonly string[]): readonly string[] {
+    const seenValues = new Set<string>();
+    const duplicatedValues = new Set<string>();
+
+    for (const value of values) {
+        if (seenValues.has(value)) {
+            duplicatedValues.add(value);
+        }
+        seenValues.add(value);
+    }
+
+    return Array
+        .from(duplicatedValues)
+        .toSorted(function (left, right) {
+            return left.localeCompare(right);
+        });
+}
+
+function collectVersionBumpLabels(versionBumps: NonNullable<PrLogSettings['versionBumps']>): readonly string[] {
+    return versionBumpLevels.flatMap(function (level) {
+        return versionBumps[level] ?? [];
+    });
+}
+
+function collectInvalidVersionBumpLabelIssues(
+    versionBumps: PrLogSettings['versionBumps'],
+    validLabels: ReadonlyMap<string, string>
+): readonly string[] {
+    return versionBumpLevels.flatMap(function (level) {
+        return (versionBumps?.[level] ?? []).flatMap(function (label) {
+            return validLabels.has(label)
+                ? []
+                : [ `changelog.prLog.versionBumps.${level} label "${label}" must be configured in validLabels` ];
+        });
+    });
+}
+
+function collectDuplicateVersionBumpLabels(
+    versionBumps: NonNullable<PrLogSettings['versionBumps']>
+): readonly string[] {
+    return collectDuplicateValueIssues(collectVersionBumpLabels(versionBumps));
+}
+
+function collectDuplicateVersionBumpLabelIssues(versionBumps: PrLogSettings['versionBumps']): readonly string[] {
+    if (versionBumps === undefined) {
+        return [];
+    }
+    return collectDuplicateVersionBumpLabels(versionBumps)
+        .map(function (label) {
+            return `changelog.prLog.versionBumps label "${label}" must be unique`;
+        });
+}
+
+function collectPrLogSettingIssues(settings: PrLogSettings | undefined): readonly string[] {
+    if (settings === undefined) {
+        return [];
+    }
+    const validLabels = createValidLabels(settings);
+    return [
+        ...validateNonNegativeInteger(
+            settings.labelLookupIntervalMilliseconds,
+            'changelog.prLog.labelLookupIntervalMilliseconds'
+        ),
+        ...validateNonNegativeInteger(
+            settings.maximumRateLimitRetryCount,
+            'changelog.prLog.maximumRateLimitRetryCount'
+        ),
+        ...collectInvalidCollapseRuleIssues(settings.collapseRules),
+        ...collectInvalidVersionBumpLabelIssues(settings.versionBumps, validLabels),
+        ...collectDuplicateVersionBumpLabelIssues(settings.versionBumps)
+    ];
+}
+
+export function createPrLogConfig(changelog: ChangelogSettings | undefined): PrLogConfig {
+    const { prLog } = changelog ?? {};
+    const issues = collectPrLogSettingIssues(prLog);
+    if (issues.length > 0) {
+        throw new Error(issues.join('\n'));
+    }
+    const validLabels = createValidLabels(prLog);
+    return {
+        validLabels,
+        ignoredLabels: resolveIgnoredLabels(prLog),
+        versionBumps: createVersionBumps(prLog, validLabels),
+        dateFormat: resolveDateFormat(prLog),
+        collapseRules: resolveCollapseRules(prLog),
+        labelLookupIntervalMilliseconds: resolveLabelLookupIntervalMilliseconds(prLog),
+        maximumRateLimitRetryCount: resolveMaximumRateLimitRetryCount(prLog)
+    };
+}

--- a/source/command-line-interface/runner/release-handler-changelog-writes.test.ts
+++ b/source/command-line-interface/runner/release-handler-changelog-writes.test.ts
@@ -113,8 +113,8 @@ suite('changelog writes', function () {
         const resolvePullRequestLabels = fake(
             async function (input: ResolvePullRequestLabelsOptions) {
                 assert.strictEqual(input.targetScopedLabelPattern, 'scope:{targetName}:{label}');
-                assert.strictEqual(input.validLabels.get('bug'), 'Bug Fixes');
-                assert.strictEqual(input.validLabels.get('operations'), 'Operations');
+                assert.strictEqual(input.config.validLabels.get('bug'), 'Bug Fixes');
+                assert.strictEqual(input.config.validLabels.get('operations'), 'Operations');
                 return [ { id: 1, title: 'Fix package', label: 'operations' } ];
             }
         );
@@ -131,7 +131,7 @@ suite('changelog writes', function () {
                     ...validConfig,
                     changelog: {
                         explicitBaseRef: 'main',
-                        labels: { operations: 'Operations' },
+                        prLog: { validLabels: { operations: 'Operations' } },
                         outputs: [ { kind: 'repository-file', path: 'CHANGELOG.md' } ],
                         packageTagFormat: 'pkg/{packageName}/v{version}',
                         targetScopedLabelPattern: 'scope:{targetName}:{label}'

--- a/source/command-line-interface/runner/release-handler.ts
+++ b/source/command-line-interface/runner/release-handler.ts
@@ -1,4 +1,4 @@
-import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
+import type { PrLogConfig, PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { Packtory, ReleasePlanPackage } from '../../packtory/packtory.ts';
 import { generateChangelogOutputs, type GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 import {
@@ -210,12 +210,11 @@ function readGitHubToken(deps: Pick<ReleaseHandlerDeps, 'readEnvironmentVariable
     return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
-function createEngine(deps: ReleaseHandlerDeps): PrLogEngine {
+function createEngine(deps: ReleaseHandlerDeps, config: PrLogConfig): PrLogEngine {
     return deps.createPrLogEngine({
         githubToken: readGitHubToken(deps),
         workingDirectory: deps.workingDirectory,
-        labelLookupIntervalMilliseconds: 250,
-        maximumRateLimitRetryCount: 3
+        config
     });
 }
 
@@ -225,19 +224,18 @@ async function generateReleaseChangelog(
     packages: readonly ReleasePlanPackage[]
 ): Promise<ReleaseChangelog> {
     const packageInfo = await deps.readPackageInfo();
-    const engine = createEngine(deps);
     const generationOptions = createChangelogGenerationOptions(config);
+    const engine = createEngine(deps, generationOptions.prLogConfig);
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
         explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
         ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
-        packageInfo,
         currentDate: deps.currentDate(),
         packageTagFormat: generationOptions.packageTagFormat,
-        targetScopedLabelPattern: generationOptions.targetScopedLabelPattern,
-        validLabels: generationOptions.validLabels
+        prLogConfig: generationOptions.prLogConfig,
+        targetScopedLabelPattern: generationOptions.targetScopedLabelPattern
     });
     return { changelog, config, engine };
 }

--- a/source/config/changelog-settings.test.ts
+++ b/source/config/changelog-settings.test.ts
@@ -59,9 +59,26 @@ suite('changelog-settings', function () {
             assert.strictEqual(result.success, true);
         });
 
-        test('schema accepts label and base-ref settings without outputs', function () {
+        test('schema accepts pr-log and base-ref settings without outputs', function () {
             const result = safeParse(changelogSettingsSchema, {
-                labels: { bug: 'Fixes', operations: 'Operations' },
+                prLog: {
+                    validLabels: { bug: 'Fixes', operations: 'Operations' },
+                    ignoredLabels: [ 'skip-changelog' ],
+                    versionBumps: { major: [ 'breaking' ], minor: [ 'feature' ], patch: [ 'bug' ] },
+                    dateFormat: 'yyyy-MM-dd',
+                    collapseRules: [
+                        {
+                            label: 'operations',
+                            pattern: '^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                            replace: 'Update $<dependency> from $<from> to $<to>',
+                            keyGroup: 'dependency',
+                            fromGroup: 'from',
+                            toGroup: 'to'
+                        }
+                    ],
+                    labelLookupIntervalMilliseconds: 500,
+                    maximumRateLimitRetryCount: 5
+                },
                 targetScopedLabelPattern: 'scope:{targetName}:{label}',
                 packageTagFormat: 'pkg/{packageName}/v{version}',
                 explicitBaseRef: 'main'
@@ -74,9 +91,7 @@ suite('changelog-settings', function () {
             assert.strictEqual(safeParse(changelogSettingsSchema, { outputs: [] }).success, false);
         });
 
-        test('schema rejects empty label, pattern and base-ref settings', function () {
-            assert.strictEqual(safeParse(changelogSettingsSchema, { labels: { bug: '' } }).success, false);
-            assert.strictEqual(safeParse(changelogSettingsSchema, { labels: { '': 'Fixes' } }).success, false);
+        test('schema rejects empty pattern and base-ref settings', function () {
             assert.strictEqual(safeParse(changelogSettingsSchema, { targetScopedLabelPattern: '' }).success, false);
             assert.strictEqual(safeParse(changelogSettingsSchema, { packageTagFormat: '' }).success, false);
             assert.strictEqual(safeParse(changelogSettingsSchema, { explicitBaseRef: '' }).success, false);

--- a/source/config/changelog-settings.ts
+++ b/source/config/changelog-settings.ts
@@ -39,20 +39,44 @@ const changelogOutputSchema = z.union([
     explicitPackageFileOutputSchema,
     githubReleaseOutputSchema
 ]);
-const validLabelsSchema = z.readonly(z.record(nonEmptyStringSchema, nonEmptyStringSchema));
-
 export const changelogSettingsSchema = z.readonly(
     z.strictObject({
         explicitBaseRef: z.optional(nonEmptyStringSchema),
-        labels: z.optional(validLabelsSchema),
         outputs: z.optional(z.readonly(z.tuple([ changelogOutputSchema ], changelogOutputSchema))),
         packageTagFormat: z.optional(nonEmptyStringSchema),
+        prLog: z.optional(z.unknown()),
         targetScopedLabelPattern: z.optional(nonEmptyStringSchema)
     })
 );
 
 export type ChangelogOutput = z.infer<typeof changelogOutputSchema>;
-export type ChangelogSettings = z.infer<typeof changelogSettingsSchema>;
+type PrLogCollapseRuleSettings = {
+    readonly label: string;
+    readonly pattern: string;
+    readonly replace: string;
+    readonly keyGroup?: string | undefined;
+    readonly fromGroup?: string | undefined;
+    readonly toGroup?: string | undefined;
+};
+export type ChangelogSettings = {
+    readonly explicitBaseRef?: string | undefined;
+    readonly outputs?: readonly [ChangelogOutput, ...(readonly ChangelogOutput[])] | undefined;
+    readonly packageTagFormat?: string | undefined;
+    readonly prLog?: {
+        readonly validLabels?: Readonly<Record<string, string>> | undefined;
+        readonly ignoredLabels?: readonly string[] | undefined;
+        readonly versionBumps?: {
+            readonly major?: readonly string[] | undefined;
+            readonly minor?: readonly string[] | undefined;
+            readonly patch?: readonly string[] | undefined;
+        } | undefined;
+        readonly dateFormat?: string | undefined;
+        readonly collapseRules?: readonly PrLogCollapseRuleSettings[] | undefined;
+        readonly labelLookupIntervalMilliseconds?: number | undefined;
+        readonly maximumRateLimitRetryCount?: number | undefined;
+    } | undefined;
+    readonly targetScopedLabelPattern?: string | undefined;
+};
 
 type PackageChangelogValidationConfig = {
     readonly [key: string]: unknown;

--- a/source/config/packtory-config-schema.test.ts
+++ b/source/config/packtory-config-schema.test.ts
@@ -135,7 +135,21 @@ suite('packtory-config-schema', function () {
             data: {
                 registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
                 changelog: {
-                    labels: { operations: 'Operations' },
+                    prLog: {
+                        validLabels: { operations: 'Operations' },
+                        ignoredLabels: [ 'skip-changelog' ],
+                        versionBumps: { patch: [ 'operations' ] },
+                        dateFormat: 'yyyy-MM-dd',
+                        collapseRules: [
+                            {
+                                label: 'operations',
+                                pattern: '^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
+                                replace: 'Update $<dependency> from $<from> to $<to>'
+                            }
+                        ],
+                        labelLookupIntervalMilliseconds: 500,
+                        maximumRateLimitRetryCount: 5
+                    },
                     targetScopedLabelPattern: 'scope:{targetName}:{label}',
                     packageTagFormat: 'pkg/{packageName}/v{version}',
                     explicitBaseRef: 'main',

--- a/source/git/git-command.test.ts
+++ b/source/git/git-command.test.ts
@@ -11,8 +11,6 @@ type FakeGitCommandChildProcess = {
     readonly once: (eventName: 'close', listener: () => void) => FakeGitCommandChildProcess;
 };
 
-const runChildProcessGitCommand = createChildProcessGitCommandExecutor(spawnChildProcessGitCommand);
-
 function createFakeGitCommandChildProcess(
     recordCloseListener: (listener: () => void) => void
 ): FakeGitCommandChildProcess {
@@ -113,6 +111,7 @@ suite('git-command', function () {
     });
 
     test('runChildProcessGitCommand resolves stdout and stderr from a child process', async function () {
+        const runChildProcessGitCommand = createChildProcessGitCommandExecutor(spawnChildProcessGitCommand);
         const result = await withPromiseDeadline(
             runChildProcessGitCommand(process.execPath, [
                 '-e',
@@ -126,6 +125,7 @@ suite('git-command', function () {
     });
 
     test('runChildProcessGitCommand rejects failed child processes', async function () {
+        const runChildProcessGitCommand = createChildProcessGitCommandExecutor(spawnChildProcessGitCommand);
         await assert.rejects(
             withPromiseDeadline(
                 runChildProcessGitCommand(process.execPath, [ '-e', 'process.exit(13);' ]),
@@ -137,6 +137,7 @@ suite('git-command', function () {
     });
 
     test('runChildProcessGitCommand rejects launch failures', async function () {
+        const runChildProcessGitCommand = createChildProcessGitCommandExecutor(spawnChildProcessGitCommand);
         await assert.rejects(
             withPromiseDeadline(
                 runChildProcessGitCommand('/definitely-missing/packtory-git-command', []),

--- a/source/git/git-command.ts
+++ b/source/git/git-command.ts
@@ -63,10 +63,6 @@ function reportExecFileResult(
     deferred.reject(error);
 }
 
-function reportClosedChildProcess(deferred: Deferred<never>): void {
-    deferred.reject(new Error('Child process closed before reporting output'));
-}
-
 function* gitCommandCompletionSignals(
     output: Deferred<GitCommandExecutorResult>,
     closed: Deferred<never>
@@ -89,10 +85,12 @@ export function createChildProcessGitCommandExecutor(spawnGitCommand: SpawnGitCo
         const callback: ExecFileCallback = function (error, stdout, stderr) {
             reportExecFileResult(output, error, stdout, stderr);
         };
+        const rejectClosedChildProcess = closed.reject.bind(
+            undefined,
+            new Error('Child process closed before reporting output')
+        );
         const childProcess = spawnGitCommand(command, Array.from(args), callback);
-        childProcess.once('close', function () {
-            reportClosedChildProcess(closed);
-        });
+        childProcess.once('close', rejectClosedChildProcess);
         return await runUntilOutputOrClose(output, closed);
     };
 }

--- a/source/packages/command-line-interface/pull-request-label-versioning.test.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.test.ts
@@ -17,7 +17,7 @@ type TokenSourceInput = {
 
 const source = { automatic: false, source: 'pull-request-labels' } as const;
 const packtoryConfig: PacktoryConfig = {
-    changelog: { labels: { bug: 'Bug fixes', feature: 'Features' } },
+    changelog: { prLog: { validLabels: { bug: 'Bug fixes', feature: 'Features' } } },
     packages: []
 };
 
@@ -66,7 +66,7 @@ function createEngine(overrides: Partial<PrLogEngine> = {}): PrLogEngine {
                     githubRepo: input.githubRepo,
                     targetName: input.targetName,
                     targetScopedLabelPattern: input.targetScopedLabelPattern,
-                    ignoredLabels: input.ignoredLabels
+                    ignoredLabels: input.config.ignoredLabels
                 },
                 {
                     githubRepo: 'owner/repo',
@@ -134,9 +134,30 @@ suite('pull-request-label-version-source', function () {
                 assert.deepStrictEqual(options, {
                     githubToken: 'gh-token',
                     workingDirectory: '/repo',
-                    labelLookupIntervalMilliseconds: 250,
-                    maximumRateLimitRetryCount: 3
+                    config: {
+                        validLabels: options.config.validLabels,
+                        ignoredLabels: [],
+                        versionBumps: options.config.versionBumps,
+                        dateFormat: undefined,
+                        collapseRules: [],
+                        labelLookupIntervalMilliseconds: 250,
+                        maximumRateLimitRetryCount: 3
+                    }
                 });
+                assert.deepStrictEqual(
+                    {
+                        bugLabel: options.config.validLabels.get('bug'),
+                        majorBumpLabels: options.config.versionBumps.major,
+                        minorBumpLabels: options.config.versionBumps.minor,
+                        patchIncludesBug: options.config.versionBumps.patch.includes('bug')
+                    },
+                    {
+                        bugLabel: 'Bug fixes',
+                        majorBumpLabels: [ 'breaking' ],
+                        minorBumpLabels: [ 'feature' ],
+                        patchIncludesBug: true
+                    }
+                );
             },
             readEnvironmentVariable(name) {
                 return name === 'GH_TOKEN' ? 'gh-token' : undefined;

--- a/source/packages/command-line-interface/pull-request-label-versioning.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.ts
@@ -1,9 +1,10 @@
 import semver from 'semver';
-import { defaultValidLabels, type PrLogEngine, type PrLogEngineOptions, type PullRequestWithLabel } from '@pr-log/core';
+import type { PrLogConfig, PrLogEngine, PrLogEngineOptions, PullRequestWithLabel } from '@pr-log/core';
 import type { VersionProvider } from '../../config/manual-versioning-settings.ts';
 import type { PacktoryConfig } from '../../config/config.ts';
 import type { VersionSourceResolver } from '../../packtory/map-config.ts';
 import { formatGitHubRepositoryName } from '../../command-line-interface/runner/github-repository.ts';
+import { createPrLogConfig } from '../../command-line-interface/runner/changelog-pr-log-config.ts';
 
 type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
 
@@ -14,10 +15,7 @@ export type PullRequestLabelVersionSourceDeps = {
     readonly workingDirectory: string;
 };
 
-type VersionBumpLevel = 'major' | 'minor' | 'patch';
-
-const labelLookupIntervalMilliseconds = 250;
-const maximumRateLimitRetryCount = 3;
+type VersionBumpLevel = keyof PrLogConfig['versionBumps'];
 
 function orderedVersionBumpLevels(): readonly VersionBumpLevel[] {
     return [ 'major', 'minor', 'patch' ];
@@ -27,42 +25,25 @@ function readGitHubToken(deps: Pick<PullRequestLabelVersionSourceDeps, 'readEnvi
     return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
-function createEngine(deps: PullRequestLabelVersionSourceDeps): PrLogEngine {
+function createEngine(deps: PullRequestLabelVersionSourceDeps, config: PrLogConfig): PrLogEngine {
     return deps.createPrLogEngine({
         githubToken: readGitHubToken(deps),
         workingDirectory: deps.workingDirectory,
-        labelLookupIntervalMilliseconds,
-        maximumRateLimitRetryCount
+        config
     });
-}
-
-function createValidLabels(config: PacktoryConfig): ReadonlyMap<string, string> {
-    return new Map([ ...defaultValidLabels, ...Object.entries(config.changelog?.labels ?? {}) ]);
-}
-
-function createVersionBumpLabels(
-    validLabels: ReadonlyMap<string, string>
-): Readonly<Record<VersionBumpLevel, readonly string[]>> {
-    const allLabels = Array.from(validLabels.keys());
-    return {
-        major: [ 'breaking' ],
-        minor: [ 'feature' ],
-        patch: allLabels
-    };
 }
 
 function selectVersionBumpLevel(
     pullRequests: readonly PullRequestWithLabel[],
-    validLabels: ReadonlyMap<string, string>
+    versionBumps: PrLogConfig['versionBumps']
 ): VersionBumpLevel | undefined {
     const labels = new Set(
         pullRequests.map(function (pullRequest) {
             return pullRequest.label;
         })
     );
-    const versionBumpLabels = createVersionBumpLabels(validLabels);
     return orderedVersionBumpLevels().find(function (level) {
-        return versionBumpLabels[level].some(function (label) {
+        return versionBumps[level].some(function (label) {
             return labels.has(label);
         });
     });
@@ -79,9 +60,9 @@ function incrementVersion(version: string, level: VersionBumpLevel): string {
 function selectNextVersion(
     currentVersion: string,
     pullRequests: readonly PullRequestWithLabel[],
-    validLabels: ReadonlyMap<string, string>
+    versionBumps: PrLogConfig['versionBumps']
 ): string {
-    const versionBumpLevel = selectVersionBumpLevel(pullRequests, validLabels);
+    const versionBumpLevel = selectVersionBumpLevel(pullRequests, versionBumps);
     return versionBumpLevel === undefined ? currentVersion : incrementVersion(currentVersion, versionBumpLevel);
 }
 
@@ -94,8 +75,8 @@ export function createPullRequestLabelVersionSourceResolver(
     ): Promise<readonly PullRequestWithLabel[]> {
         const packageInfo = await deps.readPackageInfo();
         const githubRepo = formatGitHubRepositoryName(packageInfo);
-        const validLabels = createValidLabels(packtoryConfig);
-        const prLogEngine = createEngine(deps);
+        const prLogConfig = createPrLogConfig(packtoryConfig.changelog);
+        const prLogEngine = createEngine(deps, prLogConfig);
         const baseRef = await prLogEngine.resolveChangelogBaseRef({
             packageName: input.packageName,
             previousVersion: input.currentVersion,
@@ -117,8 +98,7 @@ export function createPullRequestLabelVersionSourceResolver(
         });
         return prLogEngine.resolvePullRequestLabels({
             githubRepo,
-            validLabels,
-            ignoredLabels: [],
+            config: prLogConfig,
             pullRequests: targetPullRequests,
             targetName: input.packageName,
             targetScopedLabelPattern: packtoryConfig.changelog?.targetScopedLabelPattern
@@ -130,10 +110,11 @@ export function createPullRequestLabelVersionSourceResolver(
             if (input.currentVersion === undefined) {
                 return '0.0.1';
             }
+            const prLogConfig = createPrLogConfig(sourceInput.packtoryConfig.changelog);
             return selectNextVersion(
                 input.currentVersion,
                 await collectLabeledPullRequests(input, sourceInput.packtoryConfig),
-                createValidLabels(sourceInput.packtoryConfig)
+                prLogConfig.versionBumps
             );
         };
     };

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -76,7 +76,7 @@ packtory <command> [options]
 - `packtory changelog` computes the same release plan used by Packtory's release planning API and skips unchanged packages.
 - Without `changelog.outputs`, it prints one grouped Markdown changelog for packages that would publish a changed artifact.
 - `changelog.outputs` can write a grouped repository file with `{ kind: 'repository-file', path }`, write package-specific files below each changed package's effective `sourcesFolder` with `{ kind: 'package-file', path }`, write package-specific files to explicit repository-relative paths with `{ kind: 'package-file', paths }`, and print grouped release-body Markdown with `{ kind: 'github-release' }`.
-- `changelog.labels` extends or overrides the default pull request label mapping. `changelog.targetScopedLabelPattern` customizes package-specific labels and must contain `{targetName}` and `{label}`.
+- `changelog.prLog` passes changelog behavior into `@pr-log/core`, including `validLabels`, `ignoredLabels`, `versionBumps`, `dateFormat`, `collapseRules`, label lookup interval, and rate-limit retry count. `changelog.targetScopedLabelPattern` customizes package-specific labels and must contain `{targetName}` and `{label}`.
 - `changelog.packageTagFormat` customizes package tag lookup for changelog base refs. `changelog.explicitBaseRef` uses one fixed base ref instead.
 - Pull requests are attributed by comparing GitHub changed files against each package's attributed source files. Changelog files named `CHANGELOG.md` and configured generated changelog output paths are ignored as attribution inputs.
 - JavaScript files are attributed through referenced source maps when they have a `sourceMappingURL`. Without that reference, the JavaScript file itself is attributed.

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -40,6 +40,8 @@ type PlanReleaseAgainstLatestPublishedFunction = (config: unknown) => Promise<Re
 type PackageConfig = PacktoryConfig['packages'][number];
 type ChangelogSettings = NonNullable<PacktoryConfig['changelog']>;
 type Root = PackageConfig['roots'][string];
+type LabelLookupIntervalMilliseconds = 500;
+type MaximumRateLimitRetryCount = 5;
 type ConfigWithVersioning<TVersioning> = {
     readonly registrySettings: {
         readonly auth: { readonly type: 'bearer-token'; readonly token: 'any-token'; };
@@ -162,7 +164,21 @@ describe('PacktoryConfig - accepted shapes', function () {
             readonly checks: { readonly noDuplicatedFiles: { readonly enabled: true; }; };
             readonly changelog: {
                 readonly explicitBaseRef: 'main';
-                readonly labels: { readonly operations: 'Operations'; };
+                readonly prLog: {
+                    readonly validLabels: { readonly operations: 'Operations'; };
+                    readonly ignoredLabels: readonly ['skip-changelog'];
+                    readonly versionBumps: { readonly patch: readonly ['operations']; };
+                    readonly dateFormat: 'yyyy-MM-dd';
+                    readonly collapseRules: readonly [
+                        {
+                            readonly label: 'operations';
+                            readonly pattern: '^Update (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$';
+                            readonly replace: 'Update $<dependency> from $<from> to $<to>';
+                        }
+                    ];
+                    readonly labelLookupIntervalMilliseconds: LabelLookupIntervalMilliseconds;
+                    readonly maximumRateLimitRetryCount: MaximumRateLimitRetryCount;
+                };
                 readonly outputs: readonly [
                     { readonly kind: 'repository-file'; readonly path: 'CHANGELOG.md'; },
                     {
@@ -326,7 +342,9 @@ describe('VersionProviderInput', function () {
 describe('PacktoryConfig changelog structure', function () {
     test('changelog exposes generation and output settings', function () {
         expect<ChangelogSettings['explicitBaseRef']>().type.toBe<string | undefined>();
-        expect<ChangelogSettings['labels']>().type.toBe<Readonly<Record<string, string>> | undefined>();
+        expect<NonNullable<ChangelogSettings['prLog']>['validLabels']>().type.toBe<
+            Readonly<Record<string, string>> | undefined
+        >();
         expect<ChangelogSettings['outputs']>().type.toBeAssignableTo<readonly unknown[] | undefined>();
         expect<ChangelogSettings['packageTagFormat']>().type.toBe<string | undefined>();
         expect<ChangelogSettings['targetScopedLabelPattern']>().type.toBe<string | undefined>();

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -1,19 +1,24 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
-import type {
-    FilterPullRequestsByTargetFilesInput,
-    PrLogEngine,
-    PullRequest,
-    PullRequestWithLabel,
-    RenderGroupedTargetChangelogMarkdownInput,
-    ResolvePullRequestLabelsOptions
+import {
+    defaultPrLogConfig,
+    type FilterPullRequestsByTargetFilesInput,
+    type PrLogEngine,
+    type PullRequest,
+    type PullRequestWithLabel,
+    type RenderGroupedTargetChangelogMarkdownInput,
+    type ResolvePullRequestLabelsOptions
 } from '@pr-log/core';
 import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { generateChangelogOutputs } from './packtory-changelog.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
 
-const validLabels = new Map([ [ 'bug', 'Bug Fixes' ] ]);
+const prLogConfig = {
+    ...defaultPrLogConfig,
+    validLabels: new Map([ [ 'bug', 'Bug Fixes' ] ]),
+    versionBumps: { major: [], minor: [], patch: [ 'bug' ] }
+};
 
 function releasePackage(overrides: Partial<ReleasePlanPackage>): ReleasePlanPackage {
     return {
@@ -47,6 +52,7 @@ type EngineCalls = {
     readonly resolveChangelogBaseRef: SinonSpy;
     readonly resolveLatestSemverChangelogBaseRef: SinonSpy;
     readonly resolvePullRequestLabels: SinonSpy;
+    readonly resolveVersionNumber: SinonSpy;
 };
 
 type EngineFixture = {
@@ -98,7 +104,8 @@ function createEngine(): EngineFixture {
             return { ref: `${input.packageName}-base` };
         }),
         resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
-        resolvePullRequestLabels: fake.resolves(labeledPullRequests)
+        resolvePullRequestLabels: fake.resolves(labeledPullRequests),
+        resolveVersionNumber: fake.returns('1.0.1')
     };
 
     return { engine: calls as unknown as PrLogEngine, calls };
@@ -110,12 +117,11 @@ async function render(packages: readonly ReleasePlanPackage[], engine: PrLogEngi
         prLogEngine: engine,
         explicitBaseRef: undefined,
         githubRepo: 'owner/repo',
-        packageInfo: {},
         packageTagFormat: undefined,
         currentDate: new Date('2026-06-13T00:00:00.000Z'),
         ignoredAttributionPaths: [],
-        targetScopedLabelPattern: undefined,
-        validLabels
+        prLogConfig,
+        targetScopedLabelPattern: undefined
     });
     return changelog.groupedMarkdown;
 }
@@ -174,8 +180,7 @@ function registerTargetSelectionTests(): void {
         });
         assert.deepStrictEqual(calls.resolvePullRequestLabels.firstCall.args[0], {
             githubRepo: 'owner/repo',
-            validLabels,
-            ignoredLabels: [],
+            config: prLogConfig,
             pullRequests: [ { id: 1, title: 'Fix package' } ],
             targetName: 'pkg-a',
             targetScopedLabelPattern: undefined
@@ -250,30 +255,35 @@ function registerDependencyUpdateTests(): void {
             }
         ]);
         assert.strictEqual(
-            calls.renderGroupedTargetChangelog.firstCall.args[0].validLabels.get('upgrade'),
+            calls.renderGroupedTargetChangelog.firstCall.args[0].config.validLabels.get('upgrade'),
             'Dependency Upgrades'
         );
     });
 
     test('preserves configured dependency update changelog labels', async function () {
         const { engine, calls } = createEngine();
-        const customValidLabels = new Map([ ...validLabels, [ 'upgrade', 'Upgrades' ] ]);
+        const customPrLogConfig = {
+            ...prLogConfig,
+            validLabels: new Map([ ...prLogConfig.validLabels, [ 'upgrade', 'Upgrades' ] ])
+        };
 
         await generateChangelogOutputs({
             packages: [ releasePackage({ releaseClassification: 'dependency-only' }) ],
             prLogEngine: engine,
             githubRepo: 'owner/repo',
-            packageInfo: {},
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             explicitBaseRef: undefined,
             ignoredAttributionPaths: [],
             packageTagFormat: undefined,
-            targetScopedLabelPattern: undefined,
-            validLabels: customValidLabels
+            prLogConfig: customPrLogConfig,
+            targetScopedLabelPattern: undefined
         });
 
-        assert.strictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].validLabels, customValidLabels);
-        assert.strictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].validLabels.get('upgrade'), 'Upgrades');
+        assert.strictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].config, customPrLogConfig);
+        assert.strictEqual(
+            calls.renderGroupedTargetChangelog.firstCall.args[0].config.validLabels.get('upgrade'),
+            'Upgrades'
+        );
     });
 
     test('includes manifest dependency pull requests whose titles mention changed dependencies', async function () {
@@ -323,13 +333,12 @@ function registerPackageChangelogTests(): void {
             packages: [ releasePackage({ changelogSourceFiles: [ 'source/pkg-a.ts' ] }) ],
             prLogEngine: emptyEngine,
             githubRepo: 'owner/repo',
-            packageInfo: {},
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             explicitBaseRef: undefined,
             ignoredAttributionPaths: [],
             packageTagFormat: undefined,
-            targetScopedLabelPattern: undefined,
-            validLabels
+            prLogConfig,
+            targetScopedLabelPattern: undefined
         });
 
         assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets, []);
@@ -382,13 +391,12 @@ function registerAttributionPathTests(): void {
             packages: [ releasePackage({ changelogSourceFiles: [ 'source/pkg-a.ts' ] }) ],
             prLogEngine: engine,
             githubRepo: 'owner/repo',
-            packageInfo: {},
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             explicitBaseRef: undefined,
             ignoredAttributionPaths: [ 'docs/generated.md' ],
             packageTagFormat: undefined,
-            targetScopedLabelPattern: undefined,
-            validLabels
+            prLogConfig,
+            targetScopedLabelPattern: undefined
         });
 
         assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].ignoredAttributionPaths, [
@@ -406,12 +414,11 @@ function registerOptionForwardingTests(): void {
             prLogEngine: engine,
             explicitBaseRef: 'release-base',
             githubRepo: 'owner/repo',
-            packageInfo: {},
             packageTagFormat: 'pkg/{packageName}/v{version}',
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             ignoredAttributionPaths: [],
-            targetScopedLabelPattern: 'scope:{targetName}:{label}',
-            validLabels
+            prLogConfig,
+            targetScopedLabelPattern: 'scope:{targetName}:{label}'
         });
 
         assert.strictEqual(calls.resolveLatestSemverChangelogBaseRef.callCount, 0);

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { PrLogEngine, PullRequest, PullRequestWithLabel, TargetChangelogSection } from '@pr-log/core';
+import type { PrLogConfig, PrLogEngine, PullRequest, PullRequestWithLabel, TargetChangelogSection } from '@pr-log/core';
 import { compareValues } from '../common/sort-values.ts';
 import { releaseAnalysisClassification, type ReleasePlanPackage } from './packtory-results.ts';
 import { isPackageManifestInputPath } from './changelog-source-attribution.ts';
@@ -35,12 +35,11 @@ export type GenerateChangelogInput = {
     readonly explicitBaseRef: string | undefined;
     readonly githubRepo: string;
     readonly ignoredAttributionPaths: readonly string[];
-    readonly packageInfo: Readonly<Record<string, unknown>>;
     readonly packages: readonly ReleasePlanPackage[];
     readonly packageTagFormat: string | undefined;
+    readonly prLogConfig: PrLogConfig;
     readonly prLogEngine: Pick<PrLogEngine, PrLogMethod>;
     readonly targetScopedLabelPattern: string | undefined;
-    readonly validLabels: ReadonlyMap<string, string>;
 };
 
 export type GeneratedChangelog = {
@@ -163,8 +162,7 @@ async function collectTargetPullRequests(
 
     return input.prLogEngine.resolvePullRequestLabels({
         githubRepo: input.githubRepo,
-        validLabels: input.validLabels,
-        ignoredLabels: [],
+        config: input.prLogConfig,
         pullRequests: mergePullRequests([ ...packagePullRequests, ...dependencyPullRequests ]),
         targetName: packagePlan.name,
         targetScopedLabelPattern: input.targetScopedLabelPattern
@@ -192,11 +190,14 @@ function changelogPullRequestsFor(target: ChangelogTarget): readonly PullRequest
     });
 }
 
-function changelogLabelsForRendering(validLabels: ReadonlyMap<string, string>): ReadonlyMap<string, string> {
-    if (validLabels.has(dependencyUpdateLabel())) {
-        return validLabels;
+function prLogConfigForRendering(config: PrLogConfig): PrLogConfig {
+    if (config.validLabels.has(dependencyUpdateLabel())) {
+        return config;
     }
-    return new Map([ ...validLabels, [ dependencyUpdateLabel(), 'Dependency Upgrades' ] ]);
+    return {
+        ...config,
+        validLabels: new Map([ ...config.validLabels, [ dependencyUpdateLabel(), 'Dependency Upgrades' ] ])
+    };
 }
 
 function createTargetSection(target: ChangelogTarget): TargetChangelogSection {
@@ -216,16 +217,15 @@ function createPackageMarkdownByName(
     input: GenerateChangelogInput,
     targets: readonly ChangelogTarget[]
 ): ReadonlyMap<string, string> {
-    const validLabels = changelogLabelsForRendering(input.validLabels);
+    const config = prLogConfigForRendering(input.prLogConfig);
     return new Map(
         targets.filter(hasChangelogEntries).map(function (target) {
             const targetSection = createTargetSection(target);
             return [
                 target.packagePlan.name,
                 input.prLogEngine.renderTargetChangelog({
-                    packageInfo: input.packageInfo,
+                    config,
                     currentDate: input.currentDate,
-                    validLabels,
                     githubRepo: input.githubRepo,
                     ...targetSection
                 })
@@ -237,7 +237,7 @@ function createPackageMarkdownByName(
 export async function generateChangelogOutputs(input: GenerateChangelogInput): Promise<GeneratedChangelog> {
     const packages = selectChangedPackages(input.packages);
     const ignoredAttributionPaths = mergeIgnoredAttributionPaths(packages, input.ignoredAttributionPaths);
-    const validLabels = changelogLabelsForRendering(input.validLabels);
+    const config = prLogConfigForRendering(input.prLogConfig);
     const targets = await Promise.all(
         packages.map(async function (packagePlan) {
             return createChangelogTarget(input, packagePlan, ignoredAttributionPaths);
@@ -247,9 +247,8 @@ export async function generateChangelogOutputs(input: GenerateChangelogInput): P
 
     return {
         groupedMarkdown: input.prLogEngine.renderGroupedTargetChangelog({
-            packageInfo: input.packageInfo,
+            config,
             currentDate: input.currentDate,
-            validLabels,
             githubRepo: input.githubRepo,
             targets: targetsWithEntries.map(createTargetSection)
         }),

--- a/source/test-libraries/release-handler-test-support.ts
+++ b/source/test-libraries/release-handler-test-support.ts
@@ -140,6 +140,7 @@ export function createEngine(): PrLogEngine {
             assert.strictEqual(input.githubRepo, 'enormora/packtory');
             return [ { id: 1, title: 'Fix package', label: 'bug' } ];
         }),
+        resolveVersionNumber: fake.returns('1.0.1'),
         renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
         renderTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
         updateChangelog: fake(function (input: UpdateChangelogInput) {
@@ -359,6 +360,7 @@ export function createReleaseHandlerDeps(scenario: Scenario = {}): ReleaseHandle
             if (scenario.readEnvironmentVariable === undefined) {
                 assert.strictEqual(options.githubToken, 'gh-token');
             }
+            assert.strictEqual(options.config.labelLookupIntervalMilliseconds, 250);
             return scenario.engine ?? createEngine();
         },
         currentDate() {

--- a/source/test-libraries/release-pull-request-handler-test-support.ts
+++ b/source/test-libraries/release-pull-request-handler-test-support.ts
@@ -104,6 +104,7 @@ export function createDependencies(
             filterPullRequestsByTargetFiles: fake.returns([ { id: 1, title: 'Fix package' } ]),
             readPullRequestLabels: fake.resolves(new Map([ [ 1, [ 'bug' ] ] ])),
             readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'src/index.ts' ] ] ])),
+            resolveVersionNumber: fake.returns('1.0.1'),
             renderChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),
             renderGroupedTargetChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),
             renderTargetChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),

--- a/source/test-libraries/runner-test-support.ts
+++ b/source/test-libraries/runner-test-support.ts
@@ -86,6 +86,7 @@ function createPrLogEngineFactory(overrides: Overrides): CommandLineInterfaceRun
         readPullRequestLabels: fake.resolves(new Map()),
         filterPullRequestsByTargetFiles: fake.returns([]),
         resolvePullRequestLabels: fake.resolves([]),
+        resolveVersionNumber: fake.returns('1.0.1'),
         renderChangelog: fake.returns(''),
         renderGroupedTargetChangelog: fake.returns(''),
         renderTargetChangelog: fake.returns(''),


### PR DESCRIPTION
Updates Packtory to `@pr-log/core` `0.0.3` and routes changelog behavior through a `changelog.prLog` config node. The new config maps Packtory settings into core `PrLogConfig`, so changelog generation, release changelog writes, release PR maintenance, and pull-request-label versioning share the same label, date, collapse, version bump, retry, and lookup settings.