### PR TITLE
Split terminal and HTML preview renderers

### DIFF
--- a/source/report/html-renderer/diagnostics-renderer.ts
+++ b/source/report/html-renderer/diagnostics-renderer.ts
@@ -1,23 +1,40 @@
-/* eslint-disable complexity -- HTML template literals and diagnostic section dispatch are intentionally inline */
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { escapeHtml } from './html-escaping.ts';
 import { renderCollapsibleSection } from './html-primitives.ts';
 
+type DiagnosticSection = {
+    readonly title: string;
+    readonly value: unknown;
+};
+
+function hasEntries(value: Readonly<Record<string, unknown>>): boolean {
+    return Object.keys(value).length > 0;
+}
+
+function sectionForDefinedValue(title: string, value: unknown): readonly DiagnosticSection[] {
+    return value === undefined ? [] : [ { title, value } ];
+}
+
+function sectionForRecord(title: string, value: Readonly<Record<string, unknown>>): readonly DiagnosticSection[] {
+    return hasEntries(value) ? [ { title, value } ] : [];
+}
+
+function diagnosticSections(pkg: PreviewPackage): readonly DiagnosticSection[] {
+    return [
+        ...sectionForDefinedValue('Inputs', pkg.diagnostics.inputs),
+        ...sectionForRecord('Decisions', pkg.diagnostics.decisions),
+        ...sectionForDefinedValue('Outputs', pkg.diagnostics.outputs),
+        ...sectionForDefinedValue('Publication', pkg.diagnostics.publication),
+        ...sectionForRecord('Timings (ms)', pkg.diagnostics.timings),
+        ...sectionForDefinedValue('Failure', pkg.diagnostics.failure)
+    ];
+}
+
 export function renderDiagnostics(pkg: PreviewPackage): string {
-    const sections = [
-        pkg.diagnostics.inputs === undefined ? '' : renderCollapsibleSection('Inputs', pkg.diagnostics.inputs),
-        Object.keys(pkg.diagnostics.decisions).length === 0
-            ? ''
-            : renderCollapsibleSection('Decisions', pkg.diagnostics.decisions),
-        pkg.diagnostics.outputs === undefined ? '' : renderCollapsibleSection('Outputs', pkg.diagnostics.outputs),
-        pkg.diagnostics.publication === undefined
-            ? ''
-            : renderCollapsibleSection('Publication', pkg.diagnostics.publication),
-        Object.keys(pkg.diagnostics.timings).length === 0
-            ? ''
-            : renderCollapsibleSection('Timings (ms)', pkg.diagnostics.timings),
-        pkg.diagnostics.failure === undefined ? '' : renderCollapsibleSection('Failure', pkg.diagnostics.failure)
-    ]
+    const sections = diagnosticSections(pkg)
+        .map(function (section) {
+            return renderCollapsibleSection(section.title, section.value);
+        })
         .join('');
     if (sections === '') {
         return '';

--- a/source/report/terminal-renderer/terminal-artifact-renderer.ts
+++ b/source/report/terminal-renderer/terminal-artifact-renderer.ts
@@ -1,31 +1,41 @@
-/* eslint-disable sonarjs/no-nested-template-literals, functional/prefer-tacit -- terminal rendering is intentionally linear and string-heavy */
 import { pathTreeNodeType } from '../../common/path-tree.ts';
 import type { PreviewArtifactNode } from '../preview/artifact-tree-builder.ts';
 import { artifactBadgeLabel, artifactStatusLabel } from '../preview/preview-document.ts';
 import type { Colors } from './terminal-preview-renderer-shared.ts';
 
-function formatBytes(bytes: number): string {
+export function formatTerminalBytes(bytes: number): string {
     return `${bytes} B`;
+}
+
+function renderDirectoryNode(node: PreviewArtifactNode, indent: string, colors: Colors): string {
+    const directoryName = colors.bold(`▸ ${node.name}/`);
+    return `${indent}${directoryName}`;
+}
+
+function renderBadgeText(node: Extract<PreviewArtifactNode, { readonly type: 'file'; }>): string {
+    const { artifact } = node;
+    const badgeParts = [
+        artifactStatusLabel(artifact.status),
+        ...artifact.badges.map(artifactBadgeLabel)
+    ];
+    return badgeParts.join(', ');
+}
+
+function renderFileNode(
+    node: Extract<PreviewArtifactNode, { readonly type: 'file'; }>,
+    indent: string,
+    colors: Colors
+): string {
+    const { artifact } = node;
+    const details = colors.dim(`(${artifact.kind}, ${formatTerminalBytes(artifact.sizeBytes)})`);
+    const badges = colors.yellow(`[${renderBadgeText(node)}]`);
+    return `${indent}• ${artifact.path} ${details} ${badges}`.trimEnd();
 }
 
 export function renderArtifactNode(node: PreviewArtifactNode, colors: Colors): string {
     const indent = `  ${'  '.repeat(node.depth)}`;
     if (node.type === pathTreeNodeType.directory) {
-        return `${indent}${colors.bold(`▸ ${node.name}/`)}`;
+        return renderDirectoryNode(node, indent, colors);
     }
-    const { artifact } = node;
-    const badgeParts = [
-        artifactStatusLabel(artifact.status),
-        ...artifact.badges.map(function (badge) {
-            return artifactBadgeLabel(badge);
-        })
-    ];
-    return `${indent}• ${artifact.path} ${colors.dim(`(${artifact.kind}, ${formatBytes(artifact.sizeBytes)})`)} ${
-        colors.yellow(
-            `[${badgeParts.join(', ')}]`
-        )
-    }`
-        .trimEnd();
+    return renderFileNode(node, indent, colors);
 }
-
-export { formatBytes as formatTerminalBytes };

--- a/source/report/terminal-renderer/terminal-package-renderer.ts
+++ b/source/report/terminal-renderer/terminal-package-renderer.ts
@@ -1,35 +1,88 @@
-/* eslint-disable max-statements, complexity, sonarjs/no-nested-template-literals -- terminal rendering is intentionally linear and string-heavy */
 import type { PreviewPackage } from '../preview/preview-document.ts';
 import { formatTerminalBytes, renderArtifactNode } from './terminal-artifact-renderer.ts';
 import { renderDiffLine, type Colors } from './terminal-preview-renderer-shared.ts';
 
+type EliminatedSourceFile = PreviewPackage['eliminatedSourceFiles'][number];
+type ChangedArtifact = PreviewPackage['changedArtifacts'][number];
+type DiffHunk = ChangedArtifact['diff'][number];
+
+function renderPackageHeader(pkg: PreviewPackage, colors: Colors): string {
+    if (pkg.versionTransition === undefined) {
+        return colors.bold(pkg.name);
+    }
+    return `${colors.bold(pkg.name)} ${colors.dim(pkg.versionTransition)}`;
+}
+
+function renderFailureLine(pkg: PreviewPackage, colors: Colors): string | undefined {
+    if (pkg.failure === undefined) {
+        return undefined;
+    }
+    return `${colors.red('  failure')} ${pkg.failure.stage}: ${pkg.failure.message}`;
+}
+
+function renderTreeLines(pkg: PreviewPackage, colors: Colors): readonly string[] {
+    return pkg.tree.map(function (node) {
+        return renderArtifactNode(node, colors);
+    });
+}
+
+function renderEliminatedSourceFile(file: EliminatedSourceFile, colors: Colors): string {
+    const size = colors.dim(`(${formatTerminalBytes(file.sourceBytes)})`);
+    return `    - ${file.path} ${size}`;
+}
+
+function renderEliminatedSourceFiles(pkg: PreviewPackage, colors: Colors): readonly string[] {
+    if (pkg.eliminatedSourceFiles.length === 0) {
+        return [];
+    }
+    return [
+        `  ${colors.bold('Eliminated source files')}`,
+        ...pkg.eliminatedSourceFiles.map(function (file) {
+            return renderEliminatedSourceFile(file, colors);
+        })
+    ];
+}
+
+function renderDiffHunk(hunk: DiffHunk, colors: Colors): readonly string[] {
+    return [
+        `      ${colors.dim(hunk.header)}`,
+        ...hunk.lines.map(function (line) {
+            return `      ${renderDiffLine(line, colors)}`;
+        })
+    ];
+}
+
+function renderChangedArtifact(artifact: ChangedArtifact, colors: Colors): readonly string[] {
+    return [
+        `    ${artifact.path}`,
+        ...artifact.diff.flatMap(function (hunk) {
+            return renderDiffHunk(hunk, colors);
+        })
+    ];
+}
+
+function renderChangedArtifacts(pkg: PreviewPackage, colors: Colors): readonly string[] {
+    if (pkg.changedArtifacts.length === 0) {
+        return [];
+    }
+    return [
+        `  ${colors.bold('Diffs')}`,
+        ...pkg.changedArtifacts.flatMap(function (artifact) {
+            return renderChangedArtifact(artifact, colors);
+        })
+    ];
+}
+
 export function renderPackage(pkg: PreviewPackage, colors: Colors): string {
     const lines = [
-        `${colors.bold(pkg.name)}${pkg.versionTransition === undefined ? '' : ` ${colors.dim(pkg.versionTransition)}`}`
-    ];
-    if (pkg.failure !== undefined) {
-        lines.push(`${colors.red('  failure')} ${pkg.failure.stage}: ${pkg.failure.message}`);
-    }
-    for (const node of pkg.tree) {
-        lines.push(renderArtifactNode(node, colors));
-    }
-    if (pkg.eliminatedSourceFiles.length > 0) {
-        lines.push(`  ${colors.bold('Eliminated source files')}`);
-        for (const file of pkg.eliminatedSourceFiles) {
-            lines.push(`    - ${file.path} ${colors.dim(`(${formatTerminalBytes(file.sourceBytes)})`)}`);
-        }
-    }
-    if (pkg.changedArtifacts.length > 0) {
-        lines.push(`  ${colors.bold('Diffs')}`);
-        for (const artifact of pkg.changedArtifacts) {
-            lines.push(`    ${artifact.path}`);
-            for (const hunk of artifact.diff) {
-                lines.push(`      ${colors.dim(hunk.header)}`);
-                for (const line of hunk.lines) {
-                    lines.push(`      ${renderDiffLine(line, colors)}`);
-                }
-            }
-        }
-    }
+        renderPackageHeader(pkg, colors),
+        renderFailureLine(pkg, colors),
+        ...renderTreeLines(pkg, colors),
+        ...renderEliminatedSourceFiles(pkg, colors),
+        ...renderChangedArtifacts(pkg, colors)
+    ]
+        .filter(function (line): line is string {
+            return line !== undefined;
+        });
     return lines.join('\n');
 }

--- a/source/report/terminal-renderer/terminal-preview-renderer.ts
+++ b/source/report/terminal-renderer/terminal-preview-renderer.ts
@@ -1,37 +1,49 @@
-/* eslint-disable sonarjs/no-nested-template-literals, no-continue, @stylistic/max-len -- terminal rendering is intentionally linear and string-heavy */
 import type { PreviewDocument } from '../preview/preview-document.ts';
 import { renderPackage } from './terminal-package-renderer.ts';
-import { createColors, renderFailureDocumentHeader } from './terminal-preview-renderer-shared.ts';
+import { createColors, renderFailureDocumentHeader, type Colors } from './terminal-preview-renderer-shared.ts';
 
 type TerminalPreviewRendererOptions = {
     readonly color?: boolean | undefined;
 };
 
+function renderSummary(document: PreviewDocument): string {
+    return [
+        `${document.summary.totalPackages} package(s)`,
+        `${document.summary.changedPackages} changed`,
+        `${document.summary.failedPackages} failed`
+    ]
+        .join(' · ');
+}
+
+function renderIssues(issues: readonly string[], colors: Colors): string | undefined {
+    if (issues.length === 0) {
+        return undefined;
+    }
+
+    const issueLines = issues.map(function (issue) {
+        return `- ${issue}`;
+    });
+    return [ colors.red('Issues'), ...issueLines ].join('\n');
+}
+
+function renderTitle(document: PreviewDocument, colors: Colors): string {
+    const modeLabel = colors.yellow(`[${document.modeLabel}]`);
+    return `${colors.bold(document.title)} ${modeLabel}`;
+}
+
 export function renderTerminalPreview(document: PreviewDocument, options: TerminalPreviewRendererOptions = {}): string {
     const colors = createColors(options.color);
-    const summary =
-        `${document.summary.totalPackages} package(s) · ${document.summary.changedPackages} changed · ${document.summary.failedPackages} failed`;
     const sections = [
-        `${colors.bold(document.title)} ${colors.yellow(`[${document.modeLabel}]`)}`,
-        colors.dim(summary)
-    ];
-    if (document.issues.length > 0) {
-        sections.push(
-            `${colors.red('Issues')}\n${
-                document
-                    .issues
-                    .map(function (issue) {
-                        return `- ${issue}`;
-                    })
-                    .join('\n')
-            }`
-        );
-    }
-    sections.push(
+        renderTitle(document, colors),
+        colors.dim(renderSummary(document)),
+        renderIssues(document.issues, colors),
         ...document.packages.map(function (pkg) {
             return renderPackage(pkg, colors);
         })
-    );
+    ]
+        .filter(function (section): section is string {
+            return section !== undefined;
+        });
     return `${sections.join('\n\n')}\n`;
 }
 
@@ -40,12 +52,15 @@ export function renderFailureOnlyTerminalPreview(
     options: TerminalPreviewRendererOptions = {}
 ): string {
     const colors = createColors(options.color);
-    const lines = Array.from(renderFailureDocumentHeader(document, colors));
-    for (const pkg of document.packages) {
+    const failedPackageLines = document.packages.flatMap(function (pkg): readonly string[] {
         if (pkg.failure === undefined) {
-            continue;
+            return [];
         }
-        lines.push(`${colors.bold(pkg.name)} ${pkg.failure.stage}: ${pkg.failure.message}`);
-    }
+        return [ `${colors.bold(pkg.name)} ${pkg.failure.stage}: ${pkg.failure.message}` ];
+    });
+    const lines = [
+        ...renderFailureDocumentHeader(document, colors),
+        ...failedPackageLines
+    ];
     return `${lines.join('\n')}\n`;
 }

--- a/source/report/terminal-renderer/terminal-release-diff-package-renderer.ts
+++ b/source/report/terminal-renderer/terminal-release-diff-package-renderer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-nested-template-literals -- terminal rendering is intentionally linear and string-heavy */
 import { buildPathTree, pathTreeNodeType, type PathTreeFileNode, type PathTreeNode } from '../../common/path-tree.ts';
 import {
     modifiedFileContentChangeKind,
@@ -36,7 +35,8 @@ function renderDirectoryLine(
     node: Extract<PathTreeNode<AnyFile>, { readonly type: typeof pathTreeNodeType.directory; }>,
     colors: Colors
 ): string {
-    return `${indent(node.depth)}${colors.bold(`▸ ${node.name}/`)}`;
+    const directoryName = colors.bold(`▸ ${node.name}/`);
+    return `${indent(node.depth)}${directoryName}`;
 }
 
 function sizeLabel(sizeBytes: number, colors: Colors): string {
@@ -72,9 +72,10 @@ function renderModifiedAnnotation(file: ModifiedFile, colors: Colors): string {
 function renderModifiedHeading(node: PathTreeFileNode<ModifiedFile>, colors: Colors): string {
     const file = node.item;
     const sizeDelta = `${formatTerminalBytes(file.oldSizeBytes)} -> ${formatTerminalBytes(file.newSizeBytes)}`;
-    return `${indent(node.depth)}${colors.yellow(fileMarker.modified)} ${node.name} ${colors.dim(`(${sizeDelta})`)}${
-        renderModeChangeSuffix(file, colors)
-    }${renderModifiedAnnotation(file, colors)}`;
+    const size = colors.dim(`(${sizeDelta})`);
+    const modeChange = renderModeChangeSuffix(file, colors);
+    const annotation = renderModifiedAnnotation(file, colors);
+    return `${indent(node.depth)}${colors.yellow(fileMarker.modified)} ${node.name} ${size}${modeChange}${annotation}`;
 }
 
 function hasRenderedHunks(
@@ -136,8 +137,9 @@ function renderTreeGroup<T extends AnyFile>(
     const tree = buildPathTree(group.files, function (file) {
         return file.path;
     });
+    const groupTitle = colors.bold(`${group.title} (${group.files.length})`);
     return [
-        `  ${colors.bold(`${group.title} (${group.files.length})`)}`,
+        `  ${groupTitle}`,
         ...tree.flatMap(function (node): readonly string[] {
             if (node.type === pathTreeNodeType.directory) {
                 return [ renderDirectoryLine(node, colors) ];
@@ -158,7 +160,8 @@ function renderHeaderSummary(files: FileSetDiff, unchangedCount: number): string
 }
 
 function renderUnchangedPackage(pkg: PackageReleaseDiff, colors: Colors): string {
-    return colors.dim(`${colors.bold(pkg.name)}  ${pkg.previousVersionLabel}  ·  no changes`);
+    const packageName = colors.bold(pkg.name);
+    return colors.dim(`${packageName}  ${pkg.previousVersionLabel}  ·  no changes`);
 }
 
 function renderFirstPublishPackageLines(pkg: PackageReleaseDiff, colors: Colors): readonly string[] {
@@ -174,8 +177,11 @@ function renderFirstPublishPackageLines(pkg: PackageReleaseDiff, colors: Colors)
 
 function renderChangedPackageLines(pkg: PackageReleaseDiff, colors: Colors): readonly string[] {
     const summary = renderHeaderSummary(pkg.files, pkg.files.unchanged.length);
+    const packageName = colors.bold(pkg.name);
+    const versionTransition = colors.dim(pkg.versionTransition);
+    const summaryLabel = colors.dim(`·  ${summary}`);
     return [
-        `${colors.bold(pkg.name)}  ${colors.dim(pkg.versionTransition)}  ${colors.dim(`·  ${summary}`)}`,
+        `${packageName}  ${versionTransition}  ${summaryLabel}`,
         ...renderTreeGroup(
             { title: 'Added', files: pkg.files.added, renderFileLines: renderAddedFileLines },
             colors


### PR DESCRIPTION
Breaks dense preview renderer functions into small rendering steps without changing terminal or HTML output. This removes renderer-level lint suppressions by making sections, artifact rows, package blocks, and diagnostic sections explicit. Checked locally with compile, targeted ESLint, and unit tests in the branch worktree.