### PR TITLE
Avoid `pull-request-labels` bumps for unchanged artifacts

### DIFF
--- a/source/packtory/package-processor-publish-provider-versioning.test.ts
+++ b/source/packtory/package-processor-publish-provider-versioning.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import { Maybe } from 'true-myth';
+import {
+    createAnalyzedBundle,
+    createBuildAndPublishOptions,
+    createProcessor,
+    createVersionedBundle
+} from '../test-libraries/package-processor-test-support.ts';
+import type { BuildAndPublishOptions } from './map-config.ts';
+import type { BuildAndPublishResult, DetermineVersionAndPublishOptions } from './package-processor.ts';
+
+type VersionedBundleInput = { readonly version: string; };
+type VersionedBundleBuilder = {
+    readonly addVersion: SinonSpy;
+    readonly versions: readonly string[];
+};
+
+function publishedArtifacts(version: string, gitHead: string): BuildAndPublishResult['previousReleaseArtifacts'] {
+    return Maybe.just({
+        version,
+        publishedAt: undefined,
+        gitHead,
+        files: []
+    });
+}
+
+function tryBuildOptions(versioning: BuildAndPublishOptions['versioning']): DetermineVersionAndPublishOptions {
+    return {
+        analyzedBundle: createAnalyzedBundle(),
+        buildOptions: { ...createBuildAndPublishOptions(), versioning },
+        stage: false
+    };
+}
+
+function versionedBundleBuilder(): VersionedBundleBuilder {
+    const versions: string[] = [];
+    const addVersion = fake(function (input: VersionedBundleInput) {
+        versions.push(input.version);
+        return createVersionedBundle('package-a', input.version);
+    });
+    return { addVersion, versions };
+}
+
+suite('package-processor publish provider versioning', function () {
+    test('checks provider-versioned packages at the current version before asking for a bump', async function () {
+        const provideVersion = fake.returns('1.2.4');
+        const currentVersionedBundle = createVersionedBundle('package-a', '1.2.3');
+        const addVersion = fake.returns(currentVersionedBundle);
+        const checkBundleAlreadyPublished = fake.resolves({
+            alreadyPublishedAsLatest: true,
+            previousReleaseArtifacts: publishedArtifacts('1.2.3', 'published-head')
+        });
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion,
+            checkBundleAlreadyPublished
+        });
+
+        const result = await processor.tryBuildAndPublish(tryBuildOptions({ automatic: false, provideVersion }));
+
+        assert.deepStrictEqual(
+            [ result.status, result.bundle.version, provideVersion.callCount, addVersion.callCount ],
+            [ 'already-published', '1.2.3', 0, 1 ]
+        );
+        assert.deepStrictEqual(checkBundleAlreadyPublished.firstCall.args, [ {
+            bundle: currentVersionedBundle,
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } }
+        } ]);
+    });
+
+    test('asks the provider for a new version when current artifacts changed', async function () {
+        const provideVersion = fake.returns('1.2.4');
+        const { addVersion, versions } = versionedBundleBuilder();
+        const { processor } = createProcessor({
+            determineCurrentVersion: fake.resolves(Maybe.just('1.2.3')),
+            addVersion,
+            checkBundleAlreadyPublished: fake.resolves({
+                alreadyPublishedAsLatest: false,
+                previousReleaseArtifacts: publishedArtifacts('1.2.3', 'published-head')
+            })
+        });
+
+        const result = await processor.tryBuildAndPublish(tryBuildOptions({ automatic: false, provideVersion }));
+
+        assert.deepStrictEqual([ result.status, result.bundle.version, provideVersion.callCount ], [
+            'new-version',
+            '1.2.4',
+            1
+        ]);
+        assert.deepStrictEqual(versions, [ '1.2.3', '1.2.4' ]);
+    });
+
+    test('asks the provider directly when there is no current version to check', async function () {
+        const { addVersion, versions } = versionedBundleBuilder();
+        const determineCurrentVersion = fake.resolves(Maybe.nothing());
+        const provideVersion = fake.returns('1.2.4');
+        const versioning = {
+            automatic: false as const,
+            provideVersion
+        };
+        const { processor } = createProcessor({
+            determineCurrentVersion,
+            addVersion
+        });
+
+        await processor.tryBuildAndPublish(tryBuildOptions(versioning));
+
+        assert.deepStrictEqual(versions, [ '1.2.4' ]);
+        const expectedCurrentVersionLookup = [ {
+            name: 'package-a',
+            registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+            stage: false,
+            versioning
+        } ];
+        const actualCurrentVersionLookups = [
+            determineCurrentVersion.firstCall.args,
+            determineCurrentVersion.secondCall.args
+        ];
+        assert.deepStrictEqual(actualCurrentVersionLookups, [
+            expectedCurrentVersionLookup,
+            expectedCurrentVersionLookup
+        ]);
+    });
+});

--- a/source/packtory/package-processor-publish.ts
+++ b/source/packtory/package-processor-publish.ts
@@ -44,6 +44,7 @@ type VersionDeterminedInput = {
     readonly chosenVersion: string;
     readonly didBump: boolean;
 };
