### PR TITLE
Fix changelog attribution for historical source files

### DIFF
--- a/integration-tests/github-api/changelog-git-repository.ts
+++ b/integration-tests/github-api/changelog-git-repository.ts
@@ -49,12 +49,27 @@ async function commitMergedPullRequest(
     ]);
 }
 
+async function commitMergedPullRequests(repositoryPath: string): Promise<void> {
+    const pullRequests = [
+        [ 1, 'update-react', 'Update React to v19' ],
+        [ 2, 'move-readme', 'Move package README into source/packages' ],
+        [ 3, 'update-readme', 'Update package README content' ],
+        [ 4, 'update-old-rule', 'Update old rule behavior' ],
+        [ 5, 'rename-old-rule', 'Rename old rule' ],
+        [ 6, 'fix-subsumed-rule', 'Fix subsumed rule behavior' ],
+        [ 7, 'subsume-old-rule', 'Subsume old rule into new rule' ],
+        [ 8, 'remove-legacy-rules', 'Remove legacy rules' ]
+    ] as const;
+
+    for (const [ pullRequestNumber, branchName, title ] of pullRequests) {
+        await commitMergedPullRequest(repositoryPath, pullRequestNumber, branchName, title);
+    }
+}
+
 export async function createChangelogGitRepository(): Promise<string> {
     const repositoryPath = await mkdtemp(path.join(os.tmpdir(), 'packtory-pr-log-'));
     await configureRepository(repositoryPath);
     await commitBase(repositoryPath);
-    await commitMergedPullRequest(repositoryPath, 1, 'update-react', 'Update React to v19');
-    await commitMergedPullRequest(repositoryPath, 2, 'move-readme', 'Move package README into source/packages');
-    await commitMergedPullRequest(repositoryPath, 3, 'update-readme', 'Update package README content');
+    await commitMergedPullRequests(repositoryPath);
     return repositoryPath;
 }

--- a/integration-tests/github-api/changelog-github-api.test.ts
+++ b/integration-tests/github-api/changelog-github-api.test.ts
@@ -5,7 +5,10 @@ import { suite, test } from 'mocha';
 import { generateChangelogOutputs } from '../../source/packtory/packtory-changelog.ts';
 import type { ReleasePlanPackage } from '../../source/packtory/packtory.ts';
 import { createChangelogGitRepository } from './changelog-git-repository.ts';
