### PR TITLE
Add deterministic GitHub API integration server

### DIFF
--- a/integration-tests/github-api/deterministic-github-api-scenarios.ts
+++ b/integration-tests/github-api/deterministic-github-api-scenarios.ts
@@ -1,0 +1,104 @@
+export type DeterministicGitHubApiResponse = {
+    readonly status: number;
+    readonly body: Readonly<Record<string, unknown>> | readonly unknown[];
+};
+
+export type DeterministicGitHubRestRoute = {
+    readonly method: string;
+    readonly path: string;
+    readonly search: string;
+    readonly response: DeterministicGitHubApiResponse;
+};
+
+export type DeterministicGitHubGraphqlRoute = {
+    readonly operationName: string;
+    readonly response: DeterministicGitHubApiResponse;
+};
+
+export type DeterministicGitHubApiScenario = {
+    readonly restRoutes: readonly DeterministicGitHubRestRoute[];
+    readonly graphqlRoutes: readonly DeterministicGitHubGraphqlRoute[];
+};
+
+const okStatus = 200;
+const acceptedStatus = 202;
+const serverErrorStatus = 500;
+
+export const pullRequestScenario: DeterministicGitHubApiScenario = {
+    restRoutes: [
+        {
+            method: 'GET',
+            path: '/repos/owner/repo/pulls/123',
+            search: '',
+            response: {
+                status: okStatus,
+                body: {
+                    number: 123,
+                    title: 'Prepare release'
+                }
+            }
+        },
+        {
+            method: 'POST',
+            path: '/repos/owner/repo/statuses/head-sha',
+            search: '',
+            response: {
+                status: acceptedStatus,
+                body: {
+                    state: 'pending'
+                }
+            }
+        }
+    ],
+    graphqlRoutes: []
+};
+
+export const repositoryGraphqlScenario: DeterministicGitHubApiScenario = {
+    restRoutes: [],
+    graphqlRoutes: [
+        {
+            operationName: 'RepositoryId',
+            response: {
+                status: okStatus,
+                body: {
+                    data: {
+                        repository: {
+                            id: 'R_123'
+                        }
+                    }
+                }
+            }
+        }
+    ]
+};
+
+export const failingGitHubScenario: DeterministicGitHubApiScenario = {
+    restRoutes: [
+        {
+            method: 'GET',
+            path: '/repos/owner/repo/pulls/500',
+            search: '',
+            response: {
+                status: serverErrorStatus,
+                body: {
+                    message: 'deterministic failure'
+                }
+            }
+        }
+    ],
+    graphqlRoutes: [
+        {
+            operationName: 'FailingQuery',
+            response: {
+                status: serverErrorStatus,
+                body: {
+                    errors: [
+                        {
+                            message: 'deterministic graphql failure'
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+};

--- a/integration-tests/github-api/deterministic-github-api-server.test.ts
+++ b/integration-tests/github-api/deterministic-github-api-server.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import {
+    failingGitHubScenario,
+    pullRequestScenario,
+    repositoryGraphqlScenario
+} from './deterministic-github-api-scenarios.ts';
+import { withDeterministicGitHubApiServer } from './with-deterministic-github-api-server.ts';
+
+suite('deterministic-github-api-server', function () {
+    test(
+        'serves configured REST responses and records requests',
+        withDeterministicGitHubApiServer(pullRequestScenario, async function (context) {
+            const response = await fetch(`${context.baseUrl}/repos/owner/repo/pulls/123`);
+
+            assert.strictEqual(response.status, 200);
+            assert.deepStrictEqual(await response.json(), {
+                number: 123,
+                title: 'Prepare release'
+            });
+            assert.deepStrictEqual(context.requests(), [
+                {
+                    body: '',
+                    method: 'GET',
+                    path: '/repos/owner/repo/pulls/123',
+                    search: ''
+                }
+            ]);
+        })
+    );
+
+    test(
+        'serves configured REST responses with request bodies',
+        withDeterministicGitHubApiServer(pullRequestScenario, async function (context) {
+            const response = await fetch(`${context.baseUrl}/repos/owner/repo/statuses/head-sha`, {
+                method: 'POST',
+                body: JSON.stringify({ context: 'Node.js', state: 'pending' })
+            });
+
+            assert.strictEqual(response.status, 202);
+            assert.deepStrictEqual(await response.json(), { state: 'pending' });
+            assert.deepStrictEqual(context.requests(), [
+                {
+                    body: '{"context":"Node.js","state":"pending"}',
+                    method: 'POST',
+                    path: '/repos/owner/repo/statuses/head-sha',
+                    search: ''
+                }
+            ]);
+        })
+    );
+
+    test(
+        'serves configured GraphQL responses and records requests',
+        withDeterministicGitHubApiServer(repositoryGraphqlScenario, async function (context) {
+            const response = await fetch(context.graphqlUrl, {
+                method: 'POST',
+                body: JSON.stringify({
+                    operationName: 'RepositoryId',
+                    query: 'query RepositoryId { repository(owner: "owner", name: "repo") { id } }'
+                })
+            });
+
+            assert.strictEqual(response.status, 200);
+            assert.deepStrictEqual(await response.json(), {
+                data: {
+                    repository: {
+                        id: 'R_123'
+                    }
+                }
+            });
+            const body =
+                '{"operationName":"RepositoryId","query":"query RepositoryId { repository(owner: \\"owner\\", name: \\"repo\\") { id } }"}';
+
+            assert.deepStrictEqual(context.requests(), [
+                {
+                    body,
+                    method: 'POST',
+                    path: '/graphql',
+                    search: ''
+                }
+            ]);
+        })
+    );
+
+    test(
+        'serves configured REST errors',
+        withDeterministicGitHubApiServer(failingGitHubScenario, async function (context) {
+            const response = await fetch(`${context.baseUrl}/repos/owner/repo/pulls/500`);
+
+            assert.strictEqual(response.status, 500);
+            assert.deepStrictEqual(await response.json(), { message: 'deterministic failure' });
+        })
+    );
+
+    test(
+        'serves configured GraphQL errors',
+        withDeterministicGitHubApiServer(failingGitHubScenario, async function (context) {
+            const response = await fetch(context.graphqlUrl, {
+                method: 'POST',
+                body: JSON.stringify({
+                    operationName: 'FailingQuery',
+                    query: 'query FailingQuery { viewer { login } }'
+                })
+            });
+
+            assert.strictEqual(response.status, 500);
+            assert.deepStrictEqual(await response.json(), {
+                errors: [
+                    {
+                        message: 'deterministic graphql failure'
+                    }
+                ]
+            });
+        })
+    );
+
+    test(
+        'returns not found for missing routes',
+        withDeterministicGitHubApiServer(pullRequestScenario, async function (context) {
+            const response = await fetch(`${context.baseUrl}/repos/owner/repo/issues/123`);
+
+            assert.strictEqual(response.status, 404);
+            assert.deepStrictEqual(await response.json(), {
+                message: 'No deterministic GitHub API route for GET /repos/owner/repo/issues/123'
+            });
+        })
+    );
+});

--- a/integration-tests/github-api/deterministic-github-api-server.ts
+++ b/integration-tests/github-api/deterministic-github-api-server.ts
@@ -1,0 +1,194 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type {
+    DeterministicGitHubApiResponse,
+    DeterministicGitHubApiScenario,
+    DeterministicGitHubGraphqlRoute,
+    DeterministicGitHubRestRoute
+} from './deterministic-github-api-scenarios.ts';
+
+export type DeterministicGitHubApiRequest = {
+    readonly body: string;
+    readonly method: string;
+    readonly path: string;
+    readonly search: string;
+};
+
+export type DeterministicGitHubApiServer = {
+    readonly baseUrl: string;
+    readonly graphqlUrl: string;
+    readonly requests: () => readonly DeterministicGitHubApiRequest[];
+    readonly stop: () => Promise<void>;
+};
+
+export type DeterministicGitHubApiServerOptions = {
+    readonly port: number;
+    readonly scenario: DeterministicGitHubApiScenario;
+};
+
+const notFoundStatus = 404;
+const internalServerErrorStatus = 500;
+
+type DeterministicGitHubApiState = {
+    readonly recordRequest: (request: DeterministicGitHubApiRequest) => void;
+    readonly scenario: DeterministicGitHubApiScenario;
+};
+
+type RecordedIncomingRequest = {
+    readonly body: string;
+    readonly method: string;
+    readonly path: string;
+    readonly search: string;
+};
+
+function writeJson(response: ServerResponse, apiResponse: DeterministicGitHubApiResponse): void {
+    response.writeHead(apiResponse.status, { 'content-type': 'application/json' });
+    response.end(JSON.stringify(apiResponse.body));
+}
+
+function notFoundResponse(method: string, path: string): DeterministicGitHubApiResponse {
+    return {
+        status: notFoundStatus,
+        body: {
+            message: `No deterministic GitHub API route for ${method} ${path}`
+        }
+    };
+}
+
+function restRouteMatches(route: DeterministicGitHubRestRoute, request: RecordedIncomingRequest): boolean {
+    return route.method === request.method && route.path === request.path && route.search === request.search;
+}
+
+function findRestRoute(
+    scenario: DeterministicGitHubApiScenario,
+    request: RecordedIncomingRequest
+): DeterministicGitHubRestRoute | undefined {
+    return scenario.restRoutes.find(function (route) {
+        return restRouteMatches(route, request);
+    });
+}
+
+function operationNameFrom(body: string): string | undefined {
+    const parsedBody = JSON.parse(body) as Readonly<Record<string, unknown>>;
+    return typeof parsedBody.operationName === 'string' ? parsedBody.operationName : undefined;
+}
+
+function findGraphqlRoute(
+    scenario: DeterministicGitHubApiScenario,
+    body: string
+): DeterministicGitHubGraphqlRoute | undefined {
+    const operationName = operationNameFrom(body);
+    return scenario.graphqlRoutes.find(function (route) {
+        return route.operationName === operationName;
+    });
+}
+
+function graphqlResponse(
+    state: DeterministicGitHubApiState,
+    request: RecordedIncomingRequest
+): DeterministicGitHubApiResponse {
+    return findGraphqlRoute(state.scenario, request.body)?.response ??
+        notFoundResponse(request.method, request.path);
+}
+
+function restResponse(
+    state: DeterministicGitHubApiState,
+    request: RecordedIncomingRequest
+): DeterministicGitHubApiResponse {
+    return findRestRoute(state.scenario, request)?.response ?? notFoundResponse(request.method, request.path);
+}
+
+function routeResponse(
+    state: DeterministicGitHubApiState,
+    request: RecordedIncomingRequest
+): DeterministicGitHubApiResponse {
+    if (request.method === 'POST' && request.path === '/graphql') {
+        return graphqlResponse(state, request);
+    }
+    return restResponse(state, request);
+}
+
+function recordIncomingRequest(request: IncomingMessage, body: string): RecordedIncomingRequest {
+    const url = new URL(request.url ?? '/', 'http://localhost');
+    return {
+        body,
+        method: request.method ?? 'GET',
+        path: url.pathname,
+        search: url.search
+    };
+}
+
+function writeUnexpectedError(response: ServerResponse, error: unknown): void {
+    writeJson(response, {
+        status: internalServerErrorStatus,
+        body: { message: error instanceof Error ? error.message : 'Unexpected server error' }
+    });
+}
+
+function routeRequest(
+    state: DeterministicGitHubApiState,
+    request: IncomingMessage,
+    response: ServerResponse
+): void {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', function (chunk: string) {
+        body += chunk;
+    });
+    request.on('error', function (error: unknown) {
+        writeUnexpectedError(response, error);
+    });
+    request.on('end', function () {
+        const recordedRequest = recordIncomingRequest(request, body);
+        state.recordRequest(recordedRequest);
+        writeJson(response, routeResponse(state, recordedRequest));
+    });
+}
+
+async function listen(server: Server, port: number): Promise<void> {
+    await new Promise<void>(function (resolve) {
+        server.listen(port, '127.0.0.1', resolve);
+    });
+}
+
+async function close(server: Server): Promise<void> {
+    await new Promise<void>(function (resolve) {
+        server.close(function () {
+            resolve();
+        });
+    });
+}
+
+function serverUrl(port: number): string {
+    return `http://127.0.0.1:${port}`;
+}
+
+export async function createDeterministicGitHubApiServer(
+    options: DeterministicGitHubApiServerOptions
+): Promise<DeterministicGitHubApiServer> {
+    let requests: readonly DeterministicGitHubApiRequest[] = [];
+    const server = createServer(function (request, response) {
+        routeRequest(
+            {
+                scenario: options.scenario,
+                recordRequest(recordedRequest) {
+                    requests = [ ...requests, recordedRequest ];
+                }
+            },
+            request,
+            response
+        );
+    });
+
+    await listen(server, options.port);
+
+    return {
+        baseUrl: serverUrl(options.port),
+        graphqlUrl: `${serverUrl(options.port)}/graphql`,
+        requests() {
+            return requests;
+        },
+        async stop() {
+            await close(server);
+        }
+    };
+}

--- a/integration-tests/github-api/with-deterministic-github-api-server.ts
+++ b/integration-tests/github-api/with-deterministic-github-api-server.ts
@@ -1,0 +1,37 @@
+import type { AsyncFunc as MochaAsyncTestFunction } from 'mocha';
+import getPort from 'get-port';
+import {
+    createDeterministicGitHubApiServer,
+    type DeterministicGitHubApiRequest
+} from './deterministic-github-api-server.ts';
+import type { DeterministicGitHubApiScenario } from './deterministic-github-api-scenarios.ts';
+
+export type DeterministicGitHubApiServerContext = {
+    readonly baseUrl: string;
+    readonly graphqlUrl: string;
+    readonly requests: () => readonly DeterministicGitHubApiRequest[];
+};
+
+type DeterministicGitHubApiServerTest = (context: DeterministicGitHubApiServerContext) => Promise<void>;
+
+export function withDeterministicGitHubApiServer(
+    scenario: DeterministicGitHubApiScenario,
+    testFunction: DeterministicGitHubApiServerTest
+): MochaAsyncTestFunction {
+    return async function executeTestWithServer() {
+        const server = await createDeterministicGitHubApiServer({
+            port: await getPort(),
+            scenario
+        });
+
+        try {
+            await testFunction({
+                baseUrl: server.baseUrl,
+                graphqlUrl: server.graphqlUrl,
+                requests: server.requests
+            });
+        } finally {
+            await server.stop();
+        }
+    };
+}


### PR DESCRIPTION
Adds a shared deterministic GitHub HTTP API server for integration tests, with REST and GraphQL scenario routing plus request recording. The new server is covered by integration tests so future release PR work can consume it without introducing unused scaffolding.