### PR TITLE
Avoid PR links for substituted dependency changelogs

### DIFF
--- a/source/packtory/packtory-changelog-dependency.test.ts
+++ b/source/packtory/packtory-changelog-dependency.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import {
+    defaultPrLogConfig,
+    type FilterPullRequestsByTargetFilesInput,
+    type PullRequest,
+    type PullRequestWithLabel,
+    type RenderGroupedTargetChangelogMarkdownInput,
+    type RenderTargetChangelogMarkdownInput,
+    type ResolvePullRequestLabelsOptions
+} from '@pr-log/core';
+import { generateChangelogOutputs, type GenerateChangelogInput } from './packtory-changelog.ts';
+import type { ReleasePlanPackage } from './packtory-results.ts';
+
+type ChangelogEngine = GenerateChangelogInput['prLogEngine'];
+
+const reactDependencyMarkdown = '* Update react to 19.0.0 ([#1](https://github.com/owner/repo/pull/1))';
+
+function releasePackage(overrides: Partial<ReleasePlanPackage>): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        releaseClassification: 'dependency-only',
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'current-head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: [ 'dist/index.js' ],
+        changedArtifactFiles: [ 'package.json' ],
+        sourceFiles: [ 'source/pkg-a.ts' ],
+        changelogSourceFiles: [ 'source/pkg-a.ts' ],
+        changelogDependencyNames: [ '@scope/pkg' ],
+        changelogDependencyUpdates: [ { name: '@scope/pkg', version: '1.2.3' } ],
+        ...overrides
+    };
+}
+
+function renderPullRequests(pullRequests: readonly PullRequestWithLabel[]): string {
+    return pullRequests
+        .map(function (pullRequest) {
+            return `* ${pullRequest.title} ([#${pullRequest.id}](https://github.com/owner/repo/pull/${pullRequest.id}))`;
+        })
+        .join('\n');
+}
+
+function createEngine(overrides: Partial<ChangelogEngine>): ChangelogEngine {
+    const pullRequests: readonly PullRequest[] = [ { id: 1, title: 'Fix package' } ];
+    return {
+        collectMergedPullRequests: fake.resolves(pullRequests),
+        filterPullRequestsByTargetFiles: fake(function (input: FilterPullRequestsByTargetFilesInput) {
+            return input.pullRequests;
+        }),
+        readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'source/pkg-a.ts' ] ] ])),
+        renderGroupedTargetChangelog: fake(function (input: RenderGroupedTargetChangelogMarkdownInput) {
+            return renderPullRequests(input.targets.flatMap(function (target) {
+                return target.mergedPullRequests;
+            }));
+        }),
+        renderTargetChangelog: fake(function (input: RenderTargetChangelogMarkdownInput) {
+            return renderPullRequests(input.mergedPullRequests);
+        }),
+        resolveChangelogBaseRef: fake.resolves({ ref: 'pkg-a-base' }),
+        resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
+        resolvePullRequestLabels: fake(async function (options: ResolvePullRequestLabelsOptions) {
+            return options.pullRequests.map(function (pullRequest): PullRequestWithLabel {
+                return { ...pullRequest, label: 'bug' };
+            });
+        }),
+        ...overrides
+    };
+}
+
+async function generate(
+    packages: readonly ReleasePlanPackage[],
+    engine: ChangelogEngine
+): ReturnType<typeof generateChangelogOutputs> {
+    return generateChangelogOutputs({
+        packages,
+        prLogEngine: engine,
+        githubRepo: 'owner/repo',
+        currentDate: new Date('2026-06-13T00:00:00.000Z'),
+        explicitBaseRef: undefined,
+        ignoredAttributionPaths: [],
+        packageTagFormat: undefined,
+        prLogConfig: defaultPrLogConfig,
+        targetScopedLabelPattern: undefined
+    });
+}
+
+function reactDependencyPackage(): ReleasePlanPackage {
+    return releasePackage({
+        changelogDependencyNames: [ 'react' ],
+        changelogDependencyUpdates: [ { name: 'react', version: '19.0.0' } ]
+    });
+}
+
+async function generateReactDependencyChangelog(engine: ChangelogEngine): ReturnType<typeof generateChangelogOutputs> {
+    return generate([ reactDependencyPackage() ], engine);
+}
+
+suite('packtory-changelog dependency updates', function () {
+    test('omits pull request links for substitution-only dependency entries', async function () {
+        const engine = createEngine({});
+
+        const changelog = await generate([ releasePackage({}) ], engine);
+
+        assert.strictEqual(changelog.groupedMarkdown, '* Update @scope/pkg to 1.2.3');
+        assert.strictEqual(changelog.packageMarkdownByName.get('pkg-a'), '* Update @scope/pkg to 1.2.3');
+    });
+
+    test('preserves pull request links for manifest dependency entries', async function () {
+        const engine = createEngine({
+            collectMergedPullRequests: fake.resolves([ { id: 1, title: 'Update React to v19' } ]),
+            filterPullRequestsByTargetFiles: fake.returns([]),
+            readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'package-lock.json' ] ] ]))
+        });
+
+        const changelog = await generateReactDependencyChangelog(engine);
+
+        assert.strictEqual(changelog.groupedMarkdown, reactDependencyMarkdown);
+    });
+
+    test('uses manifest dependency pull requests over other package pull requests', async function () {
+        const engine = createEngine({
+            collectMergedPullRequests: fake.resolves([
+                { id: 1, title: 'Update React to v19' },
+                { id: 2, title: 'Fix package' }
+            ]),
+            filterPullRequestsByTargetFiles: fake.returns([ { id: 2, title: 'Fix package' } ]),
+            readPullRequestChangedFiles: fake.resolves(
+                new Map([
+                    [ 1, [ 'package-lock.json' ] ],
+                    [ 2, [ 'source/pkg-a.ts' ] ]
+                ])
+            )
+        });
+
+        const changelog = await generateReactDependencyChangelog(engine);
+
+        assert.strictEqual(changelog.groupedMarkdown, reactDependencyMarkdown);
+    });
+});

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -280,7 +280,7 @@ function registerDependencyUpdateTests(): void {
                 targetName: 'pkg-a',
                 unreleased: false,
                 versionNumber: '1.0.1',
-                mergedPullRequests: [ { id: 1, title: 'Update @scope/pkg to 1.2.3', label: 'upgrade' } ]
+                mergedPullRequests: [ { id: 0, title: 'Update @scope/pkg to 1.2.3', label: 'upgrade' } ]
             }
         ]);
     });
