### PR TITLE
Configure Renovate stale rebases explicitly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "commitMessagePrefix": "⬆️ ",
     "labels": ["renovate", "upgrade"],
     "dependencyDashboard": false,
-    "rebaseStalePrs": true,
+    "rebaseWhen": "behind-base-branch",
     "minimumReleaseAge": "3 days",
     "lockFileMaintenance": {
         "enabled": true,


### PR DESCRIPTION
Renovate should keep rebasing stale or conflicted dependency branches so automerge still sees current CI results. This replaces the deprecated stale-rebase flag with the explicit `rebaseWhen` value for the same behavior.

Custom fixes on Renovate branches are preserved by pushing them as separate non-Renovate commits. Amending Renovate commits still lets Renovate regenerate the branch and discard those changes.
