### PR TITLE
Centralize non-Error failure test fixtures

### DIFF
--- a/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
+++ b/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
@@ -9,6 +9,7 @@ import {
     timeoutMutant,
     withTemporaryReportDirectory
 } from '../../test-libraries/mutation-report-fixtures.ts';
+import { throwNonError } from '../../test-libraries/non-error-failures.ts';
 import { runMutationTimeoutCheck } from './mutation-timeout-cli-runner.ts';
 
 const checkerScriptPath = fileURLToPath(new URL('./check-mutation-timeouts.entry-point.ts', import.meta.url));
@@ -59,8 +60,7 @@ function createArgvThrowingNonErrorOnReportPath(): readonly string[] {
     const argv = [] as string[];
     Object.defineProperty(argv, '2', {
         get() {
-            // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- this test targets the non-Error catch branch explicitly
-            throw 'boom';
+            return throwNonError('boom');
         }
     });
     return argv;

--- a/source/bundle-emitter/registry/registry-client-metadata-responses.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-responses.test.ts
@@ -2,14 +2,17 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake } from 'sinon';
 import { Maybe } from 'true-myth';
+import { throwNonError } from '../../test-libraries/non-error-failures.ts';
 import { expectFailure, registryClientFactory } from '../../test-libraries/registry-client-test-support.ts';
+
+function fetchErrorWithStatusCode(statusCode: number): Error & { readonly statusCode: number; } {
+    return Object.assign(new Error('fetch-error'), { statusCode });
+}
 
 suite('registry-client metadata responses', function () {
     test('fetchLatestVersion() returns nothing for 404 and 403 responses', async function () {
         for (const statusCode of [ 404, 403 ]) {
-            const error = new Error('fetch-error');
-            // @ts-expect-error -- intentional shape for npm fetch errors
-            error.statusCode = statusCode;
+            const error = fetchErrorWithStatusCode(statusCode);
             const registryClient = registryClientFactory({ npmFetchJson: fake.rejects(error) });
 
             const result = await registryClient.fetchLatestVersion('the-name', {
@@ -130,8 +133,7 @@ suite('registry-client metadata responses', function () {
     test('fetchLatestVersion() rethrows non-object unexpected errors', async function () {
         const registryClient = registryClientFactory({
             npmFetchJson: fake(async function () {
-                // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- intentional non-object rejection to exercise the isRecord(false) branch
-                throw 'unexpected-failure';
+                throwNonError('unexpected-failure');
             })
         });
 

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -5,6 +5,7 @@ import { Result } from 'true-myth';
 import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { noPublication } from '../bundle-emitter/publication-outcome.ts';
 import { validateConfigWithoutRegistry, type ValidConfigWithoutRegistryResult } from '../config/validation.ts';
+import { rejectWithNonError } from '../test-libraries/non-error-failures.ts';
 import { getErrResult } from '../test-libraries/result-helpers.ts';
 import { createScheduler, type Scheduler as SchedulerType } from './scheduler.ts';
 
@@ -235,8 +236,7 @@ suite('scheduler', function () {
                 return context.packageName;
             },
             async execute() {
-                // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors, unicorn/no-useless-promise-resolve-reject -- we intentionally exercise non-Error rejection handling here
-                return Promise.reject('not-an-error');
+                return rejectWithNonError('not-an-error');
             },
             selectNext(params: SelectPackageNameResultParams) {
                 return params.result;

--- a/source/tar/extract-tar.test.ts
+++ b/source/tar/extract-tar.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import type { Readable } from 'node:stream';
 import { suite, test } from 'mocha';
 import sinon from 'sinon';
+import { throwNonError } from '../test-libraries/non-error-failures.ts';
 import { withPromiseDeadline } from '../test-libraries/promise-with-deadline.ts';
 import { extractTarEntries } from './extract-tar.ts';
 import { createTarballBuilder } from './tarball-builder.ts';
@@ -283,8 +284,7 @@ suite('extract-tar', function () {
 
         test('rejects with an Error when iteration throws a non-Error value', async function () {
             await runWithThrowingStream(function () {
-                // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error -- This test exercises non-Error rejection normalization.
-                throw 'boom';
+                throwNonError('boom');
             }, /^Error: boom$/u);
         });
 

--- a/source/test-libraries/non-error-failures.ts
+++ b/source/test-libraries/non-error-failures.ts
@@ -1,0 +1,7 @@
+export function throwNonError(value: unknown): never {
+    throw value;
+}
+
+export async function rejectWithNonError(value: unknown): Promise<never> {
+    throwNonError(value);
+}


### PR DESCRIPTION
Adds non-error-failures fixtures for tests that intentionally exercise hostile thrown or rejected values. Registry metadata tests also use a typed status-code error instead of a TypeScript suppression. Checked locally with compile, targeted ESLint, and unit tests in the branch worktree.