### PR TITLE
Fix typed substitution exports to publish declarations

### DIFF
--- a/benchmarks/generate-workload.ts
+++ b/benchmarks/generate-workload.ts
@@ -16,7 +16,7 @@ type BenchmarkPackage = NonNullable<PacktoryConfigWithoutRegistry['packages']>[n
 const jsonIndentationSpaces = 4;
 const packagesPerCluster = 3;
 const clusterJavaScriptFileCount = 6;
-const clusterDeclarationFileCount = 5;
+const clusterDeclarationFileCount = 7;
 const clusterSourceMapFileCount = 6;
 const clusterSourceMapVersion = 3;
 
@@ -88,8 +88,10 @@ function createClusterSourceFiles(): Record<string, string> {
         'foo.d.ts': "import { Baz } from './baz.js';\nexport type Foo = string;\n",
         'bar.js': "import { qux } from './qux.js';\nexport const bar = 'bar';\n//# sourceMappingURL=bar.js.map\n",
         'bar.js.map': createSourceMap('bar.js', 'bar.ts'),
+        'bar.d.ts': 'export type Bar = string;\n',
         'baz.d.ts': 'export type Baz = number;\n',
         'qux.js': "export const qux = 'qux';\n//# sourceMappingURL=qux.js.map\n",
+        'qux.d.ts': 'export type Qux = string;\n',
         'qux.js.map': createSourceMap('qux.js', 'qux.ts')
     };
 }

--- a/benchmarks/workloads.json
+++ b/benchmarks/workloads.json
@@ -5,7 +5,7 @@
             "clusterCount": 1,
             "packageCount": 3,
             "jsFileCount": 6,
-            "declarationFileCount": 5,
+            "declarationFileCount": 7,
             "sourceMapFileCount": 6,
             "maxImportFanOut": 2
         },
@@ -13,7 +13,7 @@
             "clusterCount": 2,
             "packageCount": 6,
             "jsFileCount": 12,
-            "declarationFileCount": 10,
+            "declarationFileCount": 14,
             "sourceMapFileCount": 12,
             "maxImportFanOut": 2
         },
@@ -21,7 +21,7 @@
             "clusterCount": 4,
             "packageCount": 12,
             "jsFileCount": 24,
-            "declarationFileCount": 20,
+            "declarationFileCount": 28,
             "sourceMapFileCount": 24,
             "maxImportFanOut": 2
         }

--- a/integration-tests/fixtures/multiple-packages-with-substitution-slightly-modified/src/bar.d.ts
+++ b/integration-tests/fixtures/multiple-packages-with-substitution-slightly-modified/src/bar.d.ts
@@ -1,0 +1,1 @@
+export declare const bar: string;

--- a/integration-tests/fixtures/multiple-packages-with-substitution-slightly-modified/src/qux.d.ts
+++ b/integration-tests/fixtures/multiple-packages-with-substitution-slightly-modified/src/qux.d.ts
@@ -1,0 +1,1 @@
+export declare const qux: string;

--- a/integration-tests/fixtures/multiple-packages-with-substitution/src/bar.d.ts
+++ b/integration-tests/fixtures/multiple-packages-with-substitution/src/bar.d.ts
@@ -1,0 +1,1 @@
+export declare const bar: string;

--- a/integration-tests/fixtures/multiple-packages-with-substitution/src/qux.d.ts
+++ b/integration-tests/fixtures/multiple-packages-with-substitution/src/qux.d.ts
@@ -1,0 +1,1 @@
+export declare const qux: string;

--- a/integration-tests/package-processor/multiple-packages.test.ts
+++ b/integration-tests/package-processor/multiple-packages.test.ts
@@ -171,6 +171,18 @@ suite('multiple-packages', function () {
                         isExplicitlyIncluded: false,
                         isSubstituted: false,
                         analysis: bindingAnalysis('Baz')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: 'export declare const qux: string;\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/qux.d.ts'),
+                            targetFilePath: 'qux.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('qux')
                     }
                 ],
                 dependencies: {},
@@ -275,6 +287,18 @@ suite('multiple-packages', function () {
                         isExplicitlyIncluded: false,
                         isSubstituted: true,
                         analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: 'export declare const bar: string;\n',
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/bar.d.ts'),
+                            targetFilePath: 'bar.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: false,
+                        analysis: bindingAnalysis('bar')
                     }
                 ],
                 dependencies: { first: '1.2.3' },
@@ -380,6 +404,18 @@ suite('multiple-packages', function () {
                         isExplicitlyIncluded: false,
                         isSubstituted: true,
                         analysis: bindingAnalysis('foo')
+                    },
+                    {
+                        directDependencies: new Set(),
+                        fileDescription: {
+                            content: "import { Baz } from 'first/baz.d.ts';\nexport type Foo = string;\n",
+                            isExecutable: false,
+                            sourceFilePath: path.join(fixture, 'src/foo.d.ts'),
+                            targetFilePath: 'foo.d.ts'
+                        },
+                        isExplicitlyIncluded: false,
+                        isSubstituted: true,
+                        analysis: bindingAnalysis('Baz', 'Foo')
                     }
                 ],
                 dependencies: { first: '1.2.3' },

--- a/integration-tests/packtory/checks.test.ts
+++ b/integration-tests/packtory/checks.test.ts
@@ -168,7 +168,9 @@ suite('checks', function () {
         if (result.error.type === 'checks') {
             assert.strictEqual(
                 result.error.issues.some(function (issue) {
-                    return issue.includes('pkg-a') && issue.includes('./internal.js') && issue.includes('No types');
+                    return issue.includes('pkg-a') &&
+                        issue.includes('./internal.js') &&
+                        issue.includes('without declaration companion');
                 }),
                 true
             );

--- a/integration-tests/packtory/publish-fixture-expectations.ts
+++ b/integration-tests/packtory/publish-fixture-expectations.ts
@@ -12,7 +12,8 @@ export const expectedFirstPackageVersion = {
                         types: './entry1.d.ts'
                     },
                     './qux.js': {
-                        import: './qux.js'
+                        import: './qux.js',
+                        types: './qux.d.ts'
                     }
                 },
                 name: 'first',
@@ -46,6 +47,11 @@ export const expectedFirstPackageVersion = {
             isExecutable: false,
             content: 'export type Baz = number;\n',
             filePath: 'package/baz.d.ts'
+        },
+        {
+            isExecutable: false,
+            content: 'export declare const qux: string;\n',
+            filePath: 'package/qux.d.ts'
         }
     ]
 } as const;
@@ -87,6 +93,11 @@ export const expectedSecondPackageFirstRunVersion = {
             isExecutable: false,
             content: "export declare const foo: import('first/foo.d.ts').Foo;\n",
             filePath: 'package/entry2.d.ts'
+        },
+        {
+            isExecutable: false,
+            content: 'export declare const bar: string;\n',
+            filePath: 'package/bar.d.ts'
         }
     ]
 } as const;
