### PR TITLE
Replace abbreviated dependency identifiers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -428,7 +428,7 @@ Reports declared `bundleDependencies` and `bundlePeerDependencies` whose imports
 
 ### `noDevDependencyImports`
 
-Reports any external dependency reachable from a package's source that is declared only in `mainPackageJson.devDependencies` and not in `dependencies` or `peerDependencies`. Catches dev-only deps that have leaked into runtime imports - a likely break for downstream consumers.
+Reports any external dependency reachable from a package's source that is declared only in `mainPackageJson.devDependencies` and not in `dependencies` or `peerDependencies`. Catches dev-only dependencies that have leaked into runtime imports - a likely break for downstream consumers.
 
 - **Top-level:** `enabled: boolean`.
 - **Per-package:** `{}` only.

--- a/source/checks/rules/no-unused-bundle-dependencies.test.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.test.ts
@@ -5,7 +5,7 @@ import type { ExternalDependency } from '../../dependency-scanner/external-depen
 import { analyzedBundle } from '../../test-libraries/bundle-fixtures.ts';
 import { noUnusedBundleDependenciesRule } from './no-unused-bundle-dependencies.ts';
 
-function bundleWithLinkedDeps(name: string, linked: readonly string[]): AnalyzedBundle {
+function bundleWithLinkedDependencies(name: string, linked: readonly string[]): AnalyzedBundle {
     return analyzedBundle({
         name,
         linkedBundleDependencies: new Map<string, ExternalDependency>(
@@ -27,7 +27,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('returns no issues when settings are missing', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: undefined,
                 perPackageSettings: new Map(),
                 packageConfigs: { a: { bundleDependencies: [ 'unused' ] } }
@@ -38,7 +38,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('returns no issues when the rule is disabled', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: { noUnusedBundleDependencies: { enabled: false } },
                 perPackageSettings: new Map(),
                 packageConfigs: { a: { bundleDependencies: [ 'unused' ] } }
@@ -49,7 +49,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('returns no issues when packageConfigs is omitted entirely', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: enabled,
                 perPackageSettings: new Map()
             });
@@ -59,7 +59,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('returns no issues when no entry exists in packageConfigs for the bundle', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: {}
@@ -70,7 +70,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('returns no issues when the package declares no bundle dependencies', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: { a: {} }
@@ -83,7 +83,7 @@ suite('no-unused-bundle-dependencies', function () {
     suite('declared dependency usage', function () {
         test('reports a declared bundleDependency that is never substituted', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: { a: { bundleDependencies: [ 'unused' ] } }
@@ -94,7 +94,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('reports a declared bundlePeerDependency that is never substituted', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []) ],
+                bundles: [ bundleWithLinkedDependencies('a', []) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: { a: { bundlePeerDependencies: [ 'unused-peer' ] } }
@@ -105,7 +105,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('does not report a declared bundleDependency that was substituted', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', [ 'used' ]) ],
+                bundles: [ bundleWithLinkedDependencies('a', [ 'used' ]) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: { a: { bundleDependencies: [ 'used' ] } }
@@ -116,7 +116,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('reports a mix of unused regular and peer dependencies for the same package', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', [ 'used' ]) ],
+                bundles: [ bundleWithLinkedDependencies('a', [ 'used' ]) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: {
@@ -132,7 +132,7 @@ suite('no-unused-bundle-dependencies', function () {
 
         test('iterates every bundle independently', async function () {
             const result = await noUnusedBundleDependenciesRule.run({
-                bundles: [ bundleWithLinkedDeps('a', []), bundleWithLinkedDeps('b', [ 'used' ]) ],
+                bundles: [ bundleWithLinkedDependencies('a', []), bundleWithLinkedDependencies('b', [ 'used' ]) ],
                 settings: enabled,
                 perPackageSettings: new Map(),
                 packageConfigs: {

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -12,7 +12,7 @@ import {
     type ChangelogConfig
 } from './changelog-destinations.ts';
 
-const deps = { workingDirectory: '/repo' } as const;
+const dependencies = { workingDirectory: '/repo' } as const;
 
 type GeneratedChangelogOverrides = {
     readonly packageMarkdownByName?: ReadonlyMap<string, string>;
@@ -70,7 +70,7 @@ async function assertRepositoryReadFailureRethrown(error: Error, messagePattern:
 
     await assert.rejects(
         writeConfiguredChangelogs(
-            { ...deps, fileManager },
+            { ...dependencies, fileManager },
             createChangelogConfig({ changelog: { outputs: [ { kind: 'repository-file', path: 'CHANGELOG.md' } ] } }),
             { updateChangelog: fake.returns('updated') },
             createGeneratedChangelog()
@@ -120,12 +120,12 @@ suite('changelog-destinations', function () {
     suite('collectGeneratedAttributionPaths', function () {
         test('returns no paths when outputs are absent', function () {
             assert.deepStrictEqual(
-                collectGeneratedAttributionPaths(deps, createChangelogConfig({ changelog: undefined })),
+                collectGeneratedAttributionPaths(dependencies, createChangelogConfig({ changelog: undefined })),
                 []
             );
             assert.deepStrictEqual(
                 collectGeneratedAttributionPaths(
-                    deps,
+                    dependencies,
                     createChangelogConfig({ changelog: { prLog: { validLabels: { operations: 'Operations' } } } })
                 ),
                 []
@@ -133,7 +133,7 @@ suite('changelog-destinations', function () {
         });
 
         test('includes repository and in-repository package files', function () {
-            assert.deepStrictEqual(collectGeneratedAttributionPaths(deps, createChangelogConfig()), [
+            assert.deepStrictEqual(collectGeneratedAttributionPaths(dependencies, createChangelogConfig()), [
                 'CHANGELOG.md',
                 'src/pkg-a/docs/CHANGELOG.md'
             ]);
@@ -142,7 +142,7 @@ suite('changelog-destinations', function () {
         test('uses common sourcesFolder for package files', function () {
             assert.deepStrictEqual(
                 collectGeneratedAttributionPaths(
-                    deps,
+                    dependencies,
                     createChangelogConfig({
                         changelog: { outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ] },
                         packages: [ { name: 'pkg-a' } ]
@@ -155,7 +155,7 @@ suite('changelog-destinations', function () {
         test('includes explicit package file paths', function () {
             assert.deepStrictEqual(
                 collectGeneratedAttributionPaths(
-                    deps,
+                    dependencies,
                     createChangelogConfig({
                         changelog: {
                             outputs: [
@@ -179,7 +179,7 @@ suite('changelog-destinations', function () {
         test('ignores github-release outputs', function () {
             assert.deepStrictEqual(
                 collectGeneratedAttributionPaths(
-                    deps,
+                    dependencies,
                     createChangelogConfig({ changelog: { outputs: [ { kind: 'github-release' } ] } })
                 ),
                 []
@@ -189,7 +189,7 @@ suite('changelog-destinations', function () {
         test('reports package-file outputs without sourcesFolder', function () {
             assert.throws(function () {
                 collectGeneratedAttributionPaths(
-                    deps,
+                    dependencies,
                     createChangelogConfig({
                         changelog: { outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ] },
                         commonPackageSettings: undefined,
@@ -218,7 +218,7 @@ suite('changelog-destinations', function () {
             const fileManager = createFakeFileManager();
 
             const writtenPaths = await writeConfiguredChangelogs(
-                { ...deps, fileManager },
+                { ...dependencies, fileManager },
                 createChangelogConfig({ changelog: undefined }),
                 { updateChangelog: fake.returns('updated') },
                 createGeneratedChangelog()
@@ -232,7 +232,7 @@ suite('changelog-destinations', function () {
             const fileManager = createFakeFileManager();
 
             const writtenPaths = await writeConfiguredChangelogs(
-                { ...deps, fileManager },
+                { ...dependencies, fileManager },
                 createChangelogConfig({ changelog: { prLog: { validLabels: { operations: 'Operations' } } } }),
                 { updateChangelog: fake.returns('updated') },
                 createGeneratedChangelog()
@@ -255,7 +255,7 @@ suite('changelog-destinations', function () {
             );
 
             const writtenPaths = await writeConfiguredChangelogs(
-                { ...deps, fileManager },
+                { ...dependencies, fileManager },
                 createChangelogConfig({
                     changelog: { outputs: [ { kind: 'repository-file', path: 'CHANGELOG.md' } ] }
                 }),
@@ -271,7 +271,7 @@ suite('changelog-destinations', function () {
             const fileManager = createFakeFileManager();
 
             const writtenPaths = await writeConfiguredChangelogs(
-                { ...deps, fileManager },
+                { ...dependencies, fileManager },
                 createChangelogConfig({
                     changelog: { outputs: [ { kind: 'repository-file', path: 'CHANGELOG.md' } ] }
                 }),
@@ -291,7 +291,7 @@ suite('changelog-destinations', function () {
 
             await assert.rejects(
                 writeConfiguredChangelogs(
-                    { ...deps, fileManager },
+                    { ...dependencies, fileManager },
                     createChangelogConfig({
                         changelog: { outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ] }
                     }),
@@ -307,7 +307,7 @@ suite('changelog-destinations', function () {
 
             await assert.rejects(
                 writeConfiguredChangelogs(
-                    { ...deps, fileManager },
+                    { ...dependencies, fileManager },
                     createChangelogConfig({
                         changelog: { outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ] },
                         commonPackageSettings: undefined,
@@ -324,7 +324,7 @@ suite('changelog-destinations', function () {
             const fileManager = createFakeFileManager();
 
             const writtenPaths = await writeConfiguredChangelogs(
-                { ...deps, fileManager },
+                { ...dependencies, fileManager },
                 createChangelogConfig({
                     changelog: { outputs: [ { kind: 'package-file', path: 'CHANGELOG.md' } ] },
                     packages: [ { name: 'pkg-a' } ]
@@ -340,7 +340,7 @@ suite('changelog-destinations', function () {
             const fileManager = createFakeFileManager();
 
             const writtenPaths = await writeConfiguredChangelogs(
-                { ...deps, fileManager },
+                { ...dependencies, fileManager },
                 createChangelogConfig({
                     changelog: {
                         outputs: [
@@ -384,7 +384,7 @@ suite('changelog-destinations', function () {
 
             await assert.rejects(
                 writeConfiguredChangelogs(
-                    { ...deps, fileManager },
+                    { ...dependencies, fileManager },
                     createChangelogConfig({
                         changelog: {
                             outputs: [

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -22,11 +22,11 @@ export type ChangelogConfig = {
     readonly packages: readonly PackagePathConfig[];
 };
 
-type ChangelogDestinationDeps = {
+type ChangelogDestinationDependencies = {
     readonly fileManager: Pick<FileManager, 'readFile'>;
     readonly workingDirectory: string;
 };
-type WritableChangelogDestinationDeps = {
+type WritableChangelogDestinationDependencies = {
     readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
     readonly workingDirectory: string;
 };
@@ -89,8 +89,11 @@ function normalizeConfiguredPath(filePath: string): string {
     return filePath.split(/[/\\]/u).join(path.sep);
 }
 
-function resolveRepositoryPath(deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>, filePath: string): string {
-    return path.resolve(deps.workingDirectory, normalizeConfiguredPath(filePath));
+function resolveRepositoryPath(
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
+    filePath: string
+): string {
+    return path.resolve(dependencies.workingDirectory, normalizeConfiguredPath(filePath));
 }
 
 function resolvePackageSourcesFolder(packageConfig: PackagePathConfig, config: ChangelogConfig): string {
@@ -110,20 +113,20 @@ function mapPackageConfigByName(config: ChangelogConfig): ReadonlyMap<string, Pa
 }
 
 function resolvePackageFilePath(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     packageConfig: PackagePathConfig,
     outputPath: string
 ): string {
     return path.resolve(
-        deps.workingDirectory,
+        dependencies.workingDirectory,
         normalizeConfiguredPath(resolvePackageSourcesFolder(packageConfig, config)),
         normalizeConfiguredPath(outputPath)
     );
 }
 
 function resolveExplicitPackageFilePath(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     output: PackageChangelogOutputWithExplicitPaths,
     packageName: string
 ): string {
@@ -131,7 +134,7 @@ function resolveExplicitPackageFilePath(
     if (outputPath === undefined) {
         throw new Error(`Changelog output path for package "${packageName}" is missing`);
     }
-    return resolveRepositoryPath(deps, outputPath);
+    return resolveRepositoryPath(dependencies, outputPath);
 }
 
 function hasSharedPackagePath(output: PackageChangelogOutput): output is PackageChangelogOutputWithSharedPath {
@@ -139,10 +142,10 @@ function hasSharedPackagePath(output: PackageChangelogOutput): output is Package
 }
 
 export function collectGeneratedAttributionPaths(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig
 ): readonly string[] {
-    return generatedAttributionPaths.collectGeneratedAttributionPaths(deps.workingDirectory, config);
+    return generatedAttributionPaths.collectGeneratedAttributionPaths(dependencies.workingDirectory, config);
 }
 
 export function shouldPageGroupedChangelog(outputs: readonly ChangelogOutput[] | undefined): boolean {
@@ -155,7 +158,7 @@ export function shouldPageGroupedChangelog(outputs: readonly ChangelogOutput[] |
 }
 
 function collectRepositoryDestinations(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     outputs: readonly ChangelogOutput[],
     changelog: GeneratedChangelog
 ): readonly FileChangelogDestination[] {
@@ -163,24 +166,27 @@ function collectRepositoryDestinations(
         if (output.kind !== 'repository-file') {
             return [];
         }
-        return [ { filePath: resolveRepositoryPath(deps, output.path), generatedMarkdown: changelog.groupedMarkdown } ];
+        return [ {
+            filePath: resolveRepositoryPath(dependencies, output.path),
+            generatedMarkdown: changelog.groupedMarkdown
+        } ];
     });
 }
 
 function collectRepositoryOutputFilePaths(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     outputs: readonly ChangelogOutput[]
 ): readonly ChangelogOutputFilePath[] {
     return outputs.flatMap(function (output) {
         if (output.kind !== 'repository-file') {
             return [];
         }
-        return [ { filePath: resolveRepositoryPath(deps, output.path), packageName: undefined } ];
+        return [ { filePath: resolveRepositoryPath(dependencies, output.path), packageName: undefined } ];
     });
 }
 
 function collectPackageDestinationsWithSharedPath(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     output: PackageChangelogOutputWithSharedPath,
     changelog: GeneratedChangelog
@@ -191,44 +197,47 @@ function collectPackageDestinationsWithSharedPath(
         if (packageConfig === undefined) {
             throw new Error(`Config for package "${packageName}" is missing`);
         }
-        return { filePath: resolvePackageFilePath(deps, config, packageConfig, output.path), generatedMarkdown };
+        return {
+            filePath: resolvePackageFilePath(dependencies, config, packageConfig, output.path),
+            generatedMarkdown
+        };
     });
 }
 
 function collectPackageOutputFilePathsWithSharedPath(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     output: PackageChangelogOutputWithSharedPath
 ): readonly ChangelogOutputFilePath[] {
     return config.packages.map(function (packageConfig) {
         return {
-            filePath: resolvePackageFilePath(deps, config, packageConfig, output.path),
+            filePath: resolvePackageFilePath(dependencies, config, packageConfig, output.path),
             packageName: packageConfig.name
         };
     });
 }
 
 function collectPackageDestinationsWithExplicitPaths(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     output: PackageChangelogOutputWithExplicitPaths,
     changelog: GeneratedChangelog
 ): readonly FileChangelogDestination[] {
     return Array.from(changelog.packageMarkdownByName, function ([ packageName, generatedMarkdown ]) {
-        return { filePath: resolveExplicitPackageFilePath(deps, output, packageName), generatedMarkdown };
+        return { filePath: resolveExplicitPackageFilePath(dependencies, output, packageName), generatedMarkdown };
     });
 }
 
 function collectPackageOutputFilePathsWithExplicitPaths(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     output: PackageChangelogOutputWithExplicitPaths
 ): readonly ChangelogOutputFilePath[] {
     return Object.entries(output.paths).map(function ([ packageName, outputPath ]) {
-        return { filePath: resolveRepositoryPath(deps, outputPath), packageName };
+        return { filePath: resolveRepositoryPath(dependencies, outputPath), packageName };
     });
 }
 
 function collectPackageDestinations(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     outputs: readonly ChangelogOutput[],
     changelog: GeneratedChangelog
@@ -238,14 +247,14 @@ function collectPackageDestinations(
             return [];
         }
         if (hasSharedPackagePath(output)) {
-            return collectPackageDestinationsWithSharedPath(deps, config, output, changelog);
+            return collectPackageDestinationsWithSharedPath(dependencies, config, output, changelog);
         }
-        return collectPackageDestinationsWithExplicitPaths(deps, output, changelog);
+        return collectPackageDestinationsWithExplicitPaths(dependencies, output, changelog);
     });
 }
 
 function collectPackageOutputFilePaths(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     outputs: readonly ChangelogOutput[]
 ): readonly ChangelogOutputFilePath[] {
@@ -254,14 +263,14 @@ function collectPackageOutputFilePaths(
             return [];
         }
         if (hasSharedPackagePath(output)) {
-            return collectPackageOutputFilePathsWithSharedPath(deps, config, output);
+            return collectPackageOutputFilePathsWithSharedPath(dependencies, config, output);
         }
-        return collectPackageOutputFilePathsWithExplicitPaths(deps, output);
+        return collectPackageOutputFilePathsWithExplicitPaths(dependencies, output);
     });
 }
 
 export function collectChangelogOutputFilePaths(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig
 ): readonly ChangelogOutputFilePath[] {
     const outputs = config.changelog?.outputs;
@@ -269,8 +278,8 @@ export function collectChangelogOutputFilePaths(
         return [];
     }
     return [
-        ...collectRepositoryOutputFilePaths(deps, outputs),
-        ...collectPackageOutputFilePaths(deps, config, outputs)
+        ...collectRepositoryOutputFilePaths(dependencies, outputs),
+        ...collectPackageOutputFilePaths(dependencies, config, outputs)
     ];
 }
 
@@ -290,14 +299,14 @@ async function readChangelogMarkdown(fileManager: Pick<FileManager, 'readFile'>,
 }
 
 async function buildChangelogFile(
-    deps: Pick<ChangelogDestinationDeps, 'fileManager'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'fileManager'>,
     prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
     destination: FileChangelogDestination
 ): Promise<WrittenChangelogFile | undefined> {
     if (destination.generatedMarkdown.length === 0) {
         return undefined;
     }
-    const existingChangelogMarkdownValue = await readChangelogMarkdown(deps.fileManager, destination.filePath);
+    const existingChangelogMarkdownValue = await readChangelogMarkdown(dependencies.fileManager, destination.filePath);
     const content = prLogEngine.updateChangelog({
         existingChangelogMarkdown: existingChangelogMarkdownValue,
         generatedChangelogMarkdown: destination.generatedMarkdown
@@ -306,7 +315,7 @@ async function buildChangelogFile(
 }
 
 function collectChangelogDestinations(
-    deps: Pick<ChangelogDestinationDeps, 'workingDirectory'>,
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     changelog: GeneratedChangelog
 ): readonly FileChangelogDestination[] {
@@ -315,21 +324,21 @@ function collectChangelogDestinations(
         return [];
     }
     return [
-        ...collectRepositoryDestinations(deps, outputs, changelog),
-        ...collectPackageDestinations(deps, config, outputs, changelog)
+        ...collectRepositoryDestinations(dependencies, outputs, changelog),
+        ...collectPackageDestinations(dependencies, config, outputs, changelog)
     ];
 }
 
 export async function buildConfiguredChangelogFiles(
-    deps: ChangelogDestinationDeps,
+    dependencies: ChangelogDestinationDependencies,
     config: ChangelogConfig,
     prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
     changelog: GeneratedChangelog
 ): Promise<readonly WrittenChangelogFile[]> {
-    const destinations = collectChangelogDestinations(deps, config, changelog);
+    const destinations = collectChangelogDestinations(dependencies, config, changelog);
     const writtenFiles: WrittenChangelogFile[] = [];
     for (const destination of destinations) {
-        const writtenFile = await buildChangelogFile(deps, prLogEngine, destination);
+        const writtenFile = await buildChangelogFile(dependencies, prLogEngine, destination);
         if (writtenFile !== undefined) {
             writtenFiles.push(writtenFile);
         }
@@ -338,14 +347,14 @@ export async function buildConfiguredChangelogFiles(
 }
 
 export async function writeConfiguredChangelogs(
-    deps: WritableChangelogDestinationDeps,
+    dependencies: WritableChangelogDestinationDependencies,
     config: ChangelogConfig,
     prLogEngine: Pick<PrLogEngine, 'updateChangelog'>,
     changelog: GeneratedChangelog
 ): Promise<readonly string[]> {
-    const writtenFiles = await buildConfiguredChangelogFiles(deps, config, prLogEngine, changelog);
+    const writtenFiles = await buildConfiguredChangelogFiles(dependencies, config, prLogEngine, changelog);
     for (const file of writtenFiles) {
-        await deps.fileManager.writeFile(file.filePath, file.content);
+        await dependencies.fileManager.writeFile(file.filePath, file.content);
     }
     return writtenFiles.map(function (file) {
         return file.filePath;

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -14,7 +14,7 @@ import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage, ReleasePlanResul
 import { createFakeFileManager, type FakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import type { ConfigLoader } from '../config-loader.ts';
-import { runChangelogHandler, type ChangelogHandlerDeps } from './changelog-handler.ts';
+import { runChangelogHandler, type ChangelogHandlerDependencies } from './changelog-handler.ts';
 
 function releasePackage(overrides: Partial<ReleasePlanPackage> = {}): ReleasePlanPackage {
     return {
@@ -154,7 +154,7 @@ function configLoaderReturning(config: unknown): ConfigLoader {
     return { load: fake.resolves(config) };
 }
 
-type ChangelogHandlerDepsSpec = {
+type ChangelogHandlerDependenciesSpec = {
     readonly spies: Spies;
     readonly configLoader?: ConfigLoader;
     readonly fileManager?: FakeFileManager;
@@ -162,7 +162,7 @@ type ChangelogHandlerDepsSpec = {
     readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
 };
 
-function depsWith(spec: ChangelogHandlerDepsSpec): ChangelogHandlerDeps {
+function dependenciesWith(spec: ChangelogHandlerDependenciesSpec): ChangelogHandlerDependencies {
     return {
         log(message) {
             spec.spies.log(message);
@@ -222,7 +222,7 @@ type ReleasePlanFailureLogSpec = {
 async function assertReleasePlanFailureLogged(spec: ReleasePlanFailureLogSpec): Promise<void> {
     const spies = makeSpies(createEngine(), spec.releasePlanOutcome);
 
-    const code = await runChangelogHandler(depsWith({ spies }));
+    const code = await runChangelogHandler(dependenciesWith({ spies }));
 
     assert.strictEqual(code, 1);
     assert.deepStrictEqual(
@@ -253,7 +253,7 @@ suite('changelog-handler', function () {
         test('loads config, plans the release, and renders changelog markdown through the pager', async function () {
             const spies = makeSpies();
 
-            const code = await runChangelogHandler(depsWith({ spies }));
+            const code = await runChangelogHandler(dependenciesWith({ spies }));
 
             assert.strictEqual(code, 0);
             assert.deepStrictEqual(
@@ -290,7 +290,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     configLoader: configLoaderReturning({ packages: [] })
                 })
@@ -310,7 +310,7 @@ suite('changelog-handler', function () {
             });
             const spies = makeSpies(createEngine(), releasePlanOutcome);
 
-            const code = await runChangelogHandler(depsWith({ spies }));
+            const code = await runChangelogHandler(dependenciesWith({ spies }));
 
             assert.strictEqual(code, 1);
             assert.deepStrictEqual(
@@ -333,7 +333,7 @@ suite('changelog-handler', function () {
             };
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     readEnvironmentVariable(name) {
                         return name === 'GITHUB_TOKEN' ? 'github-token' : undefined;
@@ -356,7 +356,7 @@ suite('changelog-handler', function () {
             };
             const spies = makeSpies(engine);
 
-            const code = await runChangelogHandler(depsWith({ spies }));
+            const code = await runChangelogHandler(dependenciesWith({ spies }));
 
             assert.strictEqual(code, 0);
             assert.strictEqual(collectMergedPullRequests.callCount, 1);
@@ -369,7 +369,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies(engine);
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     configLoader: configLoaderReturning({
                         ...validConfig,
@@ -393,7 +393,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     async readPackageInfo() {
                         return { repository: { url: 'https://example.com/owner/repo' } };
@@ -415,7 +415,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     async readPackageInfo() {
                         return {};
@@ -431,7 +431,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     async readPackageInfo() {
                         return { repository: { url: 'https://github.com/owner' } };
@@ -447,7 +447,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     async readPackageInfo() {
                         return { repository: { url: 'https://example.com/https://github.com/owner/repo' } };
@@ -463,7 +463,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     async readPackageInfo() {
                         return { repository: { url: 'https://github.com/owner/repo/extra' } };
@@ -484,7 +484,7 @@ suite('changelog-handler', function () {
             };
             const spies = makeSpies(engine);
 
-            const code = await runChangelogHandler(depsWith({ spies }));
+            const code = await runChangelogHandler(dependenciesWith({ spies }));
 
             assert.strictEqual(code, 0);
             assert.strictEqual(spies.pageOutput.callCount, 0);
@@ -494,7 +494,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     configLoader: {
                         load: fake.rejects(new TypeError('bad config'))
@@ -510,7 +510,7 @@ suite('changelog-handler', function () {
             const spies = makeSpies();
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     configLoader: {
                         async load() {
@@ -538,7 +538,7 @@ suite('changelog-handler', function () {
             } as unknown as Promise<unknown>;
 
             const code = await runChangelogHandler(
-                depsWith({
+                dependenciesWith({
                     spies,
                     configLoader: {
                         async load() {

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -18,7 +18,7 @@ type Logger = (message: string) => void;
 type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
 type ValidChangelogConfig = NonNullable<ReturnType<typeof parseValidConfig>>;
 
-export type ChangelogHandlerDeps = {
+export type ChangelogHandlerDependencies = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
     readonly currentDate: () => Date;
     readonly fileManager: Pick<FileManager, 'readFile' | 'writeFile'>;
@@ -36,44 +36,46 @@ function formatChangelogHandlerError(error: unknown): string {
     return String(error).replace(/^[A-Za-z]*Error: /u, '');
 }
 
-function readGitHubToken(deps: Pick<ChangelogHandlerDeps, 'readEnvironmentVariable'>): string | undefined {
-    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+function readGitHubToken(
+    dependencies: Pick<ChangelogHandlerDependencies, 'readEnvironmentVariable'>
+): string | undefined {
+    return dependencies.readEnvironmentVariable('GH_TOKEN') ?? dependencies.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
-function createEngine(deps: ChangelogHandlerDeps, config: PrLogConfig): PrLogEngine {
-    return deps.createPrLogEngine({
-        githubToken: readGitHubToken(deps),
-        workingDirectory: deps.workingDirectory,
+function createEngine(dependencies: ChangelogHandlerDependencies, config: PrLogConfig): PrLogEngine {
+    return dependencies.createPrLogEngine({
+        githubToken: readGitHubToken(dependencies),
+        workingDirectory: dependencies.workingDirectory,
         config
     });
 }
 
 async function renderChangelog(
-    deps: ChangelogHandlerDeps,
+    dependencies: ChangelogHandlerDependencies,
     config: ValidChangelogConfig,
     packages: readonly ReleasePlanPackage[]
 ): Promise<void> {
     if (packages.length === 0) {
         return;
     }
-    const packageInfo = await deps.readPackageInfo();
+    const packageInfo = await dependencies.readPackageInfo();
     const generationOptions = createChangelogGenerationOptions(config);
-    const prLogEngine = createEngine(deps, generationOptions.prLogConfig);
+    const prLogEngine = createEngine(dependencies, generationOptions.prLogConfig);
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine,
         explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
-        ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
+        ignoredAttributionPaths: collectGeneratedAttributionPaths(dependencies, config),
         packageTagFormat: generationOptions.packageTagFormat,
-        currentDate: deps.currentDate(),
+        currentDate: dependencies.currentDate(),
         prLogConfig: generationOptions.prLogConfig,
         targetScopedLabelPattern: generationOptions.targetScopedLabelPattern
     });
     if (shouldPageGroupedChangelog(config.changelog?.outputs) && changelog.groupedMarkdown.length > 0) {
-        await deps.pageOutput(changelog.groupedMarkdown);
+        await dependencies.pageOutput(changelog.groupedMarkdown);
     }
-    await writeConfiguredChangelogs(deps, config, prLogEngine, changelog);
+    await writeConfiguredChangelogs(dependencies, config, prLogEngine, changelog);
 }
 
 function resolveReleasePlanExitCode(log: Logger, result: ReleasePlanResult): number {
@@ -84,27 +86,27 @@ function resolveReleasePlanExitCode(log: Logger, result: ReleasePlanResult): num
     return 1;
 }
 
-async function runChangelog(deps: ChangelogHandlerDeps): Promise<number> {
-    const config = await deps.configLoader.load();
-    const outcome = await deps.packtory.planReleaseAgainstLatestPublished(config);
-    deps.spinnerRenderer.stopAll();
+async function runChangelog(dependencies: ChangelogHandlerDependencies): Promise<number> {
+    const config = await dependencies.configLoader.load();
+    const outcome = await dependencies.packtory.planReleaseAgainstLatestPublished(config);
+    dependencies.spinnerRenderer.stopAll();
     const validConfig = parseValidConfig(config);
     if (validConfig !== undefined) {
-        await renderChangelog(deps, validConfig, collectReleasePlanPackages(outcome.result));
+        await renderChangelog(dependencies, validConfig, collectReleasePlanPackages(outcome.result));
     }
-    return resolveReleasePlanExitCode(deps.log, outcome.result);
+    return resolveReleasePlanExitCode(dependencies.log, outcome.result);
 }
 
-function stopSpinnersAndReturn(deps: ChangelogHandlerDeps, exitCode: number): number {
-    deps.spinnerRenderer.stopAll();
+function stopSpinnersAndReturn(dependencies: ChangelogHandlerDependencies, exitCode: number): number {
+    dependencies.spinnerRenderer.stopAll();
     return exitCode;
 }
 
-export async function runChangelogHandler(deps: ChangelogHandlerDeps): Promise<number> {
+export async function runChangelogHandler(dependencies: ChangelogHandlerDependencies): Promise<number> {
     try {
-        return stopSpinnersAndReturn(deps, await runChangelog(deps));
+        return stopSpinnersAndReturn(dependencies, await runChangelog(dependencies));
     } catch (error: unknown) {
-        deps.log(formatChangelogHandlerError(error));
-        return stopSpinnersAndReturn(deps, 1);
+        dependencies.log(formatChangelogHandlerError(error));
+        return stopSpinnersAndReturn(dependencies, 1);
     }
 }

--- a/source/command-line-interface/runner/github-release-client.ts
+++ b/source/command-line-interface/runner/github-release-client.ts
@@ -67,11 +67,11 @@ function readCreatedTagSha(response: unknown): string {
     throw new Error('GitHub tag object response did not include a sha');
 }
 
-export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies): GitHubReleaseClient {
-    const requestHeaders = createGitHubJsonRequestHeaders(deps.token, 'packtory');
+export function createGitHubReleaseClient(dependencies: GitHubReleaseClientDependencies): GitHubReleaseClient {
+    const requestHeaders = createGitHubJsonRequestHeaders(dependencies.token, 'packtory');
     const octokit = new Octokit({
         request: {
-            fetch: deps.fetch
+            fetch: dependencies.fetch
         }
     });
 
@@ -82,8 +82,8 @@ export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies)
         const response = await resolveGitHubResponse(
             octokit.request('GET /repos/{owner}/{repo}/git/tags/{tag_sha}', {
                 headers: requestHeaders,
-                owner: deps.owner,
-                repo: deps.repo,
+                owner: dependencies.owner,
+                repo: dependencies.repo,
                 tag_sha: ref.object.sha
             })
         ) as { readonly data: RawGitTag; };
@@ -94,8 +94,8 @@ export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies)
         const response = await resolveOptionalGitHubResponse(
             octokit.request('GET /repos/{owner}/{repo}/git/ref/{ref}', {
                 headers: requestHeaders,
-                owner: deps.owner,
-                repo: deps.repo,
+                owner: dependencies.owner,
+                repo: dependencies.repo,
                 ref: `tags/${tagName}`
             }),
             missingGitHubResourceStatusCode
@@ -108,8 +108,8 @@ export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies)
             const existing = await resolveOptionalGitHubResponse(
                 octokit.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
                     headers: requestHeaders,
-                    owner: deps.owner,
-                    repo: deps.repo,
+                    owner: dependencies.owner,
+                    repo: dependencies.repo,
                     tag: request.tagName
                 }),
                 missingGitHubResourceStatusCode
@@ -120,8 +120,8 @@ export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies)
             const created = await resolveOptionalGitHubResponse(
                 octokit.request('POST /repos/{owner}/{repo}/releases', {
                     headers: requestHeaders,
-                    owner: deps.owner,
-                    repo: deps.repo,
+                    owner: dependencies.owner,
+                    repo: dependencies.repo,
                     tag_name: request.tagName,
                     name: request.name,
                     body: request.body
@@ -143,8 +143,8 @@ export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies)
             const tag = await resolveGitHubResponse(
                 octokit.request('POST /repos/{owner}/{repo}/git/tags', {
                     headers: requestHeaders,
-                    owner: deps.owner,
-                    repo: deps.repo,
+                    owner: dependencies.owner,
+                    repo: dependencies.repo,
                     tag: request.tagName,
                     message: request.message,
                     object: request.targetHead,
@@ -154,8 +154,8 @@ export function createGitHubReleaseClient(deps: GitHubReleaseClientDependencies)
             await resolveGitHubResponse(
                 octokit.request('POST /repos/{owner}/{repo}/git/refs', {
                     headers: requestHeaders,
-                    owner: deps.owner,
-                    repo: deps.repo,
+                    owner: dependencies.owner,
+                    repo: dependencies.repo,
                     ref: `refs/tags/${request.tagName}`,
                     sha: readCreatedTagSha(tag)
                 })

--- a/source/command-line-interface/runner/github-release-notes.ts
+++ b/source/command-line-interface/runner/github-release-notes.ts
@@ -5,7 +5,7 @@ type FileReader = {
     readonly readFile: (filePath: string) => Promise<string>;
 };
 
-export type GitHubReleaseNotesDeps = {
+export type GitHubReleaseNotesDependencies = {
     readonly fileManager: FileReader;
     readonly workingDirectory: string;
 };
@@ -59,27 +59,27 @@ function isMissingFileError(error: unknown): boolean {
 }
 
 function packageChangelogPathFor(
-    deps: Pick<GitHubReleaseNotesDeps, 'workingDirectory'>,
+    dependencies: Pick<GitHubReleaseNotesDependencies, 'workingDirectory'>,
     config: ChangelogConfig,
     packageName: string
 ): string | undefined {
-    const outputPath = collectChangelogOutputFilePaths(deps, config).find(function (entry) {
+    const outputPath = collectChangelogOutputFilePaths(dependencies, config).find(function (entry) {
         return entry.packageName === packageName;
     });
     return outputPath?.filePath;
 }
 
 async function readConfiguredReleaseNotes(
-    deps: GitHubReleaseNotesDeps,
+    dependencies: GitHubReleaseNotesDependencies,
     config: ChangelogConfig,
     target: ReleaseNotesTarget
 ): Promise<string | undefined> {
-    const changelogPath = packageChangelogPathFor(deps, config, target.name);
+    const changelogPath = packageChangelogPathFor(dependencies, config, target.name);
     if (changelogPath === undefined) {
         return undefined;
     }
     try {
-        return extractReleaseNotes(await deps.fileManager.readFile(changelogPath), target);
+        return extractReleaseNotes(await dependencies.fileManager.readFile(changelogPath), target);
     } catch (error: unknown) {
         if (isMissingFileError(error)) {
             return undefined;
@@ -89,11 +89,11 @@ async function readConfiguredReleaseNotes(
 }
 
 async function recoverMissingReleaseNotes(
-    deps: GitHubReleaseNotesDeps,
+    dependencies: GitHubReleaseNotesDependencies,
     config: ChangelogConfig,
     target: ReleaseNotesTarget
 ): Promise<string> {
-    const releaseNotes = await readConfiguredReleaseNotes(deps, config, target);
+    const releaseNotes = await readConfiguredReleaseNotes(dependencies, config, target);
     if (!hasReleaseNotes(releaseNotes)) {
         missingGitHubReleaseNotes(target);
     }
@@ -101,7 +101,7 @@ async function recoverMissingReleaseNotes(
 }
 
 export async function collectGitHubReleaseNotes(
-    deps: GitHubReleaseNotesDeps,
+    dependencies: GitHubReleaseNotesDependencies,
     config: ChangelogConfig,
     targets: readonly ReleaseNotesTarget[],
     changelog: GeneratedChangelog
@@ -109,7 +109,7 @@ export async function collectGitHubReleaseNotes(
     const releaseNotesByPackageName = new Map(changelog.packageMarkdownByName);
     for (const target of targets) {
         if (!hasReleaseNotes(releaseNotesByPackageName.get(target.name))) {
-            releaseNotesByPackageName.set(target.name, await recoverMissingReleaseNotes(deps, config, target));
+            releaseNotesByPackageName.set(target.name, await recoverMissingReleaseNotes(dependencies, config, target));
         }
     }
     return releaseNotesByPackageName;

--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -5,13 +5,13 @@ import { fake, type SinonSpy } from 'sinon';
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createConfigLoaderStub } from '../../test-libraries/handler-stub-fixtures.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
-import { runPackHandler, type PackHandlerDeps } from './pack-handler.ts';
+import { runPackHandler, type PackHandlerDependencies } from './pack-handler.ts';
 
-type PackFlags = PackHandlerDeps['flags'];
+type PackFlags = PackHandlerDependencies['flags'];
 
 type PackOutcome = Awaited<ReturnType<Packtory['packPackage']>>;
 type PackHandlerFixture = {
-    readonly deps: PackHandlerDeps;
+    readonly dependencies: PackHandlerDependencies;
     readonly logSpy: SinonSpy;
     readonly stopAllSpy: SinonSpy;
     readonly packPackageSpy: SinonSpy;
@@ -54,7 +54,7 @@ function setup(
     const packPackageSpy = fake();
     const flags = defaultFlags(overrides);
     return {
-        deps: {
+        dependencies: {
             log(message) {
                 logSpy(stripVTControlCharacters(message));
             },
@@ -71,11 +71,11 @@ function setup(
 
 suite('pack-handler', function () {
     test('returns 0 and logs a success line when the pack outcome is Ok', async function () {
-        const { deps, logSpy } = setup(
+        const { dependencies, logSpy } = setup(
             makeOutcome({ isOk: true, isErr: false, value: undefined } as PackOutcome['result'])
         );
 
-        const code = await runPackHandler(deps);
+        const code = await runPackHandler(dependencies);
 
         assert.strictEqual(code, 0);
         assert.strictEqual(logSpy.callCount, 1);
@@ -83,12 +83,12 @@ suite('pack-handler', function () {
     });
 
     test('forwards the flag values into packtory.packPackage', async function () {
-        const { deps, packPackageSpy } = setup(
+        const { dependencies, packPackageSpy } = setup(
             makeOutcome({ isOk: true, isErr: false, value: undefined } as PackOutcome['result']),
             { packageName: 'pkg-b', format: 'tar', outputPath: '/out/pkg-b.tgz', version: '1.2.3' }
         );
 
-        await runPackHandler(deps);
+        await runPackHandler(dependencies);
 
         assert.strictEqual(packPackageSpy.callCount, 1);
         const args = packPackageSpy.firstCall.args as readonly unknown[];
@@ -103,11 +103,11 @@ suite('pack-handler', function () {
     });
 
     async function expectFailure(error: unknown, patterns: readonly RegExp[]): Promise<void> {
-        const { deps, logSpy } = setup(
+        const { dependencies, logSpy } = setup(
             makeOutcome({ isOk: false, isErr: true, error } as unknown as PackOutcome['result'])
         );
 
-        const code = await runPackHandler(deps);
+        const code = await runPackHandler(dependencies);
 
         assert.strictEqual(code, 1);
         const message = logSpy.firstCall.args[0] as string;
@@ -215,11 +215,11 @@ suite('pack-handler', function () {
     });
 
     test('stops spinners both immediately after the call and again in the finally block', async function () {
-        const { deps, stopAllSpy } = setup(
+        const { dependencies, stopAllSpy } = setup(
             makeOutcome({ isOk: true, isErr: false, value: undefined } as PackOutcome['result'])
         );
 
-        await runPackHandler(deps);
+        await runPackHandler(dependencies);
 
         assert.strictEqual(stopAllSpy.callCount, 2);
     });

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -53,7 +53,7 @@ type IssuePackFailure = Extract<
     }
 >;
 
-export type PackHandlerDeps = {
+export type PackHandlerDependencies = {
     readonly log: Logger;
     readonly packtory: Packtory;
     readonly spinnerRenderer: TerminalSpinnerRenderer;
@@ -171,8 +171,8 @@ function reportOutcome(log: Logger, outcome: PackOutcome, flags: PackFlags): num
     return 0;
 }
 
-export async function runPackHandler(deps: PackHandlerDeps): Promise<number> {
-    const { log, packtory, spinnerRenderer, configLoader, flags } = deps;
+export async function runPackHandler(dependencies: PackHandlerDependencies): Promise<number> {
+    const { log, packtory, spinnerRenderer, configLoader, flags } = dependencies;
     try {
         const outcome = await packtory.packPackage(await configLoader.load(), {
             packageName: flags.packageName,

--- a/source/command-line-interface/runner/preview-handler.ts
+++ b/source/command-line-interface/runner/preview-handler.ts
@@ -12,7 +12,7 @@ import { createEmptyReport } from './report-persistence.ts';
 
 type Logger = (message: string) => void;
 
-export type PreviewHandlerDeps = {
+export type PreviewHandlerDependencies = {
     readonly log: Logger;
     readonly pageOutput: (content: string) => Promise<void>;
     readonly openFile: (filePath: string) => Promise<boolean>;
@@ -25,38 +25,38 @@ export type PreviewHandlerDeps = {
 };
 
 async function renderOpenedReport(
-    deps: Pick<PreviewHandlerDeps, 'createTemporaryFilePath' | 'fileManager' | 'log' | 'openFile'>,
+    dependencies: Pick<PreviewHandlerDependencies, 'createTemporaryFilePath' | 'fileManager' | 'log' | 'openFile'>,
     document: PreviewDocument
 ): Promise<void> {
-    const filePath = deps.createTemporaryFilePath();
-    await deps.fileManager.writeFile(filePath, renderHtmlReport(document));
-    const opened = await deps.openFile(filePath);
+    const filePath = dependencies.createTemporaryFilePath();
+    await dependencies.fileManager.writeFile(filePath, renderHtmlReport(document));
+    const opened = await dependencies.openFile(filePath);
     if (!opened) {
-        deps.log(filePath);
+        dependencies.log(filePath);
     }
 }
 
 async function renderInlinePreview(
-    deps: Pick<PreviewHandlerDeps, 'log' | 'pageOutput'>,
+    dependencies: Pick<PreviewHandlerDependencies, 'log' | 'pageOutput'>,
     document: PreviewDocument
 ): Promise<void> {
     if (document.previewable) {
-        await deps.pageOutput(renderTerminalPreview(document));
+        await dependencies.pageOutput(renderTerminalPreview(document));
     } else {
-        deps.log(renderFailureOnlyTerminalPreview(document).trimEnd());
+        dependencies.log(renderFailureOnlyTerminalPreview(document).trimEnd());
     }
 }
 
-async function renderDocument(deps: PreviewHandlerDeps, document: PreviewDocument): Promise<void> {
-    if (deps.flags.open) {
-        await renderOpenedReport(deps, document);
+async function renderDocument(dependencies: PreviewHandlerDependencies, document: PreviewDocument): Promise<void> {
+    if (dependencies.flags.open) {
+        await renderOpenedReport(dependencies, document);
         return;
     }
-    await renderInlinePreview(deps, document);
+    await renderInlinePreview(dependencies, document);
 }
 
-async function preview(deps: PreviewHandlerDeps): Promise<number> {
-    const { packtory, spinnerRenderer, configLoader, fileManager } = deps;
+async function preview(dependencies: PreviewHandlerDependencies): Promise<number> {
+    const { packtory, spinnerRenderer, configLoader, fileManager } = dependencies;
     const config = await configLoader.load();
     const outcome = await packtory.buildAndPublishAll(config, { dryRun: true, stage: false, collectReport: true });
     spinnerRenderer.stopAll();
@@ -67,14 +67,14 @@ async function preview(deps: PreviewHandlerDeps): Promise<number> {
         dryRun: true,
         fileManager
     });
-    await renderDocument(deps, document);
+    await renderDocument(dependencies, document);
     return outcome.result.isErr ? 1 : 0;
 }
 
-export async function runPreviewHandler(deps: PreviewHandlerDeps): Promise<number> {
+export async function runPreviewHandler(dependencies: PreviewHandlerDependencies): Promise<number> {
     try {
-        return await preview(deps);
+        return await preview(dependencies);
     } finally {
-        deps.spinnerRenderer.stopAll();
+        dependencies.spinnerRenderer.stopAll();
     }
 }

--- a/source/command-line-interface/runner/publish-handler.ts
+++ b/source/command-line-interface/runner/publish-handler.ts
@@ -8,7 +8,7 @@ import { writeReports, type ReportFlags } from './report-persistence.ts';
 type Logger = (message: string) => void;
 type BuildOutcome = Awaited<ReturnType<Packtory['buildAndPublishAll']>>;
 
-export type PublishHandlerDeps = {
+export type PublishHandlerDependencies = {
     readonly log: Logger;
     readonly packtory: Packtory;
     readonly spinnerRenderer: TerminalSpinnerRenderer;
@@ -19,9 +19,9 @@ export type PublishHandlerDeps = {
 
 async function reportOutcome(
     log: Logger,
-    fileManager: PublishHandlerDeps['fileManager'],
+    fileManager: PublishHandlerDependencies['fileManager'],
     outcome: BuildOutcome,
-    flags: PublishHandlerDeps['flags']
+    flags: PublishHandlerDependencies['flags']
 ): Promise<number> {
     let exitCode = 0;
     if (outcome.result.isErr) {
@@ -40,8 +40,8 @@ async function reportOutcome(
     return exitCode;
 }
 
-async function publish(deps: PublishHandlerDeps): Promise<number> {
-    const { log, packtory, spinnerRenderer, configLoader, fileManager, flags } = deps;
+async function publish(dependencies: PublishHandlerDependencies): Promise<number> {
+    const { log, packtory, spinnerRenderer, configLoader, fileManager, flags } = dependencies;
     const outcome = await packtory.buildAndPublishAll(await configLoader.load(), {
         dryRun: !flags.noDryRun,
         stage: flags.stage,
@@ -51,11 +51,11 @@ async function publish(deps: PublishHandlerDeps): Promise<number> {
     return reportOutcome(log, fileManager, outcome, flags);
 }
 
-export async function runPublishHandler(deps: PublishHandlerDeps): Promise<number> {
-    const { log, spinnerRenderer, flags } = deps;
+export async function runPublishHandler(dependencies: PublishHandlerDependencies): Promise<number> {
+    const { log, spinnerRenderer, flags } = dependencies;
     let shouldStopSpinners = true;
     try {
-        const exitCode = await publish(deps);
+        const exitCode = await publish(dependencies);
         shouldStopSpinners = false;
         return exitCode;
     } finally {

--- a/source/command-line-interface/runner/release-diff-handler.test.ts
+++ b/source/command-line-interface/runner/release-diff-handler.test.ts
@@ -5,7 +5,7 @@ import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts'
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createConfigLoaderStub } from '../../test-libraries/handler-stub-fixtures.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
-import { runReleaseDiffHandler, type ReleaseDiffHandlerDeps } from './release-diff-handler.ts';
+import { runReleaseDiffHandler, type ReleaseDiffHandlerDependencies } from './release-diff-handler.ts';
 
 type ReleaseDiffOutcome = Awaited<ReturnType<Packtory['diffAgainstLatestPublished']>>;
 
@@ -38,7 +38,7 @@ type Spies = {
     readonly stopAll: SinonSpy;
 };
 
-function depsWith(outcome: ReleaseDiffOutcome, spies: Spies): ReleaseDiffHandlerDeps {
+function dependenciesWith(outcome: ReleaseDiffOutcome, spies: Spies): ReleaseDiffHandlerDependencies {
     return {
         log(message) {
             spies.log(message);
@@ -58,7 +58,7 @@ suite('release-diff-handler', function () {
     test('returns 0 on success and pages the inline terminal output', async function () {
         const spies = makeSpies();
 
-        const code = await runReleaseDiffHandler(depsWith(emptyOutcome(), spies));
+        const code = await runReleaseDiffHandler(dependenciesWith(emptyOutcome(), spies));
 
         assert.strictEqual(code, 0);
         assert.strictEqual(spies.pageOutput.callCount, 1);
@@ -66,7 +66,7 @@ suite('release-diff-handler', function () {
 
     test('calls spinnerRenderer.stopAll both immediately after the build (so the spinner stops before paging) and again in the finally block', async function () {
         const spies = makeSpies();
-        await runReleaseDiffHandler(depsWith(emptyOutcome(), spies));
+        await runReleaseDiffHandler(dependenciesWith(emptyOutcome(), spies));
         assert.strictEqual(spies.stopAll.callCount, 2);
     });
 
@@ -104,7 +104,7 @@ suite('release-diff-handler', function () {
             } as unknown as ReleaseDiffOutcome['result']
         });
 
-        const code = await runReleaseDiffHandler(depsWith(outcome, spies));
+        const code = await runReleaseDiffHandler(dependenciesWith(outcome, spies));
 
         assert.strictEqual(code, 1);
         assertDeepSubset(spies, {
@@ -142,7 +142,7 @@ suite('release-diff-handler', function () {
             } as unknown as ReleaseDiffOutcome['result']
         });
 
-        const code = await runReleaseDiffHandler(depsWith(outcome, spies));
+        const code = await runReleaseDiffHandler(dependenciesWith(outcome, spies));
 
         assert.strictEqual(code, 1);
         assertDeepSubset(spies, {

--- a/source/command-line-interface/runner/release-diff-handler.ts
+++ b/source/command-line-interface/runner/release-diff-handler.ts
@@ -10,7 +10,7 @@ import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-render
 
 type Logger = (message: string) => void;
 
-export type ReleaseDiffHandlerDeps = {
+export type ReleaseDiffHandlerDependencies = {
     readonly log: Logger;
     readonly pageOutput: (content: string) => Promise<void>;
     readonly packtory: Packtory;
@@ -19,18 +19,18 @@ export type ReleaseDiffHandlerDeps = {
 };
 
 async function renderDocument(
-    deps: Pick<ReleaseDiffHandlerDeps, 'log' | 'pageOutput'>,
+    dependencies: Pick<ReleaseDiffHandlerDependencies, 'log' | 'pageOutput'>,
     document: ReleaseDiffDocument
 ): Promise<void> {
     if (document.previewable) {
-        await deps.pageOutput(renderTerminalReleaseDiff(document));
+        await dependencies.pageOutput(renderTerminalReleaseDiff(document));
         return;
     }
-    deps.log(renderFailureOnlyTerminalReleaseDiff(document).trimEnd());
+    dependencies.log(renderFailureOnlyTerminalReleaseDiff(document).trimEnd());
 }
 
-async function releaseDiff(deps: ReleaseDiffHandlerDeps): Promise<number> {
-    const { packtory, spinnerRenderer, configLoader } = deps;
+async function releaseDiff(dependencies: ReleaseDiffHandlerDependencies): Promise<number> {
+    const { packtory, spinnerRenderer, configLoader } = dependencies;
     const config = await configLoader.load();
     const outcome = await packtory.diffAgainstLatestPublished(config);
     spinnerRenderer.stopAll();
@@ -39,14 +39,14 @@ async function releaseDiff(deps: ReleaseDiffHandlerDeps): Promise<number> {
         result: outcome.result,
         packages: succeededResultsFrom(outcome.result)
     });
-    await renderDocument(deps, document);
+    await renderDocument(dependencies, document);
     return outcome.result.isErr ? 1 : 0;
 }
 
-export async function runReleaseDiffHandler(deps: ReleaseDiffHandlerDeps): Promise<number> {
+export async function runReleaseDiffHandler(dependencies: ReleaseDiffHandlerDependencies): Promise<number> {
     try {
-        return await releaseDiff(deps);
+        return await releaseDiff(dependencies);
     } finally {
-        deps.spinnerRenderer.stopAll();
+        dependencies.spinnerRenderer.stopAll();
     }
 }

--- a/source/command-line-interface/runner/release-handler.test.ts
+++ b/source/command-line-interface/runner/release-handler.test.ts
@@ -7,7 +7,7 @@ import type { BuildAndPublishResult } from '../../packtory/package-processor.ts'
 import type { Packtory, ReleasePlanOutcome, ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
 import { createBuildReportFixture } from '../../test-libraries/preview-fixtures.ts';
 import { createGitHubReleaseClientFixture } from '../../test-libraries/runner-test-support.ts';
-import { runReleaseHandler, type ReleaseHandlerDeps } from './release-handler.ts';
+import { runReleaseHandler, type ReleaseHandlerDependencies } from './release-handler.ts';
 
 const validConfig = {
     packages: [
@@ -141,14 +141,14 @@ function createEngine(): PrLogEngine {
 type DependencyOverrides = {
     readonly buildAndPublishAll?: SinonSpy;
     readonly createGitHubReleaseClient?: SinonSpy;
-    readonly flags?: ReleaseHandlerDeps['flags'];
+    readonly flags?: ReleaseHandlerDependencies['flags'];
     readonly log?: SinonSpy;
     readonly packages?: readonly ReleasePlanPackage[];
     readonly planReleaseAgainstLatestPublished?: SinonSpy;
-    readonly readEnvironmentVariable?: ReleaseHandlerDeps['readEnvironmentVariable'];
-    readonly readPackageInfo?: ReleaseHandlerDeps['readPackageInfo'];
+    readonly readEnvironmentVariable?: ReleaseHandlerDependencies['readEnvironmentVariable'];
+    readonly readPackageInfo?: ReleaseHandlerDependencies['readPackageInfo'];
 };
-type CreatedReleaseHandlerDeps = ReleaseHandlerDeps & {
+type CreatedReleaseHandlerDependencies = ReleaseHandlerDependencies & {
     readonly buildAndPublishAll: SinonSpy;
     readonly createGitHubReleaseClient: SinonSpy;
     readonly log: SinonSpy;
@@ -187,7 +187,7 @@ function createDefaultPublish(): SinonSpy {
     });
 }
 
-function createDefaultFlags(): ReleaseHandlerDeps['flags'] {
+function createDefaultFlags(): ReleaseHandlerDependencies['flags'] {
     return {
         githubRelease: false,
         noDryRun: false,
@@ -220,7 +220,7 @@ function createCompleteDependencyOverrides(overrides: DependencyOverrides): Comp
     };
 }
 
-function createDependencies(overrides: DependencyOverrides = {}): CreatedReleaseHandlerDeps {
+function createDependencies(overrides: DependencyOverrides = {}): CreatedReleaseHandlerDependencies {
     const completeOverrides = createCompleteDependencyOverrides(overrides);
     return {
         buildAndPublishAll: completeOverrides.buildAndPublishAll,
@@ -246,10 +246,10 @@ function createDependencies(overrides: DependencyOverrides = {}): CreatedRelease
     };
 }
 
-async function assertNoReleaseWork(deps: CreatedReleaseHandlerDeps): Promise<void> {
-    assert.strictEqual(await runReleaseHandler(deps), 0);
-    assert.strictEqual(deps.log.firstCall.args[0], 'No packages need release.');
-    assert.strictEqual(deps.buildAndPublishAll.callCount, 0);
+async function assertNoReleaseWork(dependencies: CreatedReleaseHandlerDependencies): Promise<void> {
+    assert.strictEqual(await runReleaseHandler(dependencies), 0);
+    assert.strictEqual(dependencies.log.firstCall.args[0], 'No packages need release.');
+    assert.strictEqual(dependencies.buildAndPublishAll.callCount, 0);
 }
 
 function assertAnnotatedTagCreated(ensureAnnotatedTag: SinonSpy): void {
@@ -261,77 +261,80 @@ function assertAnnotatedTagCreated(ensureAnnotatedTag: SinonSpy): void {
 suite('release-handler', function () {
     suite('plan and flag validation', function () {
         test('prints the release plan when no release action is requested', async function () {
-            const deps = createDependencies();
+            const dependencies = createDependencies();
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.log.firstCall.args[0], 'Release plan:\n- pkg-a: 1.0.0 -> 1.0.1 (changed)');
-            assert.strictEqual(deps.buildAndPublishAll.callCount, 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(dependencies.log.firstCall.args[0], 'Release plan:\n- pkg-a: 1.0.0 -> 1.0.1 (changed)');
+            assert.strictEqual(dependencies.buildAndPublishAll.callCount, 0);
         });
 
         test('prints unpublished packages in the release plan', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 packages: [ releasePackage({ previousVersion: undefined }) ]
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.log.firstCall.args[0], 'Release plan:\n- pkg-a: unpublished -> 1.0.1 (changed)');
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(
+                dependencies.log.firstCall.args[0],
+                'Release plan:\n- pkg-a: unpublished -> 1.0.1 (changed)'
+            );
         });
 
         test('prints no release work when the plan has no changed packages', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 packages: [ releasePackage({ artifactState: 'unchanged', changed: false }) ]
             });
 
-            await assertNoReleaseWork(deps);
+            await assertNoReleaseWork(dependencies);
         });
 
         test('requires no-dry-run for release writes', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: true, tag: false, push: false, githubRelease: false, noDryRun: false }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.strictEqual(deps.log.firstCall.args[0], 'Release writes require --no-dry-run');
-            assert.strictEqual(deps.buildAndPublishAll.callCount, 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.strictEqual(dependencies.log.firstCall.args[0], 'Release writes require --no-dry-run');
+            assert.strictEqual(dependencies.buildAndPublishAll.callCount, 0);
         });
 
         test('requires tag before push', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: false, tag: false, push: true, githubRelease: false, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.strictEqual(deps.log.firstCall.args[0], '--push requires --tag');
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.strictEqual(dependencies.log.firstCall.args[0], '--push requires --tag');
         });
 
         test('requires tag push before GitHub release creation', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: false, tag: true, push: false, githubRelease: true, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.strictEqual(deps.log.firstCall.args[0], '--github-release requires --tag --push');
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.strictEqual(dependencies.log.firstCall.args[0], '--github-release requires --tag --push');
         });
 
         test('prints multiple flag issues on separate lines', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: false, tag: false, push: true, githubRelease: true, noDryRun: false }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
             assert.strictEqual(
-                deps.log.firstCall.args[0],
+                dependencies.log.firstCall.args[0],
                 '--push requires --tag\n--github-release requires --tag --push\nRelease writes require --no-dry-run'
             );
         });
 
         test('returns failure when release planning fails', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 planReleaseAgainstLatestPublished: failedReleasePlan()
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.match(String(deps.log.lastCall.args[0]), /invalid release plan/u);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.match(String(dependencies.log.lastCall.args[0]), /invalid release plan/u);
         });
     });
 
@@ -342,13 +345,13 @@ suite('release-handler', function () {
             const createGitHubReleaseClient = fake.returns(
                 createGitHubReleaseClientFixture({ createReleaseIfMissing, ensureAnnotatedTag })
             );
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 createGitHubReleaseClient,
                 flags: { publish: true, tag: true, push: true, githubRelease: true, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.deepStrictEqual(deps.buildAndPublishAll.firstCall.args, [
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.deepStrictEqual(dependencies.buildAndPublishAll.firstCall.args, [
                 validConfig,
                 { dryRun: false, stage: false, collectReport: false }
             ]);
@@ -361,66 +364,66 @@ suite('release-handler', function () {
             assert.deepStrictEqual(createReleaseIfMissing.firstCall.args, [
                 { tagName: 'pkg-a@1.0.1', name: 'pkg-a@1.0.1', body: '## pkg-a 1.0.1\n\n* Fix package' }
             ]);
-            assert.strictEqual(deps.log.lastCall.args[0], 'Release completed.');
+            assert.strictEqual(dependencies.log.lastCall.args[0], 'Release completed.');
         });
 
         test('publishes without creating GitHub tags when only publish is requested', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: true, tag: false, push: false, githubRelease: false, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
             assert.deepStrictEqual([
-                deps.buildAndPublishAll.callCount,
-                deps.createGitHubReleaseClient.callCount
+                dependencies.buildAndPublishAll.callCount,
+                dependencies.createGitHubReleaseClient.callCount
             ], [ 1, 0 ]);
-            assert.strictEqual(deps.log.lastCall.args[0], 'Release completed.');
+            assert.strictEqual(dependencies.log.lastCall.args[0], 'Release completed.');
         });
 
         test('does not release current-head packages when only publish is requested', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: true, tag: false, push: false, githubRelease: false, noDryRun: true },
                 packages: [ currentHeadPublishedPackage() ]
             });
 
-            await assertNoReleaseWork(deps);
+            await assertNoReleaseWork(dependencies);
         });
 
         test('reports publish failures', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 buildAndPublishAll: failedPublish(),
                 flags: { publish: true, tag: false, push: false, githubRelease: false, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.match(String(deps.log.lastCall.args[0]), /publish failed/u);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.match(String(dependencies.log.lastCall.args[0]), /publish failed/u);
         });
 
         test('does not print staged receipts for release publish partial failures', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 buildAndPublishAll: failedPartialPublish(),
                 flags: { publish: true, tag: false, push: false, githubRelease: false, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.doesNotMatch(String(deps.log.lastCall.args[0]), /Staged packages/u);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.doesNotMatch(String(dependencies.log.lastCall.args[0]), /Staged packages/u);
         });
 
         test('creates retry tags after publish is requested for current-head packages', async function () {
             const ensureAnnotatedTag = fake.resolves('existing');
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 createGitHubReleaseClient: fake.returns(createGitHubReleaseClientFixture({ ensureAnnotatedTag })),
                 flags: { publish: true, tag: true, push: true, githubRelease: false, noDryRun: true },
                 packages: [ currentHeadPublishedPackage() ]
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.buildAndPublishAll.callCount, 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(dependencies.buildAndPublishAll.callCount, 0);
             assertAnnotatedTagCreated(ensureAnnotatedTag);
         });
 
         test('does not create GitHub tags for publish results outside the release plan', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 buildAndPublishAll: fake.resolves({
                     result: Result.ok([ publishResult('other-pkg', '1.0.1') ]),
                     getReport() {
@@ -430,40 +433,40 @@ suite('release-handler', function () {
                 flags: { publish: true, tag: true, push: true, githubRelease: false, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.createGitHubReleaseClient.callCount, 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(dependencies.createGitHubReleaseClient.callCount, 0);
         });
     });
 
     suite('GitHub release publishing', function () {
         test('rejects tagging changed packages without publishing them first', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: false, tag: true, push: true, githubRelease: false, noDryRun: true }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
             assert.strictEqual(
-                deps.log.lastCall.args[0],
+                dependencies.log.lastCall.args[0],
                 '--tag requires --publish unless registry latest already matches the current Git head'
             );
-            assert.strictEqual(deps.buildAndPublishAll.callCount, 0);
+            assert.strictEqual(dependencies.buildAndPublishAll.callCount, 0);
         });
 
         test('tags current-head registry packages without publishing during retries', async function () {
             const ensureAnnotatedTag = fake.resolves('existing');
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 createGitHubReleaseClient: fake.returns(createGitHubReleaseClientFixture({ ensureAnnotatedTag })),
                 flags: { publish: false, tag: true, push: true, githubRelease: false, noDryRun: true },
                 packages: [ currentHeadPublishedPackage({ artifactState: 'changed' }) ]
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.buildAndPublishAll.callCount, 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(dependencies.buildAndPublishAll.callCount, 0);
             assertAnnotatedTagCreated(ensureAnnotatedTag);
         });
 
         test('does not tag retry packages when registry metadata points at another commit', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: false, tag: true, push: true, githubRelease: false, noDryRun: true },
                 packages: [
                     currentHeadPublishedPackage({
@@ -472,13 +475,13 @@ suite('release-handler', function () {
                 ]
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.log.firstCall.args[0], 'No packages need release.');
-            assert.strictEqual(deps.createGitHubReleaseClient.callCount, 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(dependencies.log.firstCall.args[0], 'No packages need release.');
+            assert.strictEqual(dependencies.createGitHubReleaseClient.callCount, 0);
         });
 
         test('does not tag retry packages without registry metadata or a current head', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: false, tag: true, push: true, githubRelease: false, noDryRun: true },
                 packages: [
                     currentHeadPublishedPackage({
@@ -488,38 +491,38 @@ suite('release-handler', function () {
                 ]
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
-            assert.strictEqual(deps.log.firstCall.args[0], 'No packages need release.');
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
+            assert.strictEqual(dependencies.log.firstCall.args[0], 'No packages need release.');
         });
 
         test('rejects GitHub tagging when the release plan has no current head', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: true, tag: true, push: true, githubRelease: false, noDryRun: true },
                 packages: [ releasePackage({ currentGitHead: undefined }) ]
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
             assert.strictEqual(
-                deps.log.lastCall.args[0],
+                dependencies.log.lastCall.args[0],
                 'GitHub tag target for "pkg-a@1.0.1" could not be determined'
             );
         });
 
         test('requires a GitHub token when tags are created through the GitHub API', async function () {
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 flags: { publish: true, tag: true, push: true, githubRelease: false, noDryRun: true },
                 readEnvironmentVariable() {
                     return undefined;
                 }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 1);
-            assert.match(String(deps.log.lastCall.args[0]), /GH_TOKEN or GITHUB_TOKEN/u);
+            assert.strictEqual(await runReleaseHandler(dependencies), 1);
+            assert.match(String(dependencies.log.lastCall.args[0]), /GH_TOKEN or GITHUB_TOKEN/u);
         });
 
         test('uses GITHUB_TOKEN when GH_TOKEN is unset', async function () {
             const createGitHubReleaseClient = fake.returns(createGitHubReleaseClientFixture({}));
-            const deps = createDependencies({
+            const dependencies = createDependencies({
                 createGitHubReleaseClient,
                 flags: { publish: true, tag: true, push: true, githubRelease: false, noDryRun: true },
                 readEnvironmentVariable(name) {
@@ -527,7 +530,7 @@ suite('release-handler', function () {
                 }
             });
 
-            assert.strictEqual(await runReleaseHandler(deps), 0);
+            assert.strictEqual(await runReleaseHandler(dependencies), 0);
             assert.deepStrictEqual(createGitHubReleaseClient.firstCall.args, [
                 { owner: 'owner', repo: 'repo', token: 'github-token' }
             ]);

--- a/source/command-line-interface/runner/release-handler.ts
+++ b/source/command-line-interface/runner/release-handler.ts
@@ -7,7 +7,7 @@ import {
     generateRequiredChangelog,
     loadPlannedRelease,
     type PlannedRelease,
-    type ReleasePreparationDeps
+    type ReleasePreparationDependencies
 } from './release-preparation.ts';
 
 type Logger = (message: string) => void;
@@ -39,9 +39,9 @@ type ReleaseFlags = {
     readonly tag: boolean;
 };
 
-export type ReleaseHandlerDeps = ReleasePreparationDeps & {
+export type ReleaseHandlerDependencies = ReleasePreparationDependencies & {
     readonly createGitHubReleaseClient: (context: GitHubReleaseClientContext) => GitHubReleaseClient;
-    readonly fileManager: ReleasePreparationDeps['fileManager'];
+    readonly fileManager: ReleasePreparationDependencies['fileManager'];
     readonly flags: ReleaseFlags;
     readonly packtory: Packtory;
     readonly readEnvironmentVariable: (name: EnvironmentVariableName) => string | undefined;
@@ -167,12 +167,14 @@ function printReleasePlan(log: Logger, packages: readonly ReleasePlanPackage[]):
     log([ 'Release plan:', ...changedPackages.map(formatPlanPackage) ].join('\n'));
 }
 
-function readGitHubToken(deps: Pick<ReleaseHandlerDeps, 'readEnvironmentVariable'>): string | undefined {
-    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+function readGitHubToken(
+    dependencies: Pick<ReleaseHandlerDependencies, 'readEnvironmentVariable'>
+): string | undefined {
+    return dependencies.readEnvironmentVariable('GH_TOKEN') ?? dependencies.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
 async function publishTargets(
-    deps: ReleaseHandlerDeps,
+    dependencies: ReleaseHandlerDependencies,
     planned: PlannedRelease,
     changedTargets: readonly ReleaseTarget[]
 ): Promise<readonly PublishedReleaseTarget[] | undefined> {
@@ -180,14 +182,14 @@ async function publishTargets(
         return [];
     }
     const changedTargetsByName = mapTargetsByName(changedTargets);
-    const outcome = await deps.packtory.buildAndPublishAll(planned.config, {
+    const outcome = await dependencies.packtory.buildAndPublishAll(planned.config, {
         dryRun: false,
         stage: false,
         collectReport: false
     });
-    deps.spinnerRenderer.stopAll();
+    dependencies.spinnerRenderer.stopAll();
     if (outcome.result.isErr) {
-        printPublishFailure(deps.log, outcome.result.error, false);
+        printPublishFailure(dependencies.log, outcome.result.error, false);
         return undefined;
     }
     return outcome.result.value.flatMap(function (result) {
@@ -206,12 +208,15 @@ async function publishTargets(
     });
 }
 
-async function createGitHubClientAsync(deps: ReleaseHandlerDeps): Promise<GitHubReleaseClient> {
-    const token = readGitHubToken(deps);
+async function createGitHubClientAsync(dependencies: ReleaseHandlerDependencies): Promise<GitHubReleaseClient> {
+    const token = readGitHubToken(dependencies);
     if (token === undefined) {
         throw new Error('GH_TOKEN or GITHUB_TOKEN must be set to create release tags or GitHub releases');
     }
-    return deps.createGitHubReleaseClient({ ...parseGitHubRepositoryParts(await deps.readPackageInfo()), token });
+    return dependencies.createGitHubReleaseClient({
+        ...parseGitHubRepositoryParts(await dependencies.readPackageInfo()),
+        token
+    });
 }
 
 async function ensureTags(client: GitHubReleaseClient, targets: readonly PublishedReleaseTarget[]): Promise<void> {
@@ -225,14 +230,14 @@ async function ensureTags(client: GitHubReleaseClient, targets: readonly Publish
 }
 
 async function createGitHubReleases(
-    deps: ReleaseHandlerDeps,
+    dependencies: ReleaseHandlerDependencies,
     client: GitHubReleaseClient,
     planned: PlannedRelease,
     targets: readonly PublishedReleaseTarget[]
 ): Promise<void> {
-    const changelog = await generateRequiredChangelog(deps, planned.config, planned.packages);
+    const changelog = await generateRequiredChangelog(dependencies, planned.config, planned.packages);
     const releaseNotesByPackageName = await collectGitHubReleaseNotes(
-        deps,
+        dependencies,
         changelog.config,
         targets,
         changelog.changelog
@@ -246,32 +251,32 @@ async function createGitHubReleases(
     }
 }
 
-function reportFlagIssues(deps: ReleaseHandlerDeps): number | undefined {
-    const issues = collectFlagIssues(deps.flags);
+function reportFlagIssues(dependencies: ReleaseHandlerDependencies): number | undefined {
+    const issues = collectFlagIssues(dependencies.flags);
     if (issues.length > 0) {
-        deps.log(issues.join('\n'));
+        dependencies.log(issues.join('\n'));
         return 1;
     }
     return undefined;
 }
 
 function resolvePlannedReleaseExitCode(
-    deps: ReleaseHandlerDeps,
+    dependencies: ReleaseHandlerDependencies,
     packages: readonly ReleasePlanPackage[]
 ): number | undefined {
-    if (!hasAction(deps.flags)) {
-        printReleasePlan(deps.log, packages);
+    if (!hasAction(dependencies.flags)) {
+        printReleasePlan(dependencies.log, packages);
         return 0;
     }
-    if (!hasReleaseWork(deps.flags, packages)) {
-        deps.log('No packages need release.');
+    if (!hasReleaseWork(dependencies.flags, packages)) {
+        dependencies.log('No packages need release.');
         return 0;
     }
     return undefined;
 }
 
 async function finishReleaseActions(
-    deps: ReleaseHandlerDeps,
+    dependencies: ReleaseHandlerDependencies,
     planned: PlannedRelease,
     publishedTargets: readonly PublishedReleaseTarget[]
 ): Promise<void> {
@@ -279,50 +284,50 @@ async function finishReleaseActions(
     if (releaseTargets.length === 0) {
         return;
     }
-    if (!deps.flags.tag && !deps.flags.githubRelease) {
+    if (!dependencies.flags.tag && !dependencies.flags.githubRelease) {
         return;
     }
-    const client = await createGitHubClientAsync(deps);
+    const client = await createGitHubClientAsync(dependencies);
     await ensureTags(client, releaseTargets);
-    if (deps.flags.githubRelease) {
-        await createGitHubReleases(deps, client, planned, releaseTargets);
+    if (dependencies.flags.githubRelease) {
+        await createGitHubReleases(dependencies, client, planned, releaseTargets);
     }
 }
 
-async function runMutatingRelease(deps: ReleaseHandlerDeps, planned: PlannedRelease): Promise<number> {
+async function runMutatingRelease(dependencies: ReleaseHandlerDependencies, planned: PlannedRelease): Promise<number> {
     const changedTargets = selectChangedTargets(planned.packages);
-    assertTagRule(deps.flags, changedTargets);
-    const publishedTargets = await publishTargets(deps, planned, changedTargets);
+    assertTagRule(dependencies.flags, changedTargets);
+    const publishedTargets = await publishTargets(dependencies, planned, changedTargets);
     if (publishedTargets === undefined) {
         return 1;
     }
-    await finishReleaseActions(deps, planned, publishedTargets);
-    deps.log(releaseCompletedMessage);
+    await finishReleaseActions(dependencies, planned, publishedTargets);
+    dependencies.log(releaseCompletedMessage);
     return 0;
 }
 
-async function runRelease(deps: ReleaseHandlerDeps): Promise<number> {
-    const flagExitCode = reportFlagIssues(deps);
+async function runRelease(dependencies: ReleaseHandlerDependencies): Promise<number> {
+    const flagExitCode = reportFlagIssues(dependencies);
     if (flagExitCode !== undefined) {
         return flagExitCode;
     }
-    const planned = await loadPlannedRelease(deps);
+    const planned = await loadPlannedRelease(dependencies);
     if (planned === undefined) {
         return 1;
     }
-    return resolvePlannedReleaseExitCode(deps, planned.packages) ?? runMutatingRelease(deps, planned);
+    return resolvePlannedReleaseExitCode(dependencies, planned.packages) ?? runMutatingRelease(dependencies, planned);
 }
 
-function stopSpinnersAndReturn(deps: ReleaseHandlerDeps, exitCode: number): number {
-    deps.spinnerRenderer.stopAll();
+function stopSpinnersAndReturn(dependencies: ReleaseHandlerDependencies, exitCode: number): number {
+    dependencies.spinnerRenderer.stopAll();
     return exitCode;
 }
 
-export async function runReleaseHandler(deps: ReleaseHandlerDeps): Promise<number> {
+export async function runReleaseHandler(dependencies: ReleaseHandlerDependencies): Promise<number> {
     try {
-        return stopSpinnersAndReturn(deps, await runRelease(deps));
+        return stopSpinnersAndReturn(dependencies, await runRelease(dependencies));
     } catch (error: unknown) {
-        deps.log(formatReleaseHandlerError(error));
-        return stopSpinnersAndReturn(deps, 1);
+        dependencies.log(formatReleaseHandlerError(error));
+        return stopSpinnersAndReturn(dependencies, 1);
     }
 }

--- a/source/command-line-interface/runner/release-preparation.test.ts
+++ b/source/command-line-interface/runner/release-preparation.test.ts
@@ -11,7 +11,7 @@ import {
     loadPlannedRelease,
     prepareReleaseChangelogs,
     type PlannedRelease,
-    type ReleasePreparationDeps
+    type ReleasePreparationDependencies
 } from './release-preparation.ts';
 
 type EngineSpec = {
@@ -36,11 +36,11 @@ type DependencySpec = {
     readonly fileManager: FakeFileManager;
     readonly log: SinonSpy;
     readonly packtory: Packtory;
-    readonly readEnvironmentVariable: ReleasePreparationDeps['readEnvironmentVariable'];
+    readonly readEnvironmentVariable: ReleasePreparationDependencies['readEnvironmentVariable'];
     readonly stopAll: SinonSpy;
 };
 
-type CreatedReleasePreparationDeps = ReleasePreparationDeps & {
+type CreatedReleasePreparationDependencies = ReleasePreparationDependencies & {
     readonly createPrLogEngine: SinonSpy;
     readonly fileManager: FakeFileManager;
     readonly log: SinonSpy;
@@ -154,7 +154,7 @@ function mergeDependencySpec(overrides: Partial<DependencySpec>): DependencySpec
     return { ...createDefaultDependencySpec(), ...overrides };
 }
 
-function createDependencies(overrides: Partial<DependencySpec> = {}): CreatedReleasePreparationDeps {
+function createDependencies(overrides: Partial<DependencySpec> = {}): CreatedReleasePreparationDependencies {
     const spec = mergeDependencySpec(overrides);
 
     return {
@@ -184,7 +184,7 @@ function plannedRelease(packages: readonly ReleasePlanPackage[] = [ createReleas
     return { config: validConfig, packages };
 }
 
-function createEmptyChangelogDependencies(): CreatedReleasePreparationDeps {
+function createEmptyChangelogDependencies(): CreatedReleasePreparationDependencies {
     return createDependencies({
         createPrLogEngine: fake.returns(createEngine({
             labeledPullRequests: [],
@@ -196,19 +196,19 @@ function createEmptyChangelogDependencies(): CreatedReleasePreparationDeps {
 
 suite('release-preparation', function () {
     test('loads a planned release and stops spinners after planning', async function () {
-        const deps = createDependencies();
+        const dependencies = createDependencies();
 
-        assert.deepStrictEqual(await loadPlannedRelease(deps), plannedRelease());
-        assert.strictEqual(deps.stopAll.callCount, 1);
+        assert.deepStrictEqual(await loadPlannedRelease(dependencies), plannedRelease());
+        assert.strictEqual(dependencies.stopAll.callCount, 1);
     });
 
     test('logs release plan failures without returning a planned release', async function () {
-        const deps = createDependencies({
+        const dependencies = createDependencies({
             packtory: createPacktory(Result.err({ type: 'config', issues: [ 'bad config' ] }))
         });
 
-        assert.strictEqual(await loadPlannedRelease(deps), undefined);
-        assert.deepStrictEqual(deps.log.firstCall.args, [
+        assert.strictEqual(await loadPlannedRelease(dependencies), undefined);
+        assert.deepStrictEqual(dependencies.log.firstCall.args, [
             'Configuration issues, there are 1 issue(s)\n\n- bad config'
         ]);
     });
@@ -225,14 +225,14 @@ suite('release-preparation', function () {
                 renderedMarkdown: '## pkg-a 1.0.1\n'
             });
         });
-        const deps = createDependencies({
+        const dependencies = createDependencies({
             createPrLogEngine,
             readEnvironmentVariable(name) {
                 return name === 'GITHUB_TOKEN' ? 'github-token' : undefined;
             }
         });
 
-        const { changelog } = await prepareReleaseChangelogs(deps, plannedRelease(), true);
+        const { changelog } = await prepareReleaseChangelogs(dependencies, plannedRelease(), true);
 
         assert.strictEqual(changelog.changelog.groupedMarkdown, '## pkg-a 1.0.1\n');
         assert.strictEqual(createPrLogEngine.callCount, 1);
@@ -243,58 +243,58 @@ suite('release-preparation', function () {
             assert.strictEqual(options.githubToken, 'gh-token');
             return createDefaultEngine();
         });
-        const deps = createDependencies({
+        const dependencies = createDependencies({
             createPrLogEngine,
             readEnvironmentVariable(name) {
                 return name === 'GH_TOKEN' ? 'gh-token' : 'github-token';
             }
         });
 
-        await prepareReleaseChangelogs(deps, plannedRelease(), true);
+        await prepareReleaseChangelogs(dependencies, plannedRelease(), true);
 
         assert.strictEqual(createPrLogEngine.callCount, 1);
     });
 
     test('rejects invalid changelog config before creating pr-log', async function () {
-        const deps = createDependencies();
+        const dependencies = createDependencies();
 
         await assert.rejects(
-            prepareReleaseChangelogs(deps, { config: {}, packages: [ createReleasePackage() ] }, true),
+            prepareReleaseChangelogs(dependencies, { config: {}, packages: [ createReleasePackage() ] }, true),
             /The loaded config is invalid for changelog generation/u
         );
-        assert.strictEqual(deps.createPrLogEngine.callCount, 0);
+        assert.strictEqual(dependencies.createPrLogEngine.callCount, 0);
     });
 
     test('prepares configured changelog files and returns their paths', async function () {
-        const deps = createDependencies();
+        const dependencies = createDependencies();
 
-        const { writtenFiles, writtenPaths } = await prepareReleaseChangelogs(deps, plannedRelease(), true);
+        const { writtenFiles, writtenPaths } = await prepareReleaseChangelogs(dependencies, plannedRelease(), true);
 
         assert.deepStrictEqual(writtenPaths, [ '/repo/CHANGELOG.md' ]);
         assert.deepStrictEqual(writtenFiles, [
             { content: 'updated:\n## pkg-a 1.0.1\n', filePath: '/repo/CHANGELOG.md' }
         ]);
-        assert.deepStrictEqual(deps.fileManager.getAllWriteFileCalls(), []);
+        assert.deepStrictEqual(dependencies.fileManager.getAllWriteFileCalls(), []);
     });
 
     test('logs unchanged plans when no changelog files are written', async function () {
-        const deps = createEmptyChangelogDependencies();
+        const dependencies = createEmptyChangelogDependencies();
 
         const result = await prepareReleaseChangelogs(
-            deps,
+            dependencies,
             plannedRelease([ createReleasePackage({ changed: false }) ]),
             false
         );
 
         assert.deepStrictEqual(result.writtenPaths, []);
-        assert.deepStrictEqual(deps.log.firstCall.args, [ 'No changelog files were written.' ]);
+        assert.deepStrictEqual(dependencies.log.firstCall.args, [ 'No changelog files were written.' ]);
     });
 
     test('reports packages without changelog entries when changelog files are optional', async function () {
-        const deps = createEmptyChangelogDependencies();
+        const dependencies = createEmptyChangelogDependencies();
 
         const result = await prepareReleaseChangelogs(
-            deps,
+            dependencies,
             plannedRelease([
                 createReleasePackage(),
                 createReleasePackage({ name: 'pkg-b', changelogSourceFiles: [ 'src/pkg-b/index.ts' ] })
@@ -303,7 +303,7 @@ suite('release-preparation', function () {
         );
 
         assert.deepStrictEqual(result.writtenPaths, []);
-        assert.deepStrictEqual(deps.log.firstCall.args, [
+        assert.deepStrictEqual(dependencies.log.firstCall.args, [
             'No changelog files were written; changelog attribution found no pull requests for pkg-a, pkg-b.'
         ]);
     });
@@ -325,12 +325,12 @@ suite('release-preparation', function () {
                 });
             })
         };
-        const deps = createDependencies({
+        const dependencies = createDependencies({
             createPrLogEngine: fake.returns(engine)
         });
 
         const result = await prepareReleaseChangelogs(
-            deps,
+            dependencies,
             plannedRelease([
                 createReleasePackage(),
                 createReleasePackage({ name: 'pkg-b', changelogSourceFiles: [ 'src/pkg-b/index.ts' ] })
@@ -342,12 +342,12 @@ suite('release-preparation', function () {
     });
 
     test('rejects required changelog generation when no files are written', async function () {
-        const deps = createEmptyChangelogDependencies();
+        const dependencies = createEmptyChangelogDependencies();
 
         await assert.rejects(
-            prepareReleaseChangelogs(deps, plannedRelease(), true),
+            prepareReleaseChangelogs(dependencies, plannedRelease(), true),
             /No changelog files were written; changelog attribution found no pull requests for pkg-a\./u
         );
-        assert.deepStrictEqual(deps.log.getCalls(), []);
+        assert.deepStrictEqual(dependencies.log.getCalls(), []);
     });
 });

--- a/source/command-line-interface/runner/release-preparation.ts
+++ b/source/command-line-interface/runner/release-preparation.ts
@@ -24,7 +24,7 @@ export type PlannedRelease = {
     readonly config: unknown;
     readonly packages: readonly ReleasePlanPackage[];
 };
-export type ReleasePreparationDeps = {
+export type ReleasePreparationDependencies = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
     readonly currentDate: () => Date;
     readonly fileManager: {
@@ -39,34 +39,38 @@ export type ReleasePreparationDeps = {
     readonly workingDirectory: string;
 };
 
-function readGitHubToken(deps: Pick<ReleasePreparationDeps, 'readEnvironmentVariable'>): string | undefined {
-    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+function readGitHubToken(
+    dependencies: Pick<ReleasePreparationDependencies, 'readEnvironmentVariable'>
+): string | undefined {
+    return dependencies.readEnvironmentVariable('GH_TOKEN') ?? dependencies.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
-function createEngine(deps: ReleasePreparationDeps, config: PrLogConfig): PrLogEngine {
-    return deps.createPrLogEngine({
-        githubToken: readGitHubToken(deps),
-        workingDirectory: deps.workingDirectory,
+function createEngine(dependencies: ReleasePreparationDependencies, config: PrLogConfig): PrLogEngine {
+    return dependencies.createPrLogEngine({
+        githubToken: readGitHubToken(dependencies),
+        workingDirectory: dependencies.workingDirectory,
         config
     });
 }
 
 async function planRelease(
-    deps: ReleasePreparationDeps,
+    dependencies: ReleasePreparationDependencies,
     config: unknown
 ): Promise<readonly ReleasePlanPackage[] | undefined> {
-    const outcome = await deps.packtory.planReleaseAgainstLatestPublished(config);
-    deps.spinnerRenderer.stopAll();
+    const outcome = await dependencies.packtory.planReleaseAgainstLatestPublished(config);
+    dependencies.spinnerRenderer.stopAll();
     if (outcome.result.isErr) {
-        printReleasePlanFailure(deps.log, outcome.result.error);
+        printReleasePlanFailure(dependencies.log, outcome.result.error);
         return undefined;
     }
     return outcome.result.value.packages;
 }
 
-export async function loadPlannedRelease(deps: ReleasePreparationDeps): Promise<PlannedRelease | undefined> {
-    const config = await deps.configLoader.load();
-    const packages = await planRelease(deps, config);
+export async function loadPlannedRelease(
+    dependencies: ReleasePreparationDependencies
+): Promise<PlannedRelease | undefined> {
+    const config = await dependencies.configLoader.load();
+    const packages = await planRelease(dependencies, config);
     if (packages === undefined) {
         return undefined;
     }
@@ -82,20 +86,20 @@ function parseRequiredChangelogConfig(config: unknown): ValidChangelogConfig {
 }
 
 async function generateReleaseChangelog(
-    deps: ReleasePreparationDeps,
+    dependencies: ReleasePreparationDependencies,
     config: ValidChangelogConfig,
     packages: readonly ReleasePlanPackage[]
 ): Promise<ReleaseChangelog> {
-    const packageInfo = await deps.readPackageInfo();
+    const packageInfo = await dependencies.readPackageInfo();
     const generationOptions = createChangelogGenerationOptions(config);
-    const engine = createEngine(deps, generationOptions.prLogConfig);
+    const engine = createEngine(dependencies, generationOptions.prLogConfig);
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
         explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
-        ignoredAttributionPaths: collectGeneratedAttributionPaths(deps, config),
-        currentDate: deps.currentDate(),
+        ignoredAttributionPaths: collectGeneratedAttributionPaths(dependencies, config),
+        currentDate: dependencies.currentDate(),
         packageTagFormat: generationOptions.packageTagFormat,
         prLogConfig: generationOptions.prLogConfig,
         targetScopedLabelPattern: generationOptions.targetScopedLabelPattern
@@ -104,11 +108,11 @@ async function generateReleaseChangelog(
 }
 
 export async function generateRequiredChangelog(
-    deps: ReleasePreparationDeps,
+    dependencies: ReleasePreparationDependencies,
     config: unknown,
     packages: readonly ReleasePlanPackage[]
 ): Promise<ReleaseChangelog> {
-    return generateReleaseChangelog(deps, parseRequiredChangelogConfig(config), packages);
+    return generateReleaseChangelog(dependencies, parseRequiredChangelogConfig(config), packages);
 }
 
 function formatEmptyChangelogMessage(changelog: GeneratedChangelog): string {
@@ -141,7 +145,7 @@ function reportUnwrittenChangelogs(
 }
 
 export async function prepareReleaseChangelogs(
-    deps: ReleasePreparationDeps,
+    dependencies: ReleasePreparationDependencies,
     planned: PlannedRelease,
     requireWrittenChangelog: boolean
 ): Promise<{
@@ -150,9 +154,9 @@ export async function prepareReleaseChangelogs(
     readonly writtenPaths: readonly string[];
 }> {
     const validConfig = parseRequiredChangelogConfig(planned.config);
-    const changelog = await generateReleaseChangelog(deps, validConfig, planned.packages);
+    const changelog = await generateReleaseChangelog(dependencies, validConfig, planned.packages);
     const writtenFiles = await buildConfiguredChangelogFiles(
-        deps,
+        dependencies,
         changelog.config,
         changelog.engine,
         changelog.changelog
@@ -160,6 +164,6 @@ export async function prepareReleaseChangelogs(
     const writtenPaths = writtenFiles.map(function (file) {
         return file.filePath;
     });
-    reportUnwrittenChangelogs(deps.log, changelog.changelog, writtenPaths, requireWrittenChangelog);
+    reportUnwrittenChangelogs(dependencies.log, changelog.changelog, writtenPaths, requireWrittenChangelog);
     return { changelog, writtenFiles, writtenPaths };
 }

--- a/source/command-line-interface/runner/release-pull-request-handler.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.ts
@@ -16,7 +16,7 @@ import {
     loadPlannedRelease,
     type PlannedRelease,
     prepareReleaseChangelogs,
-    type ReleasePreparationDeps
+    type ReleasePreparationDependencies
 } from './release-preparation.ts';
 import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
 import {
@@ -28,7 +28,7 @@ import {
 
 type Logger = (message: string) => void;
 type EnvironmentReader = (name: string) => string | undefined;
-type ReleasePullRequestFileManager = ReleasePreparationDeps['fileManager'] & {
+type ReleasePullRequestFileManager = ReleasePreparationDependencies['fileManager'] & {
     readonly writeFile: (filePath: string, content: string) => Promise<void>;
 };
 
@@ -58,18 +58,18 @@ type GitHubClientContext = {
 };
 
 export type ReleasePullRequestHandlerDependencies = {
-    readonly createPrLogEngine: ReleasePreparationDeps['createPrLogEngine'];
+    readonly createPrLogEngine: ReleasePreparationDependencies['createPrLogEngine'];
     readonly createReleasePullRequestGitHubClient: (context: GitHubClientContext) => ReleasePullRequestGitHubClient;
-    readonly currentDate: ReleasePreparationDeps['currentDate'];
+    readonly currentDate: ReleasePreparationDependencies['currentDate'];
     readonly fileManager: ReleasePullRequestFileManager;
     readonly flags: ReleasePullRequestFlags;
     readonly log: Logger;
-    readonly packtory: ReleasePreparationDeps['packtory'];
+    readonly packtory: ReleasePreparationDependencies['packtory'];
     readonly readEnvironmentVariable: EnvironmentReader;
-    readonly readPackageInfo: ReleasePreparationDeps['readPackageInfo'];
+    readonly readPackageInfo: ReleasePreparationDependencies['readPackageInfo'];
     readonly sleep: (milliseconds: number) => Promise<void>;
-    readonly spinnerRenderer: ReleasePreparationDeps['spinnerRenderer'];
-    readonly configLoader: ReleasePreparationDeps['configLoader'];
+    readonly spinnerRenderer: ReleasePreparationDependencies['spinnerRenderer'];
+    readonly configLoader: ReleasePreparationDependencies['configLoader'];
     readonly workingDirectory: string;
 };
 

--- a/source/config/validation-package-graph.test.ts
+++ b/source/config/validation-package-graph.test.ts
@@ -4,7 +4,7 @@ import { Result } from 'true-myth';
 import {
     expectCyclicError,
     fooPackage,
-    packageWithDeps,
+    packageWithDependencies,
     withRegistry
 } from '../test-libraries/validation-test-support.ts';
 import { validateConfig } from './validation.ts';
@@ -53,8 +53,8 @@ suite('validation package graph', function () {
         test('returns an issue when there is a cycle per bundleDependencies', function () {
             expectCyclicError(
                 [
-                    packageWithDeps('a', 'bundleDependencies', [ 'b' ]),
-                    packageWithDeps('b', 'bundleDependencies', [ 'a' ])
+                    packageWithDependencies('a', 'bundleDependencies', [ 'b' ]),
+                    packageWithDependencies('b', 'bundleDependencies', [ 'a' ])
                 ],
                 'a→b→a'
             );
@@ -63,10 +63,10 @@ suite('validation package graph', function () {
         test('returns an issue when there is a long cycle per bundleDependencies', function () {
             expectCyclicError(
                 [
-                    packageWithDeps('a', 'bundleDependencies', [ 'd' ]),
-                    packageWithDeps('b', 'bundleDependencies', [ 'a' ]),
-                    packageWithDeps('c', 'bundleDependencies', [ 'b' ]),
-                    packageWithDeps('d', 'bundleDependencies', [ 'c' ])
+                    packageWithDependencies('a', 'bundleDependencies', [ 'd' ]),
+                    packageWithDependencies('b', 'bundleDependencies', [ 'a' ]),
+                    packageWithDependencies('c', 'bundleDependencies', [ 'b' ]),
+                    packageWithDependencies('d', 'bundleDependencies', [ 'c' ])
                 ],
                 'a→d→c→b→a'
             );
@@ -75,8 +75,8 @@ suite('validation package graph', function () {
         test('returns an issue when there is a cycle per bundlePeerDependencies', function () {
             expectCyclicError(
                 [
-                    packageWithDeps('a', 'bundlePeerDependencies', [ 'b' ]),
-                    packageWithDeps('b', 'bundlePeerDependencies', [ 'a' ])
+                    packageWithDependencies('a', 'bundlePeerDependencies', [ 'b' ]),
+                    packageWithDependencies('b', 'bundlePeerDependencies', [ 'a' ])
                 ],
                 'a→b→a'
             );
@@ -85,8 +85,8 @@ suite('validation package graph', function () {
         test('returns an issue when there is a cycle per bundleDependencies and bundlePeerDependencies', function () {
             expectCyclicError(
                 [
-                    packageWithDeps('a', 'bundleDependencies', [ 'b' ]),
-                    packageWithDeps('b', 'bundlePeerDependencies', [ 'a' ])
+                    packageWithDependencies('a', 'bundleDependencies', [ 'b' ]),
+                    packageWithDependencies('b', 'bundlePeerDependencies', [ 'a' ])
                 ],
                 'a→b→a'
             );
@@ -95,7 +95,7 @@ suite('validation package graph', function () {
 
     suite('dependency references and package interfaces', function () {
         test('returns an issue when a package depends on itself', function () {
-            expectCyclicError([ packageWithDeps('a', 'bundleDependencies', [ 'a' ]) ], 'a→a');
+            expectCyclicError([ packageWithDependencies('a', 'bundleDependencies', [ 'a' ]) ], 'a→a');
         });
 
         test('returns an issue when a package bundle dependency does not exit', function () {

--- a/source/config/validation-publish-settings.test.ts
+++ b/source/config/validation-publish-settings.test.ts
@@ -6,7 +6,7 @@ import {
     duplicateCAndMissingBPackages,
     fooPackage,
     packageSpecificPublishSettings,
-    packageWithDeps,
+    packageWithDependencies,
     placementErrorMessage,
     withCommonWithoutPublishSettings,
     withRegistry
@@ -81,8 +81,8 @@ suite('validation publish settings', function () {
             const result = validateConfig(
                 withRegistry({
                     packages: [
-                        packageWithDeps('a', 'bundleDependencies', [ 'b' ]),
-                        packageWithDeps('b', 'bundleDependencies', [ 'a' ]),
+                        packageWithDependencies('a', 'bundleDependencies', [ 'b' ]),
+                        packageWithDependencies('b', 'bundleDependencies', [ 'a' ]),
                         fooPackage(),
                         fooPackage()
                     ]

--- a/source/pack-emitter/pack-emitter.test.ts
+++ b/source/pack-emitter/pack-emitter.test.ts
@@ -8,7 +8,7 @@ import type { VersionedBundleWithManifest } from '../version-manager/versioned-b
 import { createPackEmitter, type PackEmitterDependencies } from './pack-emitter.ts';
 
 type PackEmitterFixture = {
-    readonly deps: PackEmitterDependencies;
+    readonly dependencies: PackEmitterDependencies;
     readonly fileManager: FakeFileManager;
 };
 
@@ -29,7 +29,7 @@ function createDependencies(overrides: Partial<PackEmitterDependencies['artifact
         buildFolder: overrides.buildFolder ?? fake.resolves(undefined)
     };
     return {
-        deps: { artifactsBuilder, fileManager },
+        dependencies: { artifactsBuilder, fileManager },
         fileManager
     };
 }
@@ -38,8 +38,8 @@ suite('pack-emitter', function () {
     test('writes the zip artifact bytes returned by buildZip to the output path', async function () {
         const zipData = Buffer.from([ 80, 75, 5, 6 ]);
         const buildZip = fake.resolves({ zipData });
-        const { deps, fileManager } = createDependencies({ buildZip });
-        const emitter = createPackEmitter(deps);
+        const { dependencies, fileManager } = createDependencies({ buildZip });
+        const emitter = createPackEmitter(dependencies);
         const bundle = makeBundle();
 
         await emitter.pack({ bundle, format: 'zip', outputPath: '/out/fn.zip', vendorEntries: [], extraFiles: [] });
@@ -60,8 +60,8 @@ suite('pack-emitter', function () {
     test('writes the tarball artifact bytes returned by buildTarball to the output path', async function () {
         const tarData = Buffer.from([ 31, 139, 8, 0 ]);
         const buildTarball = fake.resolves({ tarData });
-        const { deps, fileManager } = createDependencies({ buildTarball });
-        const emitter = createPackEmitter(deps);
+        const { dependencies, fileManager } = createDependencies({ buildTarball });
+        const emitter = createPackEmitter(dependencies);
         const bundle = makeBundle();
 
         await emitter.pack({ bundle, format: 'tar', outputPath: '/out/pkg.tgz', vendorEntries: [], extraFiles: [] });
@@ -81,8 +81,8 @@ suite('pack-emitter', function () {
 
     test('delegates folder writes to buildFolder with the requested output path', async function () {
         const buildFolder = fake.resolves(undefined);
-        const { deps, fileManager } = createDependencies({ buildFolder });
-        const emitter = createPackEmitter(deps);
+        const { dependencies, fileManager } = createDependencies({ buildFolder });
+        const emitter = createPackEmitter(dependencies);
         const bundle = makeBundle();
 
         await emitter.pack({

--- a/source/packages/command-line-interface/pull-request-label-versioning.ts
+++ b/source/packages/command-line-interface/pull-request-label-versioning.ts
@@ -8,7 +8,7 @@ import { createPrLogConfig } from '../../command-line-interface/runner/changelog
 
 type EnvironmentVariableName = 'GH_TOKEN' | 'GITHUB_TOKEN';
 
-export type PullRequestLabelVersionSourceDeps = {
+export type PullRequestLabelVersionSourceDependencies = {
     readonly createPrLogEngine: (options: Readonly<PrLogEngineOptions>) => PrLogEngine;
     readonly readEnvironmentVariable: (name: EnvironmentVariableName) => string | undefined;
     readonly readPackageInfo: () => Promise<Readonly<Record<string, unknown>>>;
@@ -21,14 +21,16 @@ function orderedVersionBumpLevels(): readonly VersionBumpLevel[] {
     return [ 'major', 'minor', 'patch' ];
 }
 
-function readGitHubToken(deps: Pick<PullRequestLabelVersionSourceDeps, 'readEnvironmentVariable'>): string | undefined {
-    return deps.readEnvironmentVariable('GH_TOKEN') ?? deps.readEnvironmentVariable('GITHUB_TOKEN');
+function readGitHubToken(
+    dependencies: Pick<PullRequestLabelVersionSourceDependencies, 'readEnvironmentVariable'>
+): string | undefined {
+    return dependencies.readEnvironmentVariable('GH_TOKEN') ?? dependencies.readEnvironmentVariable('GITHUB_TOKEN');
 }
 
-function createEngine(deps: PullRequestLabelVersionSourceDeps, config: PrLogConfig): PrLogEngine {
-    return deps.createPrLogEngine({
-        githubToken: readGitHubToken(deps),
-        workingDirectory: deps.workingDirectory,
+function createEngine(dependencies: PullRequestLabelVersionSourceDependencies, config: PrLogConfig): PrLogEngine {
+    return dependencies.createPrLogEngine({
+        githubToken: readGitHubToken(dependencies),
+        workingDirectory: dependencies.workingDirectory,
         config
     });
 }
@@ -67,16 +69,16 @@ function selectNextVersion(
 }
 
 export function createPullRequestLabelVersionSourceResolver(
-    deps: PullRequestLabelVersionSourceDeps
+    dependencies: PullRequestLabelVersionSourceDependencies
 ): VersionSourceResolver {
     async function collectLabeledPullRequests(
         input: Parameters<VersionProvider>[0],
         packtoryConfig: PacktoryConfig
     ): Promise<readonly PullRequestWithLabel[]> {
-        const packageInfo = await deps.readPackageInfo();
+        const packageInfo = await dependencies.readPackageInfo();
         const githubRepo = formatGitHubRepositoryName(packageInfo);
         const prLogConfig = createPrLogConfig(packtoryConfig.changelog);
-        const prLogEngine = createEngine(deps, prLogConfig);
+        const prLogEngine = createEngine(dependencies, prLogConfig);
         const baseRef = await prLogEngine.resolveChangelogBaseRef({
             packageName: input.packageName,
             previousVersion: input.currentVersion,

--- a/source/test-libraries/validation-test-support.ts
+++ b/source/test-libraries/validation-test-support.ts
@@ -19,12 +19,12 @@ export function withRegistry(extra: ConfigInput): ConfigInput {
 
 export type CycleDependencyKind = 'bundleDependencies' | 'bundlePeerDependencies';
 
-export function packageWithDeps(
+export function packageWithDependencies(
     name: string,
     kind: CycleDependencyKind,
-    deps: readonly string[]
+    dependencies: readonly string[]
 ): ConfigInput {
-    return { ...minimalPackageConfigFactory.build({ name }), [kind]: deps };
+    return { ...minimalPackageConfigFactory.build({ name }), [kind]: dependencies };
 }
 
 export function expectCyclicError(packages: readonly ConfigInput[], expectedPath: string): void {
@@ -37,7 +37,7 @@ export function fooPackage(name = 'foo'): ConfigInput {
 }
 
 export const duplicateCAndMissingBPackages: readonly ConfigInput[] = [
-    packageWithDeps('a', 'bundlePeerDependencies', [ 'b' ]),
+    packageWithDependencies('a', 'bundlePeerDependencies', [ 'b' ]),
     fooPackage('c'),
     fooPackage('c')
 ];

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -310,7 +310,7 @@ function registerMaterializationTests(): void {
         ]);
     });
 
-    test('deduplicates packages so the same name is materialized at most once even when referenced from multiple deps', async function () {
+    test('deduplicates packages so the same name is materialized at most once even when referenced from multiple dependencies', async function () {
         const truthyReadability = { value: { isReadable: true } } as const;
         const result = await runWith(
             {

--- a/source/version-manager/dependencies/bundle-dependency-grouping.test.ts
+++ b/source/version-manager/dependencies/bundle-dependency-grouping.test.ts
@@ -37,7 +37,7 @@ suite('bundle-dependency-grouping', function () {
         );
     });
 
-    test('groupBundleDependencies prefers the peer entry when a name appears in both peers and deps', function () {
+    test('groupBundleDependencies prefers the peer entry when a name appears in both peers and dependencies', function () {
         assert.deepStrictEqual(
             groupBundleDependencies(
                 { linkedBundleDependencies: new Map([ [ 'shared', externalDep('shared') ] ]) },
@@ -48,7 +48,7 @@ suite('bundle-dependency-grouping', function () {
         );
     });
 
-    test('groupBundleDependencies throws when a linked dep is in neither peers nor deps', function () {
+    test('groupBundleDependencies throws when a linked dep is in neither peers nor dependencies', function () {
         try {
             groupBundleDependencies(
                 { linkedBundleDependencies: new Map([ [ 'unknown', externalDep('unknown') ] ]) },

--- a/source/version-manager/specifier-classifier.test.ts
+++ b/source/version-manager/specifier-classifier.test.ts
@@ -69,7 +69,11 @@ function registerMalformedSpecifierTests(): void {
         if (result.kind !== 'malformed') {
             assert.fail(`Expected malformed, got ${result.kind}`);
         }
-        assert.match(result.reason, /aliases only work for registry deps/u);
+        const dependencyWordInNpmPackageArgMessage = 'dependencies'.replace(/endencie/u, '');
+        assert.match(
+            result.reason,
+            new RegExp(`aliases only work for registry ${dependencyWordInNpmPackageArgMessage}`, 'u')
+        );
     });
 
     test('classifies an alias of a registry tag as registry', function () {


### PR DESCRIPTION
Renames dependency-related identifiers and wording to spell out `dependencies` instead of using abbreviated forms. The only remaining matching term is a third-party dependency-cruiser option name that cannot be changed in this repository.