-import type { DeterministicGitHubApiScenario } from './deterministic-github-api-scenarios.ts';
+import type {
+    DeterministicGitHubApiScenario,
+    DeterministicGitHubRestRoute
+} from './deterministic-github-api-scenarios.ts';
 import {
     type DeterministicGitHubApiServerContext,
     withDeterministicGitHubApiServer
@@ -35,6 +38,14 @@ type PackagePlanInput = {
 type ChangelogScenarioInput = {
     readonly includeReadmeContentChange: boolean;
     readonly includeReadmeMove: boolean;
+};
+type ChangedFileResponse = {
+    readonly additions: number;
+    readonly changes: number;
+    readonly deletions: number;
+    readonly filename: string;
+    readonly previous_filename?: string | undefined;
+    readonly status: string;
 };
 
 function packagePlan(input: PackagePlanInput): ReleasePlanPackage {
@@ -82,6 +93,46 @@ function pureMovePackagePlan(): ReleasePlanPackage {
         changelogSourceFiles: [],
         releaseClassification: 'dependency-only'
     });
+}
+
+function rulePackagePlan(changelogSourceFiles: readonly string[]): ReleasePlanPackage {
+    return {
+        ...packagePlan({
+            changelogDependencyNames: [],
+            changelogDependencyUpdates: [],
+            changelogSourceFiles,
+            releaseClassification: 'substantive'
+        }),
+        sourceFiles: [ 'source/rules/current-rule.ts' ],
+        changedArtifactFiles: [ 'rules/current-rule.js' ]
+    };
+}
+
+function changedFilesRoute(
+    pullRequestNumber: number,
+    files: readonly ChangedFileResponse[]
+): DeterministicGitHubRestRoute {
+    return {
+        method: 'GET',
+        path: `/repos/owner/repo/pulls/${pullRequestNumber}/files`,
+        search: '',
+        response: {
+            status: 200,
+            body: files
+        }
+    };
+}
+
+function labelRoute(pullRequestNumber: number, label: string): DeterministicGitHubRestRoute {
+    return {
+        method: 'GET',
+        path: `/repos/owner/repo/issues/${pullRequestNumber}/labels`,
+        search: '',
+        response: {
+            status: 200,
+            body: [ { name: label } ]
+        }
+    };
 }
 
 function changelogScenario(input: ChangelogScenarioInput): DeterministicGitHubApiScenario {
@@ -169,7 +220,89 @@ function changelogScenario(input: ChangelogScenarioInput): DeterministicGitHubAp
                     status: 200,
                     body: [ { name: 'feature' } ]
                 }
-            }
+            },
+            changedFilesRoute(4, []),
+            changedFilesRoute(5, []),
+            changedFilesRoute(6, []),
+            changedFilesRoute(7, []),
+            changedFilesRoute(8, []),
+            labelRoute(4, 'feature'),
+            labelRoute(5, 'breaking'),
+            labelRoute(6, 'bug'),
+            labelRoute(7, 'breaking'),
+            labelRoute(8, 'breaking')
+        ],
+        graphqlRoutes: []
+    };
+}
+
+function historicalRuleScenario(): DeterministicGitHubApiScenario {
+    return {
+        restRoutes: [
+            changedFilesRoute(1, []),
+            changedFilesRoute(2, []),
+            changedFilesRoute(3, []),
+            changedFilesRoute(4, [
+                {
+                    filename: 'source/rules/old-rule.ts',
+                    status: 'modified',
+                    additions: 1,
+                    deletions: 1,
+                    changes: 2
+                }
+            ]),
+            changedFilesRoute(5, [
+                {
+                    filename: 'source/rules/current-rule.ts',
+                    previous_filename: 'source/rules/old-rule.ts',
+                    status: 'renamed',
+                    additions: 1,
+                    deletions: 1,
+                    changes: 2
+                }
+            ]),
+            changedFilesRoute(6, [
+                {
+                    filename: 'source/rules/subsumed-rule.ts',
+                    status: 'modified',
+                    additions: 1,
+                    deletions: 1,
+                    changes: 2
+                }
+            ]),
+            changedFilesRoute(7, [
+                {
+                    filename: 'source/rules/current-rule.ts',
+                    status: 'modified',
+                    additions: 1,
+                    deletions: 1,
+                    changes: 2
+                },
+                {
+                    filename: 'source/rules/subsumed-rule.ts',
+                    status: 'removed',
+                    additions: 0,
+                    deletions: 20,
+                    changes: 20
+                }
+            ]),
+            changedFilesRoute(8, [
+                {
+                    filename: 'source/rules/removed-rule.ts',
+                    status: 'removed',
+                    additions: 0,
+                    deletions: 20,
+                    changes: 20
+                }
+            ]),
+            labelRoute(1, 'bug'),
+            labelRoute(2, 'maintenance'),
+            labelRoute(3, 'feature'),
+            labelRoute(4, 'feature'),
+            labelRoute(5, 'breaking'),
+            labelRoute(6, 'bug'),
+            labelRoute(7, 'breaking'),
+            labelRoute(8, 'breaking')
         ],
         graphqlRoutes: []
     };
@@ -177,7 +310,8 @@ function changelogScenario(input: ChangelogScenarioInput): DeterministicGitHubAp
 
 async function generateChangelog(
     githubApi: DeterministicGitHubApiServerContext,
-    packages: readonly ReleasePlanPackage[]
+    packages: readonly ReleasePlanPackage[],
+    changelogSourceFileRootsByPackageName: ReadonlyMap<string, readonly string[]>
 ): ReturnType<typeof generateChangelogOutputs> {
     const repositoryPath = await createChangelogGitRepository();
     const engine = createPrLogEngine({
@@ -191,6 +325,7 @@ async function generateChangelog(
         githubApi,
         generateChangelogOutputs({
             currentDate: new Date('2026-07-13T00:00:00.000Z'),
+            changelogSourceFileRootsByPackageName,
             explicitBaseRef: undefined,
             githubRepo: 'owner/repo',
             ignoredAttributionPaths: [],
@@ -209,7 +344,7 @@ suite('changelog GitHub API integration', function () {
         withDeterministicGitHubApiServer(
             changelogScenario({ includeReadmeContentChange: false, includeReadmeMove: true }),
             async function (githubApi) {
-                const changelog = await generateChangelog(githubApi, [ dependencyOnlyPackagePlan() ]);
+                const changelog = await generateChangelog(githubApi, [ dependencyOnlyPackagePlan() ], new Map());
 
                 assert.match(changelog.groupedMarkdown, /Update react to \^19\.0\.0/u);
                 assert.match(changelog.groupedMarkdown, /\/owner\/repo\/pull\/1/u);
@@ -223,7 +358,7 @@ suite('changelog GitHub API integration', function () {
         withDeterministicGitHubApiServer(
             changelogScenario({ includeReadmeContentChange: true, includeReadmeMove: false }),
             async function (githubApi) {
-                const changelog = await generateChangelog(githubApi, [ contentChangePackagePlan() ]);
+                const changelog = await generateChangelog(githubApi, [ contentChangePackagePlan() ], new Map());
 
                 assert.match(changelog.groupedMarkdown, /Update package README content/u);
                 assert.match(changelog.groupedMarkdown, /\/owner\/repo\/pull\/3/u);
@@ -236,12 +371,62 @@ suite('changelog GitHub API integration', function () {
         withDeterministicGitHubApiServer(
             changelogScenario({ includeReadmeContentChange: false, includeReadmeMove: true }),
             async function (githubApi) {
-                const changelog = await generateChangelog(githubApi, [ pureMovePackagePlan() ]);
+                const changelog = await generateChangelog(githubApi, [ pureMovePackagePlan() ], new Map());
 
                 assert.partialDeepStrictEqual(changelog, {
                     groupedMarkdown: '',
                     packageNamesWithoutChangelogEntries: [ 'pkg-a' ]
                 });
+            }
+        )
+    );
+
+    test(
+        'attributes pull requests that changed a source file before it was renamed in the release range',
+        withDeterministicGitHubApiServer(
+            historicalRuleScenario(),
+            async function (githubApi) {
+                const changelog = await generateChangelog(
+                    githubApi,
+                    [ rulePackagePlan([ 'source/rules/current-rule.ts' ]) ],
+                    new Map([ [ 'pkg-a', [ 'source/rules' ] ] ])
+                );
+
+                assert.match(changelog.groupedMarkdown, /Update old rule behavior/u);
+                assert.match(changelog.groupedMarkdown, /Rename old rule/u);
+            }
+        )
+    );
+
+    test(
+        'attributes pull requests that changed a source file before it was deleted by a subsuming change',
+        withDeterministicGitHubApiServer(
+            historicalRuleScenario(),
+            async function (githubApi) {
+                const changelog = await generateChangelog(
+                    githubApi,
+                    [ rulePackagePlan([ 'source/rules/current-rule.ts' ]) ],
+                    new Map([ [ 'pkg-a', [ 'source/rules' ] ] ])
+                );
+
+                assert.match(changelog.groupedMarkdown, /Fix subsumed rule behavior/u);
+                assert.match(changelog.groupedMarkdown, /Subsume old rule into new rule/u);
+            }
+        )
+    );
+
+    test(
+        'attributes pure deleted source files from substantive releases to the package source root',
+        withDeterministicGitHubApiServer(
+            historicalRuleScenario(),
+            async function (githubApi) {
+                const changelog = await generateChangelog(
+                    githubApi,
+                    [ rulePackagePlan([]) ],
+                    new Map([ [ 'pkg-a', [ 'source/rules' ] ] ])
+                );
+
+                assert.match(changelog.groupedMarkdown, /Remove legacy rules/u);
             }
         )
     );

--- a/source/command-line-interface/runner/changelog-destinations.test.ts
+++ b/source/command-line-interface/runner/changelog-destinations.test.ts
@@ -4,6 +4,7 @@ import { fake } from 'sinon';
 import type { GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
+    collectChangelogSourceFileRoots,
     collectGeneratedAttributionPaths,
     createChangelogGenerationOptions,
     parseValidConfig,
@@ -115,6 +116,26 @@ suite('changelog-destinations', function () {
         });
         assert.strictEqual(options.prLogConfig.validLabels.get('bug'), 'Fixed Bugs');
         assert.strictEqual(options.prLogConfig.validLabels.get('operations'), 'Operations');
+    });
+
+    test('collectChangelogSourceFileRoots resolves package source folders relative to the repository', function () {
+        assert.deepStrictEqual(
+            collectChangelogSourceFileRoots(
+                { workingDirectory: '/repo' },
+                createChangelogConfig({
+                    packages: [
+                        { name: 'pkg-a', sourcesFolder: 'packages/pkg-a/src' },
+                        { name: 'pkg-b', sourcesFolder: '/repo/packages/pkg-b/source' },
+                        { name: 'pkg-c', sourcesFolder: '.' }
+                    ]
+                })
+            ),
+            new Map([
+                [ 'pkg-a', [ 'packages/pkg-a/src' ] ],
+                [ 'pkg-b', [ 'packages/pkg-b/source' ] ],
+                [ 'pkg-c', [ '' ] ]
+            ])
+        );
     });
 
     suite('collectGeneratedAttributionPaths', function () {

--- a/source/command-line-interface/runner/changelog-destinations.ts
+++ b/source/command-line-interface/runner/changelog-destinations.ts
@@ -96,12 +96,32 @@ function resolveRepositoryPath(
     return path.resolve(dependencies.workingDirectory, normalizeConfiguredPath(filePath));
 }
 
+function toRepositoryRelativePath(workingDirectory: string, filePath: string): string {
+    return path.relative(workingDirectory, filePath).split(path.sep).join('/');
+}
+
 function resolvePackageSourcesFolder(packageConfig: PackagePathConfig, config: ChangelogConfig): string {
     const sourcesFolder = packageConfig.sourcesFolder ?? config.commonPackageSettings?.sourcesFolder;
     if (sourcesFolder === undefined) {
         throw new Error(`Config for package "${packageConfig.name}" is missing the sources folder`);
     }
     return sourcesFolder;
+}
+
+export function collectChangelogSourceFileRoots(
+    dependencies: Pick<ChangelogDestinationDependencies, 'workingDirectory'>,
+    config: ChangelogConfig
+): ReadonlyMap<string, readonly string[]> {
+    return new Map(
+        config.packages.map(function (packageConfig) {
+            const sourcesFolder = resolvePackageSourcesFolder(packageConfig, config);
+            const absoluteSourceFolder = resolveRepositoryPath(dependencies, sourcesFolder);
+            return [
+                packageConfig.name,
+                [ toRepositoryRelativePath(dependencies.workingDirectory, absoluteSourceFolder) ]
+            ] as const;
+        })
+    );
 }
 
 function mapPackageConfigByName(config: ChangelogConfig): ReadonlyMap<string, PackagePathConfig> {

--- a/source/command-line-interface/runner/changelog-handler.ts
+++ b/source/command-line-interface/runner/changelog-handler.ts
@@ -6,6 +6,7 @@ import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import {
     createChangelogGenerationOptions,
+    collectChangelogSourceFileRoots,
     collectGeneratedAttributionPaths,
     parseValidConfig,
     shouldPageGroupedChangelog,
@@ -64,6 +65,7 @@ async function renderChangelog(
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine,
+        changelogSourceFileRootsByPackageName: collectChangelogSourceFileRoots(dependencies, config),
         explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
         ignoredAttributionPaths: collectGeneratedAttributionPaths(dependencies, config),

--- a/source/command-line-interface/runner/release-preparation.ts
+++ b/source/command-line-interface/runner/release-preparation.ts
@@ -2,6 +2,7 @@ import type { PrLogConfig, PrLogEngine, PrLogEngineOptions } from '@pr-log/core'
 import type { Packtory, ReleasePlanPackage } from '../../packtory/packtory.ts';
 import { generateChangelogOutputs, type GeneratedChangelog } from '../../packtory/packtory-changelog.ts';
 import {
+    collectChangelogSourceFileRoots,
     collectGeneratedAttributionPaths,
     createChangelogGenerationOptions,
     parseValidConfig,
@@ -96,6 +97,7 @@ async function generateReleaseChangelog(
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
+        changelogSourceFileRootsByPackageName: collectChangelogSourceFileRoots(dependencies, config),
         explicitBaseRef: generationOptions.explicitBaseRef,
         githubRepo: formatGitHubRepositoryName(packageInfo),
         ignoredAttributionPaths: collectGeneratedAttributionPaths(dependencies, config),

--- a/source/packtory/changelog-source-file-history.test.ts
+++ b/source/packtory/changelog-source-file-history.test.ts
@@ -1,0 +1,328 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { pullRequestChangedFileFactory, type PullRequestChangedFileShape } from '../test-libraries/pr-log-fixtures.ts';
+import { expandChangelogSourceFilesForHistory } from './changelog-source-file-history.ts';
+import type { ReleasePlanPackage } from './packtory-results.ts';
+
+function packagePlan(
+    changelogSourceFiles: readonly string[],
+    releaseClassification: ReleasePlanPackage['releaseClassification'] = 'substantive'
+): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        releaseClassification,
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: [],
+        changedArtifactFiles: [],
+        sourceFiles: [],
+        changelogDependencyNames: [],
+        changelogDependencyUpdates: [],
+        changelogSourceFiles
+    };
+}
+
+function changedFilesByPullRequest(
+    entries: readonly (readonly [number, PullRequestChangedFileShape])[]
+): ReadonlyMap<number, readonly PullRequestChangedFileShape[]> {
+    const filesByPullRequest = new Map<number, PullRequestChangedFileShape[]>();
+    for (const [ pullRequestNumber, file ] of entries) {
+        filesByPullRequest.set(pullRequestNumber, [ ...filesByPullRequest.get(pullRequestNumber) ?? [], file ]);
+    }
+    return filesByPullRequest;
+}
+
+function expand(
+    plan: ReleasePlanPackage,
+    filesByPullRequest: ReadonlyMap<number, readonly PullRequestChangedFileShape[]>,
+    sourceFileRoots: readonly string[] = [ 'source/rules' ]
+): readonly string[] {
+    return expandChangelogSourceFilesForHistory({
+        packagePlan: plan,
+        changedFilesByPullRequest: filesByPullRequest,
+        sourceFileRoots
+    });
+}
+
+function registerRenameTests(): void {
+    test('follows rename chains from the current source file to earlier source names', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ]),
+            changedFilesByPullRequest([
+                [
+                    2,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/current-rule.ts',
+                        previousPath: 'source/rules/middle-rule.ts',
+                        status: 'renamed'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/middle-rule.ts',
+                        previousPath: 'source/rules/old-rule.ts',
+                        status: 'renamed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [
+            'source/rules/current-rule.ts',
+            'source/rules/middle-rule.ts',
+            'source/rules/old-rule.ts'
+        ]);
+    });
+
+    test('follows rename chains from a selected previous source file to its newer name', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/old-rule.ts' ]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/current-rule.ts',
+                        previousPath: 'source/rules/old-rule.ts',
+                        status: 'renamed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/old-rule.ts', 'source/rules/current-rule.ts' ]);
+    });
+
+    test('does not add unrelated renamed files', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/unrelated-rule.ts',
+                        previousPath: 'source/rules/unrelated-old-rule.ts',
+                        status: 'renamed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts' ]);
+    });
+}
+
+function registerTargetAttachedDeleteTests(): void {
+    test('adds deleted package source files from pull requests that also touch selected source files', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ], 'dependency-only'),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/other/unrelated.ts',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/current-rule.ts',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/subsumed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts', 'source/rules/subsumed-rule.ts' ]);
+    });
+
+    test('does not add deleted files from pull requests that do not touch selected source files', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ], 'dependency-only'),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/unrelated-rule.ts',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/subsumed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts' ]);
+    });
+
+    test('does not add target-attached deleted files outside the package source roots', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ], 'dependency-only'),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/current-rule.ts',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/other/subsumed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts' ]);
+    });
+}
+
+function registerPureDeleteTests(): void {
+    test('adds pure deleted package source files for substantive releases', function () {
+        const result = expand(
+            packagePlan([]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/removed-rule.ts',
+                        status: 'removed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/removed-rule.ts' ]);
+    });
+
+    test('does not add pure deleted source files for dependency-only releases', function () {
+        const result = expand(
+            packagePlan([], 'dependency-only'),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/removed-rule.ts',
+                        status: 'removed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('does not add modified source files as pure deletes', function () {
+        const result = expand(
+            packagePlan([]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/modified-rule.ts',
+                        status: 'modified'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('does not add deleted files outside the package source roots', function () {
+        const result = expand(
+            packagePlan([]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules-old/removed-rule.ts',
+                        status: 'removed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('matches pure deleted source files against every configured source root', function () {
+        const result = expand(
+            packagePlan([]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'packages/pkg-a/rules/removed-rule.ts',
+                        status: 'removed'
+                    })
+                ]
+            ]),
+            [ 'source/rules', 'packages/pkg-a/rules' ]
+        );
+
+        assert.deepStrictEqual(result, [ 'packages/pkg-a/rules/removed-rule.ts' ]);
+    });
+
+    test('matches pure deleted source files when the package source root is the repository root', function () {
+        const result = expand(
+            packagePlan([]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'removed-rule.ts',
+                        status: 'removed'
+                    })
+                ]
+            ]),
+            [ '' ]
+        );
+
+        assert.deepStrictEqual(result, [ 'removed-rule.ts' ]);
+    });
+
+    test('normalizes absolute changed file paths before matching', function () {
+        const result = expand(
+            packagePlan([]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: '///source/rules/removed-rule.ts',
+                        status: 'removed'
+                    })
+                ]
+            ])
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/removed-rule.ts' ]);
+    });
+}
+
+suite('changelog-source-file-history', function () {
+    registerRenameTests();
+    registerTargetAttachedDeleteTests();
+    registerPureDeleteTests();
+});

