### PR TITLE
Ignore unchanged sources for dependency-only changelogs

### DIFF
--- a/integration-tests/github-api/changelog-git-repository.ts
+++ b/integration-tests/github-api/changelog-git-repository.ts
@@ -1,0 +1,60 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const gitExecutable = '/usr/bin/git';
+
+async function git(workingDirectory: string, args: readonly string[]): Promise<void> {
+    await new Promise<void>(function (resolve, reject) {
+        execFile(gitExecutable, args, {
+            cwd: workingDirectory,
+            timeout: 5000
+        }, function (error) {
+            if (error === null) {
+                resolve();
+                return;
+            }
+            reject(error instanceof Error ? error : new Error('Git command failed', { cause: error }));
+        });
+    });
+}
+
+async function configureRepository(repositoryPath: string): Promise<void> {
+    await git(repositoryPath, [ 'init', '--initial-branch=main' ]);
+    await git(repositoryPath, [ 'config', 'user.name', 'Packtory Test' ]);
+    await git(repositoryPath, [ 'config', 'user.email', 'packtory@example.test' ]);
+}
+
+async function commitBase(repositoryPath: string): Promise<void> {
+    await writeFile(path.join(repositoryPath, 'README.md'), 'base\n');
+    await git(repositoryPath, [ 'add', 'README.md' ]);
+    await git(repositoryPath, [ 'commit', '-m', 'Initial commit' ]);
+    await git(repositoryPath, [ '-c', 'tag.gpgSign=false', 'tag', '--no-sign', 'pkg-a@1.0.0', 'HEAD' ]);
+}
+
+async function commitMergedPullRequest(
+    repositoryPath: string,
+    pullRequestNumber: number,
+    branchName: string,
+    title: string
+): Promise<void> {
+    await git(repositoryPath, [
+        'commit',
+        '--allow-empty',
+        '-m',
+        `Merge pull request #${pullRequestNumber} from owner/${branchName}`,
+        '-m',
+        title
+    ]);
+}
+
+export async function createChangelogGitRepository(): Promise<string> {
+    const repositoryPath = await mkdtemp(path.join(os.tmpdir(), 'packtory-pr-log-'));
+    await configureRepository(repositoryPath);
+    await commitBase(repositoryPath);
+    await commitMergedPullRequest(repositoryPath, 1, 'update-react', 'Update React to v19');
+    await commitMergedPullRequest(repositoryPath, 2, 'move-readme', 'Move package README into source/packages');
+    await commitMergedPullRequest(repositoryPath, 3, 'update-readme', 'Update package README content');
+    return repositoryPath;
+}

