### PR TITLE
Fix changelog attribution for deleted source files

### DIFF
--- a/integration-tests/github-api/changelog-github-api.test.ts
+++ b/integration-tests/github-api/changelog-github-api.test.ts
@@ -416,6 +416,23 @@ suite('changelog GitHub API integration', function () {
     );
 
     test(
+        'attributes deleted historical repository sources when package source roots point at generated output',
+        withDeterministicGitHubApiServer(
+            historicalRuleScenario(),
+            async function (githubApi) {
+                const changelog = await generateChangelog(
+                    githubApi,
+                    [ rulePackagePlan([ 'source/rules/current-rule.ts' ]) ],
+                    new Map([ [ 'pkg-a', [ 'target/build/source' ] ] ])
+                );
+
+                assert.match(changelog.groupedMarkdown, /Fix subsumed rule behavior/u);
+                assert.match(changelog.groupedMarkdown, /Subsume old rule into new rule/u);
+            }
+        )
+    );
+
+    test(
         'attributes pure deleted source files from substantive releases to the package source root',
         withDeterministicGitHubApiServer(
             historicalRuleScenario(),

--- a/source/packtory/changelog-source-file-history.test.ts
+++ b/source/packtory/changelog-source-file-history.test.ts
@@ -149,6 +149,120 @@ function registerTargetAttachedDeleteTests(): void {
         assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts', 'source/rules/subsumed-rule.ts' ]);
     });
 
+    test('adds deleted repository source files from derived changelog source roots', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/current-rule.ts',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/subsumed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ]),
+            [ 'target/build/source' ]
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts', 'source/rules/subsumed-rule.ts' ]);
+    });
+
+    test('keeps dependency-only root matching limited to configured source roots', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ], 'dependency-only'),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/current-rule.ts',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/subsumed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ]),
+            [ 'target/build/source' ]
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts' ]);
+    });
+
+    test('does not derive the repository root from root-level changelog source files', function () {
+        const result = expand(
+            packagePlan([ 'README.md' ]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/rules/removed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ]),
+            [ 'target/build/source' ]
+        );
+
+        assert.deepStrictEqual(result, [ 'README.md' ]);
+    });
+
+    test('does not derive ancestor folders from nested changelog source files', function () {
+        const result = expand(
+            packagePlan([ 'source/rules/current-rule.ts' ]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'source/other/removed-rule.ts',
+                        status: 'deleted'
+                    })
+                ]
+            ]),
+            [ 'target/build/source' ]
+        );
+
+        assert.deepStrictEqual(result, [ 'source/rules/current-rule.ts' ]);
+    });
+
+    test('keeps configured generated source roots for deleted generated files', function () {
+        const result = expand(
+            packagePlan([ 'target/build/source/current-rule.js' ]),
+            changedFilesByPullRequest([
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'target/build/source/current-rule.js',
+                        status: 'modified'
+                    })
+                ],
+                [
+                    1,
+                    pullRequestChangedFileFactory.build({
+                        path: 'target/build/source/subsumed-rule.js',
+                        status: 'deleted'
+                    })
+                ]
+            ]),
+            [ 'target/build/source' ]
+        );
+
+        assert.deepStrictEqual(result, [
+            'target/build/source/current-rule.js',
+            'target/build/source/subsumed-rule.js'
+        ]);
+    });
+
     test('does not add deleted files from pull requests that do not touch selected source files', function () {
         const result = expand(
             packagePlan([ 'source/rules/current-rule.ts' ], 'dependency-only'),

--- a/source/packtory/changelog-source-file-history.ts
+++ b/source/packtory/changelog-source-file-history.ts
@@ -24,6 +24,32 @@ function isDeletedFile(file: PullRequestChangedFile): boolean {
     return file.status === 'removed' || file.status === 'deleted';
 }
 
+function sourceRootFromSourceFile(filePath: string): string {
+    return filePath.split('/').slice(0, -1).join('/');
+}
+
+function collectDerivedSourceFileRoots(packagePlan: ReleasePlanPackage): readonly string[] {
+    const sourceFileRoots = new Set<string>();
+    if (packagePlan.releaseClassification !== releaseAnalysisClassification.dependencyOnly) {
+        for (const sourceFile of packagePlan.changelogSourceFiles) {
+            const sourceRoot = sourceRootFromSourceFile(normalizeRepositoryPath(sourceFile));
+            if (sourceRoot !== '') {
+                sourceFileRoots.add(sourceRoot);
+            }
+        }
+    }
+    return Array.from(sourceFileRoots);
+}
+
+function historicalSourceFileRoots(input: ChangelogSourceFileHistoryInput): readonly string[] {
+    return Array.from(
+        new Set([
+            ...input.sourceFileRoots.map(normalizeRepositoryPath),
+            ...collectDerivedSourceFileRoots(input.packagePlan)
+        ])
+    );
+}
+
 function isHistoricalPath(filePath: string, roots: readonly string[]): boolean {
     return roots.some(function (root) {
         return root === '' || filePath.startsWith(`${root}/`);
@@ -115,7 +141,7 @@ function shouldAttributePureDeletes(packagePlan: ReleasePlanPackage): boolean {
 }
 
 export function expandChangelogSourceFilesForHistory(input: ChangelogSourceFileHistoryInput): readonly string[] {
-    const sourceFileRoots = input.sourceFileRoots.map(normalizeRepositoryPath);
+    const sourceFileRoots = historicalSourceFileRoots(input);
     const changedFiles = Array.from(input.changedFilesByPullRequest.values()).flat();
     const renamedSourceFiles = expandRenameHistory(
         new Set(input.packagePlan.changelogSourceFiles.map(normalizeRepositoryPath)),


### PR DESCRIPTION
Historical changelog attribution now combines configured source roots with repository-relative roots derived from `changelogSourceFiles` for substantive releases. This keeps deleted source paths attributed even when a package is built from `target/build/source`, while dependency-only releases keep using only configured roots.