--- a/source/packtory/changelog-source-file-history.ts
+++ b/source/packtory/changelog-source-file-history.ts
@@ -1,0 +1,134 @@
+import path from 'node:path';
+import type { PullRequestChangedFile } from '@pr-log/core';
+import { releaseAnalysisClassification, type ReleasePlanPackage } from './packtory-results.ts';
+
+export type ChangelogSourceFileHistoryInput = {
+    readonly changedFilesByPullRequest: ReadonlyMap<number, readonly PullRequestChangedFile[]>;
+    readonly packagePlan: ReleasePlanPackage;
+    readonly sourceFileRoots: readonly string[];
+};
+
+function normalizeRepositoryPath(filePath: string): string {
+    return filePath.split(path.sep).join('/').replace(/^\/+/u, '');
+}
+
+function previousPathFor(file: PullRequestChangedFile): string | undefined {
+    return file.previousPath === undefined ? undefined : normalizeRepositoryPath(file.previousPath);
+}
+
+function pathFor(file: PullRequestChangedFile): string {
+    return normalizeRepositoryPath(file.path);
+}
+
+function isDeletedFile(file: PullRequestChangedFile): boolean {
+    return file.status === 'removed' || file.status === 'deleted';
+}
+
+function isHistoricalPath(filePath: string, roots: readonly string[]): boolean {
+    return roots.some(function (root) {
+        return root === '' || filePath.startsWith(`${root}/`);
+    });
+}
+
+function fileTouchesTarget(file: PullRequestChangedFile, targetSourceFiles: ReadonlySet<string>): boolean {
+    return targetSourceFiles.has(pathFor(file));
+}
+
+function pullRequestTouchesTarget(
+    changedFiles: readonly PullRequestChangedFile[],
+    targetSourceFiles: ReadonlySet<string>
+): boolean {
+    return changedFiles.some(function (file) {
+        return fileTouchesTarget(file, targetSourceFiles);
+    });
+}
+
+function renamedFilePaths(file: PullRequestChangedFile, targetSourceFiles: ReadonlySet<string>): readonly string[] {
+    const currentPath = pathFor(file);
+    const previousPath = previousPathFor(file);
+    if (previousPath === undefined) {
+        return [];
+    }
+    return [
+        ...targetSourceFiles.has(currentPath) ? [ previousPath ] : [],
+        ...targetSourceFiles.has(previousPath) ? [ currentPath ] : []
+    ];
+}
+
+function expandRenamedFiles(
+    targetSourceFiles: ReadonlySet<string>,
+    changedFiles: readonly PullRequestChangedFile[]
+): ReadonlySet<string> {
+    return new Set([
+        ...targetSourceFiles,
+        ...changedFiles.flatMap(function (file) {
+            return renamedFilePaths(file, targetSourceFiles);
+        })
+    ]);
+}
+
+function expandRenameHistory(
+    targetSourceFiles: ReadonlySet<string>,
+    changedFiles: readonly PullRequestChangedFile[]
+): ReadonlySet<string> {
+    const expanded = expandRenamedFiles(targetSourceFiles, changedFiles);
+    return expanded.size === targetSourceFiles.size ? expanded : expandRenameHistory(expanded, changedFiles);
+}
+
+function addDeletedFilesFromTargetPullRequests(
+    targetSourceFiles: ReadonlySet<string>,
+    changedFilesByPullRequest: ChangelogSourceFileHistoryInput['changedFilesByPullRequest'],
+    sourceFileRoots: readonly string[]
+): ReadonlySet<string> {
+    const expanded = new Set(targetSourceFiles);
+    for (const changedFiles of changedFilesByPullRequest.values()) {
+        if (pullRequestTouchesTarget(changedFiles, targetSourceFiles)) {
+            for (const file of changedFiles) {
+                const filePath = pathFor(file);
+                if (isDeletedFile(file) && isHistoricalPath(filePath, sourceFileRoots)) {
+                    expanded.add(filePath);
+                }
+            }
+        }
+    }
+    return expanded;
+}
+
+function addPureDeletedFiles(
+    targetSourceFiles: ReadonlySet<string>,
+    changedFiles: readonly PullRequestChangedFile[],
+    sourceFileRoots: readonly string[]
+): ReadonlySet<string> {
+    const expanded = new Set(targetSourceFiles);
+    for (const file of changedFiles) {
+        const filePath = pathFor(file);
+        if (isDeletedFile(file) && isHistoricalPath(filePath, sourceFileRoots)) {
+            expanded.add(filePath);
+        }
+    }
+    return expanded;
+}
+
+function shouldAttributePureDeletes(packagePlan: ReleasePlanPackage): boolean {
+    return packagePlan.releaseClassification !== releaseAnalysisClassification.dependencyOnly;
+}
+
+export function expandChangelogSourceFilesForHistory(input: ChangelogSourceFileHistoryInput): readonly string[] {
+    const sourceFileRoots = input.sourceFileRoots.map(normalizeRepositoryPath);
+    const changedFiles = Array.from(input.changedFilesByPullRequest.values()).flat();
+    const renamedSourceFiles = expandRenameHistory(
+        new Set(input.packagePlan.changelogSourceFiles.map(normalizeRepositoryPath)),
+        changedFiles
+    );
+    const targetSourceFiles = addDeletedFilesFromTargetPullRequests(
+        renamedSourceFiles,
+        input.changedFilesByPullRequest,
+        sourceFileRoots
+    );
+
+    return Array.from(
+        shouldAttributePureDeletes(input.packagePlan)
+            ? addPureDeletedFiles(targetSourceFiles, changedFiles, sourceFileRoots)
+            : targetSourceFiles
+    );
+}

