### PR TITLE
Fix `areTheTypesWrong` check to include substitution exports

### DIFF
--- a/integration-tests/fixtures/substitution-type-check/package.json
+++ b/integration-tests/fixtures/substitution-type-check/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "substitution-type-check",
+    "version": "0.0.0-dev",
+    "type": "module"
+}

--- a/integration-tests/fixtures/substitution-type-check/src/a-entry.d.ts
+++ b/integration-tests/fixtures/substitution-type-check/src/a-entry.d.ts
@@ -1,0 +1,1 @@
+export declare const entry: string;

--- a/integration-tests/fixtures/substitution-type-check/src/a-entry.js
+++ b/integration-tests/fixtures/substitution-type-check/src/a-entry.js
@@ -1,0 +1,3 @@
+import { internal } from './internal.js';
+
+export const entry = internal;

--- a/integration-tests/fixtures/substitution-type-check/src/b-entry.d.ts
+++ b/integration-tests/fixtures/substitution-type-check/src/b-entry.d.ts
@@ -1,0 +1,1 @@
+export declare const consumer: string;

--- a/integration-tests/fixtures/substitution-type-check/src/b-entry.js
+++ b/integration-tests/fixtures/substitution-type-check/src/b-entry.js
@@ -1,0 +1,3 @@
+import { internal } from './internal.js';
+
+export const consumer = internal;

--- a/integration-tests/fixtures/substitution-type-check/src/internal.js
+++ b/integration-tests/fixtures/substitution-type-check/src/internal.js
@@ -1,0 +1,1 @@
+export const internal = 'internal';

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -126,6 +126,57 @@ suite('checks', function () {
         assert.strictEqual(result.value.length, 2);
     });
 
+    test('resolveAndLinkAll checks substitution exports in generated package candidates', async function () {
+        const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/substitution-type-check');
+        const config: PacktoryConfigWithoutRegistry = {
+            commonPackageSettings: {
+                sourcesFolder: path.join(fixturePath, 'src'),
+                mainPackageJson: await loadPackageJson(fixturePath),
+                publishSettings: { access: 'public' }
+            },
+            checks: { areTheTypesWrong: { enabled: true } },
+            packages: [
+                {
+                    name: 'pkg-a',
+                    roots: {
+                        main: {
+                            js: path.join(fixturePath, 'src/a-entry.js'),
+                            declarationFile: path.join(fixturePath, 'src/a-entry.d.ts')
+                        }
+                    }
+                },
+                {
+                    name: 'pkg-b',
+                    roots: {
+                        main: {
+                            js: path.join(fixturePath, 'src/b-entry.js'),
+                            declarationFile: path.join(fixturePath, 'src/b-entry.d.ts')
+                        }
+                    },
+                    bundleDependencies: [ 'pkg-a' ]
+                }
+            ]
+        };
+
+        const { result } = await resolveAndLinkAll(config);
+
+        if (!result.isErr) {
+            assert.fail('Expected resolveAndLinkAll to fail because a substitution export has no types');
+            return;
+        }
+
+        if (result.error.type === 'checks') {
+            assert.strictEqual(
+                result.error.issues.some(function (issue) {
+                    return issue.includes('pkg-a') && issue.includes('./internal.js') && issue.includes('No types');
+                }),
+                true
+            );
+        } else {
+            assert.fail(`Expected a checks failure, but received "${result.error.type}"`);
+        }
+    });
+
     test('resolveAndLinkAll succeeds when the global allowList covers the duplicated file', async function () {
         const fixturePath = path.join(process.cwd(), 'integration-tests/fixtures/duplicate-files');
         const baseConfig = await createBaseConfig(fixturePath);

--- a/readme.md
+++ b/readme.md
@@ -295,6 +295,7 @@ The configuration for `packtory` is an object with the following properties:
      - Example: `{ sourceFilePath: 'LICENSE', targetFilePath: 'LICENSE' }`.
      - If defined in both per-package and common settings, they are merged.
      - Code files (`.js`, `.cjs`, `.mjs`, `.jsx`, `.ts`, `.cts`, `.mts`, `.tsx`, `.d.ts`) are rejected: code that ships in the bundle must be reachable from a root so dependency, side-effect and dead-code analyses can run on it. If you need to ship code as a static asset (e.g. a template), give it a non-code extension like `.txt`.
+     - `package.json` is reserved for packtory's generated manifest and cannot be used as an `additionalFiles.targetFilePath`.
      - `targetFilePath` must be a bundle-relative path. Absolute paths (POSIX `/foo` or Windows `C:\\foo`) and parent-traversing paths (`..`, `foo/../bar`) are rejected at config-validation time so a malicious or mistaken config cannot write outside the artifact target during `pack --format folder`.
 
    - **`additionalPackageJsonAttributes`** (Optional, Object):

--- a/source/packtory/resolved-package.test.ts
+++ b/source/packtory/resolved-package.test.ts
@@ -6,8 +6,13 @@ import { checkBundle } from '../test-libraries/check-bundle-fixture.ts';
 import { analyzedBundleResource, versionedBundleWithManifest } from '../test-libraries/bundle-fixtures.ts';
 import { validConfigWithoutRegistryFixture } from '../test-libraries/config-fixtures.ts';
 import { createLinkedBundle, createResolveOptions } from '../test-libraries/package-processor-test-support.ts';
-import type { VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
-import { buildChecksResult, createResolvedPackage, type ResolvedPackage } from './resolved-package.ts';
+import type { BuildVersionedBundleOptions, VersionedBundleWithManifest } from '../version-manager/versioned-bundle.ts';
+import {
+    buildChecksResult,
+    createResolvedPackage,
+    type CheckEvaluationDependencies,
+    type ResolvedPackage
+} from './resolved-package.ts';
 
 const validated: (config: Partial<PacktoryConfigWithoutRegistry>) => ValidConfigWithoutRegistryResult =
     validConfigWithoutRegistryFixture;
@@ -98,6 +103,26 @@ function createPublishedPackageWithManifest(packageName: string): VersionedBundl
             version: '0.0.0'
         }
     });
