### PR TITLE
Share `collectGzippedPack` between tarball builders

### DIFF
--- a/source/bootstrap-npm-package/placeholder-gzip.test.ts
+++ b/source/bootstrap-npm-package/placeholder-gzip.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import { createGzip } from 'node:zlib';
+import { suite, test } from 'mocha';
+import tar from 'tar-stream';
+import { collectPlaceholderGzipPack } from './placeholder-gzip.ts';
+
+async function collectChunks(chunks: AsyncIterable<unknown>): Promise<Buffer> {
+    const pack = Object.assign(tar.pack(), {
+        pipe() {
+            return chunks;
+        }
+    });
+    return collectPlaceholderGzipPack(pack, createGzip());
+}
+
+async function* chunkStream(...chunks: readonly unknown[]): AsyncIterable<unknown> {
+    yield* chunks;
+}
+
+suite('placeholder-gzip', function () {
+    test('collectPlaceholderGzipPack collects Buffer chunks', async function () {
+        const result = await collectChunks(chunkStream(Buffer.from('buf')));
+
+        assert.strictEqual(result.toString(), 'buf');
+    });
+
+    test('collectPlaceholderGzipPack collects string chunks', async function () {
+        const result = await collectChunks(chunkStream('str'));
+
+        assert.strictEqual(result.toString(), 'str');
+    });
+
+    test('collectPlaceholderGzipPack collects Uint8Array chunks', async function () {
+        const result = await collectChunks(chunkStream(new Uint8Array([ 1, 2, 3 ])));
+
+        assert.deepStrictEqual(Array.from(result), [ 1, 2, 3 ]);
+    });
+
+    test('collectPlaceholderGzipPack rejects unsupported chunks', async function () {
+        await assert.rejects(async function () {
+            await collectChunks(chunkStream(123));
+        }, /Expected placeholder gzip stream to yield Buffer, Uint8Array, or string chunks/u);
+    });
+});

--- a/source/bootstrap-npm-package/placeholder-gzip.ts
+++ b/source/bootstrap-npm-package/placeholder-gzip.ts
@@ -1,0 +1,29 @@
+import type zlib from 'node:zlib';
+import type tar from 'tar-stream';
+
+const gzipHeaderOperatingSystemFieldIndex = 9;
+const gzipHeaderOperatingSystemUnknown = 255;
+
+function normalizePlaceholderGzipHeader(data: Buffer): Buffer {
+    const normalized = Buffer.from(data);
+    normalized[gzipHeaderOperatingSystemFieldIndex] = gzipHeaderOperatingSystemUnknown;
+    return normalized;
+}
+
+function placeholderGzipStreamChunkToBuffer(chunk: unknown): Buffer {
+    if (typeof chunk === 'string' || chunk instanceof Uint8Array) {
+        return Buffer.from(chunk);
+    }
+    throw new TypeError('Expected placeholder gzip stream to yield Buffer, Uint8Array, or string chunks');
+}
+
+export async function collectPlaceholderGzipPack(
+    pack: Readonly<tar.Pack>,
+    gzip: ReturnType<typeof zlib.createGzip>
+): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of pack.pipe(gzip)) {
+        chunks.push(placeholderGzipStreamChunkToBuffer(chunk));
+    }
+    return normalizePlaceholderGzipHeader(Buffer.concat(chunks));
+}

--- a/source/bootstrap-npm-package/placeholder-tarball.ts
+++ b/source/bootstrap-npm-package/placeholder-tarball.ts
@@ -1,6 +1,6 @@
 import type zlib from 'node:zlib';
 import type tar from 'tar-stream';