@@ -128,6 +139,11 @@ export const expectedSecondPackageSecondRunVersion = {
             isExecutable: false,
             content: "export declare const foo: import('first/foo.d.ts').Foo;\n",
             filePath: 'package/entry2.d.ts'
+        },
+        {
+            isExecutable: false,
+            content: 'export declare const bar: string;\n',
+            filePath: 'package/bar.d.ts'
         }
     ]
 } as const;

--- a/integration-tests/packtory/publish.test.ts
+++ b/integration-tests/packtory/publish.test.ts
@@ -316,6 +316,41 @@ suite('publish', function () {
 
     suite('publish cases 2', function () {
         test(
+            'rejects typed substitution exports without declaration companions',
+            checkWithRegistry(async function (registryDetails) {
+                const fixturePathValue = getFixturePath('substitution-type-check');
+                const packages = createPackageConfigList(
+                    createPackageConfig(fixturePathValue, 'pkg-a', 'a-entry'),
+                    createPackageConfig(fixturePathValue, 'pkg-b', 'b-entry', { bundleDependencies: [ 'pkg-a' ] })
+                );
+                const result = await publishFixturePackages({
+                    fixturePath: fixturePathValue,
+                    registryDetails,
+                    packages
+                });
+
+                if (result.isOk) {
+                    assert.fail('Expected publish to fail');
+                }
+                if (result.error.type !== 'partial') {
+                    assert.fail(`Expected partial failure, got ${result.error.type}`);
+                }
+                const failureMessages = result.error.failures.map(function (failure) {
+                    return failure.message;
+                });
+                assert.ok(
+                    failureMessages.some(function (message) {
+                        return message.includes('Package "pkg-a"') &&
+                            message.includes('./internal.js') &&
+                            message.includes('internal.d.ts');
+                    }),
+                    `Expected a missing declaration companion failure, got: ${failureMessages.join(' | ')}`
+                );
+                await assertPackageNotPublished('pkg-a', registryDetails);
+            })
+        );
+
+        test(
             'produces byte-identical SBOMs across two unchanged publish runs',
             checkWithRegistry(async function (registryDetails) {
                 const fixturePathValue = getFixturePath('multiple-packages-with-substitution');

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -95,6 +95,7 @@ export async function buildConfig() {
             {
                 name: 'packtory',
                 exportPackageJson: true,
+                checks: { maxBundleSize: { bytes: 1_070_000 } },
                 roots: {
                     main: {
                         js: 'packages/packtory/packtory.entry-point.js',

--- a/source/common/declaration-companion-paths.test.ts
+++ b/source/common/declaration-companion-paths.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { declarationCompanionCandidates, isDeclarationCompanionFilePath } from './declaration-companion-paths.ts';
+
+suite('declaration-companion-paths', function () {
+    test('declarationCompanionCandidates() returns module-specific declaration candidates', function () {
+        assert.deepStrictEqual(declarationCompanionCandidates('/src/index.js'), [ '/src/index.d.ts' ]);
+        assert.deepStrictEqual(declarationCompanionCandidates('/src/index.mjs'), [
+            '/src/index.d.mts',
+            '/src/index.d.ts'
+        ]);
+        assert.deepStrictEqual(declarationCompanionCandidates('/src/index.cjs'), [
+            '/src/index.d.cts',
+            '/src/index.d.ts'
+        ]);
+    });
+
+    test('declarationCompanionCandidates() returns no candidates for non-js files', function () {
+        assert.deepStrictEqual(declarationCompanionCandidates('/src/data.json'), []);
+    });
+
+    test('isDeclarationCompanionFilePath() recognizes declaration companion file paths', function () {
+        assert.strictEqual(isDeclarationCompanionFilePath('/src/index.d.ts'), true);
+        assert.strictEqual(isDeclarationCompanionFilePath('/src/index.d.mts'), true);
+        assert.strictEqual(isDeclarationCompanionFilePath('/src/index.d.cts'), true);
+        assert.strictEqual(isDeclarationCompanionFilePath('/src/index.js'), false);
+    });
+});

--- a/source/common/declaration-companion-paths.ts
+++ b/source/common/declaration-companion-paths.ts
@@ -1,0 +1,32 @@
+type DeclarationCompanionRule = {
+    readonly declarationExtensions: readonly string[];
+    readonly jsExtension: string;
+};
+
+const declarationCompanionRules: readonly DeclarationCompanionRule[] = [
+    { declarationExtensions: [ '.d.mts', '.d.ts' ], jsExtension: '.mjs' },
+    { declarationExtensions: [ '.d.cts', '.d.ts' ], jsExtension: '.cjs' },
+    { declarationExtensions: [ '.d.ts' ], jsExtension: '.js' }
+];
+
+export function declarationCompanionCandidates(filePath: string): readonly string[] {
+    const rule = declarationCompanionRules.find(function (candidate) {
+        return filePath.endsWith(candidate.jsExtension);
+    });
+    if (rule === undefined) {
+        return [];
+    }
+
+    const pathWithoutExtension = filePath.slice(0, -rule.jsExtension.length);
+    return rule.declarationExtensions.map(function (declarationExtension) {
+        return `${pathWithoutExtension}${declarationExtension}`;
+    });
+}
+
+export function isDeclarationCompanionFilePath(filePath: string): boolean {
+    return declarationCompanionRules.some(function (rule) {
+        return rule.declarationExtensions.some(function (declarationExtension) {
+            return filePath.endsWith(declarationExtension);
+        });
+    });
+}

--- a/source/linker/linker.test.ts
+++ b/source/linker/linker.test.ts
@@ -2,10 +2,71 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { assertDeepSubset } from '../test-libraries/deep-subset-assertion.ts';
 import { createProject } from '../test-libraries/typescript-project.ts';
-import { createBundleLinker } from './linker.ts';
+import type { ResolvedBundle } from '../resource-resolver/resolved-bundle.ts';
+import { createBundleLinker, type BundleLinker } from './linker.ts';
+
+type LinkedBundleResult = Awaited<ReturnType<BundleLinker['linkBundle']>>;
 
 function compareText(left: string, right: string): number {
     return left.localeCompare(right);
+}
+
+function testFileDescription(
+    sourceFilePath: string,
+    targetFilePath: string,
+    content: string
+): ResolvedBundle['contents'][number]['fileDescription'] {
+    return {
+        content,
+        isExecutable: false,
+        sourceFilePath,
+        targetFilePath
+    };
+}
+
+function testResource(
+    sourceFilePath: string,
+    targetFilePath: string,
+    content: string,
+    directDependencies: readonly string[]
+): ResolvedBundle['contents'][number] {
+    return {
+        fileDescription: testFileDescription(sourceFilePath, targetFilePath, content),
+        directDependencies: new Set(directDependencies),
+        isExplicitlyIncluded: false
+    };
+}
+
+function testRootWithDeclaration(): ResolvedBundle['roots'][string] {
+    return {
+        js: testFileDescription('/src/index.js', 'index.js', ''),
+        declarationFile: testFileDescription('/src/index.d.ts', 'index.d.ts', '')
+    };
+}
+
+async function linkTestBundle(
+    root: ResolvedBundle['roots'][string],
+    contents: ResolvedBundle['contents']
+): Promise<LinkedBundleResult> {
+    const linker = createBundleLinker();
+    return await linker.linkBundle({
+        bundle: {
+            name: 'package-a',
+            contents,
+            roots: { main: root },
+            surface: { mode: 'implicit', defaultModuleRoot: 'main' },
+            externalDependencies: new Map()
+        },
+        bundleDependencies: []
+    });
+}
+
+function sourceFilePathsOf(
+    contents: LinkedBundleResult['contents']
+): readonly string[] {
+    return contents.map(function (content) {
+        return content.fileDescription.sourceFilePath;
+    });
 }
 
 suite('linker', function () {
@@ -197,6 +258,37 @@ suite('linker', function () {
         assert.strictEqual(result.contents.length, 2);
         assert.strictEqual(result.contents[0]?.isSubstituted, true);
         assert.deepStrictEqual(Array.from(result.linkedBundleDependencies.keys()), [ 'bundle-dependency' ]);
+    });
+
+    test('linkBundle() keeps declaration companions for non-root js files', async function () {
+        const root = testRootWithDeclaration();
+        const result = await linkTestBundle(root, [
+            testResource('/src/index.js', 'index.js', 'import "./public.js";', [ '/src/public.js' ]),
+            testResource('/src/index.d.ts', 'index.d.ts', 'export declare const root: string;', []),
+            testResource('/src/public.js', 'public.js', 'export const publicValue = "value";', []),
+            testResource('/src/public.d.ts', 'public.d.ts', 'export declare const publicValue: string;', [])
+        ]);
+
+        assert.deepStrictEqual(
+            sourceFilePathsOf(result.contents),
+            [ '/src/index.js', '/src/public.js', '/src/index.d.ts', '/src/public.d.ts' ]
+        );
+    });
+
+    test('linkBundle() keeps declaration roots that are not js companions', async function () {
+        const root = {
+            js: testFileDescription('/src/index.js', 'index.js', ''),
+            declarationFile: testFileDescription('/src/types/root.d.ts', 'types/root.d.ts', '')
+        };
+        const result = await linkTestBundle(root, [
+            testResource('/src/index.js', 'index.js', 'export {};', []),
+            testResource('/src/types/root.d.ts', 'types/root.d.ts', 'export {};', [])
+        ]);
+
+        assert.deepStrictEqual(
+            sourceFilePathsOf(result.contents),
+            [ '/src/index.js', '/src/types/root.d.ts' ]
+        );
     });
 
     test('linkBundle() tolerates explicit roots that share transitive files', async function () {

--- a/source/linker/linker.ts
+++ b/source/linker/linker.ts
@@ -1,7 +1,9 @@
 import { rootHasDeclarationFile, type ResolvedBundle } from '../resource-resolver/resolved-bundle.ts';
+import { declarationCompanionCandidates } from '../common/declaration-companion-paths.ts';
 import { substituteDependencies } from './substitute-bundles.ts';
 import type { BundleSubstitutionSource, LinkedBundle } from './linked-bundle.ts';
 import { createGraphFromResolvedBundle } from './resource-graph.ts';
+import { ownsSourcePath } from './replacement-lookup.ts';
 
 type LinkBundleOptions = {
     readonly bundle: ResolvedBundle;
@@ -21,6 +23,39 @@ function flattenRoots(roots: ResolvedBundle['roots']): string[] {
     });
 }
 
+function isSubstitutedBundleSourcePath(
+    sourceFilePath: string,
+    bundleDependencies: readonly BundleSubstitutionSource[]
+): boolean {
+    return bundleDependencies.some(function (bundleDependency) {
+        return ownsSourcePath(sourceFilePath, bundleDependency);
+    });
+}
+
+function declarationCompanionRoots(
+    contents: ResolvedBundle['contents'],
+    bundleDependencies: readonly BundleSubstitutionSource[]
+): readonly string[] {
+    const sourceFilePaths = new Set(contents.map(function (content) {
+        return content.fileDescription.sourceFilePath;
+    }));
+    return contents.flatMap(function (content) {
+        if (isSubstitutedBundleSourcePath(content.fileDescription.sourceFilePath, bundleDependencies)) {
+            return [];
+        }
+        return declarationCompanionCandidates(content.fileDescription.sourceFilePath).filter(function (candidate) {
+            return sourceFilePaths.has(candidate);
+        });
+    });
+}
+
+function flattenRootFilePaths(
+    bundle: ResolvedBundle,
+    bundleDependencies: readonly BundleSubstitutionSource[]
+): readonly string[] {
+    return [ ...flattenRoots(bundle.roots), ...declarationCompanionRoots(bundle.contents, bundleDependencies) ];
+}
+
 export function createBundleLinker(): BundleLinker {
     return {
         async linkBundle(options) {
@@ -29,7 +64,7 @@ export function createBundleLinker(): BundleLinker {
             const substitutedGraph = substituteDependencies(resourceGraph, bundleDependencies);
 
             return {
-                ...substitutedGraph.flatten(flattenRoots(bundle.roots)),
+                ...substitutedGraph.flatten(flattenRootFilePaths(bundle, bundleDependencies)),
                 name: bundle.name,
                 exportPackageJson: bundle.exportPackageJson,
                 roots: bundle.roots,

--- a/source/linker/replacement-lookup.ts
+++ b/source/linker/replacement-lookup.ts
@@ -12,7 +12,7 @@ export type Replacements = {
     readonly bundleDependencies: readonly string[];
 };
 
-function ownsSourcePath(file: string, bundle: BundleSubstitutionSource): boolean {
+export function ownsSourcePath(file: string, bundle: BundleSubstitutionSource): boolean {
     return bundle.contents.some(function (content) {
         return content.fileDescription.sourceFilePath === file;
     });

--- a/source/package-surface/substitution-exports.test.ts
+++ b/source/package-surface/substitution-exports.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { content, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
+import { content, rootWithDeclaration, rootWithSource } from '../test-libraries/package-surface-fixtures.ts';
 import { collectSubstitutionExports } from './substitution-exports.ts';
 
 suite('substitution-exports', function () {
@@ -68,6 +68,19 @@ suite('substitution-exports', function () {
             assert.deepStrictEqual(result['./module.mjs'], { import: './module.mjs', types: './module.d.mts' });
         });
 
+        test('pairs a .mjs substitution with its .d.ts fallback companion when present', function () {
+            const result = collectSubstitutionExports(
+                {
+                    name: 'package-a',
+                    roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                    contents: [ content('/src/module.mjs', 'module.mjs'), content('/src/module.d.ts', 'module.d.ts') ]
+                },
+                new Set([ '/src/module.mjs' ])
+            );
+
+            assert.deepStrictEqual(result['./module.mjs'], { import: './module.mjs', types: './module.d.ts' });
+        });
+
         test('pairs a .cjs substitution with its .d.cts companion when present', function () {
             const result = collectSubstitutionExports(
                 {
@@ -94,11 +107,101 @@ suite('substitution-exports', function () {
             assert.deepStrictEqual(result['./feature.js'], { import: './feature.js' });
         });
 
+        test('throws when a typed package exposes a substitution without a declaration companion', function () {
+            assert.throws(
+                function () {
+                    collectSubstitutionExports(
+                        {
+                            name: 'package-a',
+                            roots: {
+                                main: rootWithDeclaration(
+                                    '/src/index.js',
+                                    'index.js',
+                                    '/src/index.d.ts',
+                                    'index.d.ts'
+                                )
+                            },
+                            contents: [ content('/src/feature.js', 'feature.js') ]
+                        },
+                        new Set([ '/src/feature.js' ])
+                    );
+                },
+                /^Error: Package "package-a" exposes substituted module "\.\/feature\.js" without declaration companion \.\/feature\.d\.ts$/u
+            );
+        });
+
+        test('throws when any root is typed and a substitution has no declaration companion', function () {
+            assert.throws(
+                function () {
+                    collectSubstitutionExports(
+                        {
+                            name: 'package-a',
+                            roots: {
+                                main: rootWithDeclaration(
+                                    '/src/index.js',
+                                    'index.js',
+                                    '/src/index.d.ts',
+                                    'index.d.ts'
+                                ),
+                                worker: rootWithSource('/src/worker.js', 'worker.js')
+                            },
+                            contents: [ content('/src/feature.js', 'feature.js') ]
+                        },
+                        new Set([ '/src/feature.js' ])
+                    );
+                },
+                /^Error: Package "package-a" exposes substituted module "\.\/feature\.js" without declaration companion \.\/feature\.d\.ts$/u
+            );
+        });
+
+        test('lists every declaration candidate for missing .mjs companions', function () {
+            assert.throws(
+                function () {
+                    collectSubstitutionExports(
+                        {
+                            name: 'package-a',
+                            roots: {
+                                main: rootWithDeclaration(
+                                    '/src/index.js',
+                                    'index.js',
+                                    '/src/index.d.ts',
+                                    'index.d.ts'
+                                )
+                            },
+                            contents: [ content('/src/feature.mjs', 'feature.mjs') ]
+                        },
+                        new Set([ '/src/feature.mjs' ])
+                    );
+                },
+                /^Error: Package "package-a" exposes substituted module "\.\/feature\.mjs" without declaration companion \.\/feature\.d\.mts or \.\/feature\.d\.ts$/u
+            );
+        });
+
         test('exposes a non-code substitution target without searching for a declaration companion', function () {
             const result = collectSubstitutionExports(
                 {
                     name: 'package-a',
                     roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                    contents: [ content('/src/data.json', 'data.json') ]
+                },
+                new Set([ '/src/data.json' ])
+            );
+
+            assert.deepStrictEqual(result['./data.json'], { import: './data.json' });
+        });
+
+        test('exposes a non-code substitution target in typed packages', function () {
+            const result = collectSubstitutionExports(
+                {
+                    name: 'package-a',
+                    roots: {
+                        main: rootWithDeclaration(
+                            '/src/index.js',
+                            'index.js',
+                            '/src/index.d.ts',
+                            'index.d.ts'
+                        )
+                    },
                     contents: [ content('/src/data.json', 'data.json') ]
                 },
                 new Set([ '/src/data.json' ])

--- a/source/package-surface/substitution-exports.ts
+++ b/source/package-surface/substitution-exports.ts
@@ -1,20 +1,21 @@
 import { isDefined, pickBy } from 'remeda';
+import {
+    declarationCompanionCandidates,
+    isDeclarationCompanionFilePath
+} from '../common/declaration-companion-paths.ts';
 import { toImportTarget, type BundleLike, type ExportEntry } from './package-shape.ts';
 
 type SubstitutionBundle = Pick<BundleLike, 'contents' | 'name' | 'roots'>;
 type BundleContent = BundleLike['contents'][number];
 type SubstitutionBundleLookups = {
     readonly contentBySourceFilePath: ReadonlyMap<string, BundleContent>;
+    readonly hasDeclarationRoots: boolean;
     readonly targetFilePaths: ReadonlySet<string>;
     readonly rootSourceFilePaths: ReadonlySet<string>;
 };
 type BundleContentLookups = {
     readonly contentBySourceFilePath: ReadonlyMap<string, BundleContent>;
     readonly targetFilePaths: ReadonlySet<string>;
-};
-type DeclarationCompanionRule = {
-    readonly declarationExtension: string;
-    readonly jsExtension: string;
 };
 
 function collectRootSourceFilePaths(bundle: SubstitutionBundle): ReadonlySet<string> {
@@ -25,6 +26,12 @@ function collectRootSourceFilePaths(bundle: SubstitutionBundle): ReadonlySet<str
     }
 
     return rootSourceFilePaths;
+}
+
+function hasDeclarationRoots(bundle: SubstitutionBundle): boolean {
+    return Object.values(bundle.roots).some(function (root) {
+        return root.declarationFile !== undefined;
+    });
 }
 
 function collectBundleContentLookups(bundle: SubstitutionBundle): BundleContentLookups {
@@ -49,6 +56,7 @@ function createSubstitutionBundleLookups(bundle: SubstitutionBundle): Substituti
 
     return {
         contentBySourceFilePath,
+        hasDeclarationRoots: hasDeclarationRoots(bundle),
         targetFilePaths,
         rootSourceFilePaths: collectRootSourceFilePaths(bundle)
     };
@@ -67,42 +75,71 @@ function findBundleContent(
     return content;
 }
 
-function declarationCompanionTargetPathFor(
-    rule: DeclarationCompanionRule,
-    targetFilePaths: ReadonlySet<string>,
+function declarationCompanionTargetPaths(
     targetFilePath: string
-): string | null | undefined {
-    if (targetFilePath.endsWith(rule.declarationExtension)) {
+): readonly string[] | null | undefined {
+    if (isDeclarationCompanionFilePath(targetFilePath)) {
         return null;
     }
 
-    if (!targetFilePath.endsWith(rule.jsExtension)) {
-        return undefined;
-    }
-
-    const targetPathWithoutExtension = targetFilePath.slice(0, -rule.jsExtension.length);
-    const declarationTargetFilePath = `${targetPathWithoutExtension}${rule.declarationExtension}`;
-    return targetFilePaths.has(declarationTargetFilePath) ? declarationTargetFilePath : undefined;
+    const candidates = declarationCompanionCandidates(targetFilePath);
+    return candidates.length === 0 ? undefined : candidates;
 }
 
 function findDeclarationCompanionTargetPath(
     targetFilePaths: ReadonlySet<string>,
-    targetFilePath: string
+    candidatePaths: readonly string[]
+): string | undefined {
+    return candidatePaths.find(function (candidatePath) {
+        return targetFilePaths.has(candidatePath);
+    });
+}
+
+function rejectMissingTypedDeclarationCompanion(
+    bundleName: string,
+    jsTargetFilePath: string,
+    candidatePaths: readonly string[]
+): never {
+    throw new Error(
+        `Package "${bundleName}" exposes substituted module "./${jsTargetFilePath}" without declaration companion ${
+            candidatePaths.map(toImportTarget).join(' or ')
+        }`
+    );
+}
+
+function existingDeclarationTargetFilePathFor(
+    bundleName: string,
+    lookups: SubstitutionBundleLookups,
+    jsTargetFilePath: string,
+    declarationCandidates: readonly string[]
+): string | undefined {
+    const declarationTargetFilePath = findDeclarationCompanionTargetPath(
+        lookups.targetFilePaths,
+        declarationCandidates
+    );
+    if (declarationTargetFilePath !== undefined) {
+        return declarationTargetFilePath;
+    }
+    if (lookups.hasDeclarationRoots) {
+        rejectMissingTypedDeclarationCompanion(bundleName, jsTargetFilePath, declarationCandidates);
+    }
+    return undefined;
+}
+
+function declarationTargetFilePathFor(
+    bundleName: string,
+    lookups: SubstitutionBundleLookups,
+    jsTargetFilePath: string
 ): string | null | undefined {
-    for (
-        const rule of [
-            { declarationExtension: '.d.mts', jsExtension: '.mjs' },
-            { declarationExtension: '.d.cts', jsExtension: '.cjs' },
-            { declarationExtension: '.d.ts', jsExtension: '.js' }
-        ] as const
-    ) {
-        const declarationTargetPath = declarationCompanionTargetPathFor(rule, targetFilePaths, targetFilePath);
-        if (declarationTargetPath !== undefined) {
-            return declarationTargetPath;
-        }
+    const declarationCandidates = declarationCompanionTargetPaths(jsTargetFilePath);
+    if (declarationCandidates === null) {
+        return null;
+    }
+    if (declarationCandidates === undefined) {
+        return undefined;
     }
 
-    return undefined;
+    return existingDeclarationTargetFilePathFor(bundleName, lookups, jsTargetFilePath, declarationCandidates);
 }
 
 function buildSubstitutionExportEntry(
@@ -116,7 +153,7 @@ function buildSubstitutionExportEntry(
 
     const content = findBundleContent(bundleName, lookups.contentBySourceFilePath, sourceFilePath);
     const jsTargetFilePath = content.fileDescription.targetFilePath;
-    const declarationTargetFilePath = findDeclarationCompanionTargetPath(lookups.targetFilePaths, jsTargetFilePath);
+    const declarationTargetFilePath = declarationTargetFilePathFor(bundleName, lookups, jsTargetFilePath);
     if (declarationTargetFilePath === null) {
         return undefined;
     }

--- a/source/packtory/resolved-package.test.ts
+++ b/source/packtory/resolved-package.test.ts
@@ -279,6 +279,32 @@ suite('resolved-package', function () {
         });
     });
 
+    test('buildChecksResult reports generated package errors as check issues', async function () {
+        const result = await buildChecksResult(
+            {
+                runChecks: fakeCheckRunner(),
+                versionManager: {
+                    addVersion() {
+                        throw new Error('Package "pkg-a" exposes substituted module "./internal.js"');
+                    }
+                }
+            },
+            validated({
+                checks: { typeScriptIntegrity: { enabled: true } },
+                packages: [ packageConfig('pkg-a') ]
+            }),
+            [ resolvedPackage('pkg-a', checkBundle('pkg-a', [ 'index.js' ])) ]
+        );
+
+        if (!result.isErr) {
+            assert.fail('expected checks result to fail');
+        }
+        assert.deepStrictEqual(result.error, {
+            type: 'checks',
+            issues: [ 'Package "pkg-a" exposes substituted module "./internal.js"' ]
+        });
+    });
+
     test('buildChecksResult includes substitution public module usage in generated check packages', async function () {
         const packageBundle = checkBundle('pkg-a', [ 'index.js', 'lib/internal.js' ]);
         const consumerBundle = checkBundle('pkg-b', [ 'index.js' ]);

--- a/source/packtory/resolved-package.ts
+++ b/source/packtory/resolved-package.ts
@@ -25,6 +25,8 @@ export type CheckEvaluationDependencies = {
     readonly runChecks: CheckRunner;
 };
 
+type StaticCheckInputs = Pick<Parameters<CheckRunner>[0], 'bundles' | 'packageConfigs' | 'perPackageSettings'>;
+
 const checkManifestVersion = '0.0.0';
 
 export function createResolvedPackage(
@@ -83,15 +85,29 @@ function maybeBuildPublishedPackagesForChecks(
         : undefined;
 }
 
-export async function buildChecksResult(
+function checkPackageIssue(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function tryBuildPublishedPackagesForChecks(
     dependencies: CheckEvaluationDependencies,
-    validated: ConfigWithGraph<PacktoryConfigWithoutRegistry>,
+    config: PacktoryConfigWithoutRegistry,
     resolvedPackages: readonly ResolvedPackage[]
-): Promise<Result<readonly ResolvedPackage[], CheckError>> {
-    const { packtoryConfig: config } = validated;
+): Result<ReadonlyMap<string, PublishedPackageWithManifest> | undefined, CheckError> {
+    try {
+        return Result.ok(maybeBuildPublishedPackagesForChecks(dependencies, config, resolvedPackages));
+    } catch (error) {
+        return Result.err({ type: 'checks', issues: [ checkPackageIssue(error) ] });
+    }
+}
+
+function createStaticCheckInputs(
+    config: PacktoryConfigWithoutRegistry,
+    resolvedPackages: readonly ResolvedPackage[]
+): StaticCheckInputs {
     const perPackageSettings = new Map<string, (typeof config.packages)[number]['checks']>();
     const commonMainPackageJson = config.commonPackageSettings?.mainPackageJson;
-    const effectivePackageConfigs = mapToObj(config.packages, function (packageConfig) {
+    const packageConfigs = mapToObj(config.packages, function (packageConfig) {
         perPackageSettings.set(packageConfig.name, packageConfig.checks);
 
         return [
@@ -105,13 +121,27 @@ export async function buildChecksResult(
     const bundles = resolvedPackages.map(function (resolvedPackage) {
         return resolvedPackage.analyzedBundle;
     });
-    const publishedPackages = maybeBuildPublishedPackagesForChecks(dependencies, config, resolvedPackages);
+
+    return { bundles, packageConfigs, perPackageSettings };
+}
+
+export async function buildChecksResult(
+    dependencies: CheckEvaluationDependencies,
+    validated: ConfigWithGraph<PacktoryConfigWithoutRegistry>,
+    resolvedPackages: readonly ResolvedPackage[]
+): Promise<Result<readonly ResolvedPackage[], CheckError>> {
+    const { packtoryConfig: config } = validated;
+    const checkInputs = createStaticCheckInputs(config, resolvedPackages);
+    const publishedPackagesResult = tryBuildPublishedPackagesForChecks(dependencies, config, resolvedPackages);
+    if (publishedPackagesResult.isErr) {
+        return Result.err(publishedPackagesResult.error);
+    }
     const checkIssues = await dependencies.runChecks({
         settings: config.checks ?? {},
-        perPackageSettings,
-        packageConfigs: effectivePackageConfigs,
-        bundles,
-        publishedPackages
+        perPackageSettings: checkInputs.perPackageSettings,
+        packageConfigs: checkInputs.packageConfigs,
+        bundles: checkInputs.bundles,
+        publishedPackages: publishedPackagesResult.value
     });
 
     if (checkIssues.length > 0) {

--- a/source/resource-resolver/dependency-resolution-walker.test.ts
+++ b/source/resource-resolver/dependency-resolution-walker.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import type { DependencyGraph } from '../dependency-scanner/dependency-graph.ts';
 import type { DependencyScanner } from '../dependency-scanner/scanner.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
 import type { ResourceResolveOptions } from './resource-resolve-options.ts';
 import { resolveDependenciesForAllRoots } from './dependency-resolution-walker.ts';
 
@@ -14,6 +15,7 @@ type TrackingScanner = {
     readonly scanner: DependencyScanner;
     readonly calls: readonly ScanCall[];
 };
+type ReadabilityFileManager = Pick<FileManager, 'checkReadability'>;
 
 function emptyGraph(): DependencyGraph {
     return {
@@ -38,6 +40,23 @@ function emptyGraph(): DependencyGraph {
     };
 }
 
+function graphWithFiles(rootFile: string, additionalLocalFiles: readonly string[]): DependencyGraph {
+    return {
+        ...emptyGraph(),
+        flatten() {
+            return {
+                externalDependencies: new Map(),
+                localFiles: [
+                    { directDependencies: new Set(additionalLocalFiles), filePath: rootFile },
+                    ...additionalLocalFiles.map(function (filePath) {
+                        return { directDependencies: new Set<string>(), filePath };
+                    })
+                ]
+            };
+        }
+    };
+}
+
 function trackingScanner(): TrackingScanner {
     const calls: ScanCall[] = [];
     const scanner: DependencyScanner = {
@@ -49,6 +68,38 @@ function trackingScanner(): TrackingScanner {
     return {
         calls,
         scanner
+    };
+}
+
+function scannerWithGraphs(entries: readonly (readonly [string, DependencyGraph])[]): TrackingScanner {
+    const graphs = new Map(entries);
+    const calls: ScanCall[] = [];
+    const scanner: DependencyScanner = {
+        async scan(entry, _sourcesFolder, options) {
+            calls.push({ entry, resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
+            return graphs.get(entry) ?? emptyGraph();
+        }
+    };
+    return {
+        calls,
+        scanner
+    };
+}
+
+function alwaysUnreadable(): ReadabilityFileManager {
+    return {
+        async checkReadability() {
+            return { isReadable: false };
+        }
+    };
+}
+
+function readableFiles(files: readonly string[]): ReadabilityFileManager {
+    const fileSet = new Set(files);
+    return {
+        async checkReadability(fileOrFolderPath) {
+            return { isReadable: fileSet.has(fileOrFolderPath) };
+        }
     };
 }
 
@@ -69,7 +120,7 @@ suite('dependency-resolution-walker', function () {
     test('resolveDependenciesForAllRoots scans every root js entry once', async function () {
         const { scanner, calls } = trackingScanner();
         await resolveDependenciesForAllRoots(
-            scanner,
+            { dependencyScanner: scanner, fileManager: alwaysUnreadable() },
             optionsForRoots({
                 main: { js: '/src/index.js' },
                 other: { js: '/src/other.js' }
@@ -91,13 +142,107 @@ suite('dependency-resolution-walker', function () {
     test('resolveDependenciesForAllRoots also scans the declaration entry with resolveDeclarationFiles=true when present', async function () {
         const { scanner, calls } = trackingScanner();
         await resolveDependenciesForAllRoots(
-            scanner,
+            { dependencyScanner: scanner, fileManager: alwaysUnreadable() },
             optionsForRoots({ main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' } })
         );
 
         assert.deepStrictEqual(calls, [
             { entry: '/src/index.js', resolveDeclarationFiles: false },
             { entry: '/src/index.d.ts', resolveDeclarationFiles: true }
+        ]);
+    });
+
+    test('resolveDependenciesForAllRoots scans declaration companions for js dependencies in typed packages', async function () {
+        const { scanner, calls } = scannerWithGraphs([
+            [ '/src/index.js', graphWithFiles('/src/index.js', [ '/src/internal.js' ]) ],
+            [ '/src/internal.d.ts', graphWithFiles('/src/internal.d.ts', []) ]
+        ]);
+
+        const result = await resolveDependenciesForAllRoots(
+            { dependencyScanner: scanner, fileManager: readableFiles([ '/src/internal.d.ts' ]) },
+            optionsForRoots({ main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' } })
+        );
+        const indexFile = result.localFiles.find(function (localFile) {
+            return localFile.filePath === '/src/index.js';
+        });
+
+        assert.deepStrictEqual(calls, [
+            { entry: '/src/index.js', resolveDeclarationFiles: false },
+            { entry: '/src/index.d.ts', resolveDeclarationFiles: true },
+            { entry: '/src/internal.d.ts', resolveDeclarationFiles: true }
+        ]);
+        assert.deepStrictEqual(indexFile?.directDependencies, new Set([ '/src/internal.js' ]));
+        const internalDeclarationFile = result.localFiles.find(function (localFile) {
+            return localFile.filePath === '/src/internal.d.ts';
+        });
+        assert.deepStrictEqual(internalDeclarationFile?.directDependencies, new Set());
+    });
+
+    test('resolveDependenciesForAllRoots scans a shared declaration root once', async function () {
+        const { scanner, calls } = trackingScanner();
+        await resolveDependenciesForAllRoots(
+            { dependencyScanner: scanner, fileManager: alwaysUnreadable() },
+            optionsForRoots({
+                main: { js: '/src/index.js', declarationFile: '/src/shared.d.ts' },
+                other: { js: '/src/other.js', declarationFile: '/src/shared.d.ts' }
+            })
+        );
+
+        assert.deepStrictEqual(calls, [
+            { entry: '/src/index.js', resolveDeclarationFiles: false },
+            { entry: '/src/shared.d.ts', resolveDeclarationFiles: true },
+            { entry: '/src/other.js', resolveDeclarationFiles: false }
+        ]);
+    });
+
+    test('resolveDependenciesForAllRoots does not scan root js declaration companions', async function () {
+        const { scanner, calls } = scannerWithGraphs([
+            [ '/src/index.js', graphWithFiles('/src/index.js', []) ]
+        ]);
+
+        await resolveDependenciesForAllRoots(
+            { dependencyScanner: scanner, fileManager: readableFiles([ '/src/index.d.ts' ]) },
+            optionsForRoots({ main: { js: '/src/index.js', declarationFile: '/src/types.d.ts' } })
+        );
+
+        assert.deepStrictEqual(calls, [
+            { entry: '/src/index.js', resolveDeclarationFiles: false },
+            { entry: '/src/types.d.ts', resolveDeclarationFiles: true }
+        ]);
+    });
+
+    test('resolveDependenciesForAllRoots skips declaration companions for js-only packages', async function () {
+        const { scanner, calls } = scannerWithGraphs([
+            [ '/src/index.js', graphWithFiles('/src/index.js', [ '/src/internal.js' ]) ]
+        ]);
+
+        await resolveDependenciesForAllRoots(
+            { dependencyScanner: scanner, fileManager: readableFiles([ '/src/internal.d.ts' ]) },
+            optionsForRoots({ main: { js: '/src/index.js' } })
+        );
+
+        assert.deepStrictEqual(calls, [ { entry: '/src/index.js', resolveDeclarationFiles: false } ]);
+    });
+
+    test('resolveDependenciesForAllRoots scans companions when any root has declarations', async function () {
+        const { scanner, calls } = scannerWithGraphs([
+            [ '/src/other.js', graphWithFiles('/src/other.js', [ '/src/internal.js' ]) ],
+            [ '/src/internal.d.ts', graphWithFiles('/src/internal.d.ts', []) ]
+        ]);
+
+        await resolveDependenciesForAllRoots(
+            { dependencyScanner: scanner, fileManager: readableFiles([ '/src/internal.d.ts' ]) },
+            optionsForRoots({
+                main: { js: '/src/index.js', declarationFile: '/src/index.d.ts' },
+                other: { js: '/src/other.js' }
+            })
+        );
+
+        assert.deepStrictEqual(calls, [
+            { entry: '/src/index.js', resolveDeclarationFiles: false },
+            { entry: '/src/index.d.ts', resolveDeclarationFiles: true },
+            { entry: '/src/other.js', resolveDeclarationFiles: false },
+            { entry: '/src/internal.d.ts', resolveDeclarationFiles: true }
         ]);
     });
 });

--- a/source/resource-resolver/dependency-resolution-walker.ts
+++ b/source/resource-resolver/dependency-resolution-walker.ts
@@ -1,34 +1,177 @@
 import { mergeDependencyFiles, type DependencyFiles } from '../dependency-scanner/dependency-graph.ts';
 import type { DependencyScanner } from '../dependency-scanner/scanner.ts';
-import { resolveRootsAndSurface, type ResourceResolveOptions } from './resource-resolve-options.ts';
+import type { FileManager } from '../file-manager/file-manager.ts';
+import { declarationCompanionCandidates } from '../common/declaration-companion-paths.ts';
+import {
+    type ResolvedRootsAndSurface,
+    resolveRootsAndSurface,
+    type ResourceResolveOptions
+} from './resource-resolve-options.ts';
+
+type DependencyResolutionDependencies = {
+    readonly dependencyScanner: DependencyScanner;
+    readonly fileManager: Pick<FileManager, 'checkReadability'>;
+};
+
+type DeclarationScanTracker = {
+    readonly has: (filePath: string) => boolean;
+    readonly record: (filePath: string) => void;
+};
+type RootResolutionContext = {
+    readonly dependencies: DependencyResolutionDependencies;
+    readonly options: ResourceResolveOptions;
+    readonly packageHasDeclarationRoots: boolean;
+    readonly rootJsSourceFilePaths: ReadonlySet<string>;
+    readonly scannedDeclarationFiles: DeclarationScanTracker;
+};
+
+function emptyDependencyFiles(): DependencyFiles {
+    return { externalDependencies: new Map(), localFiles: [] };
+}
+
+async function findReadableDeclarationCompanion(
+    fileManager: Pick<FileManager, 'checkReadability'>,
+    filePath: string
+): Promise<string | undefined> {
+    for (const candidate of declarationCompanionCandidates(filePath)) {
+        const readability = await fileManager.checkReadability(candidate);
+        if (readability.isReadable) {
+            return candidate;
+        }
+    }
+
+    return undefined;
+}
+
+async function scanDeclarationGraph(
+    dependencies: DependencyResolutionDependencies,
+    options: ResourceResolveOptions,
+    entryFile: string,
+    scannedDeclarationFiles: DeclarationScanTracker
+): Promise<DependencyFiles> {
+    if (scannedDeclarationFiles.has(entryFile)) {
+        return emptyDependencyFiles();
+    }
+    scannedDeclarationFiles.record(entryFile);
+
+    const declarationDependencyGraph = await dependencies.dependencyScanner.scan(entryFile, options.sourcesFolder, {
+        includeSourceMapFiles: options.includeSourceMapFiles,
+        resolveDeclarationFiles: true,
+        mainPackageJson: options.mainPackageJson
+    });
+    return declarationDependencyGraph.flatten(entryFile);
+}
+
+async function resolveDeclarationCompanionDependencies(
+    context: RootResolutionContext,
+    jsDependencies: DependencyFiles
+): Promise<DependencyFiles> {
+    let result = emptyDependencyFiles();
+    const nonRootLocalFiles = jsDependencies.localFiles.filter(function (localFile) {
+        return !context.rootJsSourceFilePaths.has(localFile.filePath);
+    });
+    for (const localFile of nonRootLocalFiles) {
+        const declarationCompanion = await findReadableDeclarationCompanion(
+            context.dependencies.fileManager,
+            localFile.filePath
+        );
+        if (declarationCompanion !== undefined) {
+            result = mergeDependencyFiles(
+                result,
+                await scanDeclarationGraph(
+                    context.dependencies,
+                    context.options,
+                    declarationCompanion,
+                    context.scannedDeclarationFiles
+                )
+            );
+        }
+    }
+
+    return result;
+}
+
+function createDeclarationScanTracker(): DeclarationScanTracker {
+    const scannedDeclarationFiles = new Set<string>();
+    return {
+        has(filePath) {
+            return scannedDeclarationFiles.has(filePath);
+        },
+        record(filePath) {
+            scannedDeclarationFiles.add(filePath);
+        }
+    };
+}
+
+async function resolveJsDependencies(
+    context: RootResolutionContext,
+    root: ResolvedRootsAndSurface['roots'][string]
+): Promise<DependencyFiles> {
+    const { dependencies, options } = context;
+    const { sourcesFolder, includeSourceMapFiles, mainPackageJson } = options;
+    const jsDependencyGraph = await dependencies.dependencyScanner.scan(root.js, sourcesFolder, {
+        includeSourceMapFiles,
+        resolveDeclarationFiles: false,
+        mainPackageJson
+    });
+    return jsDependencyGraph.flatten(root.js);
+}
+
+async function resolveRootDeclarationDependencies(
+    context: RootResolutionContext,
+    root: ResolvedRootsAndSurface['roots'][string]
+): Promise<DependencyFiles> {
+    if (root.declarationFile !== undefined) {
+        return await scanDeclarationGraph(
+            context.dependencies,
+            context.options,
+            root.declarationFile,
+            context.scannedDeclarationFiles
+        );
+    }
+
+    return emptyDependencyFiles();
+}
+
+async function resolveDependenciesForRoot(
+    context: RootResolutionContext,
+    root: ResolvedRootsAndSurface['roots'][string]
+): Promise<DependencyFiles> {
+    const jsDependencies = await resolveJsDependencies(context, root);
+    const declarationDependencies = await resolveRootDeclarationDependencies(context, root);
+    let dependencyFiles = mergeDependencyFiles(jsDependencies, declarationDependencies);
+
+    if (context.packageHasDeclarationRoots) {
+        dependencyFiles = mergeDependencyFiles(
+            dependencyFiles,
+            await resolveDeclarationCompanionDependencies(context, jsDependencies)
+        );
+    }
+
+    return dependencyFiles;
+}
 
 export async function resolveDependenciesForAllRoots(
-    dependencyScanner: DependencyScanner,
+    dependencies: DependencyResolutionDependencies,
     options: ResourceResolveOptions
 ): Promise<DependencyFiles> {
     const { roots } = resolveRootsAndSurface(options);
-    const { sourcesFolder, includeSourceMapFiles, mainPackageJson } = options;
-    let dependencyFiles: DependencyFiles = { externalDependencies: new Map(), localFiles: [] };
+    const rootValues = Object.values(roots);
+    const context: RootResolutionContext = {
+        dependencies,
+        options,
+        packageHasDeclarationRoots: rootValues.some(function (root) {
+            return root.declarationFile !== undefined;
+        }),
+        rootJsSourceFilePaths: new Set(rootValues.map(function (root) {
+            return root.js;
+        })),
+        scannedDeclarationFiles: createDeclarationScanTracker()
+    };
+    let dependencyFiles = emptyDependencyFiles();
 
-    for (const root of Object.values(roots)) {
-        const jsDependencyGraph = await dependencyScanner.scan(root.js, sourcesFolder, {
-            includeSourceMapFiles,
-            resolveDeclarationFiles: false,
-            mainPackageJson
-        });
-        dependencyFiles = mergeDependencyFiles(dependencyFiles, jsDependencyGraph.flatten(root.js));
-
-        if (root.declarationFile !== undefined) {
-            const declarationDependencyGraph = await dependencyScanner.scan(root.declarationFile, sourcesFolder, {
-                includeSourceMapFiles,
-                resolveDeclarationFiles: true,
-                mainPackageJson
-            });
-            dependencyFiles = mergeDependencyFiles(
-                dependencyFiles,
-                declarationDependencyGraph.flatten(root.declarationFile)
-            );
-        }
+    for (const root of rootValues) {
+        dependencyFiles = mergeDependencyFiles(dependencyFiles, await resolveDependenciesForRoot(context, root));
     }
 
     return dependencyFiles;

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -75,6 +75,7 @@ function createGraph(params: GraphParams): DependencyGraph {
 }
 
 type Overrides = {
+    readonly readableFiles?: readonly string[];
     readonly scan?: SinonSpy;
     readonly transferableFileDescriptionResponder?: (
         sourceFilePath: string,
@@ -85,11 +86,20 @@ type Overrides = {
 function createResolver(overrides: Overrides = {}): ResolverFixture {
     const scan = overrides.scan ?? fake();
     const responder = overrides.transferableFileDescriptionResponder ?? createTransferableFile;
-    const fileManager = createFakeFileManager({
+    const baseFileManager = createFakeFileManager({
         transferableFileDescriptionResponder(sourceFilePath, targetFilePath) {
             return { value: responder(sourceFilePath, targetFilePath) };
         }
     });
+    const readableFiles = overrides.readableFiles === undefined
+        ? new Set<string>()
+        : new Set(overrides.readableFiles);
+    const fileManager = {
+        ...baseFileManager,
+        async checkReadability(fileOrFolderPath: string) {
+            return { isReadable: readableFiles.has(fileOrFolderPath) };
+        }
+    };
 
     const dependencies: ResourceResolverDependencies = {
         dependencyScanner: { scan },

--- a/source/resource-resolver/resource-resolver.ts
+++ b/source/resource-resolver/resource-resolver.ts
@@ -53,7 +53,10 @@ export function createResourceResolver(dependencies: ResourceResolverDependencie
     return {
         async resolve(options) {
             const normalized = resolveRootsAndSurface(options);
-            const resolvedDependencies = await resolveDependenciesForAllRoots(dependencyScanner, options);
+            const resolvedDependencies = await resolveDependenciesForAllRoots(
+                { dependencyScanner, fileManager },
+                options
+            );
 
             const bundleFiles = combineAllBundleFiles(
                 options.sourcesFolder,


### PR DESCRIPTION
Typed substitution exports now require declaration companions, and linked packages keep resolved companions for runtime files that remain in the package. This prevents generated `exports` entries from exposing JavaScript subpaths that TypeScript consumers cannot resolve.