### PR TITLE
Treat missing `release-pr` branch cleanup as complete

### DIFF
--- a/source/command-line-interface/runner/github-api-request.ts
+++ b/source/command-line-interface/runner/github-api-request.ts
@@ -2,6 +2,10 @@ function defaultGitHubApiVersion(): string {
     return '2022-11-28';
 }
 
+const missingGitHubResourceStatusCode = 404;
+const missingGitHubReferenceStatusCode = 422;
+const missingGitHubReferenceMessage = 'Reference does not exist';
+
 function readReflectedProperty(value: unknown, property: string): unknown {
     return Reflect.get(new Object(value), property) as unknown;
 }
@@ -65,6 +69,18 @@ function createGitHubRequestError(error: unknown): Error {
     );
 }
 
+function isMissingGitHubResourceError(error: unknown): boolean {
+    return readGitHubErrorStatus(error) === missingGitHubResourceStatusCode;
+}
+
+export function isMissingGitHubReferenceError(error: unknown): boolean {
+    if (isMissingGitHubResourceError(error)) {
+        return true;
+    }
+    return readGitHubErrorStatus(error) === missingGitHubReferenceStatusCode &&
+        readGitHubErrorDetails(error).includes(missingGitHubReferenceMessage);
+}
+
 export function createGitHubJsonRequestHeaders(
     token: string | undefined,
     userAgent: string
@@ -91,16 +107,25 @@ export async function resolveGitHubResponse<T>(request: Promise<T>): Promise<T> 
     }
 }
 