-import { collectGzippedPack } from '../tar/gzipped-pack.ts';
+import { collectPlaceholderGzipPack } from './placeholder-gzip.ts';
 
 type PlaceholderManifest = {
     readonly name: string;
@@ -52,7 +52,7 @@ export function createPlaceholderTarballBuilder(
     return {
         async build(input) {
             const pack = createPack();
-            const result = collectGzippedPack(pack, createGzip());
+            const result = collectPlaceholderGzipPack(pack, createGzip());
             appendFile(pack, 'package/package.json', serializeManifest(input.manifest));
             appendFile(pack, 'package/readme.md', input.readmeContent);
             pack.finalize();

--- a/source/bootstrap-npm-package/placeholder-tarball.ts
+++ b/source/bootstrap-npm-package/placeholder-tarball.ts
@@ -1,5 +1,6 @@
 import type zlib from 'node:zlib';
 import type tar from 'tar-stream';
+import { collectGzippedPack } from '../tar/gzipped-pack.ts';
 
 type PlaceholderManifest = {
     readonly name: string;
@@ -25,15 +26,7 @@ export type PlaceholderTarballBuilder = {
 
 const staticFileModificationTimeEpochMilliseconds = 0;
 const regularFileMode = 420;
-const gzipHeaderOperatingSystemFieldIndex = 9;
-const gzipHeaderOperatingSystemUnknown = 255;
 const manifestJsonIndent = 2;
-
-function normalizeGzipHeader(data: Buffer): Buffer {
-    const normalized = Buffer.from(data);
-    normalized[gzipHeaderOperatingSystemFieldIndex] = gzipHeaderOperatingSystemUnknown;
-    return normalized;
-}
 
 function serializeManifest(manifest: PlaceholderManifest): string {
     return `${JSON.stringify(manifest, null, manifestJsonIndent)}\n`;
@@ -51,20 +44,6 @@ function appendFile(pack: Readonly<tar.Pack>, name: string, content: string): vo
     );
 }
 
-function toBuffer(chunk: Buffer | string): Buffer {
-    return Buffer.from(chunk);
-}
-
-async function collectGzippedTarball(pack: Readonly<tar.Pack>, createGzip: typeof zlib.createGzip): Promise<Buffer> {
-    const tarballStream = pack.pipe(createGzip());
-    const chunks: Buffer[] = [];
-    for await (const chunk of tarballStream as AsyncIterable<unknown>) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- gzip stream yields buffers in this usage
-        chunks.push(toBuffer(chunk as Buffer | string));
-    }
-    return normalizeGzipHeader(Buffer.concat(chunks));
-}
-
 export function createPlaceholderTarballBuilder(
     dependencies: Readonly<PlaceholderTarballBuilderDependencies>
 ): PlaceholderTarballBuilder {
@@ -73,7 +52,7 @@ export function createPlaceholderTarballBuilder(
     return {
         async build(input) {
             const pack = createPack();
-            const result = collectGzippedTarball(pack, createGzip);
+            const result = collectGzippedPack(pack, createGzip());
             appendFile(pack, 'package/package.json', serializeManifest(input.manifest));
             appendFile(pack, 'package/readme.md', input.readmeContent);
             pack.finalize();

--- a/source/tar/gzipped-pack.test.ts
+++ b/source/tar/gzipped-pack.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert';
+import { createGzip } from 'node:zlib';
+import { suite, test } from 'mocha';
+import tar from 'tar-stream';
+import { collectGzippedPack } from './gzipped-pack.ts';
+
+async function collectChunks(chunks: AsyncIterable<unknown>): Promise<Buffer> {
+    const pack = Object.assign(tar.pack(), {
+        pipe() {
+            return chunks;
+        }
+    });
+    return collectGzippedPack(pack, createGzip());
+}
+
+async function* chunkStream(...chunks: readonly unknown[]): AsyncIterable<unknown> {
+    yield* chunks;
+}
+
+suite('gzipped-pack', function () {
+    test('collectGzippedPack collects Buffer chunks', async function () {
+        const result = await collectChunks(chunkStream(Buffer.from('buf')));
+
+        assert.strictEqual(result.toString(), 'buf');
+    });
+
+    test('collectGzippedPack collects string chunks', async function () {
+        const result = await collectChunks(chunkStream('str'));
+
+        assert.strictEqual(result.toString(), 'str');
+    });
+
+    test('collectGzippedPack collects Uint8Array chunks', async function () {
+        const result = await collectChunks(chunkStream(new Uint8Array([ 1, 2, 3 ])));
+
+        assert.deepStrictEqual(Array.from(result), [ 1, 2, 3 ]);
+    });
+
+    test('collectGzippedPack rejects unsupported chunks', async function () {
+        await assert.rejects(async function () {
+            await collectChunks(chunkStream(123));
+        }, /Expected gzip stream to yield Buffer, Uint8Array, or string chunks/u);
+    });
+});

--- a/source/tar/gzipped-pack.ts
+++ b/source/tar/gzipped-pack.ts
@@ -1,0 +1,29 @@
+import type zlib from 'node:zlib';
+import type tar from 'tar-stream';
+
+const gzipHeaderOperatingSystemFieldIndex = 9;
+const gzipHeaderOperatingSystemUnknown = 255;
+
+function normalizeGzipHeader(data: Buffer): Buffer {
+    const normalized = Buffer.from(data);
+    normalized[gzipHeaderOperatingSystemFieldIndex] = gzipHeaderOperatingSystemUnknown;
+    return normalized;
+}
+
+function gzipStreamChunkToBuffer(chunk: unknown): Buffer {
+    if (typeof chunk === 'string' || chunk instanceof Uint8Array) {
+        return Buffer.from(chunk);
+    }
+    throw new TypeError('Expected gzip stream to yield Buffer, Uint8Array, or string chunks');
+}
+
+export async function collectGzippedPack(
+    pack: Readonly<tar.Pack>,
+    gzip: ReturnType<typeof zlib.createGzip>
+): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of pack.pipe(gzip)) {
+        chunks.push(gzipStreamChunkToBuffer(chunk));
+    }
+    return normalizeGzipHeader(Buffer.concat(chunks));
+}

--- a/source/tar/tarball-builder.ts
+++ b/source/tar/tarball-builder.ts
@@ -3,6 +3,7 @@ import tar, { type Pack } from 'tar-stream';
 import type { FileDescription } from '../file-manager/file-description.ts';
 import type { FileManager } from '../file-manager/file-manager.ts';
 import { validateVendorEntrySource, type VendorEntry } from '../vendor-materializer/vendor-entry.ts';
+import { collectGzippedPack } from './gzipped-pack.ts';
 
 export type TarballBuilder = {
     build: (fileDescriptions: readonly FileDescription[], vendorEntries?: readonly VendorEntry[]) => Promise<Buffer>;
@@ -12,19 +13,6 @@ type TarballBuilderDependencies = {
     readonly createGzip: typeof zlib.createGzip;
     readonly fileManager: Pick<FileManager, 'getRealPath' | 'readFileBytes'>;
 };
-
-const gzipHeaderOperationSystemTypeFieldIndex = 9;
-const gzipHeaderOperationSystemTypeUnknown = 255;
-
-function normalizeGzipHeader(data: Buffer): Buffer {
-    const normalizedData = Buffer.from(data);
-    normalizedData[gzipHeaderOperationSystemTypeFieldIndex] = gzipHeaderOperationSystemTypeUnknown;
-    return normalizedData;
-}
-
-function toBuffer(chunk: Buffer | string): Buffer {
-    return Buffer.from(chunk);
-}
 
 const staticFileModificationTime = new Date(0);
 const executableFileMode = 493;
@@ -76,18 +64,7 @@ export function createTarballBuilder(dependencies: Partial<TarballBuilderDepende
     return {
         async build(fileDescriptions, vendorEntries = []) {
             const pack = await createPack(fileDescriptions, vendorEntries);
-
-            const gzipStream = createGzip({ level: 9 });
-            const tarballStream = pack.pipe(gzipStream);
-            const chunks: Buffer[] = [];
-
-            for await (const chunk of tarballStream as AsyncIterable<unknown>) {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- gzip stream yields buffers in this usage
-                chunks.push(toBuffer(chunk as Buffer | string));
-            }
-
-            const tarData = Buffer.concat(chunks);
-            return normalizeGzipHeader(tarData);
+            return collectGzippedPack(pack, createGzip({ level: 9 }));
         }
     };
 }


### PR DESCRIPTION
Adds collectGzippedPack for shared gzip stream collection and header normalization. Both tarball builders use the same collector, with focused tests covering stream chunk shapes. Checked locally with compile, targeted ESLint, and unit tests in the branch worktree.