--- a/integration-tests/github-api/changelog-github-api.test.ts
+++ b/integration-tests/github-api/changelog-github-api.test.ts
@@ -1,0 +1,248 @@
+import assert from 'node:assert';
+import { setTimeout as waitForMilliseconds } from 'node:timers/promises';
+import { createPrLogEngine, defaultPrLogConfig } from '@pr-log/core';
+import { suite, test } from 'mocha';
+import { generateChangelogOutputs } from '../../source/packtory/packtory-changelog.ts';
+import type { ReleasePlanPackage } from '../../source/packtory/packtory.ts';
+import { createChangelogGitRepository } from './changelog-git-repository.ts';
+import type { DeterministicGitHubApiScenario } from './deterministic-github-api-scenarios.ts';
+import {
+    type DeterministicGitHubApiServerContext,
+    withDeterministicGitHubApiServer
+} from './with-deterministic-github-api-server.ts';
+
+async function withGitHubRequestDeadline<T>(
+    githubApi: DeterministicGitHubApiServerContext,
+    promise: Promise<T>
+): Promise<T> {
+    async function rejectAfterDeadline(): Promise<never> {
+        await waitForMilliseconds(5000);
+        throw new Error(`Timed out waiting for GitHub API calls: ${JSON.stringify(githubApi.requests())}`);
+    }
+
+    return Promise.race([
+        promise,
+        rejectAfterDeadline()
+    ]);
+}
+
+type PackagePlanInput = {
+    readonly changelogDependencyNames: readonly string[];
+    readonly changelogDependencyUpdates: ReleasePlanPackage['changelogDependencyUpdates'];
+    readonly changelogSourceFiles: readonly string[];
+    readonly releaseClassification: ReleasePlanPackage['releaseClassification'];
+};
+type ChangelogScenarioInput = {
+    readonly includeReadmeContentChange: boolean;
+    readonly includeReadmeMove: boolean;
+};
+
+function packagePlan(input: PackagePlanInput): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        releaseClassification: input.releaseClassification,
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: [ 'package.json', 'README.md' ],
+        changedArtifactFiles: [ 'package.json' ],
+        sourceFiles: [ 'source/packages/pkg-a/README.md' ],
+        changelogDependencyNames: input.changelogDependencyNames,
+        changelogDependencyUpdates: input.changelogDependencyUpdates,
+        changelogSourceFiles: input.changelogSourceFiles
+    };
+}
+
+function dependencyOnlyPackagePlan(): ReleasePlanPackage {
+    return packagePlan({
+        changelogDependencyNames: [ 'react' ],
+        changelogDependencyUpdates: [ { name: 'react', version: '^19.0.0' } ],
+        changelogSourceFiles: [],
+        releaseClassification: 'dependency-only'
+    });
+}
+
+function contentChangePackagePlan(): ReleasePlanPackage {
+    return packagePlan({
+        changelogDependencyNames: [],
+        changelogDependencyUpdates: [],
+        changelogSourceFiles: [ 'source/packages/pkg-a/README.md' ],
+        releaseClassification: 'substantive'
+    });
+}
+
+function pureMovePackagePlan(): ReleasePlanPackage {
+    return packagePlan({
+        changelogDependencyNames: [],
+        changelogDependencyUpdates: [],
+        changelogSourceFiles: [],
+        releaseClassification: 'dependency-only'
+    });
+}
+
+function changelogScenario(input: ChangelogScenarioInput): DeterministicGitHubApiScenario {
+    return {
+        restRoutes: [
+            {
+                method: 'GET',
+                path: '/repos/owner/repo/pulls/1/files',
+                search: '',
+                response: {
+                    status: 200,
+                    body: [
+                        {
+                            filename: 'package-lock.json',
+                            status: 'modified',
+                            additions: 1,
+                            deletions: 1,
+                            changes: 2
+                        }
+                    ]
+                }
+            },
+            {
+                method: 'GET',
+                path: '/repos/owner/repo/pulls/2/files',
+                search: '',
+                response: {
+                    status: 200,
+                    body: input.includeReadmeMove
+                        ? [
+                            {
+                                filename: 'source/packages/pkg-a/README.md',
+                                previous_filename: 'packages/pkg-a/README.md',
+                                status: 'renamed',
+                                additions: 0,
+                                deletions: 0,
+                                changes: 0
+                            }
+                        ]
+                        : []
+                }
+            },
+            {
+                method: 'GET',
+                path: '/repos/owner/repo/issues/1/labels',
+                search: '',
+                response: {
+                    status: 200,
+                    body: [ { name: 'bug' } ]
+                }
+            },
+            {
+                method: 'GET',
+                path: '/repos/owner/repo/issues/2/labels',
+                search: '',
+                response: {
+                    status: 200,
+                    body: [ { name: 'maintenance' } ]
+                }
+            },
+            {
+                method: 'GET',
+                path: '/repos/owner/repo/pulls/3/files',
+                search: '',
+                response: {
+                    status: 200,
+                    body: input.includeReadmeContentChange
+                        ? [
+                            {
+                                filename: 'source/packages/pkg-a/README.md',
+                                status: 'modified',
+                                additions: 1,
+                                deletions: 1,
+                                changes: 2
+                            }
+                        ]
+                        : []
+                }
+            },
+            {
+                method: 'GET',
+                path: '/repos/owner/repo/issues/3/labels',
+                search: '',
+                response: {
+                    status: 200,
+                    body: [ { name: 'feature' } ]
+                }
+            }
+        ],
+        graphqlRoutes: []
+    };
+}
+
+async function generateChangelog(
+    githubApi: DeterministicGitHubApiServerContext,
+    packages: readonly ReleasePlanPackage[]
+): ReturnType<typeof generateChangelogOutputs> {
+    const repositoryPath = await createChangelogGitRepository();
+    const engine = createPrLogEngine({
+        config: defaultPrLogConfig,
+        githubApiBaseUrl: githubApi.baseUrl,
+        githubToken: undefined,
+        workingDirectory: repositoryPath
+    });
+
+    return withGitHubRequestDeadline(
+        githubApi,
+        generateChangelogOutputs({
+            currentDate: new Date('2026-07-13T00:00:00.000Z'),
+            explicitBaseRef: undefined,
+            githubRepo: 'owner/repo',
+            ignoredAttributionPaths: [],
+            packages,
+            packageTagFormat: undefined,
+            prLogConfig: defaultPrLogConfig,
+            prLogEngine: engine,
+            targetScopedLabelPattern: undefined
+        })
+    );
+}
+
+suite('changelog GitHub API integration', function () {
+    test(
+        'keeps dependency-only changelogs focused on manifest dependency pull requests',
+        withDeterministicGitHubApiServer(
+            changelogScenario({ includeReadmeContentChange: false, includeReadmeMove: true }),
+            async function (githubApi) {
+                const changelog = await generateChangelog(githubApi, [ dependencyOnlyPackagePlan() ]);
+
+                assert.match(changelog.groupedMarkdown, /Update react to \^19\.0\.0/u);
+                assert.match(changelog.groupedMarkdown, /\/owner\/repo\/pull\/1/u);
+                assert.doesNotMatch(changelog.groupedMarkdown, /Move package README/u);
+            }
+        )
+    );
+
+    test(
+        'keeps regular source content changes attributed to their pull request',
+        withDeterministicGitHubApiServer(
+            changelogScenario({ includeReadmeContentChange: true, includeReadmeMove: false }),
+            async function (githubApi) {
+                const changelog = await generateChangelog(githubApi, [ contentChangePackagePlan() ]);
+
+                assert.match(changelog.groupedMarkdown, /Update package README content/u);
+                assert.match(changelog.groupedMarkdown, /\/owner\/repo\/pull\/3/u);
+            }
+        )
+    );
+
+    test(
+        'keeps source-only path moves without emitted package changes out of dependency-only changelogs',
+        withDeterministicGitHubApiServer(
+            changelogScenario({ includeReadmeContentChange: false, includeReadmeMove: true }),
+            async function (githubApi) {
+                const changelog = await generateChangelog(githubApi, [ pureMovePackagePlan() ]);
+
+                assert.partialDeepStrictEqual(changelog, {
+                    groupedMarkdown: '',
+                    packageNamesWithoutChangelogEntries: [ 'pkg-a' ]
+                });
+            }
+        )
+    );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@octokit/core": "7.0.6",
                 "@octokit/plugin-paginate-rest": "14.0.0",
                 "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-                "@pr-log/core": "0.0.3",
+                "@pr-log/core": "0.0.4",
                 "@schema-hub/zod-error-formatter": "0.0.12",
                 "@ts-morph/common": "0.29.0",
                 "@types/common-tags": "1.8.4",
@@ -3816,6 +3816,25 @@
                 "node": "^24 || ^26"
             }
         },
