### PR TITLE
Fix `pack` bundled peer dependency metadata

### DIFF
--- a/integration-tests/packtory/pack.test.ts
+++ b/integration-tests/packtory/pack.test.ts
@@ -1,0 +1,55 @@
+import path from 'node:path';
+import assert from 'node:assert';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { suite, test } from 'mocha';
+import {
+    packPackage,
+    type PacktoryConfig
+} from '../../source/packages/packtory/packtory.entry-point.ts';
+import { loadPackageJson } from '../load-package-json.ts';
+import {
+    createPackageConfig,
+    createPackageConfigList,
+    getFixturePath
+} from './publish-fixture-support.ts';
+
+async function createPackConfig(fixturePath: string): Promise<PacktoryConfig> {
+    return {
+        commonPackageSettings: {
+            sourcesFolder: path.join(fixturePath, 'src'),
+            mainPackageJson: await loadPackageJson(fixturePath),
+            publishSettings: { access: 'public' },
+            deadCodeElimination: { enabled: false }
+        },
+        packages: createPackageConfigList(
+            createPackageConfig(fixturePath, 'second', 'entry2'),
+            createPackageConfig(fixturePath, 'third', 'entry3', { bundlePeerDependencies: [ 'second' ] })
+        )
+    };
+}
+
+suite('pack', function () {
+    test('writes configured bundle peer dependencies into packed package metadata', async function () {
+        const fixturePath = getFixturePath('multiple-packages-with-substitution');
+        const outputPath = path.join(await mkdtemp(path.join(tmpdir(), 'packtory-pack-')), 'third');
+
+        const outcome = await packPackage(await createPackConfig(fixturePath), {
+            packageName: 'third',
+            format: 'folder',
+            outputPath,
+            version: '1.2.3',
+            vendorDependencies: false
+        });
+
+        assert.strictEqual(outcome.result.isOk, true);
+        assert.partialDeepStrictEqual(
+            JSON.parse(await readFile(path.join(outputPath, 'package.json'), 'utf8')),
+            {
+                name: 'third',
+                version: '1.2.3',
+                peerDependencies: { second: '1.2.3' }
+            }
+        );
+    });
+});

--- a/source/packtory/packtory-pack.test.ts
+++ b/source/packtory/packtory-pack.test.ts
@@ -98,7 +98,12 @@ suite('packtory-pack', function () {
         });
 
         test('packs the requested package with resolved bundle metadata when vendoring is disabled', async function () {
-            const { dependencies, fakes } = createDependencies({});
+            const bundlePeerDependency = { name: 'peer' };
+            const { dependencies, fakes } = createDependencies({
+                resolveResult: Result.ok([
+                    makeResolvedPackage({ bundlePeerDependencies: [ bundlePeerDependency ] })
+                ])
+            });
             const runPack = createRunPackValidated(dependencies);
 
             const result = await runPack(validatedConfig, baseOptions, fakes.resolveAndLinkAll);
@@ -109,7 +114,7 @@ suite('packtory-pack', function () {
                 version: '0.0.0',
                 mainPackageJson: { type: 'module' },
                 bundleDependencies: [],
-                bundlePeerDependencies: [],
+                bundlePeerDependencies: [ { ...bundlePeerDependency, version: '0.0.0' } ],
                 additionalPackageJsonAttributes: {},
                 allowMutableSpecifiers: []
             });

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -44,9 +44,23 @@ export type PackRunDependencies = {
 
 const manifestSchema = z.record(z.string(), z.unknown());
 
+type VersionedDependency = {
+    readonly name: string;
+    readonly version: string;
+};
+
 function shouldPreservePackageJsonArrayOrder(path: readonly string[]): boolean {
     const [ topLevelKey ] = path;
     return topLevelKey === 'imports' || topLevelKey === 'exports';
+}
+
+function versionedDependenciesForPack(
+    dependencies: readonly { readonly name: string; }[],
+    version: string
+): readonly VersionedDependency[] {
+    return dependencies.map(function (dependency) {
+        return { name: dependency.name, version };
+    });
 }
 
 function buildVersionedBundle(
@@ -58,8 +72,8 @@ function buildVersionedBundle(
         bundle: target.analyzedBundle,
         version,
         mainPackageJson: target.resolveOptions.mainPackageJson,
-        bundleDependencies: [],
-        bundlePeerDependencies: [],
+        bundleDependencies: versionedDependenciesForPack(target.resolveOptions.bundleDependencies, version),
+        bundlePeerDependencies: versionedDependenciesForPack(target.resolveOptions.bundlePeerDependencies, version),
         additionalPackageJsonAttributes: target.resolveOptions.additionalPackageJsonAttributes,
         allowMutableSpecifiers: target.resolveOptions.allowMutableSpecifiers
     });

--- a/source/test-libraries/packtory-pack-test-support.ts
+++ b/source/test-libraries/packtory-pack-test-support.ts
@@ -32,6 +32,7 @@ export type FakeVersionedBundle = {
 type ResolvedPackageOverrides = {
     readonly name?: string;
     readonly bundleDependencies?: readonly unknown[];
+    readonly bundlePeerDependencies?: readonly unknown[];
     readonly externalDependencyNames?: readonly string[];
     readonly bundleDependencyNames?: readonly string[];
     readonly sourcesFolder?: string;
@@ -104,7 +105,7 @@ export function makeResolvedPackage(overrides: ResolvedPackageOverrides = {}): R
             additionalPackageJsonAttributes: {},
             allowMutableSpecifiers: [],
             bundleDependencies: valueOrFallback(overrides.bundleDependencies, []),
-            bundlePeerDependencies: [],
+            bundlePeerDependencies: valueOrFallback(overrides.bundlePeerDependencies, []),
             roots: { main: { js: 'index.js' } },
             surface: { kind: 'implicit' },
             sourcesFolder: valueOrFallback(overrides.sourcesFolder, '/repo')


### PR DESCRIPTION
The `pack` path now versions configured bundle dependencies and bundle peer dependencies before assembling package metadata, matching publish behavior.

This preserves peer dependency metadata in packed artifacts and adds pack-level regression coverage for folder output.