### PR TITLE
Ignore target-unchanged sources in changelog attribution

### DIFF
--- a/source/packtory/changelog-source-attribution.test.ts
+++ b/source/packtory/changelog-source-attribution.test.ts
@@ -364,7 +364,7 @@ function registerSelectedSourceTests(): void {
             new Set([ 'dist/included.js' ])
         );
 
-        assert.deepStrictEqual(result, [ 'README.md', 'source/included.js' ]);
+        assert.deepStrictEqual(result, [ 'source/included.js' ]);
         assert.strictEqual(fileManager.getReadFileCallCount(), 1);
         assert.deepStrictEqual(fileManager.getReadFileCall(0), { filePath: '/repo/source/included.js' });
     });
@@ -377,11 +377,25 @@ function registerSelectedSourceTests(): void {
         const result = await attributeSelectedChangelogSourceFiles(
             { fileManager: createFakeFileManager(), repositoryFolder: '/repo' },
             bundleWith([ generatedManifest ]),
-            [],
+            [ 'source/package.json', 'README.md' ],
             new Set([ 'package.json' ])
         );
 
-        assert.deepStrictEqual(result, []);
+        assert.deepStrictEqual(result, [ 'source/package.json' ]);
+    });
+
+    test('attributeSelectedChangelogSourceFiles attributes selected additional package files', async function () {
+        const result = await attributeSelectedChangelogSourceFiles(
+            { fileManager: createFakeFileManager(), repositoryFolder: '/repo' },
+            bundleWith([
+                analyzedBundleResource('/repo/source/README.md', { targetFilePath: 'README.md' }),
+                analyzedBundleResource('/repo/source/LICENSE', { targetFilePath: 'LICENSE' })
+            ]),
+            [],
+            new Set([ 'README.md' ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/README.md' ]);
     });
 }
 

--- a/source/packtory/changelog-source-attribution.ts
+++ b/source/packtory/changelog-source-attribution.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { TraceMap } from '@jridgewell/trace-mapping';
-import { bundleRelativePath } from '../common/package-layout.ts';
+import { bundleRelativePath, isPackageManifestPath, packageManifestFilePath } from '../common/package-layout.ts';
 import { compareValues } from '../common/sort-values.ts';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
@@ -272,7 +272,9 @@ export async function attributeSelectedChangelogSourceFiles(
     additionalSourceFiles: readonly string[],
     selectedArtifactFiles: ReadonlySet<string>
 ): Promise<readonly string[]> {
-    const attributedFiles: string[] = Array.from(additionalSourceFiles);
+    const attributedFiles: string[] = selectedArtifactFiles.has(packageManifestFilePath)
+        ? additionalSourceFiles.filter(isPackageManifestPath)
+        : [];
     for (const entry of analyzedBundle.contents) {
         const targetFilePath = bundleRelativePath(entry.fileDescription.targetFilePath);
         if (!entry.isGeneratedManifest && selectedArtifactFiles.has(targetFilePath)) {

--- a/source/packtory/packtory-release-plan-changelog-attribution.test.ts
+++ b/source/packtory/packtory-release-plan-changelog-attribution.test.ts
@@ -1,0 +1,171 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { analyzedBundle, analyzedBundleResource } from '../test-libraries/bundle-fixtures.ts';
+import {
+    buildResultFor,
+    previousReleaseArtifactsFor
+} from '../test-libraries/release-orchestrator-fixtures.ts';
+import type { AnalyzedBundleResource } from '../dead-code-eliminator/analyzed-bundle.ts';
+import { createReleasePlanPackage } from './release-plan.ts';
+
+type ArtifactFile = {
+    readonly content: string;
+    readonly filePath: string;
+    readonly isExecutable: false;
+};
+
+type ReleasePlanFixture = {
+    readonly additionalChangelogSourceFiles: readonly string[];
+    readonly bundleContents: readonly AnalyzedBundleResource[];
+    readonly currentArtifactFiles: readonly ArtifactFile[];
+    readonly previousArtifactFiles: readonly ArtifactFile[];
+};
+
+function artifactFile(filePath: string, content: string): ArtifactFile {
+    return { filePath, content, isExecutable: false };
+}
+
+function readmeBundleResource(targetFilePath: string): AnalyzedBundleResource {
+    return analyzedBundleResource('/source/packages/pkg-a/README.md', { targetFilePath });
+}
+
+async function releasePlanFor(input: ReleasePlanFixture): ReturnType<typeof createReleasePlanPackage> {
+    return createReleasePlanPackage(
+        {
+            fileManager: {
+                async checkReadability() {
+                    return { isReadable: true };
+                },
+                async readFile() {
+                    return '';
+                }
+            },
+            repositoryFolder: '/'
+        },
+        analyzedBundle({
+            name: 'pkg-a',
+            contents: input.bundleContents
+        }),
+        buildResultFor({
+            previousReleaseArtifacts: previousReleaseArtifactsFor({
+                version: '1.0.0',
+                publishedAt: new Date('2026-05-01T00:00:00.000Z'),
+                files: input.previousArtifactFiles
+            })
+        }),
+        {
+            changelogSourceOptions: {
+                additionalChangelogSourceFiles: {
+                    packageFiles: input.additionalChangelogSourceFiles,
+                    sharedFiles: []
+                }
+            },
+            currentGitHead: undefined,
+            releaseArtifactFiles: input.currentArtifactFiles,
+            releaseClassification: 'substantive'
+        }
+    );
+}
+
+suite('packtory-release-plan changelog attribution', function () {
+    test('attributes changed shipped additional file content', async function () {
+        const result = await releasePlanFor({
+            additionalChangelogSourceFiles: [],
+            bundleContents: [ readmeBundleResource('package/README.md') ],
+            previousArtifactFiles: [ artifactFile('package/README.md', 'old') ],
+            currentArtifactFiles: [ artifactFile('package/README.md', 'new') ]
+        });
+
+        assert.partialDeepStrictEqual(result, {
+            changedArtifactFiles: [ 'README.md' ],
+            changelogSourceFiles: [ 'source/packages/pkg-a/README.md' ]
+        });
+    });
+
+    test('attributes changed shipped additional file target paths', async function () {
+        const result = await releasePlanFor({
+            additionalChangelogSourceFiles: [],
+            bundleContents: [ readmeBundleResource('package/docs/README.md') ],
+            previousArtifactFiles: [ artifactFile('package/README.md', 'readme') ],
+            currentArtifactFiles: [ artifactFile('package/docs/README.md', 'readme') ]
+        });
+
+        assert.partialDeepStrictEqual(result, {
+            changedArtifactFiles: [ 'README.md', 'docs/README.md' ],
+            changelogSourceFiles: [ 'source/packages/pkg-a/README.md' ]
+        });
+    });
+
+    test('ignores source-only moves whose shipped target artifact is unchanged', async function () {
+        const result = await releasePlanFor({
+            additionalChangelogSourceFiles: [ 'source/packages/pkg-a/README.md' ],
+            bundleContents: [
+                analyzedBundleResource('/source/pkg-a.js', { targetFilePath: 'package/index.js' }),
+                readmeBundleResource('package/README.md')
+            ],
+            previousArtifactFiles: [
+                artifactFile('package/index.js', 'old'),
+                artifactFile('package/README.md', 'readme')
+            ],
+            currentArtifactFiles: [
+                artifactFile('package/index.js', 'new'),
+                artifactFile('package/README.md', 'readme')
+            ]
+        });
+
+        assert.partialDeepStrictEqual(result, {
+            changedArtifactFiles: [ 'index.js' ],
+            changelogSourceFiles: [ 'source/pkg-a.js' ]
+        });
+    });
+
+    test('attributes additional package manifest sources when generated package manifests change', async function () {
+        const generatedManifest = {
+            ...analyzedBundleResource('/source/generated-package-json.js', { targetFilePath: 'package/package.json' }),
+            isGeneratedManifest: true as const
+        };
+
+        const result = await releasePlanFor({
+            additionalChangelogSourceFiles: [
+                'source/packages/pkg-a/package.json',
+                'source/packages/pkg-a/README.md'
+            ],
+            bundleContents: [ generatedManifest ],
+            previousArtifactFiles: [ artifactFile('package/package.json', '{"type":"module"}') ],
+            currentArtifactFiles: [ artifactFile('package/package.json', '{"type":"module","sideEffects":false}') ]
+        });
+
+        assert.partialDeepStrictEqual(result, {
+            changedArtifactFiles: [ 'package.json' ],
+            changelogSourceFiles: [ 'source/packages/pkg-a/package.json' ]
+        });
+    });
+
+    test('ignores additional package manifest sources when generated package manifests are unchanged', async function () {
+        const generatedManifest = {
+            ...analyzedBundleResource('/source/generated-package-json.js', { targetFilePath: 'package/package.json' }),
+            isGeneratedManifest: true as const
+        };
+
+        const result = await releasePlanFor({
+            additionalChangelogSourceFiles: [ 'source/packages/pkg-a/package.json' ],
+            bundleContents: [
+                analyzedBundleResource('/source/pkg-a.js', { targetFilePath: 'package/index.js' }),
+                generatedManifest
+            ],
+            previousArtifactFiles: [
+                artifactFile('package/index.js', 'old'),
+                artifactFile('package/package.json', '{"type":"module"}')
+            ],
+            currentArtifactFiles: [
+                artifactFile('package/index.js', 'new'),
+                artifactFile('package/package.json', '{"type":"module"}')
+            ]
+        });
+
+        assert.partialDeepStrictEqual(result, {
+            changedArtifactFiles: [ 'index.js' ],
+            changelogSourceFiles: [ 'source/pkg-a.js' ]
+        });
+    });
+});


### PR DESCRIPTION
Selected changelog attribution now follows changed package artifact paths for bundled and additional package files, so source-only moves no longer create changelog entries when the shipped output is unchanged. Generated `package.json` changes still keep package manifest changelog sources, while unrelated unmapped changelog-only paths stay out.