### PR TITLE
Dispatch fresh release PR CI runs

### DIFF
--- a/integration-tests/github-api/deterministic-github-api-scenarios.ts
+++ b/integration-tests/github-api/deterministic-github-api-scenarios.ts
@@ -1,7 +1,18 @@
+export type DeterministicGitHubApiRequest = {
+    readonly body: string;
+    readonly method: string;
+    readonly path: string;
+    readonly search: string;
+};
+
 export type DeterministicGitHubApiResponse = {
     readonly status: number;
     readonly body: Readonly<Record<string, unknown>> | readonly unknown[];
 };
+
+export type DeterministicGitHubApiRouteResponse = (
+    requests: readonly DeterministicGitHubApiRequest[]
+) => DeterministicGitHubApiResponse;
 
 export type DeterministicGitHubRestRoute = {
     readonly method: string;
@@ -10,14 +21,26 @@ export type DeterministicGitHubRestRoute = {
     readonly response: DeterministicGitHubApiResponse;
 };
 
+export type DeterministicGitHubRestDynamicRoute = {
+    readonly method: string;
+    readonly path: string;
+    readonly search: string;
+    readonly response: DeterministicGitHubApiRouteResponse;
+};
+
 export type DeterministicGitHubGraphqlRoute = {
     readonly operationName: string;
     readonly response: DeterministicGitHubApiResponse;
 };
 
+export type DeterministicGitHubGraphqlDynamicRoute = {
+    readonly operationName: string;
+    readonly response: DeterministicGitHubApiRouteResponse;
+};
+
 export type DeterministicGitHubApiScenario = {
-    readonly restRoutes: readonly DeterministicGitHubRestRoute[];
-    readonly graphqlRoutes: readonly DeterministicGitHubGraphqlRoute[];
+    readonly restRoutes: readonly (DeterministicGitHubRestDynamicRoute | DeterministicGitHubRestRoute)[];
+    readonly graphqlRoutes: readonly (DeterministicGitHubGraphqlDynamicRoute | DeterministicGitHubGraphqlRoute)[];
 };
 
 const okStatus = 200;

--- a/integration-tests/github-api/deterministic-github-api-server.ts
+++ b/integration-tests/github-api/deterministic-github-api-server.ts
@@ -1,17 +1,10 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type {
+    DeterministicGitHubApiRequest,
     DeterministicGitHubApiResponse,
-    DeterministicGitHubApiScenario,
-    DeterministicGitHubGraphqlRoute,
-    DeterministicGitHubRestRoute
+    DeterministicGitHubApiRouteResponse,
+    DeterministicGitHubApiScenario
 } from './deterministic-github-api-scenarios.ts';
-
-export type DeterministicGitHubApiRequest = {
-    readonly body: string;
-    readonly method: string;
-    readonly path: string;
-    readonly search: string;
-};
 
 export type DeterministicGitHubApiServer = {
     readonly baseUrl: string;
@@ -30,8 +23,12 @@ const internalServerErrorStatus = 500;
 
 type DeterministicGitHubApiState = {
     readonly recordRequest: (request: DeterministicGitHubApiRequest) => void;
+    readonly requests: () => readonly DeterministicGitHubApiRequest[];
     readonly scenario: DeterministicGitHubApiScenario;
 };
+type DeterministicGitHubRestRoute = DeterministicGitHubApiScenario['restRoutes'][number];
+type DeterministicGitHubGraphqlRoute = DeterministicGitHubApiScenario['graphqlRoutes'][number];
+type DeterministicGitHubRouteResponse = DeterministicGitHubApiResponse | DeterministicGitHubApiRouteResponse;
 
 type RecordedIncomingRequest = {
     readonly body: string;
@@ -82,19 +79,33 @@ function findGraphqlRoute(
     });
 }
 
+function resolveApiResponse(
+    response: DeterministicGitHubRouteResponse,
+    requests: readonly DeterministicGitHubApiRequest[]
+): DeterministicGitHubApiResponse {
+    return typeof response === 'function' ? response(requests) : response;
+}
+
 function graphqlResponse(
     state: DeterministicGitHubApiState,
     request: RecordedIncomingRequest
 ): DeterministicGitHubApiResponse {
-    return findGraphqlRoute(state.scenario, request.body)?.response ??
-        notFoundResponse(request.method, request.path);
+    const response = findGraphqlRoute(state.scenario, request.body)?.response;
+    return response === undefined ? notFoundResponse(request.method, request.path) : resolveApiResponse(
+        response,
+        state.requests()
+    );
 }
 
 function restResponse(
     state: DeterministicGitHubApiState,
     request: RecordedIncomingRequest
 ): DeterministicGitHubApiResponse {
-    return findRestRoute(state.scenario, request)?.response ?? notFoundResponse(request.method, request.path);
+    const response = findRestRoute(state.scenario, request)?.response;
+    return response === undefined ? notFoundResponse(request.method, request.path) : resolveApiResponse(
+        response,
+        state.requests()
+    );
 }
 
 function routeResponse(
@@ -172,6 +183,9 @@ export async function createDeterministicGitHubApiServer(
                 scenario: options.scenario,
                 recordRequest(recordedRequest) {
                     requests = [ ...requests, recordedRequest ];
+                },
+                requests() {
+                    return requests;
                 }
             },
             request,

--- a/integration-tests/github-api/release-pull-request-ci.test.ts
+++ b/integration-tests/github-api/release-pull-request-ci.test.ts
@@ -1,0 +1,484 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import type { ReleasePullRequestConfig } from '../../source/command-line-interface/runner/release-pull-request-config.ts';
+import { runConfiguredGitHubActionsCi } from '../../source/command-line-interface/runner/release-pull-request-ci.ts';
+import {
+    createReleasePullRequestGitHubClient,
+    type ReleasePullRequestGitHubClient
+} from '../../source/command-line-interface/runner/release-pr-github-client.ts';
+import type {
+    DeterministicGitHubApiRequest,
+    DeterministicGitHubApiScenario
+} from './deterministic-github-api-scenarios.ts';
+import {
+    type DeterministicGitHubApiServerContext,
+    withDeterministicGitHubApiServer
+} from './with-deterministic-github-api-server.ts';
+
+const acceptedStatus = 202;
+const okStatus = 200;
+const noContentStatus = 204;
+const releaseBranch = 'release/packtory';
+const statusPath = '/repos/owner/repo/statuses/release-head';
+const workflowRunsPath = '/repos/owner/repo/actions/workflows/101/runs';
+const repositoryWorkflowRunsPath = '/repos/owner/repo/actions/runs';
+const dispatchPath = '/repos/owner/repo/actions/workflows/101/dispatches';
+const runPath = '/repos/owner/repo/actions/runs/8';
+const jobsPath = '/repos/owner/repo/actions/runs/8/jobs';
+
+type StatusRequestBody = {
+    readonly context: string;
+    readonly description: string;
+    readonly state: string;
+    readonly target_url: string | null;
+};
+
+function searchString(parameters: Readonly<Record<string, string>>): string {
+    const searchParameters = new URLSearchParams(parameters);
+    return `?${searchParameters.toString()}`;
+}
+
+const workflowRunsSearch = searchString({ branch: releaseBranch, event: 'workflow_dispatch', per_page: '100' });
+
+function countRequests(requests: readonly DeterministicGitHubApiRequest[], method: string, path: string): number {
+    return requests
+        .filter(function (request) {
+            return request.method === method && request.path === path;
+        })
+        .length;
+}
+
+function dispatchIndex(requests: readonly DeterministicGitHubApiRequest[]): number {
+    return requests.findIndex(function (request) {
+        return request.method === 'POST' && request.path === dispatchPath;
+    });
+}
+
+function workflowRunsAfterDispatch(requests: readonly DeterministicGitHubApiRequest[]): number {
+    const index = dispatchIndex(requests);
+    if (index === -1) {
+        return 0;
+    }
+    return requests
+        .slice(index + 1)
+        .filter(function (request) {
+            return request.method === 'GET' && request.path === workflowRunsPath;
+        })
+        .length;
+}
+
+function workflowRunsBody(requests: readonly DeterministicGitHubApiRequest[]): Record<string, unknown> {
+    const oldRun = {
+        database_id: 7,
+        event: 'workflow_dispatch',
+        head_sha: 'release-head',
+        workflow_id: 101
+    };
+    if (workflowRunsAfterDispatch(requests) < 2) {
+        return { workflow_runs: [ oldRun ] };
+    }
+    return {
+        workflow_runs: [
+            oldRun,
+            {
+                database_id: 8,
+                event: 'workflow_dispatch',
+                head_sha: 'release-head',
+                workflow_id: 101
+            }
+        ]
+    };
+}
+
+function runResultBody(requests: readonly DeterministicGitHubApiRequest[]): Record<string, unknown> {
+    return {
+        conclusion: countRequests(requests, 'GET', runPath) === 1 ? null : 'success',
+        html_url: 'https://github.com/owner/repo/actions/runs/8'
+    };
+}
+
+function jobsBody(requests: readonly DeterministicGitHubApiRequest[]): Record<string, unknown> {
+    const conclusion = countRequests(requests, 'GET', jobsPath) === 1 ? null : 'success';
+    return {
+        jobs: [
+            { conclusion, html_url: 'https://github.com/owner/repo/actions/runs/8/job/1', name: 'Node.js v24.x' },
+            { conclusion, html_url: 'https://github.com/owner/repo/actions/runs/8/job/2', name: 'Mutation testing' }
+        ],
+        total_count: 2
+    };
+}
+
+function workflowListRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'GET',
+        path: '/repos/owner/repo/actions/workflows',
+        search: '?per_page=100',
+        response: {
+            status: okStatus,
+            body: {
+                workflows: [ { id: 101, name: 'Continuous integration', path: '.github/workflows/ci.yml' } ]
+            }
+        }
+    };
+}
+
+function dispatchRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'POST',
+        path: dispatchPath,
+        search: '',
+        response: { status: noContentStatus, body: {} }
+    };
+}
+
+function statusRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'POST',
+        path: statusPath,
+        search: '',
+        response: { status: acceptedStatus, body: {} }
+    };
+}
+
+function completedRunRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'GET',
+        path: runPath,
+        search: '',
+        response: {
+            status: okStatus,
+            body: {
+                conclusion: 'success',
+                html_url: 'https://github.com/owner/repo/actions/runs/8'
+            }
+        }
+    };
+}
+
+function successfulJobsRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'GET',
+        path: jobsPath,
+        search: '?per_page=100',
+        response: {
+            status: okStatus,
+            body: {
+                jobs: [
+                    {
+                        conclusion: 'success',
+                        html_url: 'https://github.com/owner/repo/actions/runs/8/job/1',
+                        name: 'Node.js v24.x'
+                    }
+                ],
+                total_count: 1
+            }
+        }
+    };
+}
+
+function immediateWorkflowRunBody(requests: readonly DeterministicGitHubApiRequest[]): Record<string, unknown> {
+    if (dispatchIndex(requests) === -1) {
+        return { workflow_runs: [] };
+    }
+    return {
+        workflow_runs: [
+            { database_id: 8, event: 'workflow_dispatch', head_sha: 'release-head', workflow_id: 101 }
+        ]
+    };
+}
+
+function immediateWorkflowRunRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'GET',
+        path: workflowRunsPath,
+        search: workflowRunsSearch,
+        response(requests) {
+            return { status: okStatus, body: immediateWorkflowRunBody(requests) };
+        }
+    };
+}
+
+function immediateRepositoryWorkflowRunRoute(): DeterministicGitHubApiScenario['restRoutes'][number] {
+    return {
+        method: 'GET',
+        path: repositoryWorkflowRunsPath,
+        search: workflowRunsSearch,
+        response(requests) {
+            return { status: okStatus, body: immediateWorkflowRunBody(requests) };
+        }
+    };
+}
+
+function successfulReleaseCiScenario(): DeterministicGitHubApiScenario {
+    return {
+        restRoutes: [
+            workflowListRoute(),
+            immediateWorkflowRunRoute(),
+            immediateRepositoryWorkflowRunRoute(),
+            dispatchRoute(),
+            completedRunRoute(),
+            successfulJobsRoute(),
+            statusRoute()
+        ],
+        graphqlRoutes: []
+    };
+}
+
+const releaseCiScenario: DeterministicGitHubApiScenario = {
+    restRoutes: [
+        workflowListRoute(),
+        {
+            method: 'GET',
+            path: workflowRunsPath,
+            search: workflowRunsSearch,
+            response(requests) {
+                return { status: okStatus, body: workflowRunsBody(requests) };
+            }
+        },
+        dispatchRoute(),
+        {
+            method: 'GET',
+            path: repositoryWorkflowRunsPath,
+            search: workflowRunsSearch,
+            response(requests) {
+                return { status: okStatus, body: workflowRunsBody(requests) };
+            }
+        },
+        {
+            method: 'GET',
+            path: runPath,
+            search: '',
+            response(requests) {
+                return { status: okStatus, body: runResultBody(requests) };
+            }
+        },
+        {
+            method: 'GET',
+            path: jobsPath,
+            search: '?per_page=100',
+            response(requests) {
+                return { status: okStatus, body: jobsBody(requests) };
+            }
+        },
+        statusRoute()
+    ],
+    graphqlRoutes: []
+};
+
+function readStatusRequests(requests: readonly DeterministicGitHubApiRequest[]): readonly StatusRequestBody[] {
+    return requests
+        .filter(function (request) {
+            return request.method === 'POST' && request.path === statusPath;
+        })
+        .map(function (request) {
+            return JSON.parse(request.body) as StatusRequestBody;
+        });
+}
+
+function statusesFor(
+    requests: readonly DeterministicGitHubApiRequest[],
+    context: string
+): readonly StatusRequestBody[] {
+    return readStatusRequests(requests).filter(function (status) {
+        return status.context === context;
+    });
+}
+
+function releaseCiConfig(requiredStatusContexts: readonly string[]): ReleasePullRequestConfig {
+    return {
+        automationAuthor: 'github-actions[bot]',
+        body: 'Body',
+        branch: releaseBranch,
+        commitSubject: 'Release packages',
+        defaultBranch: 'main',
+        githubActionsCi: {
+            deleteActionRequiredPullRequestRuns: false,
+            requiredStatusContexts,
+            workflowFile: 'ci.yml'
+        },
+        label: 'release',
+        title: 'Prepare release'
+    };
+}
+
+function createClient(server: DeterministicGitHubApiServerContext): ReleasePullRequestGitHubClient {
+    return createReleasePullRequestGitHubClient({
+        apiBaseUrl: server.baseUrl,
+        fetch,
+        owner: 'owner',
+        repo: 'repo',
+        token: 'token'
+    });
+}
+
+async function runReleaseCi(
+    server: DeterministicGitHubApiServerContext,
+    requiredStatusContexts: readonly string[]
+): Promise<boolean> {
+    return runConfiguredGitHubActionsCi({
+        client: createClient(server),
+        config: releaseCiConfig(requiredStatusContexts),
+        headSha: 'release-head',
+        sleep: fake.resolves(undefined)
+    });
+}
+
+suite('release-pull-request-ci GitHub API integration', function () {
+    test(
+        'dispatches a fresh workflow run and mirrors a successful required job',
+        withDeterministicGitHubApiServer(successfulReleaseCiScenario(), async function (server) {
+            assert.strictEqual(await runReleaseCi(server, [ 'Node.js v24.x' ]), true);
+
+            assert.deepStrictEqual(
+                statusesFor(server.requests(), 'Node.js v24.x').map(function (status) {
+                    return {
+                        description: status.description,
+                        state: status.state,
+                        targetUrl: status.target_url
+                    };
+                }),
+                [
+                    {
+                        description: 'Waiting for dispatched release CI.',
+                        state: 'pending',
+                        targetUrl: null
+                    },
+                    {
+                        description: 'Dispatched release CI job success.',
+                        state: 'success',
+                        targetUrl: 'https://github.com/owner/repo/actions/runs/8/job/1'
+                    }
+                ]
+            );
+        })
+    );
+
+    test(
+        'dispatches fresh CI and mirrors running and final job statuses',
+        withDeterministicGitHubApiServer(releaseCiScenario, async function (server) {
+            assert.strictEqual(await runReleaseCi(server, [ 'Node.js v24.x', 'Mutation testing' ]), true);
+
+            assert.strictEqual(countRequests(server.requests(), 'POST', dispatchPath), 1);
+            assert.strictEqual(countRequests(server.requests(), 'GET', workflowRunsPath), 3);
+            assert.deepStrictEqual(
+                statusesFor(server.requests(), 'Node.js v24.x').map(function (status) {
+                    return {
+                        description: status.description,
+                        state: status.state,
+                        targetUrl: status.target_url
+                    };
+                }),
+                [
+                    {
+                        description: 'Waiting for dispatched release CI.',
+                        state: 'pending',
+                        targetUrl: null
+                    },
+                    {
+                        description: 'Dispatched release CI job running.',
+                        state: 'pending',
+                        targetUrl: 'https://github.com/owner/repo/actions/runs/8/job/1'
+                    },
+                    {
+                        description: 'Dispatched release CI job success.',
+                        state: 'success',
+                        targetUrl: 'https://github.com/owner/repo/actions/runs/8/job/1'
+                    }
+                ]
+            );
+            assert.deepStrictEqual(
+                statusesFor(server.requests(), 'Mutation testing').map(function (status) {
+                    return {
+                        description: status.description,
+                        state: status.state,
+                        targetUrl: status.target_url
+                    };
+                }),
+                [
+                    {
+                        description: 'Waiting for dispatched release CI.',
+                        state: 'pending',
+                        targetUrl: null
+                    },
+                    {
+                        description: 'Dispatched release CI job running.',
+                        state: 'pending',
+                        targetUrl: 'https://github.com/owner/repo/actions/runs/8/job/2'
+                    },
+                    {
+                        description: 'Dispatched release CI job success.',
+                        state: 'success',
+                        targetUrl: 'https://github.com/owner/repo/actions/runs/8/job/2'
+                    }
+                ]
+            );
+        })
+    );
+
+    test(
+        'mirrors missing required jobs as failed statuses',
+        withDeterministicGitHubApiServer(successfulReleaseCiScenario(), async function (server) {
+            assert.strictEqual(await runReleaseCi(server, [ 'Node.js v24.x', 'Missing job' ]), false);
+
+            assert.deepStrictEqual(statusesFor(server.requests(), 'Missing job'), [
+                {
+                    context: 'Missing job',
+                    description: 'Waiting for dispatched release CI.',
+                    state: 'pending',
+                    target_url: null
+                },
+                {
+                    context: 'Missing job',
+                    description: 'Missing dispatched release CI job: Missing job.',
+                    state: 'failure',
+                    target_url: 'https://github.com/owner/repo/actions/runs/8'
+                }
+            ]);
+        })
+    );
+
+    test(
+        'marks statuses as failed when a dispatched workflow run is never created',
+        withDeterministicGitHubApiServer({
+            restRoutes: [
+                workflowListRoute(),
+                {
+                    method: 'GET',
+                    path: workflowRunsPath,
+                    search: workflowRunsSearch,
+                    response: { status: okStatus, body: { workflow_runs: [] } }
+                },
+                {
+                    method: 'GET',
+                    path: repositoryWorkflowRunsPath,
+                    search: workflowRunsSearch,
+                    response: { status: okStatus, body: { workflow_runs: [] } }
+                },
+                dispatchRoute(),
+                statusRoute()
+            ],
+            graphqlRoutes: []
+        }, async function (server) {
+            await assert.rejects(
+                runReleaseCi(server, [ 'Node.js v24.x' ]),
+                /Release workflow run was not created/u
+            );
+
+            assert.deepStrictEqual(statusesFor(server.requests(), 'Node.js v24.x'), [
+                {
+                    context: 'Node.js v24.x',
+                    description: 'Waiting for dispatched release CI.',
+                    state: 'pending',
+                    target_url: null
+                },
+                {
+                    context: 'Node.js v24.x',
+                    description: 'Dispatched release CI did not start.',
+                    state: 'error',
+                    target_url: null
+                }
+            ]);
+        })
+    );
+});