+}
+
+type RecordedPublishedPackageInputs = {
+    readonly addVersionCalls: readonly BuildVersionedBundleOptions[];
+    readonly dependencies: CheckEvaluationDependencies;
+};
+
+function recordPublishedPackageInputs(packageName: string): RecordedPublishedPackageInputs {
+    const addVersionCalls: BuildVersionedBundleOptions[] = [];
+    return {
+        addVersionCalls,
+        dependencies: {
+            versionManager: {
+                addVersion(options: BuildVersionedBundleOptions) {
+                    addVersionCalls.push(options);
+                    return createPublishedPackageWithManifest(packageName);
+                }
+            }
+        }
+    };
 }
 
 suite('resolved-package', function () {
@@ -216,15 +241,7 @@ suite('resolved-package', function () {
 
     test('buildChecksResult materializes generated packages when areTheTypesWrong is enabled', async function () {
         const analyzedBundle = checkBundle('pkg-a', [ 'index.js' ]);
-        const addVersionCalls: unknown[] = [];
-        const dependencies = {
-            versionManager: {
-                addVersion(options: unknown) {
-                    addVersionCalls.push(options);
-                    return createPublishedPackageWithManifest('pkg-a');
-                }
-            }
-        };
+        const { addVersionCalls, dependencies } = recordPublishedPackageInputs('pkg-a');
         const result = await buildChecksResult(
             dependencies,
             validated({
@@ -257,6 +274,55 @@ suite('resolved-package', function () {
             bundlePeerDependencies: [ { name: 'bundle-peer-dependency', version: '0.0.0' } ],
             additionalPackageJsonAttributes: {},
             allowMutableSpecifiers: []
+        });
+    });
+
+    test('buildChecksResult includes substitution public module usage in generated check packages', async function () {
+        const packageBundle = checkBundle('pkg-a', [ 'index.js', 'lib/internal.js' ]);
+        const consumerBundle = checkBundle('pkg-b', [ 'index.js' ]);
+        const { addVersionCalls, dependencies } = recordPublishedPackageInputs('pkg-a');
+        const result = await buildChecksResult(
+            dependencies,
+            validated({
+                checks: { areTheTypesWrong: { enabled: true } },
+                packages: [ packageConfig('pkg-a'), packageConfig('pkg-b') ]
+            }),
+            [
+                {
+                    name: 'pkg-a',
+                    analyzedBundle: packageBundle,
+                    resolveOptions: {
+                        ...createResolveOptions(),
+                        mainPackageJson: { type: 'module' },
+                        bundleDependencies: [],
+                        bundlePeerDependencies: [],
+                        additionalPackageJsonAttributes: {},
+                        allowMutableSpecifiers: []
+                    }
+                },
+                resolvedPackage('pkg-b', {
+                    ...consumerBundle,
+                    contents: [
+                        analyzedBundleResource('index.js', {
+                            content: 'import "pkg-a/lib/internal.js";\n',
+                            targetFilePath: 'index.js'
+                        })
+                    ]
+                })
+            ]
+        );
+
+        assert.strictEqual(result.isOk, true);
+        assert.strictEqual(addVersionCalls.length, 2);
+        assert.deepStrictEqual(addVersionCalls[0], {
+            bundle: packageBundle,
+            version: '0.0.0',
+            mainPackageJson: { type: 'module' },
+            bundleDependencies: [],
+            bundlePeerDependencies: [],
+            additionalPackageJsonAttributes: {},
+            allowMutableSpecifiers: [],
+            substitutionPublicModuleSourcePaths: new Set([ 'lib/internal.js' ])
         });
     });
 });

--- a/source/packtory/resolved-package.ts
+++ b/source/packtory/resolved-package.ts
@@ -4,6 +4,7 @@ import { runChecks } from '../checks/check-runner.ts';
 import type { PacktoryConfigWithoutRegistry } from '../config/config.ts';
 import type { ConfigWithGraph } from '../config/validation.ts';
 import type { AnalyzedBundle } from '../dead-code-eliminator/analyzed-bundle.ts';
+import { collectPublicModuleUsage } from '../package-surface/public-module-usage.ts';
 import type { PublishedPackageWithManifest } from '../published-package/published-package.ts';
 import type { VersionManager } from '../version-manager/manager.ts';
 import type { ResolveAndLinkOptions } from './map-config.ts';
@@ -19,7 +20,7 @@ export type CheckError = {
     readonly issues: readonly string[];
 };
 
-type CheckEvaluationDependencies = {
+export type CheckEvaluationDependencies = {
     readonly versionManager: Pick<VersionManager, 'addVersion'>;
 };
 
@@ -35,11 +36,13 @@ export function createResolvedPackage(
 
 function buildPublishedPackagesForChecks(
     dependencies: CheckEvaluationDependencies,
-    resolvedPackages: readonly ResolvedPackage[]
+    resolvedPackages: readonly ResolvedPackage[],
+    publicModuleUsageByName: ReadonlyMap<string, ReadonlySet<string>>
 ): ReadonlyMap<string, PublishedPackageWithManifest> {
     return new Map(
         resolvedPackages.map(function (resolvedPackage) {
             const { analyzedBundle, resolveOptions } = resolvedPackage;
+            const substitutionPublicModuleSourcePaths = publicModuleUsageByName.get(resolvedPackage.name);
             return [
                 resolvedPackage.name,
                 dependencies.versionManager.addVersion({
@@ -53,7 +56,10 @@ function buildPublishedPackagesForChecks(
                         return { name: bundleDependency.name, version: checkManifestVersion };
                     }),
                     additionalPackageJsonAttributes: resolveOptions.additionalPackageJsonAttributes,
-                    allowMutableSpecifiers: resolveOptions.allowMutableSpecifiers
+                    allowMutableSpecifiers: resolveOptions.allowMutableSpecifiers,
+                    ...substitutionPublicModuleSourcePaths === undefined
+                        ? {}
+                        : { substitutionPublicModuleSourcePaths }
                 })
             ] as const;
         })
@@ -66,7 +72,13 @@ function maybeBuildPublishedPackagesForChecks(
     resolvedPackages: readonly ResolvedPackage[]
 ): ReadonlyMap<string, PublishedPackageWithManifest> | undefined {
     return config.checks?.areTheTypesWrong?.enabled === true
-        ? buildPublishedPackagesForChecks(dependencies, resolvedPackages)
+        ? buildPublishedPackagesForChecks(
+            dependencies,
+            resolvedPackages,
+            collectPublicModuleUsage(resolvedPackages.map(function (resolvedPackage) {
+                return resolvedPackage.analyzedBundle;
+            }))
+        )
         : undefined;
 }
 

--- a/source/resource-resolver/content.test.ts
+++ b/source/resource-resolver/content.test.ts
@@ -145,6 +145,22 @@ function registerLocalFileTests(): void {
             assert.strictEqual((error as Error).message, 'The targetFilePath must be relative');
         }
     });
+
+    test('throws when an object-form additional file targets the generated package manifest', function () {
+        try {
+            combineAllBundleFiles(
+                '/src',
+                [],
+                [ { sourceFilePath: 'manifest-template.json', targetFilePath: 'package.json' } ]
+            );
+            assert.fail('Expected combineAllBundleFiles() should fail but it did not');
+        } catch (error: unknown) {
+            assert.strictEqual(
+                (error as Error).message,
+                'additionalFiles must not target generated package manifest "package.json".'
+            );
+        }
+    });
 }
 
 const additionalCodeFileErrorMessage = [

--- a/source/resource-resolver/content.ts
+++ b/source/resource-resolver/content.ts
@@ -27,6 +27,17 @@ function rejectCodeFile(targetFilePath: string): void {
     }
 }
 
+function rejectGeneratedManifestTarget(targetFilePath: string): void {
+    if (targetFilePath === packageManifestFilePath) {
+        throw new Error(`additionalFiles must not target generated package manifest "${packageManifestFilePath}".`);
+    }
+}
+
+function rejectAdditionalFileTarget(targetFilePath: string): void {
+    rejectGeneratedManifestTarget(targetFilePath);
+    rejectCodeFile(targetFilePath);
+}
+
 type ResolvedBundleFile = {
     readonly sourceFilePath: string;
     readonly targetFilePath: string;
@@ -67,7 +78,7 @@ export function combineAllBundleFiles(
 
     const additionalContents = additionalFiles.map(function (additionalFile): ResolvedBundleFile {
         if (typeof additionalFile === 'string') {
-            rejectCodeFile(additionalFile);
+            rejectAdditionalFileTarget(additionalFile);
             const sourceFilePath = path.join(sourcesFolder, additionalFile);
             const targetFilePath = additionalFile;
             return {
@@ -81,7 +92,7 @@ export function combineAllBundleFiles(
         if (path.isAbsolute(additionalFile.targetFilePath)) {
             throw new Error('The targetFilePath must be relative');
         }
-        rejectCodeFile(additionalFile.targetFilePath);
+        rejectAdditionalFileTarget(additionalFile.targetFilePath);
 
         return {
             sourceFilePath: prependSourcesFolderIfNecessary(sourcesFolder, additionalFile.sourceFilePath),


### PR DESCRIPTION
The `areTheTypesWrong` check now builds its package candidates with the same substitution export inputs used by publish, so `resolveAndLinkAll` checks the generated package surface instead of only the root export surface. This also reserves `package.json` for the generated manifest so `additionalFiles` cannot replace it.