### PR TITLE
Clean up waiting `release-pr maintain` workflow runs

### DIFF
--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -56,6 +56,34 @@ const defaultRoutes: ReadonlyMap<string, RouteResponse> = new Map([
                 { conclusion: 'action_required', database_id: 10, event: 'pull_request', head_sha: 'release-head' },
                 { conclusion: 'action_required', event: 'pull_request', head_sha: 'release-head' },
                 { conclusion: 'action_required', database_id: 12, event: 'pull_request', head_sha: 'other-head' },
+                {
+                    conclusion: null,
+                    database_id: 14,
+                    event: 'pull_request',
+                    head_sha: 'release-head',
+                    status: 'waiting'
+                },
+                {
+                    conclusion: null,
+                    database_id: 15,
+                    event: 'pull_request',
+                    head_sha: 'release-head',
+                    status: 'pending'
+                },
+                {
+                    conclusion: null,
+                    database_id: 17,
+                    event: 'pull_request',
+                    head_sha: 'release-head',
+                    status: 'requested'
+                },
+                {
+                    conclusion: null,
+                    database_id: 16,
+                    event: 'workflow_dispatch',
+                    head_sha: 'release-head',
+                    status: 'waiting'
+                },
                 { conclusion: 'success', database_id: 13, event: 'pull_request', head_sha: 'release-head' },
                 { conclusion: 'success', database_id: 11, event: 'workflow_dispatch', head_sha: 'release-head' }
             ]
@@ -70,6 +98,9 @@ const defaultRoutes: ReadonlyMap<string, RouteResponse> = new Map([
         });
     } ],
     [ routeKey('DELETE', '/repos/owner/repo/actions/runs/10'), emptyResponse ],
+    [ routeKey('DELETE', '/repos/owner/repo/actions/runs/14'), emptyResponse ],
+    [ routeKey('DELETE', '/repos/owner/repo/actions/runs/15'), emptyResponse ],
+    [ routeKey('DELETE', '/repos/owner/repo/actions/runs/17'), emptyResponse ],
     [ routeKey('DELETE', `/repos/owner/repo/git/refs/${encodeURIComponent('heads/release/packtory')}`), emptyResponse ],
     [ routeKey('GET', '/repos/owner/repo/actions/runs/11'), function () {
         return jsonResponse({ conclusion: 'success' });
@@ -382,7 +413,12 @@ suite('release-pr-github-client', function () {
                 .map(function (record) {
                     return record.path;
                 }),
-            [ '/repos/owner/repo/actions/runs/10' ]
+            [
+                '/repos/owner/repo/actions/runs/10',
+                '/repos/owner/repo/actions/runs/14',
+                '/repos/owner/repo/actions/runs/15',
+                '/repos/owner/repo/actions/runs/17'
+            ]
         );
         assert.ok(records.some(function (record) {
             return (

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -161,6 +161,7 @@ type GitHubRestClientConstructor = ReturnType<
 type GitHubRestClientInstance = InstanceType<GitHubRestClientConstructor>;
 
 const missingGitHubResourceStatusCode = 404;
+const approvalWaitingWorkflowRunStatuses: ReadonlySet<string | null> = new Set([ 'pending', 'requested', 'waiting' ]);
 
 function labelNames(labels: readonly RawLabel[]): readonly string[] {
     return labels
@@ -194,6 +195,20 @@ function createGitHubRestClient(
             headers: requestContext.headers
         }
     });
+}
+
+function releasePullRequestRunNeedsApproval(
+    run: RawWorkflowRun,
+    input: DeleteActionRequiredPullRequestRunsInput
+): boolean {
+    return (
+        run.event === 'pull_request' &&
+        run.head_sha === input.headSha &&
+        (
+            run.conclusion === 'action_required' ||
+            approvalWaitingWorkflowRunStatuses.has(run.status)
+        )
+    );
 }
 
 export function createReleasePullRequestGitHubClient(context: GitHubClientContext): ReleasePullRequestGitHubClient {
@@ -365,8 +380,8 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
                     per_page: 100
                 })
             );
-            const blockedRuns = response.data.workflow_runs.filter(function (run) {
-                return run.head_sha === input.headSha && run.conclusion === 'action_required';
+            const blockedRuns = (response.data.workflow_runs as readonly RawWorkflowRun[]).filter(function (run) {
+                return releasePullRequestRunNeedsApproval(run, input);
             });
             const blockedRunIds = blockedRuns
                 .map(readWorkflowRunId)


### PR DESCRIPTION
Expands release PR CI cleanup so matching pull request workflow runs still waiting for approval are deleted before dispatching replacement CI.

The GitHub client still scopes cleanup to the release branch head and `pull_request` runs, and tests cover `pending`, `requested`, and `waiting` statuses.