-export async function resolveOptionalGitHubResponse<T>(
+export async function resolveGitHubResponseUnless<T>(
     request: Promise<T>,
-    missingStatusCode: number
+    isAllowedFailure: (error: unknown) => boolean
 ): Promise<T | undefined> {
     try {
         return await request;
     } catch (error) {
-        if (readGitHubErrorStatus(error) === missingStatusCode) {
+        if (isAllowedFailure(error)) {
             return undefined;
         }
         throw createGitHubRequestError(error);
     }
+}
+
+export async function resolveOptionalGitHubResponse<T>(
+    request: Promise<T>,
+    missingStatusCode: number
+): Promise<T | undefined> {
+    return resolveGitHubResponseUnless(request, function (error) {
+        return readGitHubErrorStatus(error) === missingStatusCode;
+    });
 }

--- a/source/command-line-interface/runner/release-pr-branch-commit.ts
+++ b/source/command-line-interface/runner/release-pr-branch-commit.ts
@@ -1,5 +1,10 @@
 import { createHash } from 'node:crypto';
-import { resolveGitHubResponse, resolveOptionalGitHubResponse } from './github-api-request.ts';
+import {
+    isMissingGitHubReferenceError,
+    resolveGitHubResponse,
+    resolveGitHubResponseUnless,
+    resolveOptionalGitHubResponse
+} from './github-api-request.ts';
 
 type CreateCommitFileAddition = {
     readonly contents: string;
@@ -144,14 +149,14 @@ export function createReleasePullRequestCommitClient(
     }
 
     async function deleteBranchRef(branch: string): Promise<void> {
-        await resolveOptionalGitHubResponse(
+        await resolveGitHubResponseUnless(
             dependencies.git.deleteRef({
                 headers: dependencies.headers,
                 owner: dependencies.owner,
                 repo: dependencies.repo,
                 ref: `heads/${branch}`
             }),
-            missingGitHubResourceStatusCode
+            isMissingGitHubReferenceError
         );
     }
 

--- a/source/command-line-interface/runner/release-pr-github-client.test.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.test.ts
@@ -17,7 +17,10 @@ import {
     type RecordedRequest,
     type RouteResponse
 } from '../../test-libraries/release-pr-github-client-test-support.ts';
-import { createReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+import {
+    createReleasePullRequestGitHubClient,
+    type ReleasePullRequestGitHubClient
+} from './release-pr-github-client.ts';
 
 const defaultRoutes: ReadonlyMap<string, RouteResponse> = new Map([
     [ routeKey('GET', '/repos/owner/repo/pulls'), function () {
@@ -135,6 +138,7 @@ const defaultRoutes: ReadonlyMap<string, RouteResponse> = new Map([
         return jsonResponse({ commit: { sha: 'main-head' } });
     } ]
 ]);
+const releaseBranchRefPath = `/repos/owner/repo/git/refs/${encodeURIComponent('heads/release/packtory')}`;
 
 function createFetch(capturedRequests: CapturedRequests): typeof globalThis.fetch {
     return createRecordedRouteFetch(capturedRequests, defaultRoutes);
@@ -143,13 +147,20 @@ function createFetch(capturedRequests: CapturedRequests): typeof globalThis.fetc
 function assertBranchWasDeleted(records: readonly RecordedRequest[]): void {
     assert.strictEqual(
         records.some(function (record) {
-            return (
-                record.method === 'DELETE' &&
-                record.path === `/repos/owner/repo/git/refs/${encodeURIComponent('heads/release/packtory')}`
-            );
+            return record.method === 'DELETE' && record.path === releaseBranchRefPath;
         }),
         true
     );
+}
+
+function createDeleteReleaseBranchClient(
+    capturedRequests: CapturedRequests,
+    response: RouteResponse
+): ReleasePullRequestGitHubClient {
+    return createClient(createRecordedRouteFetch(
+        capturedRequests,
+        new Map([ [ routeKey('DELETE', releaseBranchRefPath), response ] ])
+    ));
 }
 
 function countReleasePullRequestLookups(records: readonly RecordedRequest[]): number {
@@ -228,12 +239,67 @@ suite('release-pr-github-client', function () {
             hasRequestWithBody(capturedRequests.records, 'PATCH', '/repos/owner/repo/pulls/1', '"state":"closed"'),
             true
         );
-        assertBranchWasDeleted(capturedRequests.records);
         assert.strictEqual(
             hasRequestWithBody(capturedRequests.records, 'PUT', '/repos/owner/repo/issues/1/labels', '"release"'),
             true
         );
         assert.strictEqual(readHeader(capturedRequests.records[0]?.headers, 'user-agent'), 'packtory-release-pr');
+    });
+
+    suite('release branch deletion', function () {
+        test('treats not found release branch deletion as a no-op', async function () {
+            const capturedRequests = captureRequests();
+            const client = createDeleteReleaseBranchClient(
+                capturedRequests,
+                function () {
+                    return emptyResponse(404);
+                }
+            );
+
+            await client.deleteBranch('release/packtory');
+            assertBranchWasDeleted(capturedRequests.records);
+        });
+
+        test('treats missing reference release branch deletion as a no-op', async function () {
+            const capturedRequests = captureRequests();
+            const client = createDeleteReleaseBranchClient(
+                capturedRequests,
+                function () {
+                    return jsonResponse({ message: 'Reference does not exist' }, 422);
+                }
+            );
+
+            await client.deleteBranch('release/packtory');
+            assertBranchWasDeleted(capturedRequests.records);
+        });
+
+        test('fails release branch deletion for other GitHub API errors', async function () {
+            const client = createDeleteReleaseBranchClient(
+                captureRequests(),
+                function () {
+                    return jsonResponse({ message: 'Branch cannot be deleted' }, 422);
+                }
+            );
+
+            await assert.rejects(
+                client.deleteBranch('release/packtory'),
+                /GitHub API request failed \(422\) for \/repos\/owner\/repo\/git\/refs\/heads%2Frelease%2Fpacktory/u
+            );
+        });
+
+        test('fails release branch deletion for missing reference messages with other statuses', async function () {
+            const client = createDeleteReleaseBranchClient(
+                captureRequests(),
+                function () {
+                    return jsonResponse({ message: 'Reference does not exist' }, 500);
+                }
+            );
+
+            await assert.rejects(
+                client.deleteBranch('release/packtory'),
+                /GitHub API request failed \(500\) for \/repos\/owner\/repo\/git\/refs\/heads%2Frelease%2Fpacktory/u
+            );
+        });
     });
 
     test('writes statuses and dispatches workflows', async function () {

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -4,8 +4,9 @@ import { paginateRest } from '@octokit/plugin-paginate-rest';
 import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
 import {
     createGitHubJsonRequestHeaders,
+    isMissingGitHubReferenceError,
     resolveGitHubResponse,
-    resolveOptionalGitHubResponse
+    resolveGitHubResponseUnless
 } from './github-api-request.ts';
 import { createReleasePullRequestCommitClient, type CreateCommitOnBranchInput } from './release-pr-branch-commit.ts';
 import {
@@ -160,7 +161,6 @@ type GitHubRestClientConstructor = ReturnType<
 >;
 type GitHubRestClientInstance = InstanceType<GitHubRestClientConstructor>;
 
-const missingGitHubResourceStatusCode = 404;
 const approvalWaitingWorkflowRunStatuses: ReadonlySet<string | null> = new Set([ 'pending', 'requested', 'waiting' ]);
 
 function labelNames(labels: readonly RawLabel[]): readonly string[] {
@@ -394,12 +394,12 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
         },
 
         async deleteBranch(branch) {
-            await resolveOptionalGitHubResponse(
+            await resolveGitHubResponseUnless(
                 octokit.rest.git.deleteRef({
                     ...requestContext,
                     ref: `heads/${branch}`
                 }),
-                missingGitHubResourceStatusCode
+                isMissingGitHubReferenceError
             );
         },
 

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -94,7 +94,7 @@ packtory <command> [options]
 
 - `release-pr maintain --no-dry-run` prepares changelog updates with the shared release planning logic, creates a GitHub-signed commit on `releasePullRequest.branch` with the GitHub API, creates or updates the release PR, and replaces its labels with `releasePullRequest.label`.
 - Release PR commits are authored through the GitHub credential from `GH_TOKEN` or `GITHUB_TOKEN`, so GitHub can mark them verified when the credential supports signed API commits. This allows release PRs to merge into branches that require signed commits without local Git signing setup.
-- If release planning produces no changelog content, `maintain` closes the open release PR for that branch and deletes the remote release branch.
+- If release planning produces no changelog content, `maintain` closes the open release PR for that branch and deletes the remote release branch. A missing remote release branch is already clean and does not fail maintenance.
 - Release PR settings live in top-level `releasePullRequest`. Defaults are `branch: 'release/packtory'`, `label: 'release'`, `title: 'Prepare release'`, `commitSubject: 'Release packages'`, `defaultBranch: 'main'`, and `automationAuthor: 'github-actions[bot]'`.
 - The release PR policy derives allowed files from `changelog.outputs`. Repository and package changelog files are allowed. GitHub Release outputs are ignored because they do not write repository files.
 - `release-pr validate` accepts normal PRs without a release label. Release-labeled PRs must match the configured branch, title, author, commit subject, base head, and allowed files. Merge groups must not batch release PRs with other PRs.


### PR DESCRIPTION
When release planning finds no remaining changelog content, Packtory now treats GitHub missing ref responses for release branch deletion as already clean. The GitHub response wrapper still rethrows unrelated API failures, and the release PR client tests pin both the no-op and failure paths.