### PR TITLE
Remove test type suppression comments

### DIFF
--- a/source/command-line-interface/runner/preview-handler.test.ts
+++ b/source/command-line-interface/runner/preview-handler.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { Result } from 'true-myth';
+import { configError } from '../../packtory/packtory-results.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
 import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import { createConfigLoaderStub, createSpinnerRendererStub } from '../../test-libraries/handler-stub-fixtures.ts';
@@ -17,9 +19,9 @@ function emptyOutcome(overrides: Partial<BuildOutcome> = {}): BuildOutcome {
         getReport() {
             return undefined;
         },
-        result: { isOk: true, isErr: false, value: [] },
+        result: Result.ok([]),
         ...overrides
-    } as unknown as BuildOutcome;
+    };
 }
 
 suite('preview-handler', function () {
@@ -58,8 +60,7 @@ suite('preview-handler', function () {
             },
             packtory: packtoryStub(
                 emptyOutcome({
-                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the preview-handler only inspects isOk/isErr; full Result shape is irrelevant here
-                    result: { isOk: false, isErr: true, error: { type: 'config', issues: [] } } as never
+                    result: Result.err(configError([]))
                 })
             ),
             spinnerRenderer: createSpinnerRendererStub(),

--- a/source/command-line-interface/runner/publish-handler.test.ts
+++ b/source/command-line-interface/runner/publish-handler.test.ts
@@ -1,16 +1,18 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
+import { Result } from 'true-myth';
 import { stagedForApproval } from '../../bundle-emitter/publication-outcome.ts';
+import { configError, publishPartialFailure } from '../../packtory/packtory-results.ts';
 import type { Packtory } from '../../packtory/packtory.ts';
-import { createFakeFileManager } from '../../test-libraries/fake-file-manager.ts';
 import {
     buildOutcome,
     configLoaderStub,
+    fileManagerStub,
     packtoryStub,
     spinnerRendererStub
 } from '../../test-libraries/cli-handler-fixtures.ts';
-import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
+import { createBuildResultFixture } from '../../test-libraries/preview-fixtures.ts';
 import { runPublishHandler } from './publish-handler.ts';
 
 type BuildOutcome = Awaited<ReturnType<Packtory['buildAndPublishAll']>>;
@@ -37,7 +39,7 @@ async function captureMessages(
         packtory: packtoryStub(outcome),
         spinnerRenderer: spinnerRendererStub(),
         configLoader: configLoaderStub(),
-        fileManager: createFakeFileManager(),
+        fileManager: fileManagerStub(),
         flags
     });
     return { code, messages };
@@ -48,8 +50,7 @@ suite('publish-handler', function () {
         const { code, messages } = await captureMessages(
             { noDryRun: true, stage: false, reportJson: false, reportHtml: false },
             buildOutcome({
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/value matter to the handler
-                result: { isOk: true, isErr: false, value: [ { name: 'pkg-a' } ] } as never
+                result: Result.ok([ createBuildResultFixture() ])
             })
         );
 
@@ -63,18 +64,11 @@ suite('publish-handler', function () {
         const { code, messages } = await captureMessages(
             { noDryRun: true, stage: true, reportJson: false, reportHtml: false },
             buildOutcome({
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only handler-visible fields matter here
-                result: {
-                    isOk: true,
-                    isErr: false,
-                    value: [
-                        {
-                            bundle: { name: 'pkg-a', version: '1.0.0' },
-                            publication: stagedForApproval('stage-123'),
-                            status: 'new-version'
-                        }
-                    ]
-                } as never
+                result: Result.ok([
+                    createBuildResultFixture({
+                        publication: stagedForApproval('stage-123')
+                    })
+                ])
             })
         );
 
@@ -91,8 +85,7 @@ suite('publish-handler', function () {
         const { code, messages } = await captureMessages(
             { noDryRun: true, stage: false, reportJson: false, reportHtml: false },
             buildOutcome({
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only isErr/error.type matter to the handler
-                result: { isOk: false, isErr: true, error: { type: 'config', issues: [ 'missing field' ] } } as never
+                result: Result.err(configError([ 'missing field' ]))
             })
         );
 
@@ -106,21 +99,16 @@ suite('publish-handler', function () {
         const { code, messages } = await captureMessages(
             { noDryRun: true, stage: true, reportJson: false, reportHtml: false },
             buildOutcome({
-                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- only handler-visible fields matter here
-                result: {
-                    isOk: false,
-                    isErr: true,
-                    error: {
-                        type: 'partial',
+                result: Result.err(
+                    publishPartialFailure({
                         succeeded: [
-                            {
-                                bundle: { name: 'pkg-a', version: '1.0.0' },
+                            createBuildResultFixture({
                                 publication: stagedForApproval('stage-123')
-                            }
+                            })
                         ],
                         failures: [ new Error('boom') ]
-                    }
-                } as never
+                    })
+                )
             })
         );
 
@@ -146,7 +134,7 @@ suite('publish-handler', function () {
 
     test('runPublishHandler stops spinners exactly once when the build throws', async function () {
         const stopAllSpy: SinonSpy = fake();
-        const spinner = { stopAll: stopAllSpy } as unknown as TerminalSpinnerRenderer;
+        const spinner = { ...spinnerRendererStub(), stopAll: stopAllSpy };
         const packtory = { buildAndPublishAll: fake.rejects(new Error('boom')) } as unknown as Packtory;
 
         try {
@@ -157,7 +145,7 @@ suite('publish-handler', function () {
                 packtory,
                 spinnerRenderer: spinner,
                 configLoader: configLoaderStub(),
-                fileManager: createFakeFileManager(),
+                fileManager: fileManagerStub(),
                 flags: { noDryRun: true, stage: false, reportJson: false, reportHtml: false }
             });
             assert.fail('Expected runPublishHandler to throw');

--- a/source/config/package-config.test.ts
+++ b/source/config/package-config.test.ts
@@ -1,33 +1,30 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { getBundledDependencies, type PackageConfig } from './package-config.ts';
-
-const stubRoots = { main: { js: 'index.js' } } as unknown as PackageConfig['roots'];
+import { packageConfigFixture } from '../test-libraries/config-fixtures.ts';
+import { getBundledDependencies } from './package-config.ts';
 
 suite('package-config', function () {
     test('getBundledDependencies returns an empty list when both fields are absent', function () {
-        const config = { name: 'pkg', roots: stubRoots } as PackageConfig;
+        const config = packageConfigFixture({ name: 'pkg' });
         assert.deepStrictEqual(getBundledDependencies(config), []);
     });
 
     test('getBundledDependencies returns just the bundleDependencies when only it is present', function () {
-        const config = { name: 'pkg', roots: stubRoots, bundleDependencies: [ 'dep-a' ] } as PackageConfig;
+        const config = packageConfigFixture({ name: 'pkg', bundleDependencies: [ 'dep-a' ] });
         assert.deepStrictEqual(getBundledDependencies(config), [ 'dep-a' ]);
     });
 
     test('getBundledDependencies returns just the bundlePeerDependencies when only it is present', function () {
-        const config = { name: 'pkg', roots: stubRoots, bundlePeerDependencies: [ 'peer-a' ] } as PackageConfig;
+        const config = packageConfigFixture({ name: 'pkg', bundlePeerDependencies: [ 'peer-a' ] });
         assert.deepStrictEqual(getBundledDependencies(config), [ 'peer-a' ]);
     });
 
     test('getBundledDependencies concatenates bundleDependencies and bundlePeerDependencies in property order', function () {
-        const config = {
+        const config = packageConfigFixture({
             name: 'pkg',
-            roots: stubRoots,
             bundleDependencies: [ 'a' ],
             bundlePeerDependencies: [ 'b' ]
-        } as PackageConfig;
+        });
 
         assert.deepStrictEqual(getBundledDependencies(config), [ 'a', 'b' ]);
     });

--- a/source/config/pre-graph-validation.test.ts
+++ b/source/config/pre-graph-validation.test.ts
@@ -1,17 +1,10 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test inputs use `as never` / `as PacktoryConfigWithoutRegistry` to shape narrow partial configs */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { packageConfigFixture, publicPublishSettings } from '../test-libraries/config-fixtures.ts';
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { collectPreGraphIssues, packageListToRecord } from './pre-graph-validation.ts';
 
-function pkg(overrides: Partial<PackageConfig>): PackageConfig {
-    return {
-        name: 'pkg-a',
-        roots: { main: { js: 'index.js' } },
-        sourcesFolder: 'src',
-        ...overrides
-    };
-}
+const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 suite('pre-graph-validation', function () {
     test('packageListToRecord indexes packages by name', function () {
@@ -22,15 +15,15 @@ suite('pre-graph-validation', function () {
     });
 
     test('collectPreGraphIssues returns no issues for a well-formed single-package config with publishSettings on the package', function () {
-        const config = {
-            packages: [ pkg({ publishSettings: { access: 'public' } as never }) ]
-        } as PacktoryConfigWithoutRegistry;
+        const config: PacktoryConfigWithoutRegistry = {
+            packages: [ pkg({ publishSettings: publicPublishSettings }) ]
+        };
 
         assert.deepStrictEqual(collectPreGraphIssues(config), []);
     });
 
     test('collectPreGraphIssues reports a missing publishSettings placement', function () {
-        const config = { packages: [ pkg({}) ] } as PacktoryConfigWithoutRegistry;
+        const config: PacktoryConfigWithoutRegistry = { packages: [ pkg({}) ] };
 
         assert.ok(
             collectPreGraphIssues(config).includes(
@@ -43,11 +36,11 @@ suite('pre-graph-validation', function () {
         const config = {
             packages: [
                 pkg({
-                    publishSettings: { access: 'public' } as never,
+                    publishSettings: publicPublishSettings,
                     bundleDependencies: [ 'missing' ]
                 })
             ]
-        } as PacktoryConfigWithoutRegistry;
+        };
 
         assert.ok(
             collectPreGraphIssues(config).includes('Bundle dependency "missing" referenced in "pkg-a" does not exist')
@@ -58,11 +51,11 @@ suite('pre-graph-validation', function () {
         const config = {
             packages: [
                 pkg({
-                    publishSettings: { access: 'public' } as never,
+                    publishSettings: publicPublishSettings,
                     roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } }
                 })
             ]
-        } as PacktoryConfigWithoutRegistry;
+        };
 
         assert.ok(
             collectPreGraphIssues(config).includes(

--- a/source/config/settings-validation.test.ts
+++ b/source/config/settings-validation.test.ts
@@ -1,17 +1,14 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test inputs use `as never` to shape narrow partial configs without spelling out every schema field */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import {
+    packageConfigFixture,
+    publicPublishSettings,
+    publicPublishSettingsAllowingScripts
+} from '../test-libraries/config-fixtures.ts';
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { validateAllowScriptsConsistency, validatePublishSettingsArePlaced } from './settings-validation.ts';
 
-function pkg(overrides: Partial<PackageConfig>): PackageConfig {
-    return {
-        name: 'pkg-a',
-        roots: { main: { js: 'index.js' } },
-        sourcesFolder: 'src',
-        ...overrides
-    };
-}
+const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 function config(overrides: Partial<PacktoryConfigWithoutRegistry>): PacktoryConfigWithoutRegistry {
     return { packages: [], ...overrides };
@@ -21,7 +18,7 @@ suite('settings-validation', function () {
     test('validatePublishSettingsArePlaced returns no issues when commonPackageSettings.publishSettings is provided', function () {
         const result = validatePublishSettingsArePlaced(
             config({
-                commonPackageSettings: { publishSettings: { access: 'public' } } as never,
+                commonPackageSettings: { publishSettings: publicPublishSettings },
                 packages: [ pkg({}) ]
             })
         );
@@ -33,8 +30,8 @@ suite('settings-validation', function () {
         const result = validatePublishSettingsArePlaced(
             config({
                 packages: [
-                    pkg({ publishSettings: { access: 'public' } as never }),
-                    pkg({ name: 'pkg-b', publishSettings: { access: 'public' } as never })
+                    pkg({ publishSettings: publicPublishSettings }),
+                    pkg({ name: 'pkg-b', publishSettings: publicPublishSettings })
                 ]
             })
         );
@@ -45,7 +42,7 @@ suite('settings-validation', function () {
     test('validatePublishSettingsArePlaced reports when publishSettings is missing from a package and from commonPackageSettings', function () {
         const result = validatePublishSettingsArePlaced(
             config({
-                packages: [ pkg({ publishSettings: { access: 'public' } as never }), pkg({ name: 'pkg-b' }) ]
+                packages: [ pkg({ publishSettings: publicPublishSettings }), pkg({ name: 'pkg-b' }) ]
             })
         );
 
@@ -64,7 +61,7 @@ suite('settings-validation', function () {
                 packages: [
                     pkg({
                         additionalPackageJsonAttributes: { scripts: { build: 'tsc' } },
-                        publishSettings: { access: 'public' } as never
+                        publishSettings: publicPublishSettings
                     })
                 ]
             })
@@ -81,7 +78,7 @@ suite('settings-validation', function () {
                 packages: [
                     pkg({
                         additionalPackageJsonAttributes: { scripts: { build: 'tsc' } },
-                        publishSettings: { access: 'public', allowScripts: true } as never
+                        publishSettings: publicPublishSettingsAllowingScripts
                     })
                 ]
             })
@@ -94,8 +91,8 @@ suite('settings-validation', function () {
         const result = validateAllowScriptsConsistency(
             config({
                 commonPackageSettings: {
-                    publishSettings: { access: 'public', allowScripts: true }
-                } as never,
+                    publishSettings: publicPublishSettingsAllowingScripts
+                },
                 packages: [ pkg({ additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } }) ]
             })
         );

--- a/source/config/validation.ts
+++ b/source/config/validation.ts
@@ -33,7 +33,7 @@ function validatePreGraphGenerationWithSchema<TConfig extends PacktoryConfigWith
         return Result.err(schemaValidationResult.error.issues);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- callers bind the expected config type for this schema
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- changelog.prLog is pass-through at schema parse time and validated before use
     const packtoryConfig = schemaValidationResult.data as TConfig;
     const packageConfigs = packageListToRecord(packtoryConfig.packages);
 

--- a/source/dead-code-eliminator/cross-bundle/seed-store.test.ts
+++ b/source/dead-code-eliminator/cross-bundle/seed-store.test.ts
@@ -1,7 +1,10 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { Project } from 'ts-morph';
+import { linkedBundle } from '../../test-libraries/bundle-fixtures.ts';
 import { bindingId } from '../reachability/binding-id.ts';
+import { extractTopLevelBindings } from '../reachability/binding-extractor.ts';
+import type { FileBindings } from '../reachability/local-seed-gathering.ts';
 import type { ResolvedTarget } from './bundle-index.ts';
 import { createSeedStore, recordSeed, seedAllBindings } from './seed-store.ts';
 
@@ -39,20 +42,35 @@ suite('seed-store', function () {
         assert.deepStrictEqual(Array.from(withSecondBundle.get('pkg-b') ?? new Set()), [ 'seed-b' ]);
     });
 
-    function targetWithBindings(bindings: readonly { readonly name: string; }[]): ResolvedTarget {
+    function fileBindingsWithExports(exportedNames: readonly string[]): FileBindings {
+        const sourceFilePath = '/b/helpers.ts';
+        const project = new Project({ useInMemoryFileSystem: true });
+        const sourceFile = project.createSourceFile(
+            sourceFilePath,
+            exportedNames
+                .map(function (name) {
+                    return `export const ${name} = 1;`;
+                })
+                .join('\n')
+        );
+        return {
+            sourceFilePath,
+            sourceFile,
+            bindings: extractTopLevelBindings(sourceFile)
+        };
+    }
+
+    function targetWithBindings(exportedNames: readonly string[]): ResolvedTarget {
+        const fileBindings = fileBindingsWithExports(exportedNames);
         return {
             bundleName: 'pkg-b',
             sourceFilePath: '/b/helpers.ts',
             indexedBundle: {
-                bundle: { name: 'pkg-b' } as never,
+                bundle: linkedBundle({ name: 'pkg-b' }),
                 bindingsByFilePath: new Map([
                     [
                         '/b/helpers.ts',
-                        {
-                            sourceFilePath: '/b/helpers.ts',
-                            sourceFile: undefined as never,
-                            bindings
-                        } as never
+                        fileBindings
                     ]
                 ])
             }
@@ -61,7 +79,7 @@ suite('seed-store', function () {
 
     test('seedAllBindings records one seed per binding of the resolved target file', function () {
         const store = createSeedStore();
-        const updated = seedAllBindings(store, targetWithBindings([ { name: 'a' }, { name: 'b' } ]));
+        const updated = seedAllBindings(store, targetWithBindings([ 'a', 'b' ]));
         assert.deepStrictEqual(Array.from(updated.get('pkg-b') ?? new Set()), [
             bindingId('/b/helpers.ts', 'a'),
             bindingId('/b/helpers.ts', 'b')
@@ -74,7 +92,7 @@ suite('seed-store', function () {
             bundleName: 'pkg-b',
             sourceFilePath: '/b/missing.ts',
             indexedBundle: {
-                bundle: { name: 'pkg-b' } as never,
+                bundle: linkedBundle({ name: 'pkg-b' }),
                 bindingsByFilePath: new Map()
             }
         };

--- a/source/dependency-scanner/typescript-compiler-options.test.ts
+++ b/source/dependency-scanner/typescript-compiler-options.test.ts
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import { suite, test } from 'mocha';
 import { ModuleKind, ModuleResolutionKind } from 'ts-morph';
 import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { analyzationOptionsToCompilerOptions } from './typescript-compiler-options.ts';
 
-const stubMainPackageJson = { name: 'pkg', version: '1.0.0', type: 'module' } as never;
+const stubMainPackageJson = { type: 'module' } as const;
 
 suite('typescript-compiler-options', function () {
     test('analyzationOptionsToCompilerOptions returns Node16 module resolution and module kinds', function () {

--- a/source/dependency-scanner/virtual-package-json-host.test.ts
+++ b/source/dependency-scanner/virtual-package-json-host.test.ts
@@ -7,8 +7,7 @@ import type { MainPackageJson } from '../config/package-json.ts';
 import { createDelegatingFileSystemHost } from '../test-libraries/delegating-file-system-host.ts';
 import { createVirtualPackageJsonHost } from './virtual-package-json-host.ts';
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- MainPackageJson is a complex branded type; tests only need a structurally-compatible literal
-const stubMainPackageJson: MainPackageJson = { name: 'pkg', version: '1.0.0', type: 'module' } as never;
+const stubMainPackageJson: MainPackageJson = { type: 'module' };
 
 suite('virtual-package-json-host', function () {
     test('createVirtualPackageJsonHost reports the virtual package.json as existing', async function () {

--- a/source/packtory/options/bundle-dependency-resolution.test.ts
+++ b/source/packtory/options/bundle-dependency-resolution.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { PackageConfig } from '../../config/config.ts';
+import { packageConfigFixture } from '../../test-libraries/config-fixtures.ts';
 import { resolveBundleDependencies } from './bundle-dependency-resolution.ts';
 
-function pkg(overrides: Partial<PackageConfig>): PackageConfig {
-    return { name: 'pkg-a', ...overrides } as unknown as PackageConfig;
-}
+const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 suite('bundle-dependency-resolution', function () {
     test('resolveBundleDependencies returns empty lists when the package has no declared dependencies', function () {

--- a/source/packtory/options/dead-code-elimination-resolution.test.ts
+++ b/source/packtory/options/dead-code-elimination-resolution.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { ValidConfigWithoutRegistryResult } from '../../config/validation.ts';
+import { packageConfigFixture, validConfigWithoutRegistryFixture } from '../../test-libraries/config-fixtures.ts';
 import { resolveDeadCodeEliminationByName } from './dead-code-elimination-resolution.ts';
 
 type PackageInput = {
@@ -16,17 +17,15 @@ function validated(
     packages: readonly PackageInput[],
     common?: CommonInput
 ): ValidConfigWithoutRegistryResult {
-    return {
-        packtoryConfig: {
-            commonPackageSettings: common === undefined ? undefined : { deadCodeElimination: common },
-            packages: packages.map(function (pkg) {
-                return {
-                    name: pkg.name,
-                    deadCodeElimination: pkg.enabled === undefined ? undefined : { enabled: pkg.enabled }
-                };
-            })
-        }
-    } as unknown as ValidConfigWithoutRegistryResult;
+    return validConfigWithoutRegistryFixture({
+        commonPackageSettings: common === undefined ? undefined : { deadCodeElimination: common },
+        packages: packages.map(function (pkg) {
+            return packageConfigFixture({
+                name: pkg.name,
+                deadCodeElimination: pkg.enabled === undefined ? undefined : { enabled: pkg.enabled }
+            });
+        })
+    });
 }
 
 suite('dead-code-elimination-resolution', function () {

--- a/source/packtory/options/prepare-package-options.test.ts
+++ b/source/packtory/options/prepare-package-options.test.ts
@@ -1,18 +1,18 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { PackageConfigsByName, PacktoryConfigWithoutRegistry } from '../../config/config.ts';
+import { packageConfigFixture, packageConfigsByNameFixture } from '../../test-libraries/config-fixtures.ts';
 import { preparePackageOptions } from './prepare-package-options.ts';
 
 function minimalPackageConfigsByName(): PackageConfigsByName {
-    return {
-        'pkg-a': {
+    return packageConfigsByNameFixture([
+        packageConfigFixture({
             name: 'pkg-a',
             sourcesFolder: '/src',
-            mainPackageJson: { name: 'pkg-a', version: '1.0.0', type: 'module' },
+            mainPackageJson: { type: 'module' },
             roots: { main: { js: 'index.js' } }
-        } as never
-    };
+        })
+    ]);
 }
 
 function minimalPacktoryConfig(): PacktoryConfigWithoutRegistry {

--- a/source/packtory/options/setting-resolvers.test.ts
+++ b/source/packtory/options/setting-resolvers.test.ts
@@ -13,7 +13,7 @@ import {
 } from './setting-resolvers.ts';
 
 function pkg(overrides: Partial<PackageConfig>): PackageConfig {
-    return { name: 'pkg-a', ...overrides } as unknown as PackageConfig;
+    return { name: 'pkg-a', roots: {}, ...overrides };
 }
 
 function config(overrides: Partial<PacktoryConfigWithoutRegistry> = {}): PacktoryConfigWithoutRegistry {

--- a/source/packtory/options/surface-resolution.test.ts
+++ b/source/packtory/options/surface-resolution.test.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- tests narrow PackageConfig to the fields resolveSurface actually reads */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { PackageConfig } from '../../config/config.ts';
+import type { PackageInterface } from '../../config/package-interface.ts';
+import { packageConfigFixture } from '../../test-libraries/config-fixtures.ts';
 import { resolveSurface } from './surface-resolution.ts';
 
-function pkg(overrides: Partial<PackageConfig>): PackageConfig {
-    return { name: 'pkg-a', ...overrides } as unknown as PackageConfig;
-}
+const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 suite('surface-resolution', function () {
     test('resolveSurface returns an implicit surface using the only root when there is a single root', function () {
@@ -37,9 +36,10 @@ suite('surface-resolution', function () {
     });
 
     test('resolveSurface returns an explicit surface when packageInterface is provided', function () {
+        const packageInterface: PackageInterface = { modules: [ { root: 'main', export: '.' } ] };
         const surface = resolveSurface(
             [ 'main' ],
-            pkg({ packageInterface: { modules: [ { root: 'main', export: '.' } ] } as never })
+            pkg({ packageInterface })
         );
 
         assert.strictEqual(surface.mode, 'explicit');

--- a/source/packtory/package-processor-build.test.ts
+++ b/source/packtory/package-processor-build.test.ts
@@ -1,11 +1,9 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { fake } from 'sinon';
+import { fake, type SinonSpy } from 'sinon';
 import type { AnalyzedBundle, DeadCodeEliminator } from '../dead-code-eliminator/analyzed-bundle.ts';
 import type { LinkedBundle } from '../linker/linked-bundle.ts';
-import type { ResourceResolver } from '../resource-resolver/resource-resolver.ts';
-import type { VersionManager } from '../version-manager/manager.ts';
+import type { ProgressBroadcastProvider } from '../progress/progress-broadcaster.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
 import {
     createAnalyzedBundle,
@@ -15,19 +13,50 @@ import {
     createVersionedBundle,
     getCallArgs
 } from '../test-libraries/package-processor-test-support.ts';
-import { createResolveAndBuildOperations, type ResolveAndBuildDependencies } from './package-processor-build.ts';
+import type { BuildOptions, ResolveAndLinkOptions } from './map-config.ts';
+import {
+    createResolveAndBuildOperations,
+    type ResolveAndBuildDependencies,
+    type ResolveAndBuildOperations
+} from './package-processor-build.ts';
+
+type InvalidMainPackageJson = {
+    readonly type: string;
+};
+
+type EmitArguments = Parameters<ProgressBroadcastProvider['emit']>;
 
 type PipelineDependenciesFixture = {
     readonly analyzedBundle: AnalyzedBundle;
+    readonly addVersion: SinonSpy;
     readonly dependencies: ResolveAndBuildDependencies;
+    readonly eliminate: SinonSpy;
+    readonly emit: SinonSpy;
+    readonly linkBundle: SinonSpy;
     readonly linkedBundle: LinkedBundle;
+    readonly resolve: SinonSpy;
+    readonly versionedBundle: VersionedBundleWithManifest;
+};
+
+type PipelineSpies = {
+    readonly analyzedBundle: AnalyzedBundle;
+    readonly addVersion: SinonSpy;
+    readonly eliminate: SinonSpy;
+    readonly emit: SinonSpy;
+    readonly linkBundle: SinonSpy;
+    readonly linkedBundle: LinkedBundle;
+    readonly resolve: SinonSpy;
     readonly versionedBundle: VersionedBundleWithManifest;
 };
 
 function stubDependencies(): ResolveAndBuildDependencies {
     return {
-        deadCodeEliminator: {} as DeadCodeEliminator,
-        linker: {} as ResolveAndBuildDependencies['linker'],
+        deadCodeEliminator: {
+            eliminate: fake.resolves([])
+        },
+        linker: {
+            linkBundle: fake.resolves(createLinkedBundle())
+        },
         progressBroadcaster: {
             emit() {
                 return undefined;
@@ -36,41 +65,90 @@ function stubDependencies(): ResolveAndBuildDependencies {
                 return false;
             }
         },
-        resourceResolver: {} as ResourceResolver,
-        versionManager: {} as VersionManager
+        resourceResolver: {
+            resolve: fake.resolves(createLinkedBundle())
+        },
+        versionManager: {
+            addVersion: fake.returns(createVersionedBundle()),
+            increaseVersion: fake.returns(createVersionedBundle())
+        }
+    };
+}
+
+function createPipelineSpies(): PipelineSpies {
+    const linkedBundle = createLinkedBundle();
+    const analyzedBundle = createAnalyzedBundle();
+    const versionedBundle = createVersionedBundle();
+    const eliminate = fake.resolves([ analyzedBundle ]);
+    const linkBundle = fake.resolves(linkedBundle);
+    const emit = fake(function (): void {
+        return undefined;
+    });
+    const resolve = fake.resolves(createLinkedBundle());
+    const addVersion = fake.returns(versionedBundle);
+    return {
+        addVersion,
+        eliminate,
+        emit,
+        linkBundle,
+        linkedBundle,
+        resolve,
+        analyzedBundle,
+        versionedBundle
     };
 }
 
 function createPipelineDependencies(
     overrides: Partial<ResolveAndBuildDependencies> = {}
 ): PipelineDependenciesFixture {
-    const hasSubscribers = fake(function (eventName: string) {
-        return eventName === 'scanCompleted' || eventName === 'linkingCompleted';
-    });
-    const linkedBundle = createLinkedBundle();
-    const analyzedBundle = createAnalyzedBundle();
-    const versionedBundle = createVersionedBundle();
+    const spies = createPipelineSpies();
     const dependencies: ResolveAndBuildDependencies = {
         deadCodeEliminator: {
-            eliminate: fake.resolves([ analyzedBundle ])
+            eliminate: spies.eliminate
         },
         linker: {
-            linkBundle: fake.resolves(linkedBundle)
+            linkBundle: spies.linkBundle
         },
         progressBroadcaster: {
-            emit: fake(),
-            hasSubscribers
+            emit(...args: EmitArguments) {
+                spies.emit(...args);
+            },
+            hasSubscribers: fake(function (eventName: string) {
+                return eventName === 'scanCompleted' || eventName === 'linkingCompleted';
+            })
         },
         resourceResolver: {
-            resolve: fake.resolves(createLinkedBundle())
+            resolve: spies.resolve
         },
         versionManager: {
-            addVersion: fake.returns(versionedBundle),
-            increaseVersion: fake.returns(versionedBundle)
+            addVersion: spies.addVersion,
+            increaseVersion: fake.returns(spies.versionedBundle)
         },
         ...overrides
     };
-    return { dependencies, analyzedBundle, linkedBundle, versionedBundle };
+    return {
+        dependencies,
+        ...spies
+    };
+}
+
+async function callResolveAndLinkWithMainPackageJson(
+    operations: ResolveAndBuildOperations,
+    mainPackageJson: InvalidMainPackageJson
+): Promise<unknown> {
+    const options: ResolveAndLinkOptions = Object.assign(createResolveOptions(), { mainPackageJson });
+    return operations.resolveAndLink(options);
+}
+
+async function callBuildWithMainPackageJson(
+    operations: ResolveAndBuildOperations,
+    mainPackageJson: InvalidMainPackageJson
+): Promise<unknown> {
+    const options: BuildOptions = Object.assign(
+        createBuildAndPublishOptions(),
+        { mainPackageJson, version: '1.2.3' }
+    );
+    return operations.build(options);
 }
 
 suite('package-processor-build', function () {
@@ -85,7 +163,7 @@ suite('package-processor-build', function () {
         const operations = createResolveAndBuildOperations(stubDependencies());
 
         try {
-            await operations.resolveAndLink({ mainPackageJson: { type: 'commonjs' } } as never);
+            await callResolveAndLinkWithMainPackageJson(operations, { type: 'commonjs' });
             assert.fail('expected resolveAndLink to reject the non-ESM main package json');
         } catch (error) {
             assert.ok(error instanceof Error);
@@ -97,7 +175,7 @@ suite('package-processor-build', function () {
         const operations = createResolveAndBuildOperations(stubDependencies());
 
         try {
-            await operations.build({ mainPackageJson: { type: 'commonjs' } } as never);
+            await callBuildWithMainPackageJson(operations, { type: 'commonjs' });
             assert.fail('expected build to reject the non-ESM main package json');
         } catch (error) {
             assert.ok(error instanceof Error);
@@ -114,17 +192,17 @@ suite('package-processor-build', function () {
 
         assert.deepStrictEqual(result, fixture.linkedBundle);
         assert.deepStrictEqual(
-            (fixture.dependencies.resourceResolver.resolve as never as ReturnType<typeof fake>).firstCall.args[0],
+            fixture.resolve.firstCall.args[0],
             options
         );
         assert.deepStrictEqual(
-            (fixture.dependencies.linker.linkBundle as never as ReturnType<typeof fake>).firstCall.args[0],
+            fixture.linkBundle.firstCall.args[0],
             {
                 bundle: createLinkedBundle(),
                 bundleDependencies: [ ...options.bundleDependencies, ...options.bundlePeerDependencies ]
             }
         );
-        assert.deepStrictEqual(getCallArgs(fixture.dependencies.progressBroadcaster.emit as never), [
+        assert.deepStrictEqual(getCallArgs(fixture.emit), [
             [ 'resolving', { packageName: 'package-a' } ],
             [ 'scanCompleted', { packageName: 'package-a', included: [], excluded: [] } ],
             [ 'linking', { packageName: 'package-a' } ],
@@ -133,15 +211,15 @@ suite('package-processor-build', function () {
     });
 
     test('build analyzes the linked bundle and versions the analyzed output', async function () {
-        const { dependencies, analyzedBundle, versionedBundle } = createPipelineDependencies();
-        const operations = createResolveAndBuildOperations(dependencies);
+        const fixture = createPipelineDependencies();
+        const operations = createResolveAndBuildOperations(fixture.dependencies);
         const options = { ...createBuildAndPublishOptions(), version: '1.2.3' };
 
         const result = await operations.build(options);
 
-        assert.deepStrictEqual(result, versionedBundle);
+        assert.deepStrictEqual(result, fixture.versionedBundle);
         assert.deepStrictEqual(
-            (dependencies.resourceResolver.resolve as never as ReturnType<typeof fake>).firstCall.args[0],
+            fixture.resolve.firstCall.args[0],
             {
                 name: 'package-a',
                 sourcesFolder: '/src',
@@ -158,7 +236,7 @@ suite('package-processor-build', function () {
             }
         );
         assert.deepStrictEqual(
-            (dependencies.deadCodeEliminator.eliminate as never as ReturnType<typeof fake>).firstCall.args[0],
+            fixture.eliminate.firstCall.args[0],
             [
                 {
                     bundle: createLinkedBundle(),
@@ -168,9 +246,9 @@ suite('package-processor-build', function () {
             ]
         );
         assert.deepStrictEqual(
-            (dependencies.versionManager.addVersion as never as ReturnType<typeof fake>).firstCall.args[0],
+            fixture.addVersion.firstCall.args[0],
             {
-                bundle: analyzedBundle,
+                bundle: fixture.analyzedBundle,
                 version: '1.2.3',
                 mainPackageJson: options.mainPackageJson,
                 bundleDependencies: options.bundleDependencies,
@@ -182,8 +260,8 @@ suite('package-processor-build', function () {
     });
 
     test('build passes disabled dead-code transformation settings to the eliminator', async function () {
-        const { dependencies } = createPipelineDependencies();
-        const operations = createResolveAndBuildOperations(dependencies);
+        const fixture = createPipelineDependencies();
+        const operations = createResolveAndBuildOperations(fixture.dependencies);
 
         await operations.build({
             ...createBuildAndPublishOptions(),
@@ -192,7 +270,7 @@ suite('package-processor-build', function () {
         });
 
         assert.deepStrictEqual(
-            (dependencies.deadCodeEliminator.eliminate as never as ReturnType<typeof fake>).firstCall.args[0],
+            fixture.eliminate.firstCall.args[0],
             [
                 {
                     bundle: createLinkedBundle(),
@@ -204,10 +282,11 @@ suite('package-processor-build', function () {
     });
 
     test('build rejects when the dead code eliminator returns no analyzed bundle', async function () {
+        const deadCodeEliminator: DeadCodeEliminator = {
+            eliminate: fake.resolves([])
+        };
         const { dependencies } = createPipelineDependencies({
-            deadCodeEliminator: {
-                eliminate: fake.resolves([])
-            } as unknown as DeadCodeEliminator
+            deadCodeEliminator
         });
         const operations = createResolveAndBuildOperations(dependencies);
 

--- a/source/packtory/publish-failure-mapping.test.ts
+++ b/source/packtory/publish-failure-mapping.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { mapResolveFailureToPublishFailure } from './publish-failure-mapping.ts';
@@ -15,7 +14,7 @@ suite('publish-failure-mapping', function () {
     });
 
     test('mapResolveFailureToPublishFailure converts a partial resolve failure into a publish-partial failure with empty succeeded', function () {
-        const failures = [ { message: 'boom' } as never ];
+        const failures = [ new Error('boom') ];
         const mapped = mapResolveFailureToPublishFailure({ type: 'partial', error: { succeeded: [], failures } });
 
         assert.deepStrictEqual(mapped, {

--- a/source/packtory/resolved-package.test.ts
+++ b/source/packtory/resolved-package.test.ts
@@ -1,16 +1,16 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import type { ConfigWithGraph } from '../config/validation.ts';
-import type { PacktoryConfigWithoutRegistry } from '../config/config.ts';
+import type { PackageConfig, PacktoryConfigWithoutRegistry } from '../config/config.ts';
+import type { ValidConfigWithoutRegistryResult } from '../config/validation.ts';
 import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
 import { analyzedBundleResource, versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
+import { validConfigWithoutRegistryFixture } from '../test-libraries/config-fixtures.ts';
+import { createLinkedBundle, createResolveOptions } from '../test-libraries/package-processor-test-support.ts';
 import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
 import { buildChecksResult, createResolvedPackage, type ResolvedPackage } from './resolved-package.ts';
 
-function validated(config: Partial<PacktoryConfigWithoutRegistry>): ConfigWithGraph<PacktoryConfigWithoutRegistry> {
-    return { packtoryConfig: { packages: [], ...config } } as unknown as ConfigWithGraph<PacktoryConfigWithoutRegistry>;
-}
+const validated: (config: Partial<PacktoryConfigWithoutRegistry>) => ValidConfigWithoutRegistryResult =
+    validConfigWithoutRegistryFixture;
 
 const unusedCheckDependencies = {
     versionManager: {
@@ -22,13 +22,13 @@ const unusedCheckDependencies = {
 
 function packageConfig(
     name: string,
-    overrides: Readonly<Record<string, unknown>> = {}
+    overrides: Partial<PackageConfig> = {}
 ): PacktoryConfigWithoutRegistry['packages'][number] {
     return { name, roots: {}, ...overrides };
 }
 
 function resolvedPackage(name: string, analyzedBundle: ResolvedPackage['analyzedBundle']): ResolvedPackage {
-    return { name, analyzedBundle, resolveOptions: {} as never };
+    return { name, analyzedBundle, resolveOptions: createResolveOptions() };
 }
 
 function duplicateResolvedPackages(): readonly ResolvedPackage[] {
@@ -42,7 +42,7 @@ function bundleWithExternal(packageName: string, dependencyName: string): Resolv
     return {
         ...checkBundle(packageName, [ 'shared.ts' ]),
         externalDependencies: new Map([ [ dependencyName, { name: dependencyName, referencedFrom: [ '/x' ] } ] ])
-    } as never;
+    };
 }
 
 async function runSinglePackageChecks(
@@ -102,8 +102,8 @@ function createPublishedPackageWithManifest(packageName: string): VersionedBundl
 
 suite('resolved-package', function () {
     test('createResolvedPackage assembles the three fields into a ResolvedPackage', function () {
-        const analyzedBundle = { name: 'pkg-a' } as never;
-        const resolveOptions = { name: 'pkg-a' } as never;
+        const analyzedBundle = checkBundle('pkg-a', []);
+        const resolveOptions = createResolveOptions();
 
         assert.deepStrictEqual(createResolvedPackage('pkg-a', analyzedBundle, resolveOptions), {
             name: 'pkg-a',
@@ -236,12 +236,13 @@ suite('resolved-package', function () {
                     name: 'pkg-a',
                     analyzedBundle,
                     resolveOptions: {
+                        ...createResolveOptions(),
                         mainPackageJson: { type: 'module' },
-                        bundleDependencies: [ { name: 'bundle-dependency' } ],
-                        bundlePeerDependencies: [ { name: 'bundle-peer-dependency' } ],
+                        bundleDependencies: [ createLinkedBundle('bundle-dependency') ],
+                        bundlePeerDependencies: [ createLinkedBundle('bundle-peer-dependency') ],
                         additionalPackageJsonAttributes: {},
                         allowMutableSpecifiers: []
-                    } as never
+                    }
                 }
             ]
         );

--- a/source/packtory/stages/package-analysis-stage.test.ts
+++ b/source/packtory/stages/package-analysis-stage.test.ts
@@ -1,43 +1,46 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import type { DeadCodeEliminator } from '../../dead-code-eliminator/analyzed-bundle.ts';
+import type {
+    AnalyzedBundle,
+    DeadCodeEliminator,
+    EliminationInput
+} from '../../dead-code-eliminator/analyzed-bundle.ts';
 import type { ValidConfigWithoutRegistryResult } from '../../config/validation.ts';
+import { packageConfigFixture, validConfigWithoutRegistryFixture } from '../../test-libraries/config-fixtures.ts';
+import {
+    createAnalyzedBundle,
+    createLinkedBundle,
+    createResolveOptions
+} from '../../test-libraries/package-processor-test-support.ts';
 import { analyzeResolvedPackages } from './package-analysis-stage.ts';
 import type { LinkedPackage } from './package-resolution-stage.ts';
 
 function configWithPackages(
     ...packages: readonly { readonly name: string; readonly enabled?: boolean; }[]
 ): ValidConfigWithoutRegistryResult {
-    return {
-        packtoryConfig: {
-            packages: packages.map(function (pkg) {
-                return {
-                    name: pkg.name,
-                    ...pkg.enabled === undefined ? {} : { deadCodeElimination: { enabled: pkg.enabled } }
-                };
-            })
-        }
-    } as unknown as ValidConfigWithoutRegistryResult;
+    return validConfigWithoutRegistryFixture({
+        packages: packages.map(function (pkg) {
+            return packageConfigFixture({
+                name: pkg.name,
+                ...pkg.enabled === undefined ? {} : { deadCodeElimination: { enabled: pkg.enabled } }
+            });
+        })
+    });
 }
 
 function linkedPackageNamed(name: string): LinkedPackage {
     return {
         name,
-        linkedBundle: { name } as never,
-        resolveOptions: { name } as never
+        linkedBundle: createLinkedBundle(name),
+        resolveOptions: createResolveOptions()
     };
 }
 
-function stubEliminator(
-    behavior: (
-        inputs: readonly { readonly bundle: unknown; readonly transformationsEnabled: boolean; }[]
-    ) => readonly unknown[]
-): DeadCodeEliminator {
+type EliminationBehavior = (inputs: readonly EliminationInput[]) => Promise<readonly AnalyzedBundle[]>;
+
+function stubEliminator(behavior: EliminationBehavior): DeadCodeEliminator {
     return {
-        async eliminate(inputs) {
-            return behavior(inputs) as never;
-        }
+        eliminate: behavior
     };
 }
 
@@ -48,9 +51,9 @@ type CapturedTransformationsEnabled = {
 
 function captureTransformationsEnabled(): CapturedTransformationsEnabled {
     let observed: unknown = null;
-    const eliminator = stubEliminator(function (inputs) {
+    const eliminator = stubEliminator(async function (inputs) {
         observed = inputs[0]?.transformationsEnabled;
-        return [ { name: inputs[0]?.bundle as never } ];
+        return [ createAnalyzedBundle(inputs[0]?.bundle.name) ];
     });
     return {
         eliminator,
@@ -64,7 +67,7 @@ suite('package-analysis-stage', function () {
     test('analyzeResolvedPackages returns an empty array when no linked packages are given', async function () {
         const result = await analyzeResolvedPackages(
             {
-                deadCodeEliminator: stubEliminator(function () {
+                deadCodeEliminator: stubEliminator(async function () {
                     return [];
                 })
             },
@@ -77,8 +80,8 @@ suite('package-analysis-stage', function () {
 
     test('analyzeResolvedPackages passes each linked bundle into the dead-code eliminator', async function () {
         const linkedPackage = linkedPackageNamed('pkg-a');
-        const analyzed = [ { name: 'pkg-a' } as never ];
-        const eliminator = stubEliminator(function (inputs) {
+        const analyzed = [ createAnalyzedBundle('pkg-a') ];
+        const eliminator = stubEliminator(async function (inputs) {
             assert.strictEqual(inputs[0]?.bundle, linkedPackage.linkedBundle);
             return analyzed;
         });
@@ -119,7 +122,7 @@ suite('package-analysis-stage', function () {
         try {
             await analyzeResolvedPackages(
                 {
-                    deadCodeEliminator: stubEliminator(function () {
+                    deadCodeEliminator: stubEliminator(async function () {
                         return [];
                     })
                 },
@@ -137,7 +140,7 @@ suite('package-analysis-stage', function () {
         try {
             await analyzeResolvedPackages(
                 {
-                    deadCodeEliminator: stubEliminator(function () {
+                    deadCodeEliminator: stubEliminator(async function () {
                         return [];
                     })
                 },

--- a/source/packtory/stages/publish-stage.test.ts
+++ b/source/packtory/stages/publish-stage.test.ts
@@ -1,10 +1,6 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { noPublication } from '../../bundle-emitter/publication-outcome.ts';
-import type { PackageConfig, PacktoryConfig } from '../../config/config.ts';
-import { buildPackageGraph } from '../../config/package-graph-builder.ts';
-import type { ValidConfigResult } from '../../config/validation.ts';
 import { createProgressBroadcaster } from '../../progress/progress-broadcaster.ts';
 import {
     createIteratingScheduler as iteratingScheduler,
@@ -16,54 +12,17 @@ import {
     stubPackageProcessor,
     stubProgressBroadcaster
 } from '../../test-libraries/orchestrator-stub-fixtures.ts';
+import {
+    buildAndPublishResultFixture,
+    emptyPublishConfigFixture,
+    publishableConfigFixture,
+    resolvedPublishPackageFixture,
+    versionedPublishBundleFixture
+} from '../../test-libraries/publish-stage-fixtures.ts';
+import type { PackageProcessor } from '../package-processor.ts';
 import { determineVersionAndPublishAll } from './publish-stage.ts';
 
 suite('publish-stage', function () {
-    function packageConfig(name: string): PackageConfig {
-        return {
-            name,
-            roots: { main: { js: 'index.js' } },
-            sourcesFolder: '/src',
-            mainPackageJson: { type: 'module' },
-            publishSettings: { access: 'public' }
-        };
-    }
-
-    function configWithPackages(packages: readonly PackageConfig[]): ValidConfigResult {
-        const packageConfigs: Readonly<Record<string, PackageConfig>> = Object.fromEntries(
-            packages.map(function (entry) {
-                return [ entry.name, entry ];
-            })
-        );
-        const packtoryConfig: PacktoryConfig = {
-            registrySettings: { registryUrl: 'https://example.com', auth: { type: 'bearer-token', token: 'x' } },
-            packages
-        };
-
-        return { packageConfigs, packtoryConfig, packageGraph: buildPackageGraph(packageConfigs) };
-    }
-
-    function emptyConfig(): ValidConfigResult {
-        return configWithPackages([]);
-    }
-
-    function publishableConfig(name: string): ValidConfigResult {
-        return configWithPackages([ packageConfig(name) ]);
-    }
-
-    function analyzedBundle(name: string): unknown {
-        return {
-            name,
-            analyzedBundle: {
-                name,
-                contents: [],
-                roots: {},
-                surface: { mode: 'implicit', defaultModuleRoot: 'main' }
-            },
-            resolveOptions: {}
-        };
-    }
-
     test('determineVersionAndPublishAll returns Ok([]) when no packages are scheduled', async function () {
         const result = await determineVersionAndPublishAll(
             {
@@ -72,7 +31,7 @@ suite('publish-stage', function () {
                 progressBroadcaster: stubProgressBroadcaster,
                 repositoryFolder: '/'
             },
-            emptyConfig(),
+            emptyPublishConfigFixture(),
             [],
             { dryRun: false, stage: false }
         );
@@ -83,7 +42,7 @@ suite('publish-stage', function () {
     test('determineVersionAndPublishAll forwards a scheduler failure unchanged', async function () {
         const result = await determineVersionAndPublishAll(
             failingDependencies('boom'),
-            emptyConfig(),
+            emptyPublishConfigFixture(),
             [],
             { dryRun: false, stage: false }
         );
@@ -92,7 +51,7 @@ suite('publish-stage', function () {
     });
 
     test('determineVersionAndPublishAll returns a partial failure when no analyzed bundle is found for a scheduled package', async function () {
-        const config = publishableConfig('pkg-orphan');
+        const config = publishableConfigFixture('pkg-orphan');
 
         const result = await determineVersionAndPublishAll(
             {
@@ -117,23 +76,19 @@ suite('publish-stage', function () {
     });
 
     test('determineVersionAndPublishAll exposes the published bundle via selectNext and the version+status via createProgressEvent', async function () {
-        const bundle = {
-            name: 'pkg-a',
-            version: '2.0.0',
-            packageJson: { name: 'pkg-a', version: '2.0.0' }
-        };
-        const buildResult = { bundle, status: 'new-version' as const, publication: noPublication };
-        const processor = {
+        const bundle = versionedPublishBundleFixture('pkg-a', '2.0.0');
+        const published = buildAndPublishResultFixture(bundle);
+        const processor: PackageProcessor = {
             ...stubPackageProcessor,
             async buildAndPublish() {
-                return buildResult;
+                return published;
             },
             async tryBuildAndPublish() {
-                return buildResult;
+                return published;
             }
-        } as never;
+        };
         const capture: IteratingSchedulerCapture = { events: [] as unknown[], selected: [] as unknown[] };
-        const config = publishableConfig('pkg-a');
+        const config = publishableConfigFixture('pkg-a');
 
         await determineVersionAndPublishAll(
             {
@@ -143,7 +98,7 @@ suite('publish-stage', function () {
                 repositoryFolder: '/'
             },
             config,
-            [ analyzedBundle('pkg-a') as never ],
+            [ resolvedPublishPackageFixture('pkg-a') ],
             { dryRun: false, stage: false }
         );
 
@@ -162,13 +117,13 @@ suite('publish-stage', function () {
         broadcaster.consumer.on('packageFailed', function (payload) {
             failures.push(payload);
         });
-        const config = publishableConfig('pkg-a');
-        const processor = {
+        const config = publishableConfigFixture('pkg-a');
+        const processor: PackageProcessor = {
             ...stubPackageProcessor,
             async buildAndPublish() {
                 throw new Error('publish failed');
             }
-        } as never;
+        };
 
         await determineVersionAndPublishAll(
             {
@@ -178,7 +133,7 @@ suite('publish-stage', function () {
                 repositoryFolder: '/'
             },
             config,
-            [ analyzedBundle('pkg-a') as never ],
+            [ resolvedPublishPackageFixture('pkg-a') ],
             { dryRun: false, stage: false }
         );
 

--- a/source/packtory/stages/release-diff-stage.test.ts
+++ b/source/packtory/stages/release-diff-stage.test.ts
@@ -1,14 +1,16 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions, import/max-dependencies -- test stubs cast partial mocks of complex orchestrator types */
+/* eslint-disable import/max-dependencies -- release diff tests cover scheduler, artifacts, SBOM, and result fixtures together */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import { Maybe, Result } from 'true-myth';
 import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import { noPublication } from '../../bundle-emitter/publication-outcome.ts';
-import type { ValidConfigResult } from '../../config/validation.ts';
+import { packageConfigFixture, validConfigFixture } from '../../test-libraries/config-fixtures.ts';
 import type { FileDescription } from '../../file-manager/file-description.ts';
+import type { ValidConfigResult } from '../../config/validation.ts';
 import { createIteratingScheduler, type IteratingSchedulerCapture } from '../../test-libraries/iterating-scheduler.ts';
 import { buildSbomFixtureContent } from '../../test-libraries/sbom-fixtures.ts';
+import { versionedBundleWithManifest } from '../../test-libraries/bundle-fixtures.ts';
 import type { BuildAndPublishResult } from '../package-processor.ts';
 import type { Scheduler as PackageScheduler } from '../scheduler.ts';
 import type { FileSetDiff, PackageReleaseDiff } from '../../report/release-diff/file-set-diff.ts';
@@ -19,24 +21,22 @@ type ArtifactsBuilderStub = {
 };
 
 function configFor(packageNames: readonly string[]): ValidConfigResult {
-    return {
-        packtoryConfig: {
-            packages: packageNames.map(function (name) {
-                return { name };
-            })
-        }
-    } as unknown as ValidConfigResult;
+    return validConfigFixture({
+        packages: packageNames.map(function (name) {
+            return packageConfigFixture({ name });
+        })
+    });
 }
 
 function buildResultFor(name: string, overrides: Partial<BuildAndPublishResult> = {}): BuildAndPublishResult {
     return {
         status: 'new-version',
         publication: noPublication,
-        bundle: {
+        bundle: versionedBundleWithManifest({
             name,
             version: '1.0.0',
             manifestFile: { filePath: 'package.json', content: `{"name":"${name}","version":"1.0.0"}\n` }
-        } as never,
+        }),
         extraFiles: [],
         previousReleaseArtifacts: Maybe.nothing(),
         ...overrides
@@ -184,10 +184,10 @@ function registerBasicDiffTests(): void {
     test('passes the bundle, the "package" target tag, and the extraFiles to artifactsBuilder.collectContents', async function () {
         const collectContents = fake.returns([]);
         const extraFile: FileDescription = { filePath: 'sbom.cdx.json', content: '{}', isExecutable: false };
-        const bundle = {
+        const bundle = versionedBundleWithManifest({
             name: 'pkg-a',
             version: '1.0.0'
-        } as never;
+        });
 
         await runReleaseDiffStage(
             {
@@ -227,7 +227,7 @@ function registerSchedulerTests(): void {
         const failingScheduler = {
             async runForEachScheduledPackage() {
                 return Result.err({
-                    succeeded: [ undefined ],
+                    succeeded: [],
                     failures: [ failingError ]
                 });
             }
@@ -305,10 +305,13 @@ function registerChangedDiffTests(): void {
             [
                 buildResultFor('pkg-a', {
                     bundle: {
-                        name: 'pkg-a',
-                        version: '1.0.1',
-                        manifestFile: { filePath: 'package.json', content: '{"name":"pkg-a","version":"1.0.1"}\n' }
-                    } as never,
+                        ...versionedBundleWithManifest({ name: 'pkg-a', version: '1.0.1' }),
+                        manifestFile: {
+                            filePath: 'package.json',
+                            content: '{"name":"pkg-a","version":"1.0.1"}\n',
+                            isExecutable: false
+                        }
+                    },
                     previousReleaseArtifacts: Maybe.just({ version: '1.0.0', gitHead: undefined, files: previousFiles })
                 })
             ]

--- a/source/report/preview/preview-summary.test.ts
+++ b/source/report/preview/preview-summary.test.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { createPreviewPackageFixture } from '../../test-libraries/preview-fixtures.ts';
 import { summarizePackages } from './preview-summary.ts';
 
 suite('preview-summary', function () {
@@ -18,7 +18,11 @@ suite('preview-summary', function () {
 
     test('summarizePackages counts a package as changed when it has changes', function () {
         const summary = summarizePackages([
-            { hasChanges: true, eliminatedSourceFiles: [], artifactCounts: { emitted: 1, changed: 1 } }
+            createPreviewPackageFixture({
+                hasChanges: true,
+                eliminatedSourceFiles: [],
+                artifactCounts: { emitted: 1, changed: 1 }
+            })
         ]);
         assert.partialDeepStrictEqual(summary, {
             changedPackages: 1,
@@ -28,7 +32,11 @@ suite('preview-summary', function () {
 
     test('summarizePackages counts an unchanged success as an unchanged package', function () {
         const summary = summarizePackages([
-            { hasChanges: false, eliminatedSourceFiles: [], artifactCounts: { emitted: 0, changed: 0 } }
+            createPreviewPackageFixture({
+                hasChanges: false,
+                eliminatedSourceFiles: [],
+                artifactCounts: { emitted: 0, changed: 0 }
+            })
         ]);
         assert.partialDeepStrictEqual(summary, {
             unchangedPackages: 1,
@@ -38,23 +46,23 @@ suite('preview-summary', function () {
 
     test('summarizePackages counts a package as failed when it has a failure entry', function () {
         const summary = summarizePackages([
-            {
+            createPreviewPackageFixture({
                 hasChanges: false,
-                failure: { stage: 'publish', message: 'boom' } as never,
+                failure: { stage: 'publish', message: 'boom' },
                 eliminatedSourceFiles: [],
                 artifactCounts: { emitted: 0, changed: 0 }
-            }
+            })
         ]);
         assert.strictEqual(summary.failedPackages, 1);
     });
 
     test('summarizePackages sums emitted and changed artifacts across packages and ignores directories', function () {
         const summary = summarizePackages([
-            {
+            createPreviewPackageFixture({
                 hasChanges: true,
-                eliminatedSourceFiles: [ { path: '/a.js' } ],
+                eliminatedSourceFiles: [ { path: '/a.js', reason: 'unused', sourceBytes: 1 } ],
                 artifactCounts: { emitted: 2, changed: 1 }
-            }
+            })
         ]);
         assert.partialDeepStrictEqual(summary, {
             emittedArtifacts: 2,

--- a/source/resource-resolver/dependency-resolution-walker.test.ts
+++ b/source/resource-resolver/dependency-resolution-walker.test.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/consistent-type-assertions -- test stubs cast partial mocks of complex orchestrator types */
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import type { DependencyGraph } from '../dependency-scanner/dependency-graph.ts';
 import type { DependencyScanner } from '../dependency-scanner/scanner.ts';
 import type { ResourceResolveOptions } from './resource-resolve-options.ts';
 import { resolveDependenciesForAllRoots } from './dependency-resolution-walker.ts';
@@ -15,32 +15,44 @@ type TrackingScanner = {
     readonly calls: readonly ScanCall[];
 };
 
-type ScanOptions = {
-    readonly resolveDeclarationFiles: boolean;
-};
-
-function emptyGraph(): never {
+function emptyGraph(): DependencyGraph {
     return {
+        addDependency() {
+            return undefined;
+        },
+        connect() {
+            return undefined;
+        },
+        hasConnection() {
+            return false;
+        },
+        isKnown() {
+            return false;
+        },
+        walk() {
+            return undefined;
+        },
         flatten() {
             return { externalDependencies: new Map(), localFiles: [] };
         }
-    } as never;
+    };
 }
 
 function trackingScanner(): TrackingScanner {
     const calls: ScanCall[] = [];
+    const scanner: DependencyScanner = {
+        async scan(entry, _sourcesFolder, options) {
+            calls.push({ entry, resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
+            return emptyGraph();
+        }
+    };
     return {
         calls,
-        scanner: {
-            async scan(entry: string, _sourcesFolder: string, options: ScanOptions) {
-                calls.push({ entry, resolveDeclarationFiles: options.resolveDeclarationFiles });
-                return emptyGraph();
-            }
-        } as DependencyScanner
+        scanner
     };
 }
 
-const stubMainPackageJson = { name: 'pkg-a', version: '1.0.0', type: 'module' } as never;
+const stubMainPackageJson = { type: 'module' } as const;
 
 function optionsForRoots(roots: ResourceResolveOptions['roots']): ResourceResolveOptions {
     return {

--- a/source/test-libraries/cli-handler-fixtures.ts
+++ b/source/test-libraries/cli-handler-fixtures.ts
@@ -1,7 +1,9 @@
 import { fake } from 'sinon';
+import { Result } from 'true-myth';
 import type { Packtory } from '../packtory/packtory.ts';
 import type { ConfigLoader } from '../command-line-interface/config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../command-line-interface/spinner/terminal-spinner-renderer.ts';
+import { createFakeFileManager, type FakeFileManager } from './fake-file-manager.ts';
 
 type BuildOutcome = Awaited<ReturnType<Packtory['buildAndPublishAll']>>;
 
@@ -13,6 +15,10 @@ export function configLoaderStub(): ConfigLoader {
     return { load: fake.resolves({}) };
 }
 
+export function fileManagerStub(): FakeFileManager {
+    return createFakeFileManager();
+}
+
 export function packtoryStub(outcome: BuildOutcome): Packtory {
     return { buildAndPublishAll: fake.resolves(outcome) } as unknown as Packtory;
 }
@@ -22,7 +28,7 @@ export function buildOutcome(overrides: Partial<BuildOutcome> = {}): BuildOutcom
         getReport() {
             return undefined;
         },
-        result: { isOk: true, isErr: false, value: [] },
+        result: Result.ok([]),
         ...overrides
-    } as unknown as BuildOutcome;
+    };
 }

--- a/source/test-libraries/config-fixtures.ts
+++ b/source/test-libraries/config-fixtures.ts
@@ -1,4 +1,13 @@
 import { createFactory } from '@enormora/objectory';
+import type {
+    PackageConfig,
+    PackageConfigsByName,
+    PacktoryConfig,
+    PacktoryConfigWithoutRegistry
+} from '../config/config.ts';
+import { buildPackageGraph } from '../config/package-graph-builder.ts';
+import type { PublishSettings } from '../config/publish-settings.ts';
+import type { ConfigWithGraph, ValidConfigResult, ValidConfigWithoutRegistryResult } from '../config/validation.ts';
 
 type RootShape = { readonly js: string; readonly declarationFile?: string | undefined; };
 
@@ -76,3 +85,52 @@ export const validationPackageConfigFactory = createFactory<ValidationPackageCon
         sourcesFolder: 'src'
     };
 });
+
+export const publicPublishSettings: PublishSettings = { access: 'public' };
+export const publicPublishSettingsAllowingScripts: PublishSettings = { access: 'public', allowScripts: true };
+
+export function packageConfigFixture(overrides: Partial<PackageConfig> = {}): PackageConfig {
+    return {
+        name: 'pkg-a',
+        roots: { main: { js: 'index.js' } },
+        sourcesFolder: 'src',
+        mainPackageJson: { type: 'module' },
+        ...overrides
+    };
+}
+
+export function packageConfigsByNameFixture(packages: readonly PackageConfig[]): PackageConfigsByName {
+    const packageConfigs: Record<string, PackageConfig> = {};
+    for (const packageConfig of packages) {
+        packageConfigs[packageConfig.name] = packageConfig;
+    }
+    return packageConfigs;
+}
+
+function configWithGraph<TConfig extends PacktoryConfigWithoutRegistry>(
+    packtoryConfig: TConfig
+): ConfigWithGraph<TConfig> {
+    const packageConfigs = packageConfigsByNameFixture(packtoryConfig.packages);
+    return {
+        packtoryConfig,
+        packageConfigs,
+        packageGraph: buildPackageGraph(packageConfigs)
+    };
+}
+
+export function validConfigWithoutRegistryFixture(
+    overrides: Partial<PacktoryConfigWithoutRegistry> = {}
+): ValidConfigWithoutRegistryResult {
+    return configWithGraph({
+        packages: [],
+        ...overrides
+    });
+}
+
+export function validConfigFixture(overrides: Partial<PacktoryConfig> = {}): ValidConfigResult {
+    return configWithGraph({
+        registrySettings: { auth: { type: 'bearer-token', token: 'token' } },
+        packages: [],
+        ...overrides
+    });
+}

--- a/source/test-libraries/publish-stage-fixtures.ts
+++ b/source/test-libraries/publish-stage-fixtures.ts
@@ -1,0 +1,41 @@
+import { Maybe } from 'true-myth';
+import { noPublication } from '../bundle-emitter/publication-outcome.ts';
+import type { ValidConfigResult } from '../config/validation.ts';
+import type { BuildAndPublishResult } from '../packtory/package-processor.ts';
+import type { ResolvedPackage } from '../packtory/resolved-package.ts';
+import { analyzedBundle, versionedBundleWithManifest } from './bundle-fixtures.ts';
+import { packageConfigFixture, publicPublishSettings, validConfigFixture } from './config-fixtures.ts';
+import { createResolveOptions } from './package-processor-test-support.ts';
+
+export function emptyPublishConfigFixture(): ValidConfigResult {
+    return validConfigFixture();
+}
+
+export function publishableConfigFixture(name: string): ValidConfigResult {
+    return validConfigFixture({ packages: [ packageConfigFixture({ name, publishSettings: publicPublishSettings }) ] });
+}
+
+export function resolvedPublishPackageFixture(name: string): ResolvedPackage {
+    return {
+        name,
+        analyzedBundle: analyzedBundle({ name }),
+        resolveOptions: createResolveOptions()
+    };
+}
+
+export function versionedPublishBundleFixture(name: string, version: string): BuildAndPublishResult['bundle'] {
+    return {
+        ...versionedBundleWithManifest({ name, version }),
+        packageJson: { name, version }
+    };
+}
+
+export function buildAndPublishResultFixture(bundle: BuildAndPublishResult['bundle']): BuildAndPublishResult {
+    return {
+        bundle,
+        status: 'new-version',
+        publication: noPublication,
+        extraFiles: [],
+        previousReleaseArtifacts: Maybe.nothing()
+    };
+}


### PR DESCRIPTION
Adds typed config and result fixtures, then rewrites cast-heavy tests to use real Result, package config, bundle, and scheduler shapes. Keeps the remaining validation cast at the schema boundary where changelog.prLog is intentionally pass-through until later validation. Checked locally with compile, targeted ESLint, and unit tests in the branch worktree.