### PR TITLE
Fail release PR CI statuses when dispatched workflows stall

### DIFF
--- a/source/command-line-interface/runner/release-pull-request-ci.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.test.ts
@@ -87,6 +87,7 @@ function assertSuccessfulWorkflowMirrored(
         branch: 'release/packtory',
         headSha: 'release-head'
     });
+    assert.strictEqual(deleteActionRequiredPullRequestRuns.calledBefore(findDispatchedWorkflowRun), true);
 }
 
 async function assertUnsuccessfulJobIsMirrored(conclusion: string, expectedState: 'error' | 'failure'): Promise<void> {
@@ -492,11 +493,13 @@ suite('release-pull-request-ci', function () {
         });
 
         test('fails when the dispatched workflow run does not complete', async function () {
+            const createStatus = fake.resolves(undefined);
+            const deleteActionRequiredPullRequestRuns = fake.resolves(undefined);
             const readWorkflowRunResult = fake.resolves({ conclusion: undefined, databaseId: 1, jobs: [] });
             const sleep = fake.resolves(undefined);
             await assert.rejects(
                 runConfiguredGitHubActionsCi({
-                    client: createClient({ readWorkflowRunResult }),
+                    client: createClient({ createStatus, deleteActionRequiredPullRequestRuns, readWorkflowRunResult }),
                     config: createConfig(),
                     headSha: 'release-head',
                     sleep
@@ -505,6 +508,17 @@ suite('release-pull-request-ci', function () {
             );
             assert.strictEqual(readWorkflowRunResult.callCount, 120);
             assert.strictEqual(sleep.callCount, 119);
+            assert.deepStrictEqual(deleteActionRequiredPullRequestRuns.firstCall.args[0], {
+                branch: 'release/packtory',
+                headSha: 'release-head'
+            });
+            assert.deepStrictEqual(createStatus.lastCall.args[0], {
+                commitSha: 'release-head',
+                context: 'Node.js',
+                description: 'Dispatched release CI did not complete.',
+                state: 'error',
+                targetUrl: undefined
+            });
         });
     });
 });

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -304,20 +304,11 @@ async function createFailedWorkflowStatuses(input: FailedWorkflowStatusesInput):
 
 async function dispatchWorkflowRun(input: WaitForDispatchedWorkflowRunInput): Promise<number> {
     await createPendingWorkflowStatuses(input);
-    try {
-        await input.client.dispatchWorkflow({
-            ref: input.config.branch,
-            workflowFile: input.ciConfig.workflowFile
-        });
-        const runId = await waitForDispatchedWorkflowRun(input);
-        return runId;
-    } catch (error) {
-        await createFailedWorkflowStatuses({
-            ...input,
-            description: 'Dispatched release CI did not start.'
-        });
-        throw error;
-    }
+    await input.client.dispatchWorkflow({
+        ref: input.config.branch,
+        workflowFile: input.ciConfig.workflowFile
+    });
+    return waitForDispatchedWorkflowRun(input);
 }
 
 async function resolveWorkflowRunId(input: WaitForDispatchedWorkflowRunInput): Promise<number> {
@@ -325,26 +316,68 @@ async function resolveWorkflowRunId(input: WaitForDispatchedWorkflowRunInput): P
     return runId ?? dispatchWorkflowRun(input);
 }
 
+async function deleteActionRequiredPullRequestRuns(
+    input: RunConfiguredGitHubActionsCiInput,
+    ciConfig: GitHubActionsCiConfig
+): Promise<void> {
+    if (!ciConfig.deleteActionRequiredPullRequestRuns) {
+        return;
+    }
+    await input.client.deleteActionRequiredPullRequestRuns({ branch: input.config.branch, headSha: input.headSha });
+}
+
+async function resolveWorkflowRunIdOrFailStatuses(
+    input: RunConfiguredGitHubActionsCiInput,
+    ciConfig: GitHubActionsCiConfig
+): Promise<number> {
+    try {
+        return await resolveWorkflowRunId({ ...input, ciConfig });
+    } catch (error) {
+        await createFailedWorkflowStatuses({
+            ciConfig,
+            client: input.client,
+            description: 'Dispatched release CI did not start.',
+            headSha: input.headSha
+        });
+        throw error;
+    }
+}
+
+async function waitForWorkflowCompletionOrFailStatuses(
+    input: RunConfiguredGitHubActionsCiInput,
+    ciConfig: GitHubActionsCiConfig,
+    runId: number
+): Promise<WorkflowRunResult> {
+    try {
+        return await waitForWorkflowCompletion({
+            ciConfig,
+            client: input.client,
+            headSha: input.headSha,
+            runId,
+            sleep: input.sleep
+        });
+    } catch (error) {
+        await createFailedWorkflowStatuses({
+            ciConfig,
+            client: input.client,
+            description: 'Dispatched release CI did not complete.',
+            headSha: input.headSha
+        });
+        throw error;
+    }
+}
+
 export async function runConfiguredGitHubActionsCi(input: RunConfiguredGitHubActionsCiInput): Promise<boolean> {
     const { githubActionsCi } = input.config;
     if (githubActionsCi === undefined) {
         return true;
     }
-    const runId = await resolveWorkflowRunId({ ...input, ciConfig: githubActionsCi });
-    const runResult = await waitForWorkflowCompletion({
-        ciConfig: githubActionsCi,
-        client: input.client,
-        headSha: input.headSha,
-        runId,
-        sleep: input.sleep
-    });
-    if (githubActionsCi.deleteActionRequiredPullRequestRuns) {
-        await input.client.deleteActionRequiredPullRequestRuns({ branch: input.config.branch, headSha: input.headSha });
-    }
+    await deleteActionRequiredPullRequestRuns(input, githubActionsCi);
+    const runId = await resolveWorkflowRunIdOrFailStatuses(input, githubActionsCi);
     return mirrorWorkflowStatuses({
         ciConfig: githubActionsCi,
         client: input.client,
         headSha: input.headSha,
-        runResult
+        runResult: await waitForWorkflowCompletionOrFailStatuses(input, githubActionsCi, runId)
     });
 }


### PR DESCRIPTION
Release PR CI now deletes approval-blocked `pull_request` runs before dispatch lookup instead of waiting for the dispatched run to complete. Dispatch lookup and workflow completion failures now overwrite required synthetic statuses with `error`, so release PRs do not stay pending forever.