--- a/integration-tests/github-api/with-deterministic-github-api-server.ts
+++ b/integration-tests/github-api/with-deterministic-github-api-server.ts
@@ -1,10 +1,12 @@
 import type { AsyncFunc as MochaAsyncTestFunction } from 'mocha';
 import getPort from 'get-port';
 import {
-    createDeterministicGitHubApiServer,
-    type DeterministicGitHubApiRequest
+    createDeterministicGitHubApiServer
 } from './deterministic-github-api-server.ts';
-import type { DeterministicGitHubApiScenario } from './deterministic-github-api-scenarios.ts';
+import type {
+    DeterministicGitHubApiRequest,
+    DeterministicGitHubApiScenario
+} from './deterministic-github-api-scenarios.ts';
 
 export type DeterministicGitHubApiServerContext = {
     readonly baseUrl: string;

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ npx packtory release --publish --tag --push --github-release --no-dry-run
 
 Release PR commits are authored through the GitHub credential from `GH_TOKEN` or `GITHUB_TOKEN`, so GitHub can mark them verified when the credential supports signed API commits. This allows release PRs to merge into branches that require signed commits without local Git signing setup.
 
-The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory dispatches the configured workflow on the release branch, waits for the run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch update already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human update, or another CI system.
+The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory dispatches the configured workflow on the release branch, waits for the fresh run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch update already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human update, or another CI system.
 
 For more details about the CLI application have a look at the [full documentation](./source/packages/command-line-interface/readme.md).
 

--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { fake } from 'sinon';
 import {
     captureRequests,
     createClient,
@@ -16,6 +17,7 @@ import {
     type RecordedRequest,
     type RouteResponse
 } from '../../test-libraries/release-pr-github-client-test-support.ts';
+import { createReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
 
 const defaultRoutes: ReadonlyMap<string, RouteResponse> = new Map([
     [ routeKey('GET', '/repos/owner/repo/pulls'), function () {
@@ -132,7 +134,48 @@ function countReleasePullRequestLookups(records: readonly RecordedRequest[]): nu
         .length;
 }
 
+function fetchInputUrl(input: Parameters<typeof globalThis.fetch>[0]): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+    if (input instanceof URL) {
+        return input.href;
+    }
+    return input.url;
+}
+
+async function assertBranchHeadUsesApiBaseUrl(apiBaseUrl: string, expectedUrl: string): Promise<void> {
+    const fetchImplementation = fake(async function (input: Parameters<typeof globalThis.fetch>[0]) {
+        assert.strictEqual(fetchInputUrl(input), expectedUrl);
+        return jsonResponse({ commit: { sha: 'main-head' } });
+    });
+    const client = createReleasePullRequestGitHubClient({
+        apiBaseUrl,
+        fetch: fetchImplementation,
+        owner: 'owner',
+        repo: 'repo',
+        token: 'token'
+    });
+
+    assert.strictEqual(await client.getBranchHeadSha('main'), 'main-head');
+    assert.strictEqual(fetchImplementation.callCount, 1);
+}
+
 suite('release-pr-github-client', function () {
+    test('uses the default GitHub API base URL', async function () {
+        await assertBranchHeadUsesApiBaseUrl(
+            'https://api.github.com',
+            'https://api.github.com/repos/owner/repo/branches/main'
+        );
+    });
+
+    test('uses the configured GitHub API base URL', async function () {
+        await assertBranchHeadUsesApiBaseUrl(
+            'http://127.0.0.1:1234',
+            'http://127.0.0.1:1234/repos/owner/repo/branches/main'
+        );
+    });
+
     test('maintains release pull requests', async function () {
         const capturedRequests = captureRequests();
         const client = createClient(createFetch(capturedRequests));

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -113,6 +113,7 @@ export type ReleasePullRequestGitHubClient = {
 };
 
 type GitHubClientContext = {
+    readonly apiBaseUrl: string;
     readonly fetch: typeof globalThis.fetch;
     readonly owner: string;
     readonly repo: string;
@@ -187,6 +188,7 @@ function createGitHubRestClient(
 ): GitHubRestClientInstance {
     const GitHubRestClient = Octokit.plugin(restEndpointMethods, paginateRest);
     return new GitHubRestClient({
+        baseUrl: context.apiBaseUrl,
         request: {
             fetch: context.fetch,
             headers: requestContext.headers

--- a/source/command-line-interface/runner/release-pull-request-ci.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.test.ts
@@ -9,7 +9,6 @@ import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.
 type WorkflowRunLookup = ReleasePullRequestGitHubClient['findDispatchedWorkflowRun'];
 type FakeWorkflowRunLookup = ReturnType<typeof fake> & WorkflowRunLookup;
 type WorkflowRunResult = Awaited<ReturnType<ReleasePullRequestGitHubClient['readWorkflowRunResult']>>;
-
 function createConfig(requiredStatusContexts: readonly string[] = [ 'Node.js' ]): ReleasePullRequestConfig {
     return {
         automationAuthor: 'github-actions[bot]',
@@ -34,6 +33,18 @@ function createDispatchedWorkflowRunLookup(): FakeWorkflowRunLookup {
         return callCount === 1
             ? { event: 'workflow_dispatch' as const, observedRunIds: [], runId: undefined }
             : { event: 'workflow_dispatch' as const, observedRunIds: [ 1 ], runId: 1 };
+    }) as FakeWorkflowRunLookup;
+}
+function createFreshWorkflowRunLookup(dispatchWorkflow: ReturnType<typeof fake>): FakeWorkflowRunLookup {
+    let staleLookupsAfterDispatch = 0;
+    return fake(async function (): ReturnType<WorkflowRunLookup> {
+        if (dispatchWorkflow.callCount === 0) {
+            return { event: 'workflow_dispatch' as const, observedRunIds: [ 7 ], runId: 7 };
+        }
+        staleLookupsAfterDispatch += 1;
+        return staleLookupsAfterDispatch === 1
+            ? { event: 'workflow_dispatch' as const, observedRunIds: [ 7 ], runId: 7 }
+            : { event: 'workflow_dispatch' as const, observedRunIds: [ 7, 8 ], runId: 8 };
     }) as FakeWorkflowRunLookup;
 }
 
@@ -190,17 +201,15 @@ suite('release-pull-request-ci', function () {
             });
         });
 
-        test('uses an existing dispatched workflow run without dispatching again', async function () {
+        test('ignores existing dispatched workflow runs and waits for a fresh run', async function () {
             const createStatus = fake.resolves(undefined);
             const dispatchWorkflow = fake.resolves(undefined);
+            const readWorkflowRunResult = fake.resolves(workflowRunResultForJob('success'));
             const client = createClient({
                 createStatus,
                 dispatchWorkflow,
-                findDispatchedWorkflowRun: fake.resolves({
-                    event: 'workflow_dispatch',
-                    observedRunIds: [ 7 ],
-                    runId: 7
-                })
+                findDispatchedWorkflowRun: createFreshWorkflowRunLookup(dispatchWorkflow),
+                readWorkflowRunResult
             });
 
             assert.strictEqual(
@@ -213,9 +222,15 @@ suite('release-pull-request-ci', function () {
                 true
             );
 
-            assert.strictEqual(dispatchWorkflow.callCount, 0);
-            assert.strictEqual(createStatus.callCount, 1);
+            assert.strictEqual(readWorkflowRunResult.firstCall.args[0], 8);
             assert.deepStrictEqual(createStatus.firstCall.args[0], {
+                commitSha: 'release-head',
+                context: 'Node.js',
+                description: 'Waiting for dispatched release CI.',
+                state: 'pending',
+                targetUrl: undefined
+            });
+            assert.deepStrictEqual(createStatus.secondCall.args[0], {
                 commitSha: 'release-head',
                 context: 'Node.js',
                 description: 'Dispatched release CI job success.',

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -21,6 +21,7 @@ type FindDispatchedWorkflowRunInput = {
 };
 
 type WaitForDispatchedWorkflowRunInput = FindDispatchedWorkflowRunInput & {
+    readonly ignoredRunIds: ReadonlySet<number>;
     readonly sleep: WorkflowSleep;
 };
 
@@ -106,7 +107,7 @@ async function waitForDispatchedWorkflowRun(input: WaitForDispatchedWorkflowRunI
         if (attempt !== 0) {
             lookup = await findDispatchedWorkflowRun(input);
         }
-        if (lookup.runId !== undefined) {
+        if (lookup.runId !== undefined && !input.ignoredRunIds.has(lookup.runId)) {
             return lookup.runId;
         }
         if (!isLastAttempt(attempt, workflowRunLookupAttempts)) {
@@ -304,16 +305,15 @@ async function createFailedWorkflowStatuses(input: FailedWorkflowStatusesInput):
 
 async function dispatchWorkflowRun(input: WaitForDispatchedWorkflowRunInput): Promise<number> {
     await createPendingWorkflowStatuses(input);
+    const baseline = await findDispatchedWorkflowRun(input);
     await input.client.dispatchWorkflow({
         ref: input.config.branch,
         workflowFile: input.ciConfig.workflowFile
     });
-    return waitForDispatchedWorkflowRun(input);
-}
-
-async function resolveWorkflowRunId(input: WaitForDispatchedWorkflowRunInput): Promise<number> {
-    const { runId } = await findDispatchedWorkflowRun(input);
-    return runId ?? dispatchWorkflowRun(input);
+    return waitForDispatchedWorkflowRun({
+        ...input,
+        ignoredRunIds: new Set([ ...input.ignoredRunIds, ...baseline.observedRunIds ])
+    });
 }
 
 async function deleteActionRequiredPullRequestRuns(
@@ -331,7 +331,7 @@ async function resolveWorkflowRunIdOrFailStatuses(
     ciConfig: GitHubActionsCiConfig
 ): Promise<number> {
     try {
-        return await resolveWorkflowRunId({ ...input, ciConfig });
+        return await dispatchWorkflowRun({ ...input, ciConfig, ignoredRunIds: new Set() });
     } catch (error) {
         await createFailedWorkflowStatuses({
             ciConfig,

--- a/source/command-line-interface/runner/release-pull-request-handler.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.test.ts
@@ -187,6 +187,7 @@ suite('release-pull-request-handler', function () {
 
                 assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
                 assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+                    apiBaseUrl: 'https://api.github.com',
                     owner: 'owner',
                     repo: 'repo',
                     token: undefined
@@ -208,6 +209,7 @@ suite('release-pull-request-handler', function () {
 
                 assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
                 assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+                    apiBaseUrl: 'https://api.github.com',
                     owner: 'package-owner',
                     repo: 'package-repo',
                     token: 'github-token'
@@ -223,6 +225,30 @@ suite('release-pull-request-handler', function () {
 
                 assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
                 assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+                    apiBaseUrl: 'https://api.github.com',
+                    owner: 'owner',
+                    repo: 'repo',
+                    token: 'token'
+                });
+            });
+
+            test('maintain passes GITHUB_API_BASE_URL to the GitHub client', async function () {
+                const createReleasePullRequestGitHubClient = fake.returns(createReleasePullRequestClient({}));
+                const { dependencies } = createDependencies({
+                    createReleasePullRequestGitHubClient,
+                    flags: { command: 'maintain', noDryRun: true, releasePullRequestNumber: undefined },
+                    readEnvironmentVariable(name) {
+                        return {
+                            GH_TOKEN: 'token',
+                            GITHUB_API_BASE_URL: 'http://127.0.0.1:1234',
+                            GITHUB_REPOSITORY: 'owner/repo'
+                        }[name];
+                    }
+                });
+
+                assert.strictEqual(await runReleasePullRequestHandler(dependencies), 0);
+                assert.deepStrictEqual(createReleasePullRequestGitHubClient.firstCall.args[0], {
+                    apiBaseUrl: 'http://127.0.0.1:1234',
                     owner: 'owner',
                     repo: 'repo',
                     token: 'token'

--- a/source/command-line-interface/runner/release-pull-request-handler.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.ts
@@ -51,6 +51,7 @@ type ValidateReleasePullRequestFlags = {
 type ReleasePullRequestWriteFlags = AuthorizePublishReleasePullRequestFlags | MaintainReleasePullRequestFlags;
 type ReleasePullRequestFlags = ReleasePullRequestWriteFlags | ValidateReleasePullRequestFlags;
 type GitHubClientContext = {
+    readonly apiBaseUrl: string;
     readonly owner: string;
     readonly repo: string;
     readonly token: string | undefined;
@@ -111,6 +112,9 @@ type GitHubRepositoryNameParts = {
 type GitHubRepository = GitHubRepositoryNameParts & {
     readonly name: string;
 };
+
+const defaultGitHubApiBaseUrl = 'https://api.github.com';
+
 function formatHandlerError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
 }
@@ -149,6 +153,7 @@ async function createGitHubClient(dependencies: ReleasePullRequestHandlerDepende
     const repository = await readGitHubRepository(dependencies);
     return {
         client: dependencies.createReleasePullRequestGitHubClient({
+            apiBaseUrl: dependencies.readEnvironmentVariable('GITHUB_API_BASE_URL') ?? defaultGitHubApiBaseUrl,
             owner: repository.owner,
             repo: repository.repo,
             token: readGitHubToken(dependencies)

--- a/source/command-line-interface/runner/runner.ts
+++ b/source/command-line-interface/runner/runner.ts
@@ -30,6 +30,7 @@ import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.
 import { runReleasePullRequestHandler } from './release-pull-request-handler.ts';
 
 type ReleasePullRequestGitHubClientContext = {
+    readonly apiBaseUrl: string;
     readonly owner: string;
     readonly repo: string;
     readonly token: string | undefined;

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -99,7 +99,7 @@ packtory <command> [options]
 - The release PR policy derives allowed files from `changelog.outputs`. Repository and package changelog files are allowed. GitHub Release outputs are ignored because they do not write repository files.
 - `release-pr validate` accepts normal PRs without a release label. Release-labeled PRs must match the configured branch, title, author, commit subject, base head, and allowed files. Merge groups must not batch release PRs with other PRs.
 - `release-pr authorize-publish` writes GitHub step outputs when `$GITHUB_OUTPUT` exists, otherwise it prints them. Normal commits get `should_publish=false`. A merged valid release PR gets `should_publish=true`, `publish_commit_sha`, `release_commit_sha`, and `release_pull_request_number`.
-- Set `releasePullRequest.githubActionsCi` only for the GitHub Actions `GITHUB_TOKEN` workaround. With `trigger: 'workflow-dispatch'`, `workflowFile`, and `requiredStatusContexts`, `maintain` dispatches CI for the release branch, waits for the exact release commit run, and mirrors the configured job names as commit statuses.
+- Set `releasePullRequest.githubActionsCi` only for the GitHub Actions `GITHUB_TOKEN` workaround. With `trigger: 'workflow-dispatch'`, `workflowFile`, and `requiredStatusContexts`, `maintain` dispatches fresh CI for the release branch, waits for that release commit run, and mirrors the configured job names as commit statuses.
 - Leave `githubActionsCi` unset when the release branch update already triggers normal CI, such as with a GitHub App token, PAT, human update, external automation, or non-GitHub CI.
 
 **Pack behavior:**

--- a/source/test-libraries/release-pr-github-client-test-support.ts
+++ b/source/test-libraries/release-pr-github-client-test-support.ts
@@ -85,6 +85,7 @@ export function createClientWithToken(
     token: string | undefined
 ): ReleasePullRequestGitHubClient {
     return createReleasePullRequestGitHubClient({
+        apiBaseUrl: 'https://api.github.com',
         fetch: fetchImplementation,
         owner: 'owner',
         repo: 'repo',

--- a/source/test-libraries/release-pull-request-handler-test-support.ts
+++ b/source/test-libraries/release-pull-request-handler-test-support.ts
@@ -96,9 +96,15 @@ export function createDependencies(
 ): CreatedReleasePullRequestDependencies {
     const log = fake();
     const fileManager = createFakeFileManager();
+    let workflowRunLookupCount = 0;
     const releasePullRequestClient = createReleasePullRequestClient({
         createOrUpdateReleasePullRequest: fake.resolves(12),
-        findDispatchedWorkflowRun: fake.resolves({ event: 'workflow_dispatch', observedRunIds: [ 1 ], runId: 1 }),
+        findDispatchedWorkflowRun: fake(async function () {
+            workflowRunLookupCount += 1;
+            return workflowRunLookupCount === 1
+                ? { event: 'workflow_dispatch' as const, observedRunIds: [ 1 ], runId: 1 }
+                : { event: 'workflow_dispatch' as const, observedRunIds: [ 1, 2 ], runId: 2 };
+        }),
         getPullRequest: fake.resolves({
             author: 'github-actions[bot]',
             baseRef: 'main',

--- a/source/test-libraries/runner-test-support.ts
+++ b/source/test-libraries/runner-test-support.ts
@@ -96,6 +96,7 @@ function createPrLogEngineFactory(overrides: Overrides): CommandLineInterfaceRun
 function createReleasePullRequestClientFixture(
     overrides: Readonly<Partial<ReleasePullRequestGitHubClientFixture>>
 ): ReleasePullRequestGitHubClientFixture {
+    let workflowRunLookupCount = 0;
     return {
         closeOpenReleasePullRequests: fake.resolves(undefined),
         createCommitOnBranch: fake.resolves('signed-release-head'),
@@ -104,10 +105,11 @@ function createReleasePullRequestClientFixture(
         deleteActionRequiredPullRequestRuns: fake.resolves(undefined),
         deleteBranch: fake.resolves(undefined),
         dispatchWorkflow: fake.resolves(undefined),
-        findDispatchedWorkflowRun: fake.resolves({
-            event: 'workflow_dispatch',
-            observedRunIds: [],
-            runId: undefined
+        findDispatchedWorkflowRun: fake(async function () {
+            workflowRunLookupCount += 1;
+            return workflowRunLookupCount === 1
+                ? { event: 'workflow_dispatch' as const, observedRunIds: [], runId: undefined }
+                : { event: 'workflow_dispatch' as const, observedRunIds: [ 1 ], runId: 1 };
         }),
         getBranchHeadSha: fake.resolves('main-head'),
         getPullRequest: fake.resolves(undefined as never),


### PR DESCRIPTION
Release PR maintenance now treats existing workflow_dispatch runs as baseline history, dispatches fresh CI for the current release commit, and mirrors running plus final job states back to the configured commit statuses. The deterministic GitHub API integration setup now supports stateful route responses so delayed workflow creation and job progress are covered through the real release PR GitHub client.