+type CurrentHeadPublishAttempt = BuildAndPublishResult | false | undefined;
 type FinalizeWithoutBumpExtras = {
     readonly extraFiles: ExtraFiles;
     readonly previousReleaseArtifacts: PreviousReleaseArtifacts;
@@ -55,7 +56,6 @@ type BuildVersionedBundleForVersionInput = {
     readonly version: string;
     readonly substitutionPublicModuleSourcePaths: ReadonlySet<string> | undefined;
 };
-
 export type BuildAndPublishResult = {
     readonly status: PublishedReleaseStatus;
     readonly bundle: VersionedBundleWithManifest;
@@ -79,6 +79,10 @@ function assertEsmMainPackageJson(mainPackageJson: MainPackageTypeField): void {
 
 function siblingsFromOptions(buildOptions: BuildAndPublishOptions): readonly SiblingPackage[] {
     return [ ...buildOptions.bundleDependencies, ...buildOptions.bundlePeerDependencies ];
+}
+
+function usesVersionProvider(versioning: BuildAndPublishOptions['versioning']): boolean {
+    return Object.hasOwn(versioning, 'provideVersion');
 }
 
 function buildVersionedBundleForVersion(input: BuildVersionedBundleForVersionInput): VersionedBundleWithManifest {
@@ -147,7 +151,7 @@ function isVerifiedFinalizedPublish(
 async function tryFinalizePublishedCurrentHead(
     dependencies: PublishDependencies,
     options: DetermineVersionAndPublishOptions
-): Promise<BuildAndPublishResult | undefined> {
+): Promise<CurrentHeadPublishAttempt> {
     const candidate = options.stage
         ? undefined
         : await dependencies.bundleEmitter.findCurrentHeadPublishedVersion({
@@ -174,7 +178,7 @@ async function tryFinalizePublishedCurrentHead(
     );
 
     if (!isVerifiedFinalizedPublish(candidate, alreadyPublished)) {
-        return undefined;
+        return false;
     }
 
     return {
@@ -294,6 +298,43 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
         return undefined;
     }
 
+    async function tryFinalizeCurrentProviderVersion(
+        options: DetermineVersionAndPublishOptions
+    ): Promise<BuildAndPublishResult | undefined> {
+        const currentVersion = await dependencies.bundleEmitter.determineCurrentVersion({
+            name: options.analyzedBundle.name,
+            registrySettings: options.buildOptions.registrySettings,
+            stage: options.stage,
+            versioning: options.buildOptions.versioning
+        });
+        if (!usesVersionProvider(options.buildOptions.versioning) || currentVersion.isNothing) {
+            return undefined;
+        }
+        const versionedBundle = buildVersionedBundleForVersion({
+            dependencies,
+            analyzedBundle: options.analyzedBundle,
+            options: options.buildOptions,
+            version: currentVersion.value,
+            substitutionPublicModuleSourcePaths: options.substitutionPublicModuleSourcePaths
+        });
+        const extraFiles = await generateExtraFiles(dependencies, versionedBundle, options.buildOptions);
+        const alreadyPublished = await checkBundleAlreadyPublished(
+            dependencies,
+            versionedBundle,
+            options.buildOptions,
+            extraFiles
+        );
+        return alreadyPublished.alreadyPublishedAsLatest
+            ? {
+                bundle: versionedBundle,
+                status: publishedReleaseStatus.alreadyPublished,
+                publication: noPublication,
+                extraFiles,
+                previousReleaseArtifacts: alreadyPublished.previousReleaseArtifacts
+            }
+            : undefined;
+    }
+
     async function buildPendingPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {
         const buildContext = await buildVersionedBundle(
             options.analyzedBundle,
@@ -322,7 +363,9 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
         if (finalizedWithoutBump !== undefined) {
             return finalizedWithoutBump;
         }
-        const newVersionedBundle = await bumpVersion(buildContext, options.buildOptions);
+        const newVersionedBundle = usesVersionProvider(options.buildOptions.versioning)
+            ? buildContext.versionedBundle
+            : await bumpVersion(buildContext, options.buildOptions);
         const extraFiles = await generateExtraFiles(dependencies, newVersionedBundle, options.buildOptions);
         return {
             bundle: newVersionedBundle,
@@ -336,8 +379,14 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
     }
 
     async function tryBuildAndPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {
-        const finalizedPublish = await tryFinalizePublishedCurrentHead(dependencies, options);
-        return finalizedPublish ?? await buildPendingPublish(options);
+        assertEsmMainPackageJson(options.buildOptions.mainPackageJson);
+        const currentHeadPublishAttempt = await tryFinalizePublishedCurrentHead(dependencies, options);
+        if (currentHeadPublishAttempt === false) {
+            return buildPendingPublish(options);
+        }
+        return currentHeadPublishAttempt ??
+            await tryFinalizeCurrentProviderVersion(options) ??
+            await buildPendingPublish(options);
     }
 
     async function buildAndPublish(options: DetermineVersionAndPublishOptions): Promise<BuildAndPublishResult> {


### PR DESCRIPTION
Provider-driven versioning now checks the current published version first when a current version exists. If those artifacts already match the latest published package, Packtory treats the package as unchanged instead of asking the provider for a new version.