--- a/source/packtory/changelog-source-file-history.ts
+++ b/source/packtory/changelog-source-file-history.ts
@@ -71,8 +71,9 @@ function expandRenameHistory(
     targetSourceFiles: ReadonlySet<string>,
     changedFiles: readonly PullRequestChangedFile[]
 ): ReadonlySet<string> {
-    const expanded = expandRenamedFiles(targetSourceFiles, changedFiles);
-    return expanded.size === targetSourceFiles.size ? expanded : expandRenameHistory(expanded, changedFiles);
+    return changedFiles.reduce(function (expandedSoFar) {
+        return expandRenamedFiles(expandedSoFar, changedFiles);
+    }, targetSourceFiles);
 }
 
 function addDeletedFilesFromTargetPullRequests(

--- a/source/packtory/packtory-changelog-dependency.test.ts
+++ b/source/packtory/packtory-changelog-dependency.test.ts
@@ -87,6 +87,7 @@ async function generate(
     return generateChangelogOutputs({
         packages,
         prLogEngine: engine,
+        changelogSourceFileRootsByPackageName: new Map(),
         githubRepo: 'owner/repo',
         currentDate: new Date('2026-06-13T00:00:00.000Z'),
         explicitBaseRef: undefined,

--- a/source/packtory/packtory-changelog-source-file-history.test.ts
+++ b/source/packtory/packtory-changelog-source-file-history.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake, type SinonSpy } from 'sinon';
+import {
+    defaultPrLogConfig,
+    type FilterPullRequestsByTargetFilesInput,
+    type PrLogEngine,
+    type PullRequest,
+    type PullRequestChangedFile,
+    type PullRequestWithLabel
+} from '@pr-log/core';
+import { pullRequestChangedFileFactory } from '../test-libraries/pr-log-fixtures.ts';
+import { generateChangelogOutputs } from './packtory-changelog.ts';
+import type { ReleasePlanPackage } from './packtory-results.ts';
+
+type ChangelogEngine = {
+    readonly engine: PrLogEngine;
+    readonly filterPullRequestsByTargetFiles: SinonSpy<
+        readonly [FilterPullRequestsByTargetFilesInput],
+        readonly PullRequest[]
+    >;
+};
+
+type PullRequestLabelsInput = {
+    readonly pullRequests: readonly PullRequest[];
+};
+
+function releasePackage(): ReleasePlanPackage {
+    return {
+        name: 'pkg-a',
+        previousVersion: '1.0.0',
+        nextVersion: '1.0.1',
+        artifactState: 'changed',
+        releaseClassification: 'substantive',
+        changed: true,
+        previousGitHead: undefined,
+        currentGitHead: 'current-head',
+        latestRegistryMetadata: undefined,
+        artifactFiles: [],
+        changedArtifactFiles: [],
+        sourceFiles: [],
+        changelogSourceFiles: [],
+        changelogDependencyNames: [],
+        changelogDependencyUpdates: []
+    };
+}
+
+function createEngine(
+    changedFilesByPullRequest: ReadonlyMap<number, readonly PullRequestChangedFile[]>
+): ChangelogEngine {
+    const pullRequests: readonly PullRequest[] = [ { id: 1, title: 'Remove feature' } ];
+    const filterPullRequestsByTargetFiles = fake(function (input: FilterPullRequestsByTargetFilesInput) {
+        return input.pullRequests;
+    });
+    const engine = {
+        collectMergedPullRequests: fake.resolves(pullRequests),
+        filterPullRequestsByTargetFiles,
+        readPullRequestChangedFiles: fake.resolves(changedFilesByPullRequest),
+        renderGroupedTargetChangelog: fake.returns(''),
+        renderTargetChangelog: fake.returns(''),
+        resolveChangelogBaseRef: fake.resolves({ ref: 'pkg-a-base' }),
+        resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
+        resolvePullRequestLabels: fake(
+            async function (input: PullRequestLabelsInput): Promise<readonly PullRequestWithLabel[]> {
+                return input.pullRequests.map(function (pullRequest) {
+                    return { ...pullRequest, label: 'bug' };
+                });
+            }
+        )
+    };
+
+    return {
+        engine: engine as unknown as PrLogEngine,
+        filterPullRequestsByTargetFiles
+    };
+}
+
+async function generateWithSourceRoots(
+    engine: PrLogEngine,
+    changelogSourceFileRootsByPackageName: ReadonlyMap<string, readonly string[]>
+): Promise<void> {
+    await generateChangelogOutputs({
+        packages: [ releasePackage() ],
+        prLogEngine: engine,
+        changelogSourceFileRootsByPackageName,
+        explicitBaseRef: undefined,
+        githubRepo: 'owner/repo',
+        packageTagFormat: undefined,
+        currentDate: new Date('2026-06-13T00:00:00.000Z'),
+        ignoredAttributionPaths: [],
+        prLogConfig: defaultPrLogConfig,
+        targetScopedLabelPattern: undefined
+    });
+}
+
+suite('packtory changelog source file history', function () {
+    test('adds deleted source files from configured package source roots', async function () {
+        const { engine, filterPullRequestsByTargetFiles } = createEngine(
+            new Map([
+                [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/removed.ts', status: 'removed' }) ] ]
+            ])
+        );
+
+        await generateWithSourceRoots(engine, new Map([ [ 'pkg-a', [ 'source' ] ] ]));
+
+        assert.deepStrictEqual(filterPullRequestsByTargetFiles.firstCall.args[0].targetSourceFiles, [
+            'source/removed.ts'
+        ]);
+    });
+});

--- a/source/packtory/packtory-changelog.test.ts
+++ b/source/packtory/packtory-changelog.test.ts
@@ -117,6 +117,7 @@ async function render(packages: readonly ReleasePlanPackage[], engine: PrLogEngi
     const changelog = await generateChangelogOutputs({
         packages,
         prLogEngine: engine,
+        changelogSourceFileRootsByPackageName: new Map(),
         explicitBaseRef: undefined,
         githubRepo: 'owner/repo',
         packageTagFormat: undefined,
@@ -232,6 +233,32 @@ function registerTargetSelectionTests(): void {
             ignoredAttributionPaths: [ 'CHANGELOG.md' ]
         });
     });
+
+    test('does not add deleted source files when no package source root is configured', async function () {
+        const { engine, calls } = createEngine();
+        const readPullRequestChangedFiles = fake.resolves(
+            new Map([
+                [ 1, [ pullRequestChangedFileFactory.build({ path: 'source/removed.ts', status: 'removed' }) ] ]
+            ])
+        );
+        const sourceRootlessEngine = {
+            ...engine,
+            readPullRequestChangedFiles
+        } as unknown as PrLogEngine;
+
+        await render(
+            [
+                releasePackage({
+                    changelogSourceFiles: [],
+                    sourceFiles: [],
+                    changedArtifactFiles: []
+                })
+            ],
+            sourceRootlessEngine
+        );
+
+        assert.deepStrictEqual(calls.filterPullRequestsByTargetFiles.firstCall.args[0].targetSourceFiles, []);
+    });
 }
 
 function registerDependencyUpdateTests(): void {
@@ -334,6 +361,7 @@ function registerDependencyUpdateTests(): void {
         await generateChangelogOutputs({
             packages: [ releasePackage({ releaseClassification: 'dependency-only' }) ],
             prLogEngine: engine,
+            changelogSourceFileRootsByPackageName: new Map(),
             githubRepo: 'owner/repo',
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             explicitBaseRef: undefined,
@@ -402,6 +430,7 @@ function registerPackageChangelogTests(): void {
         const changelog = await generateChangelogOutputs({
             packages: [ releasePackage({ changelogSourceFiles: [ 'source/pkg-a.ts' ] }) ],
             prLogEngine: emptyEngine,
+            changelogSourceFileRootsByPackageName: new Map(),
             githubRepo: 'owner/repo',
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             explicitBaseRef: undefined,
@@ -460,6 +489,7 @@ function registerAttributionPathTests(): void {
         await generateChangelogOutputs({
             packages: [ releasePackage({ changelogSourceFiles: [ 'source/pkg-a.ts' ] }) ],
             prLogEngine: engine,
+            changelogSourceFileRootsByPackageName: new Map(),
             githubRepo: 'owner/repo',
             currentDate: new Date('2026-06-13T00:00:00.000Z'),
             explicitBaseRef: undefined,
@@ -482,6 +512,7 @@ function registerOptionForwardingTests(): void {
         await generateChangelogOutputs({
             packages: [ releasePackage({ previousVersion: undefined, previousGitHead: undefined }) ],
             prLogEngine: engine,
+            changelogSourceFileRootsByPackageName: new Map(),
             explicitBaseRef: 'release-base',
             githubRepo: 'owner/repo',
             packageTagFormat: 'pkg/{packageName}/v{version}',

--- a/source/packtory/packtory-changelog.ts
+++ b/source/packtory/packtory-changelog.ts
@@ -10,6 +10,7 @@ import type {
 import { compareValues } from '../common/sort-values.ts';
 import { releaseAnalysisClassification, type ReleasePlanPackage } from './packtory-results.ts';
 import { isPackageManifestInputPath } from './changelog-source-attribution.ts';
+import { expandChangelogSourceFilesForHistory } from './changelog-source-file-history.ts';
 
 type ChangelogTarget = {
     readonly packagePlan: ReleasePlanPackage;
@@ -55,7 +56,23 @@ function syntheticDependencyPullRequestId(): 0 {
     return 0;
 }
 
+function emptyChangelogSourceFileRoots(): readonly string[] {
+    return new Array<string>();
+}
+
+function changelogSourceFileRootsForPackage(
+    changelogSourceFileRootsByPackageName: ReadonlyMap<string, readonly string[]>,
+    packageName: string
+): readonly string[] {
+    const sourceFileRoots = changelogSourceFileRootsByPackageName.get(packageName);
+    if (sourceFileRoots === undefined) {
+        return emptyChangelogSourceFileRoots();
+    }
+    return sourceFileRoots;
+}
+
 export type GenerateChangelogInput = {
+    readonly changelogSourceFileRootsByPackageName: ReadonlyMap<string, readonly string[]>;
     readonly currentDate: Date;
     readonly explicitBaseRef: string | undefined;
     readonly githubRepo: string;
@@ -174,9 +191,17 @@ async function collectTargetPullRequests(
         githubRepo: input.githubRepo,
         pullRequests
     });
+    const targetSourceFiles = expandChangelogSourceFilesForHistory({
+        changedFilesByPullRequest,
+        packagePlan,
+        sourceFileRoots: changelogSourceFileRootsForPackage(
+            input.changelogSourceFileRootsByPackageName,
+            packagePlan.name
+        )
+    });
     const packagePullRequests = input.prLogEngine.filterPullRequestsByTargetFiles({
         targetName: packagePlan.name,
-        targetSourceFiles: packagePlan.changelogSourceFiles,
+        targetSourceFiles,
         pullRequests,
         changedFilesByPullRequest,
         ignoredAttributionPaths

--- a/source/test-libraries/pr-log-fixtures.ts
+++ b/source/test-libraries/pr-log-fixtures.ts
@@ -1,6 +1,6 @@
 import { createFactory } from '@enormora/objectory';
 
-type PullRequestChangedFileShape = {
+export type PullRequestChangedFileShape = {
     readonly path: string;
     readonly previousPath: string | undefined;
     readonly status: string;


### PR DESCRIPTION
Expands changelog attribution with release-range PR file history before passing target files to `pr-log`. This keeps PRs attributed when package source files are renamed, deleted by a later subsuming change, or removed in a pure delete release without fetching file contents or full diffs.