@@ -302,7 +302,7 @@ function registerDependencyUpdateTests(): void {
         );
 
         assert.deepStrictEqual(calls.renderGroupedTargetChangelog.firstCall.args[0].targets[0]?.mergedPullRequests, [
-            { id: 1, title: 'Update dependencies', label: 'upgrade' }
+            { id: 0, title: 'Update dependencies', label: 'upgrade' }
         ]);
     });
 

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -6,6 +6,12 @@ import { isPackageManifestInputPath } from './changelog-source-attribution.ts';
 
 type ChangelogTarget = {
     readonly packagePlan: ReleasePlanPackage;
+    readonly manifestDependencyPullRequests: readonly PullRequestWithLabel[];
+    readonly pullRequests: readonly PullRequestWithLabel[];
+};
+
+type CollectedPullRequests = {
+    readonly manifestDependencyPullRequests: readonly PullRequestWithLabel[];
     readonly pullRequests: readonly PullRequestWithLabel[];
 };
 
@@ -36,6 +42,10 @@ function dependencyUpdateTitle(packagePlan: ReleasePlanPackage): string {
         throw new Error('Expected a dependency update');
     }
     return `Update ${update.name} to ${update.version}`;
+}
+
+function syntheticDependencyPullRequestId(): 0 {
+    return 0;
 }
 
 export type GenerateChangelogInput = {
@@ -145,7 +155,7 @@ async function collectTargetPullRequests(
     input: GenerateChangelogInput,
     packagePlan: ReleasePlanPackage,
     ignoredAttributionPaths: readonly string[]
-): Promise<readonly PullRequestWithLabel[]> {
+): Promise<CollectedPullRequests> {
     const baseRef = await resolveBaseRefFor(input.prLogEngine, packagePlan, input);
     const pullRequests = await input.prLogEngine.collectMergedPullRequests({
         githubRepo: input.githubRepo,
@@ -167,14 +177,25 @@ async function collectTargetPullRequests(
         pullRequests,
         changedFilesByPullRequest
     );
-
-    return input.prLogEngine.resolvePullRequestLabels({
+    const dependencyPullRequestIds = new Set(
+        dependencyPullRequests.map(function (pullRequest) {
+            return pullRequest.id;
+        })
+    );
+    const labeledPullRequests = await input.prLogEngine.resolvePullRequestLabels({
         githubRepo: input.githubRepo,
         config: input.prLogConfig,
         pullRequests: mergePullRequests([ ...packagePullRequests, ...dependencyPullRequests ]),
         targetName: packagePlan.name,
         targetScopedLabelPattern: input.targetScopedLabelPattern
     });
+
+    return {
+        manifestDependencyPullRequests: labeledPullRequests.filter(function (pullRequest) {
+            return dependencyPullRequestIds.has(pullRequest.id);
+        }),
+        pullRequests: labeledPullRequests
+    };
 }
 
 async function createChangelogTarget(
@@ -182,18 +203,45 @@ async function createChangelogTarget(
     packagePlan: ReleasePlanPackage,
     ignoredAttributionPaths: readonly string[]
 ): Promise<ChangelogTarget> {
+    const pullRequests = await collectTargetPullRequests(input, packagePlan, ignoredAttributionPaths);
     return {
         packagePlan,
-        pullRequests: await collectTargetPullRequests(input, packagePlan, ignoredAttributionPaths)
+        manifestDependencyPullRequests: pullRequests.manifestDependencyPullRequests,
+        pullRequests: pullRequests.pullRequests
     };
 }
 
+function isDependencyOnlyTarget(target: ChangelogTarget): boolean {
+    return target.packagePlan.releaseClassification === releaseAnalysisClassification.dependencyOnly;
+}
+
+function isSubstitutionOnlyDependencyTarget(target: ChangelogTarget): boolean {
+    return (
+        isDependencyOnlyTarget(target) &&
+        target.packagePlan.changelogDependencyUpdates.length > 0 &&
+        target.manifestDependencyPullRequests.length === 0
+    );
+}
+
 function changelogPullRequestsFor(target: ChangelogTarget): readonly PullRequestWithLabel[] {
-    if (target.packagePlan.releaseClassification !== releaseAnalysisClassification.dependencyOnly) {
+    if (!isDependencyOnlyTarget(target)) {
         return target.pullRequests;
     }
 
-    return target.pullRequests.map(function (pullRequest) {
+    if (isSubstitutionOnlyDependencyTarget(target)) {
+        return [
+            {
+                id: syntheticDependencyPullRequestId(),
+                title: dependencyUpdateTitle(target.packagePlan),
+                label: dependencyUpdateLabel()
+            }
+        ];
+    }
+
+    const pullRequests = target.manifestDependencyPullRequests.length > 0
+        ? target.manifestDependencyPullRequests
+        : target.pullRequests;
+    return pullRequests.map(function (pullRequest) {
         return { ...pullRequest, title: dependencyUpdateTitle(target.packagePlan), label: dependencyUpdateLabel() };
     });
 }
@@ -218,7 +266,14 @@ function createTargetSection(target: ChangelogTarget): TargetChangelogSection {
 }
 
 function hasChangelogEntries(target: ChangelogTarget): boolean {
-    return target.pullRequests.length > 0;
+    return target.pullRequests.length > 0 || isSubstitutionOnlyDependencyTarget(target);
+}
+
+function removeSyntheticDependencyPullRequestLinks(markdown: string, githubRepo: string): string {
+    return markdown.replaceAll(
+        ` ([#${syntheticDependencyPullRequestId()}](https://github.com/${githubRepo}/pull/${syntheticDependencyPullRequestId()}))`,
+        ''
+    );
 }
 
 function createPackageMarkdownByName(
@@ -231,12 +286,15 @@ function createPackageMarkdownByName(
             const targetSection = createTargetSection(target);
             return [
                 target.packagePlan.name,
-                input.prLogEngine.renderTargetChangelog({
-                    config,
-                    currentDate: input.currentDate,
-                    githubRepo: input.githubRepo,
-                    ...targetSection
-                })
+                removeSyntheticDependencyPullRequestLinks(
+                    input.prLogEngine.renderTargetChangelog({
+                        config,
+                        currentDate: input.currentDate,
+                        githubRepo: input.githubRepo,
+                        ...targetSection
+                    }),
+                    input.githubRepo
+                )
             ] as const;
         })
     );
@@ -254,12 +312,15 @@ export async function generateChangelogOutputs(input: GenerateChangelogInput): P
     const targetsWithEntries = targets.filter(hasChangelogEntries);
 
     return {
-        groupedMarkdown: input.prLogEngine.renderGroupedTargetChangelog({
-            config,
-            currentDate: input.currentDate,
-            githubRepo: input.githubRepo,
-            targets: targetsWithEntries.map(createTargetSection)
-        }),
+        groupedMarkdown: removeSyntheticDependencyPullRequestLinks(
+            input.prLogEngine.renderGroupedTargetChangelog({
+                config,
+                currentDate: input.currentDate,
+                githubRepo: input.githubRepo,
+                targets: targetsWithEntries.map(createTargetSection)
+            }),
+            input.githubRepo
+        ),
         packageNamesWithoutChangelogEntries: targets
             .filter(function (target) {
                 return !hasChangelogEntries(target);


### PR DESCRIPTION
Substitution-only dependency changelog entries now render as dependency updates without preserving unrelated PR links. Manifest dependency PRs still keep their original links, and dependency-only entries outside substitution keep the existing linked behavior.