+        "node_modules/@packtory/cli/node_modules/@pr-log/core": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.3.tgz",
+            "integrity": "sha512-zzMVv+AL5KwuDIpjxyu6jRs9qLLbEcgQYAzg6+o+mQCBuvyzL5J1e8st2xocA87WSD1DeY1lewvXXrorubFyFg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/rest": "22.0.1",
+                "@sindresorhus/is": "8.1.0",
+                "common-tags": "1.8.2",
+                "date-fns": "4.4.0",
+                "execa": "9.6.1",
+                "semver": "7.8.5",
+                "true-myth": "9.4.0"
+            },
+            "engines": {
+                "node": "^24.0.0 || ^26.0.0"
+            }
+        },
         "node_modules/@packtory/github-release-gate": {
             "version": "0.0.32",
             "resolved": "https://registry.npmjs.org/@packtory/github-release-gate/-/github-release-gate-0.0.32.tgz",
@@ -3909,9 +3928,9 @@
             }
         },
         "node_modules/@pr-log/core": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.3.tgz",
-            "integrity": "sha512-zzMVv+AL5KwuDIpjxyu6jRs9qLLbEcgQYAzg6+o+mQCBuvyzL5J1e8st2xocA87WSD1DeY1lewvXXrorubFyFg==",
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@pr-log/core/-/core-0.0.4.tgz",
+            "integrity": "sha512-dAgierqsL4tgLGhYp8k+b6czmujIBba7ovdPpu4A1hiQpBw0WnVCo3MP0MtWz1tDajLhssLBzLA7ilcwokcL9Q==",
             "license": "MIT",
             "dependencies": {
                 "@octokit/rest": "22.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@octokit/core": "7.0.6",
         "@octokit/plugin-paginate-rest": "14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "17.0.0",
-        "@pr-log/core": "0.0.3",
+        "@pr-log/core": "0.0.4",
         "@schema-hub/zod-error-formatter": "0.0.12",
         "@ts-morph/common": "0.29.0",
         "@types/common-tags": "1.8.4",

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -7,6 +7,7 @@ import type {
     PrLogEngine,
     PrLogEngineOptions,
     PullRequest,
+    PullRequestChangedFile,
     PullRequestWithLabel
 } from '@pr-log/core';
 import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
@@ -103,6 +104,10 @@ type EngineOverrides = {
     readonly readPullRequestChangedFiles?: SinonSpy;
 };
 
+function changedFile(path: string): PullRequestChangedFile {
+    return { path, previousPath: undefined, status: 'modified', additions: 1, deletions: 0, changes: 1 };
+}
+
 function createEngine(overrides: EngineOverrides = {}): PrLogEngine {
     const pullRequests: readonly PullRequest[] = [ { id: 1, title: 'Fix package' } ];
     const labeledPullRequests: readonly PullRequestWithLabel[] = [ { id: 1, title: 'Fix package', label: 'bug' } ];
@@ -112,13 +117,16 @@ function createEngine(overrides: EngineOverrides = {}): PrLogEngine {
         resolveChangelogBaseRef: overrides.resolveChangelogBaseRef ?? fake.resolves({ ref: 'old-head' }),
         collectMergedPullRequests: fake.resolves(pullRequests),
         readPullRequestChangedFiles: overrides.readPullRequestChangedFiles ??
-            fake.resolves(new Map([ [ 1, [ 'source/pkg-a.ts' ] ] ])),
+            fake.resolves(new Map([ [ 1, [ changedFile('source/pkg-a.ts') ] ] ])),
         readPullRequestLabels: fake.resolves(new Map([ [ 1, [ 'bug' ] ] ])),
         filterPullRequestsByTargetFiles: fake(function (input: PullRequestFilterInput) {
             return input.pullRequests;
         }),
         resolvePullRequestLabels: overrides.resolvePullRequestLabels ?? fake.resolves(labeledPullRequests),
         resolveVersionNumber: fake.returns('1.0.1'),
+        extractChangelogReleaseSection: fake(function (): never {
+            throw new Error('unexpected changelog section extraction');
+        }),
         renderGroupedTargetChangelog: fake.returns('## pkg-a 1.0.1\n'),
         renderTargetChangelog: fake(function (input: TargetChangelogInput) {
             return `## ${input.targetName} 1.0.1\n`;

--- a/source/command-line-interface/runner/release-handler.test.ts
+++ b/source/command-line-interface/runner/release-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import type { PrLogEngine } from '@pr-log/core';
+import type { PrLogEngine, PullRequestChangedFile } from '@pr-log/core';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Result } from 'true-myth';
@@ -110,6 +110,10 @@ function failedReleasePlan(): SinonSpy {
     );
 }
 
+function changedFile(path: string): PullRequestChangedFile {
+    return { path, previousPath: undefined, status: 'modified', additions: 1, deletions: 0, changes: 1 };
+}
+
 function createEngine(): PrLogEngine {
     const pullRequest = { id: 1, title: 'Fix package' };
     const releaseNotes = '## pkg-a 1.0.1\n\n* Fix package';
@@ -118,8 +122,13 @@ function createEngine(): PrLogEngine {
         filterPullRequestsByTargetFiles: fake.returns([ pullRequest ]),
         renderChangelog: fake.returns(''),
         renderGroupedTargetChangelog: fake.returns(releaseNotes),
-        readPullRequestChangedFiles: fake.resolves(new Map([ [ pullRequest.id, [ 'src/pkg-a/index.ts' ] ] ])),
+        readPullRequestChangedFiles: fake.resolves(
+            new Map([ [ pullRequest.id, [ changedFile('src/pkg-a/index.ts') ] ] ])
+        ),
         readPullRequestLabels: fake.resolves(new Map([ [ pullRequest.id, [ 'bug' ] ] ])),
+        extractChangelogReleaseSection: fake(function (): never {
+            throw new Error('unexpected changelog section extraction');
+        }),
         renderTargetChangelog: fake.returns(releaseNotes),
         resolveChangelogBaseRef: fake.resolves({ ref: 'old-head' }),
         resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),

--- a/source/command-line-interface/runner/release-preparation.test.ts
+++ b/source/command-line-interface/runner/release-preparation.test.ts
@@ -6,6 +6,7 @@ import { Result } from 'true-myth';
 import type { Packtory, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
 import { createFakeFileManager, type FakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import { createBuildReportFixture } from '../../test-libraries/preview-fixtures.ts';
+import { pullRequestChangedFileFactory } from '../../test-libraries/pr-log-fixtures.ts';
 import {
     loadPlannedRelease,
     prepareReleaseChangelogs,
@@ -86,8 +87,13 @@ function createEngine(spec: EngineSpec): PrLogEngine {
         filterPullRequestsByTargetFiles: fake(function () {
             return spec.pullRequests;
         }),
-        readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'src/pkg-a/index.ts' ] ] ])),
+        readPullRequestChangedFiles: fake.resolves(
+            new Map([ [ 1, [ pullRequestChangedFileFactory.build({ path: 'src/pkg-a/index.ts' }) ] ] ])
+        ),
         readPullRequestLabels: fake.resolves(new Map([ [ 1, [ 'bug' ] ] ])),
+        extractChangelogReleaseSection: fake(function (): never {
+            throw new Error('unexpected changelog section extraction');
+        }),
         renderChangelog: fake.returns(''),
         renderGroupedTargetChangelog: fake.returns(spec.renderedMarkdown),
         renderTargetChangelog: fake.returns(spec.renderedMarkdown),

--- a/source/packages/command-line-interface/pull-request-label-versioning.test.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.test.ts
@@ -3,6 +3,7 @@ import { suite, test } from 'mocha';
 import type { PrLogEngine, PrLogEngineOptions } from '@pr-log/core';
 import type { PacktoryConfig } from '../../config/config.ts';
 import type { VersionProvider } from '../../config/manual-versioning-settings.ts';
+import { pullRequestChangedFileFactory } from '../../test-libraries/pr-log-fixtures.ts';
 import { createPullRequestLabelVersionSourceResolver } from './pull-request-label-versioning.ts';
 
 type ResolveBaseRefInput = Parameters<PrLogEngine['resolveChangelogBaseRef']>[0];
@@ -48,8 +49,8 @@ function createEngine(overrides: Partial<PrLogEngine> = {}): PrLogEngine {
                 [ 1, 2 ]
             );
             return new Map([
-                [ 1, [ 'source/index.ts' ] ],
-                [ 2, [ 'source/index.ts' ] ]
+                [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/index.ts' }) ] ],
+                [ 2, [ pullRequestChangedFileFactory.build({ path: 'source/index.ts' }) ] ]
             ]);
         },
         filterPullRequestsByTargetFiles(input: FilterPullRequestsInput) {
@@ -273,7 +274,7 @@ suite('pull-request-label-version-source', function () {
                     return [ { id: 1, title: 'Fix bug' } ];
                 },
                 async readPullRequestChangedFiles() {
-                    return new Map([ [ 1, [ 'source/index.ts' ] ] ]);
+                    return new Map([ [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/index.ts' }) ] ] ]);
                 },
                 filterPullRequestsByTargetFiles(input) {
                     return input.pullRequests;

--- a/source/packtory/packtory-changelog-dependency.test.ts
+++ b/source/packtory/packtory-changelog-dependency.test.ts
@@ -3,6 +3,7 @@ import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import {
     defaultPrLogConfig,
+    type ChangelogEntryInput,
     type FilterPullRequestsByTargetFilesInput,
     type PullRequest,
     type PullRequestWithLabel,
@@ -10,6 +11,7 @@ import {
     type RenderTargetChangelogMarkdownInput,
     type ResolvePullRequestLabelsOptions
 } from '@pr-log/core';
+import { pullRequestChangedFileFactory } from '../test-libraries/pr-log-fixtures.ts';
 import { generateChangelogOutputs, type GenerateChangelogInput } from './packtory-changelog.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
 
@@ -38,9 +40,12 @@ function releasePackage(overrides: Partial<ReleasePlanPackage>): ReleasePlanPack
     };
 }
 
-function renderPullRequests(pullRequests: readonly PullRequestWithLabel[]): string {
+function renderPullRequests(pullRequests: readonly ChangelogEntryInput[]): string {
     return pullRequests
         .map(function (pullRequest) {
+            if (pullRequest.id === undefined) {
+                return `* ${pullRequest.title}`;
+            }
             return `* ${pullRequest.title} ([#${pullRequest.id}](https://github.com/owner/repo/pull/${pullRequest.id}))`;
         })
         .join('\n');
@@ -53,7 +58,9 @@ function createEngine(overrides: Partial<ChangelogEngine>): ChangelogEngine {
         filterPullRequestsByTargetFiles: fake(function (input: FilterPullRequestsByTargetFilesInput) {
             return input.pullRequests;
         }),
-        readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'source/pkg-a.ts' ] ] ])),
+        readPullRequestChangedFiles: fake.resolves(
+            new Map([ [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/pkg-a.ts' }) ] ] ])
+        ),
         renderGroupedTargetChangelog: fake(function (input: RenderGroupedTargetChangelogMarkdownInput) {
             return renderPullRequests(input.targets.flatMap(function (target) {
                 return target.mergedPullRequests;
@@ -115,7 +122,9 @@ suite('packtory-changelog dependency updates', function () {
         const engine = createEngine({
             collectMergedPullRequests: fake.resolves([ { id: 1, title: 'Update React to v19' } ]),
             filterPullRequestsByTargetFiles: fake.returns([]),
-            readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'package-lock.json' ] ] ]))
+            readPullRequestChangedFiles: fake.resolves(
+                new Map([ [ 1, [ pullRequestChangedFileFactory.build({ path: 'package-lock.json' }) ] ] ])
+            )
         });
 
         const changelog = await generateReactDependencyChangelog(engine);
@@ -132,8 +141,8 @@ suite('packtory-changelog dependency updates', function () {
             filterPullRequestsByTargetFiles: fake.returns([ { id: 2, title: 'Fix package' } ]),
             readPullRequestChangedFiles: fake.resolves(
                 new Map([
-                    [ 1, [ 'package-lock.json' ] ],
-                    [ 2, [ 'source/pkg-a.ts' ] ]
+                    [ 1, [ pullRequestChangedFileFactory.build({ path: 'package-lock.json' }) ] ],
+                    [ 2, [ pullRequestChangedFileFactory.build({ path: 'source/pkg-a.ts' }) ] ]
                 ])
             )
         });

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -11,6 +11,7 @@ import {
     type ResolvePullRequestLabelsOptions
 } from '@pr-log/core';
 import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
+import { pullRequestChangedFileFactory } from '../test-libraries/pr-log-fixtures.ts';
 import { generateChangelogOutputs } from './packtory-changelog.ts';
 import type { ReleasePlanPackage } from './packtory-results.ts';
 
@@ -86,8 +87,8 @@ function createEngine(): EngineFixture {
         }),
         readPullRequestChangedFiles: fake.resolves(
             new Map([
-                [ 1, [ 'source/pkg-a.ts' ] ],
-                [ 2, [ 'CHANGELOG.md' ] ]
+                [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/pkg-a.ts' }) ] ],
+                [ 2, [ pullRequestChangedFileFactory.build({ path: 'CHANGELOG.md' }) ] ]
             ])
         ),
         renderGroupedTargetChangelog: fake(function (input: RenderGroupedTargetChangelogMarkdownInput) {
@@ -225,8 +226,8 @@ function registerTargetSelectionTests(): void {
                 { id: 2, title: 'Update changelog only' }
             ],
             changedFilesByPullRequest: new Map([
-                [ 1, [ 'source/pkg-a.ts' ] ],
-                [ 2, [ 'CHANGELOG.md' ] ]
+                [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/pkg-a.ts' }) ] ],
+                [ 2, [ pullRequestChangedFileFactory.build({ path: 'CHANGELOG.md' }) ] ]
             ]),
             ignoredAttributionPaths: [ 'CHANGELOG.md' ]
         });
@@ -360,9 +361,15 @@ function registerDependencyUpdateTests(): void {
         ]);
         const readPullRequestChangedFiles = fake.resolves(
             new Map([
-                [ 1, [ 'package-lock.json', 'source/index.ts' ] ],
-                [ 2, [ 'package-lock.json' ] ],
-                [ 3, [ 'source/index.ts' ] ]
+                [
+                    1,
+                    [
+                        pullRequestChangedFileFactory.build({ path: 'package-lock.json' }),
+                        pullRequestChangedFileFactory.build({ path: 'source/index.ts' })
+                    ]
+                ],
+                [ 2, [ pullRequestChangedFileFactory.build({ path: 'package-lock.json' }) ] ],
+                [ 3, [ pullRequestChangedFileFactory.build({ path: 'source/index.ts' }) ] ]
             ])
         );
         const dependencyEngine = {

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -1,5 +1,12 @@
 import path from 'node:path';
-import type { PrLogConfig, PrLogEngine, PullRequest, PullRequestWithLabel, TargetChangelogSection } from '@pr-log/core';
+import type {
+    PrLogConfig,
+    PrLogEngine,
+    PullRequest,
+    PullRequestChangedFile,
+    PullRequestWithLabel,
+    TargetChangelogSection
+} from '@pr-log/core';
 import { compareValues } from '../common/sort-values.ts';
 import { releaseAnalysisClassification, type ReleasePlanPackage } from './packtory-results.ts';
 import { isPackageManifestInputPath } from './changelog-source-attribution.ts';
@@ -104,13 +111,15 @@ function pullRequestTitleMentionsDependency(pullRequest: PullRequest, dependency
 function selectManifestDependencyPullRequests(
     packagePlan: ReleasePlanPackage,
     pullRequests: readonly PullRequest[],
-    changedFilesByPullRequest: ReadonlyMap<number, readonly string[]>
+    changedFilesByPullRequest: ReadonlyMap<number, readonly PullRequestChangedFile[]>
 ): readonly PullRequest[] {
     return pullRequests.filter(function (pullRequest) {
         const changedFiles = changedFilesByPullRequest.get(pullRequest.id);
         return (
             changedFiles !== undefined &&
-            changedFiles.some(isPackageManifestInputPath) &&
+            changedFiles.some(function (changedFile) {
+                return isPackageManifestInputPath(changedFile.path);
+            }) &&
             packagePlan.changelogDependencyNames.some(function (dependencyName) {
                 return pullRequestTitleMentionsDependency(pullRequest, dependencyName);
             })

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -21,8 +21,29 @@ import {
     type ReleaseArtifactDescription,
     type ReleasePackageResolver
 } from '../test-libraries/release-plan-test-support.ts';
+import type { BuildAndPublishResult } from './package-processor.ts';
 import type { ResolveAndLinkFailure } from './packtory-results.ts';
 import type { ResolvedPackage } from './resolved-package.ts';
+
+const previousPublishedAt = new Date('2026-05-01T00:00:00.000Z');
+
+function artifact(filePath: string, content: string): ReleaseArtifactDescription {
+    return { filePath, content, isExecutable: false };
+}
+
+function manifestArtifact(dependencies: Readonly<Record<string, string>>): ReleaseArtifactDescription {
+    return artifact('package/package.json', JSON.stringify({ dependencies }));
+}
+
+function buildResultWithPreviousArtifacts(files: readonly ReleaseArtifactDescription[]): BuildAndPublishResult {
+    return buildResultFor({
+        previousReleaseArtifacts: previousReleaseArtifactsFor({
+            version: '1.0.0',
+            publishedAt: previousPublishedAt,
+            files
+        })
+    });
+}
 
 function registerPlanningTests(): void {
     test('runs dry-run release planning with staged publishing disabled', async function () {
@@ -200,27 +221,13 @@ function registerDependencyAttributionTests(): void {
         const result = await planFor({
             packageNames: [ 'pkg-a' ],
             buildResults: [
-                buildResultFor({
-                    previousReleaseArtifacts: previousReleaseArtifactsFor({
-                        version: '1.0.0',
-                        publishedAt: new Date('2026-05-01T00:00:00.000Z'),
-                        files: [
-                            {
-                                filePath: 'package/package.json',
-                                content: JSON.stringify({ dependencies: { react: '^18.0.0', shared: '^1.0.0' } }),
-                                isExecutable: false
-                            }
-                        ]
-                    })
-                })
+                buildResultWithPreviousArtifacts([
+                    manifestArtifact({ react: '^18.0.0', shared: '^1.0.0' })
+                ])
             ],
             collectContents() {
                 return [
-                    {
-                        filePath: 'package/package.json',
-                        content: JSON.stringify({ dependencies: { react: '^19.0.0', shared: '^1.0.0' } }),
-                        isExecutable: false
-                    }
+                    manifestArtifact({ react: '^19.0.0', shared: '^1.0.0' })
                 ];
             },
             bundleContents: {
@@ -236,7 +243,39 @@ function registerDependencyAttributionTests(): void {
             changelogDependencyNames: [ 'react' ],
             changelogDependencyUpdates: [ { name: 'react', version: '^19.0.0' } ],
             releaseClassification: 'dependency-only',
-            changelogSourceFiles: [ 'source/pkg-a.js', 'source/unused.js' ]
+            changelogSourceFiles: []
+        });
+    });
+
+    test('does not attribute unchanged bundled files for dependency-only releases', async function () {
+        const result = await planFor({
+            packageNames: [ 'pkg-a' ],
+            buildResults: [
+                buildResultWithPreviousArtifacts([
+                    manifestArtifact({ react: '^18.0.0' }),
+                    artifact('readme.md', 'same readme')
+                ])
+            ],
+            collectContents() {
+                return [
+                    manifestArtifact({ react: '^19.0.0' }),
+                    artifact('readme.md', 'same readme')
+                ];
+            },
+            bundleContents: {
+                'pkg-a': [
+                    analyzedBundleResource('/source/pkg-a.js', { targetFilePath: 'package/index.js' }),
+                    analyzedBundleResource('/source/packages/pkg-a/readme.md', { targetFilePath: 'readme.md' })
+                ]
+            }
+        });
+
+        const pkg = expectFirstPackage(result);
+        assert.partialDeepStrictEqual(pkg, {
+            changedArtifactFiles: [ 'package.json' ],
+            changelogDependencyNames: [ 'react' ],
+            releaseClassification: 'dependency-only',
+            changelogSourceFiles: []
         });
     });
 
@@ -244,19 +283,9 @@ function registerDependencyAttributionTests(): void {
         const result = await planFor({
             packageNames: [ 'pkg-a' ],
             buildResults: [
-                buildResultFor({
-                    previousReleaseArtifacts: previousReleaseArtifactsFor({
-                        version: '1.0.0',
-                        publishedAt: new Date('2026-05-01T00:00:00.000Z'),
-                        files: [
-                            {
-                                filePath: 'package/package.json',
-                                content: JSON.stringify({ dependencies: { react: '^18.0.0' } }),
-                                isExecutable: false
-                            }
-                        ]
-                    })
-                })
+                buildResultWithPreviousArtifacts([
+                    manifestArtifact({ react: '^18.0.0' })
+                ])
             ],
             collectContents() {
                 return [ { filePath: 'package/index.js', content: 'new', isExecutable: false } ];
@@ -381,21 +410,15 @@ function registerSourceFileTests(): void {
         const result = await planFor({
             packageNames: [ 'pkg-a' ],
             buildResults: [
-                buildResultFor({
-                    previousReleaseArtifacts: previousReleaseArtifactsFor({
-                        version: '1.0.0',
-                        publishedAt: new Date('2026-05-01T00:00:00.000Z'),
-                        files: [
-                            { filePath: 'package/index.js', content: 'old', isExecutable: false },
-                            { filePath: 'package/unused.js', content: 'unchanged', isExecutable: false }
-                        ]
-                    })
-                })
+                buildResultWithPreviousArtifacts([
+                    artifact('package/index.js', 'old'),
+                    artifact('package/unused.js', 'unchanged')
+                ])
             ],
             collectContents() {
                 return [
-                    { filePath: 'package/index.js', content: 'new', isExecutable: false },
-                    { filePath: 'package/unused.js', content: 'unchanged', isExecutable: false }
+                    artifact('package/index.js', 'new'),
+                    artifact('package/unused.js', 'unchanged')
                 ];
             },
             bundleContents: {

--- a/source/packtory/release-plan.ts
+++ b/source/packtory/release-plan.ts
@@ -157,10 +157,7 @@ function collectReleasePlanChangelogDependencyUpdates(
 }
 
 function shouldAttributeAllBundleSources(releaseClassification: ReleasePlanPackage['releaseClassification']): boolean {
-    return (
-        releaseClassification === releaseAnalysisClassification.dependencyOnly ||
-        releaseClassification === releaseAnalysisClassification.unchanged
-    );
+    return releaseClassification === releaseAnalysisClassification.unchanged;
 }
 
 async function attributedChangelogSourceFiles(input: AttributedChangelogSourceFilesInput): Promise<readonly string[]> {

--- a/source/test-libraries/pr-log-fixtures.ts
+++ b/source/test-libraries/pr-log-fixtures.ts
@@ -1,0 +1,21 @@
+import { createFactory } from '@enormora/objectory';
+
+type PullRequestChangedFileShape = {
+    readonly path: string;
+    readonly previousPath: string | undefined;
+    readonly status: string;
+    readonly additions: number;
+    readonly deletions: number;
+    readonly changes: number;
+};
+
+export const pullRequestChangedFileFactory = createFactory<PullRequestChangedFileShape>(function () {
+    return {
+        path: '',
+        previousPath: undefined,
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        changes: 1
+    };
+});

--- a/source/test-libraries/release-pull-request-handler-test-support.ts
+++ b/source/test-libraries/release-pull-request-handler-test-support.ts
@@ -10,6 +10,7 @@ import {
     createReleasePullRequestClient,
     createReleasePullRequestConfig
 } from './runner-test-support.ts';
+import { pullRequestChangedFileFactory } from './pr-log-fixtures.ts';
 
 function createReleasePackage(): ReleasePlanPackage {
     return {
@@ -43,7 +44,12 @@ function createReleaseChangelogEngine(overrides: ReleaseChangelogEngineOverrides
         collectMergedPullRequests: fake.resolves([ { id: 1, title: 'Fix package' } ]),
         filterPullRequestsByTargetFiles: fake.returns([ { id: 1, title: 'Fix package' } ]),
         readPullRequestLabels: fake.resolves(new Map([ [ 1, [ 'bug' ] ] ])),
-        readPullRequestChangedFiles: fake.resolves(new Map([ [ 1, [ 'src/index.ts' ] ] ])),
+        readPullRequestChangedFiles: fake.resolves(
+            new Map([ [ 1, [ pullRequestChangedFileFactory.build({ path: 'src/index.ts' }) ] ] ])
+        ),
+        extractChangelogReleaseSection: fake(function (): never {
+            throw new Error('unexpected changelog section extraction');
+        }),
         resolveVersionNumber: fake.returns('1.0.1'),
         renderChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),
         renderGroupedTargetChangelog: fake.returns('## 1.0.1\n\n* Fix package (#1)\n'),

--- a/source/test-libraries/runner-test-support.ts
+++ b/source/test-libraries/runner-test-support.ts
@@ -86,6 +86,9 @@ function createPrLogEngineFactory(overrides: Overrides): CommandLineInterfaceRun
         filterPullRequestsByTargetFiles: fake.returns([]),
         resolvePullRequestLabels: fake.resolves([]),
         resolveVersionNumber: fake.returns('1.0.1'),
+        extractChangelogReleaseSection: fake(function (): never {
+            throw new Error('unexpected changelog section extraction');
+        }),
         renderChangelog: fake.returns(''),
         renderGroupedTargetChangelog: fake.returns(''),
         renderTargetChangelog: fake.returns(''),


### PR DESCRIPTION
Dependency-only plans now attribute only changed package artifacts instead of every bundled source, so source-only moves such as package README relocations do not become changelog entries when the emitted package content is unchanged. The change updates packtory to pr-log core 0.0.4 and adds a deterministic GitHub API integration test covering the manifest dependency PR plus pure README move scenario.