### PR TITLE
Use shared `renovate-config` preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>enormora/renovate-config#1.0.0",
-    "github>enormora/renovate-config:github-automerge#1.0.0"
-  ],
-  "ignorePaths": [
-    "**/node_modules/**",
-    "**/integration-tests/**"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>enormora/renovate-config#1.0.0",
+        "github>enormora/renovate-config:github-automerge#1.0.0"
+    ],
+    "ignorePaths": [
+        "**/node_modules/**",
+        "**/integration-tests/**"
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,35 +1,11 @@
 {
-    "extends": [
-        "config:base",
-        "helpers:pinGitHubActionDigests"
-    ],
-    "ignorePaths": [
-        "**/node_modules/**",
-        "**/integration-tests/**"
-    ],
-    "commitMessagePrefix": "⬆️ ",
-    "labels": [
-        "renovate",
-        "upgrade"
-    ],
-    "dependencyDashboard": false,
-    "rebaseWhen": "behind-base-branch",
-    "minimumReleaseAge": "3 days",
-    "lockFileMaintenance": {
-        "enabled": true,
-        "automerge": true
-    },
-    "automerge": true,
-    "automergeType": "pr",
-    "packageRules": [
-        {
-            "matchPackagePatterns": [
-                "^@enormora/eslint-config"
-            ],
-            "groupName": "@enormora/eslint-config",
-            "groupSlug": "enormora-eslint-config"
-        }
-    ],
-    "platformAutomerge": true,
-    "automergeStrategy": "merge-commit"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>enormora/renovate-config#1.0.0",
+    "github>enormora/renovate-config:github-automerge#1.0.0"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/integration-tests/**"
+  ]
 }


### PR DESCRIPTION
This switches Renovate to the shared Enormora preset repository and leaves local exceptions in this repository configuration.

The automerge preset follows the branch rules in this repository.