### PR TITLE
Fix `typeScriptIntegrity` declaration DCE

### DIFF
--- a/integration-tests/checks/declaration-integrity.test.ts
+++ b/integration-tests/checks/declaration-integrity.test.ts
@@ -1,15 +1,22 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
+import { RealFileSystemHost } from '@ts-morph/common';
 import { Project } from 'ts-morph';
 import {
     createDeclarationIntegritySummarizer,
     type DeclarationMode
 } from '../../source/checks/rules/type-script-declaration-integrity.ts';
 import { createDeclarationProjectFactory } from '../../source/checks/rules/type-script-declaration-project.ts';
+import { createFileSystemAdapters } from '../../source/dependency-scanner/typescript-file-host.ts';
 import { manifest, publishedPackage } from './published-package-fixtures.ts';
 
+const fileSystemAdapters = createFileSystemAdapters({ fileSystemHost: new RealFileSystemHost() });
 const summarizeDeclarationIntegrity = createDeclarationIntegritySummarizer({
-    createDeclarationProjects: createDeclarationProjectFactory({ Project })
+    createDeclarationProjects: createDeclarationProjectFactory({
+        Project,
+        fileSystemHost: fileSystemAdapters.fileSystemHostWithoutFilter,
+        packageResolutionBaseFolder: process.cwd()
+    })
 });
 
 function checkDeclarations(
@@ -211,5 +218,25 @@ suite('declaration integrity against the real TypeScript compiler', function () 
             ]
                 .join('\n')
         ]);
+    });
+
+    test('resolves installed dependency declarations imported by shipped declarations', function () {
+        const issues = checkDeclarations(
+            'external-types',
+            {
+                types: './index.d.ts',
+                dependencies: { 'type-fest': '5.8.0' }
+            },
+            {
+                'index.d.ts': [
+                    'import type { PackageJson } from "type-fest";',
+                    'export type Manifest = PackageJson;'
+                ]
+                    .join('\n')
+            },
+            'all'
+        );
+
+        assert.deepStrictEqual(issues, []);
     });
 });

--- a/source/checks/rules/type-script-declaration-project.test.ts
+++ b/source/checks/rules/type-script-declaration-project.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
 import { fake, stub, type SinonSpy, type SinonStub } from 'sinon';
-import { ModuleKind, ModuleResolutionKind, ScriptTarget } from 'ts-morph';
+import { ModuleKind, ModuleResolutionKind, ScriptKind, ScriptTarget } from 'ts-morph';
 import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts';
 import {
     createDeclarationProjectFactory,
@@ -32,7 +32,12 @@ type FakeSourceFile = {
 };
 
 function createFakeSourceFile(overrides: FakeSourceFileOverrides = {}): FakeSourceFile {
-    const { filePath = '/node_modules/pkg/index.d.ts', imports = [], exports = [], line = 1 } = overrides;
+    const {
+        filePath = '/workspace/.packtory-type-integrity/node_modules/pkg/index.d.ts',
+        imports = [],
+        exports = [],
+        line = 1
+    } = overrides;
     return {
         getFilePath: fake.returns(filePath),
         getImportDeclarations: fake.returns(imports),
@@ -84,7 +89,12 @@ function declarationProjectsFor(
     projectConstructor: SinonStub,
     packageFiles: readonly { readonly filePath: string; readonly content: string; }[] = []
 ): readonly DeclarationProject[] {
-    const fakeDependencies = { Project: projectConstructor } as unknown as DeclarationProjectDependencies;
+    const fileSystemHost = {};
+    const fakeDependencies = {
+        Project: projectConstructor,
+        fileSystemHost,
+        packageResolutionBaseFolder: '/workspace'
+    } as unknown as DeclarationProjectDependencies;
     return createDeclarationProjectFactory(fakeDependencies)('pkg', packageFiles);
 }
 
@@ -104,7 +114,7 @@ const commonCompilerOptions = {
 };
 
 suite('type-script-declaration-project', function () {
-    test('creates one in-memory project per checked compiler mode', function () {
+    test('creates one project per checked compiler mode', function () {
         const TSMorphProject = createFakeProjectConstructor();
 
         const projects = declarationProjectsFor(TSMorphProject);
@@ -120,11 +130,12 @@ suite('type-script-declaration-project', function () {
             firstCall: {
                 args: [
                     {
-                        useInMemoryFileSystem: true,
+                        fileSystem: {},
                         skipAddingFilesFromTsConfig: true,
                         compilerOptions: {
                             module: ModuleKind.Node16,
                             moduleResolution: ModuleResolutionKind.Node16,
+                            resolveJsonModule: true,
                             ...commonCompilerOptions
                         }
                     }
@@ -133,11 +144,12 @@ suite('type-script-declaration-project', function () {
             secondCall: {
                 args: [
                     {
-                        useInMemoryFileSystem: true,
+                        fileSystem: {},
                         skipAddingFilesFromTsConfig: true,
                         compilerOptions: {
                             module: ModuleKind.ESNext,
                             moduleResolution: ModuleResolutionKind.Bundler,
+                            resolveJsonModule: true,
                             ...commonCompilerOptions
                         }
                     }
@@ -156,10 +168,24 @@ suite('type-script-declaration-project', function () {
         ]);
 
         assert.deepStrictEqual(createSourceFile.args, [
-            [ '/node_modules/pkg/package.json', '{}' ],
-            [ '/node_modules/pkg/nested/index.d.ts', 'export declare const value: number;' ],
-            [ '/node_modules/pkg/package.json', '{}' ],
-            [ '/node_modules/pkg/nested/index.d.ts', 'export declare const value: number;' ]
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/package.json',
+                '{}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/nested/index.d.ts',
+                'export declare const value: number;'
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/package.json',
+                '{}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/nested/index.d.ts',
+                'export declare const value: number;'
+            ]
         ]);
     });
 
@@ -174,13 +200,18 @@ suite('type-script-declaration-project', function () {
         const specifiers = firstProject(declarationProjectsFor(TSMorphProject)).moduleSpecifiersOf('nested/index.d.ts');
 
         assert.deepStrictEqual(specifiers, [ './leaf.js', './other.js' ]);
-        assert.deepStrictEqual(getSourceFileOrThrow.args, [ [ '/node_modules/pkg/nested/index.d.ts' ] ]);
+        assert.deepStrictEqual(getSourceFileOrThrow.args, [
+            [ '/workspace/.packtory-type-integrity/node_modules/pkg/nested/index.d.ts' ]
+        ]);
     });
 
     test('listDiagnostics() reports package-relative paths, lines, codes and messages', function () {
         const getPreEmitDiagnostics = fake.returns([
             createFakeDiagnostic({
-                sourceFile: createFakeSourceFile({ filePath: '/node_modules/pkg/nested/index.d.ts', line: 7 }),
+                sourceFile: createFakeSourceFile({
+                    filePath: '/workspace/.packtory-type-integrity/node_modules/pkg/nested/index.d.ts',
+                    line: 7
+                }),
                 start: 42,
                 code: 2305,
                 messageText: 'Module has no exported member'

--- a/source/checks/rules/type-script-declaration-project.ts
+++ b/source/checks/rules/type-script-declaration-project.ts
@@ -1,13 +1,15 @@
+import path from 'node:path';
 import {
     ModuleKind,
     ModuleResolutionKind,
+    ScriptKind,
     ScriptTarget,
     ts as typescript,
     type Diagnostic,
+    type FileSystemHost,
     type Project as TSMorphProject,
     type SourceFile
 } from 'ts-morph';
-import { installedPackageFilePath, packageRelativeFilePath } from '../../common/package-layout.ts';
 
 export type PackageFile = {
     readonly filePath: string;
@@ -34,6 +36,8 @@ export type DeclarationProjectsFactory = (
 
 export type DeclarationProjectDependencies = {
     readonly Project: typeof TSMorphProject;
+    readonly fileSystemHost: FileSystemHost;
+    readonly packageResolutionBaseFolder: string;
 };
 
 type DeclarationCompilerMode = {
@@ -70,8 +74,20 @@ function moduleSpecifiersIn(sourceFile: Readonly<SourceFile>): readonly string[]
         });
 }
 
+function declarationProjectPackageFolder(baseFolder: string, packageName: string): string {
+    return path.join(baseFolder, '.packtory-type-integrity', 'node_modules', packageName);
+}
+
+function declarationProjectPackageFilePath(packageFolder: string, relativeFilePath: string): string {
+    return path.join(packageFolder, relativeFilePath);
+}
+
+function declarationProjectPackageRelativeFilePath(packageFolder: string, filePath: string): string {
+    return path.relative(packageFolder, filePath).split(path.sep).join(path.posix.sep);
+}
+
 function toDeclarationDiagnostic(
-    packageName: string,
+    packageFolder: string,
     diagnostic: Readonly<Diagnostic>
 ): DeclarationDiagnostic | undefined {
     const sourceFile = diagnostic.getSourceFile();
@@ -81,7 +97,7 @@ function toDeclarationDiagnostic(
     }
 
     return {
-        declarationPath: packageRelativeFilePath(packageName, sourceFile.getFilePath()),
+        declarationPath: declarationProjectPackageRelativeFilePath(packageFolder, sourceFile.getFilePath()),
         line: sourceFile.getLineAndColumnAtPos(start).line,
         code: diagnostic.getCode(),
         message: typescript.flattenDiagnosticMessageText(diagnostic.compilerObject.messageText, '\n')
@@ -94,7 +110,7 @@ function isDeclarationDiagnostic(diagnostic: DeclarationDiagnostic | undefined):
 
 function createModeProject(
     project: Readonly<TSMorphProject>,
-    packageName: string,
+    packageFolder: string,
     modeLabel: string
 ): DeclarationProject {
     return {
@@ -102,7 +118,7 @@ function createModeProject(
 
         moduleSpecifiersOf(declarationPath) {
             return moduleSpecifiersIn(
-                project.getSourceFileOrThrow(installedPackageFilePath(packageName, declarationPath))
+                project.getSourceFileOrThrow(declarationProjectPackageFilePath(packageFolder, declarationPath))
             );
         },
 
@@ -110,7 +126,7 @@ function createModeProject(
             return project
                 .getPreEmitDiagnostics()
                 .map(function (diagnostic) {
-                    return toDeclarationDiagnostic(packageName, diagnostic);
+                    return toDeclarationDiagnostic(packageFolder, diagnostic);
                 })
                 .filter(isDeclarationDiagnostic);
         }
@@ -120,20 +136,22 @@ function createModeProject(
 export function createDeclarationProjectFactory(
     dependencies: DeclarationProjectDependencies
 ): DeclarationProjectsFactory {
-    const { Project } = dependencies;
+    const { Project, fileSystemHost, packageResolutionBaseFolder } = dependencies;
 
     function createProjectForMode(
         packageName: string,
         packageFiles: readonly PackageFile[],
         compilerMode: DeclarationCompilerMode
     ): DeclarationProject {
+        const packageFolder = declarationProjectPackageFolder(packageResolutionBaseFolder, packageName);
         const project = new Project({
-            useInMemoryFileSystem: true,
+            fileSystem: fileSystemHost,
             skipAddingFilesFromTsConfig: true,
             compilerOptions: {
                 module: compilerMode.module,
                 moduleResolution: compilerMode.moduleResolution,
                 noEmit: true,
+                resolveJsonModule: true,
                 skipLibCheck: false,
                 strict: true,
                 target: ScriptTarget.ESNext
@@ -141,10 +159,15 @@ export function createDeclarationProjectFactory(
         });
 
         for (const packageFile of packageFiles) {
-            project.createSourceFile(installedPackageFilePath(packageName, packageFile.filePath), packageFile.content);
+            const filePath = declarationProjectPackageFilePath(packageFolder, packageFile.filePath);
+            if (path.basename(packageFile.filePath) === 'package.json') {
+                project.createSourceFile(filePath, packageFile.content, { scriptKind: ScriptKind.JSON });
+            } else {
+                project.createSourceFile(filePath, packageFile.content);
+            }
         }
 
-        return createModeProject(project, packageName, compilerMode.label);
+        return createModeProject(project, packageFolder, compilerMode.label);
     }
 
     return function createDeclarationProjects(packageName, packageFiles) {

--- a/source/common/package-layout.test.ts
+++ b/source/common/package-layout.test.ts
@@ -10,8 +10,7 @@ import {
     isPackageManifestPath,
     packageManifestAbsolutePathIn,
     packageManifestFilePath,
-    packageManifestPathIn,
-    packageRelativeFilePath
+    packageManifestPathIn
 } from './package-layout.ts';
 
 suite('package-layout', function () {
@@ -44,24 +43,6 @@ suite('package-layout', function () {
             assert.strictEqual(
                 installedPackageFilePath('@scope/shared', 'package.json'),
                 '/node_modules/@scope/shared/package.json'
-            );
-        });
-
-        test('packageRelativeFilePath() strips the installed package folder again', function () {
-            assert.strictEqual(
-                packageRelativeFilePath('shared', '/node_modules/shared/dist/index.d.ts'),
-                'dist/index.d.ts'
-            );
-            assert.strictEqual(
-                packageRelativeFilePath('@scope/shared', '/node_modules/@scope/shared/package.json'),
-                'package.json'
-            );
-        });
-
-        test('packageRelativeFilePath() keeps files outside the installed package folder recognizable', function () {
-            assert.strictEqual(
-                packageRelativeFilePath('shared', '/node_modules/typescript/lib/lib.es5.d.ts'),
-                '../typescript/lib/lib.es5.d.ts'
             );
         });
     });

--- a/source/common/package-layout.ts
+++ b/source/common/package-layout.ts
@@ -55,10 +55,6 @@ export function installedPackageFilePath(packageName: string, relativeFilePath: 
     return path.posix.join(installedPackageFolderPath(packageName), relativeFilePath);
 }
 
-export function packageRelativeFilePath(packageName: string, installedFilePath: string): string {
-    return path.posix.relative(installedPackageFolderPath(packageName), installedFilePath);
-}
-
 export function isPackageManifestPath(filePath: string): boolean {
     return path.basename(filePath) === packageManifestFilePath;
 }

--- a/source/dead-code-eliminator/eliminator-reachability-seeds.test.ts
+++ b/source/dead-code-eliminator/eliminator-reachability-seeds.test.ts
@@ -42,7 +42,7 @@ suite('eliminator reachability seeds', function () {
             assert.strictEqual(emittedMap.fileDescription.content, validMapContent);
         });
 
-        test('eliminate honours a root declaration file when seeding reachability', async function () {
+        test('eliminate keeps exported bindings from retained declaration files', async function () {
             const eliminator = createTestEliminator();
             const declarationContent = 'export type Public = number;\nexport type Private = string;';
             const declarationFile = {
@@ -194,6 +194,50 @@ suite('eliminator reachability seeds', function () {
             assertDefined(runtimeHelper);
             assert.strictEqual(runtimeHelper.fileDescription.content.includes('used'), true);
             assert.strictEqual(runtimeHelper.fileDescription.content.includes('unused'), false);
+        });
+
+        test('eliminate keeps type exports imported by retained declaration files', async function () {
+            const eliminator = createTestEliminator();
+            const entryResource = {
+                ...bundleResource('/src/index.js', { content: 'export const live = 1;\n', targetFilePath: 'index.js' }),
+                isSubstituted: false
+            };
+            const privateDeclarationResource = {
+                ...bundleResource('/src/private.d.ts', {
+                    content: 'import type { Imported } from "./types.js";\nexport type Private = Imported;\n',
+                    targetFilePath: 'private.d.ts'
+                }),
+                isSubstituted: false
+            };
+            const typesDeclarationResource = {
+                ...bundleResource('/src/types.d.ts', {
+                    content: 'export type Imported = string;\nexport type Other = number;\n',
+                    targetFilePath: 'types.d.ts'
+                }),
+                isSubstituted: false
+            };
+            const bundle = linkedBundle({
+                name: 'pkg',
+                contents: [ entryResource, privateDeclarationResource, typesDeclarationResource ],
+                roots: {
+                    main: {
+                        js: {
+                            content: '',
+                            isExecutable: false,
+                            sourceFilePath: '/src/index.js',
+                            targetFilePath: 'index.js'
+                        }
+                    }
+                },
+                surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+            });
+            const [ analyzed ] = await eliminator.eliminate(inputs(bundle));
+            const emittedTypes = analyzed?.contents.find(function (resource) {
+                return resource.fileDescription.sourceFilePath === '/src/types.d.ts';
+            });
+            assertDefined(emittedTypes);
+            assert.strictEqual(emittedTypes.fileDescription.content.includes('Imported'), true);
+            assert.deepStrictEqual(emittedTypes.analysis.survivingBindings, new Set([ 'Imported', 'Other' ]));
         });
 
         test('eliminate drops a producer binding whose only consumer-side reference is in unreachable code', async function () {

--- a/source/dead-code-eliminator/load-bundle.ts
+++ b/source/dead-code-eliminator/load-bundle.ts
@@ -77,9 +77,6 @@ function entryRootFilePathsFor(bundle: LinkedBundle): ReadonlySet<string> {
         }
 
         paths.add(root.js.sourceFilePath);
-        if (root.declarationFile !== undefined) {
-            paths.add(root.declarationFile.sourceFilePath);
-        }
     }
     return paths;
 }

--- a/source/dead-code-eliminator/reachability/local-seed-gathering.test.ts
+++ b/source/dead-code-eliminator/reachability/local-seed-gathering.test.ts
@@ -61,6 +61,17 @@ suite('local-seed-gathering', function () {
         assert.strictEqual(seeds.has('/lib.ts::foo'), false);
     });
 
+    test('gatherLocalSeeds adds exported bindings from declaration files outside entry points', function () {
+        const seeds = gatherSeedsForSingleBinding(
+            'export declare const foo: string;',
+            '/private.d.ts',
+            new Set([ '/index.ts' ]),
+            true
+        );
+
+        assert.strictEqual(seeds.has('/private.d.ts::foo'), true);
+    });
+
     test('gatherLocalSeeds ignores non-exported bindings of entry-point files', function () {
         const seeds = gatherSeedsForSingleBinding('const foo = 1;', '/index.ts', new Set([ '/index.ts' ]), false);
 

--- a/source/dead-code-eliminator/reachability/local-seed-gathering.ts
+++ b/source/dead-code-eliminator/reachability/local-seed-gathering.ts
@@ -1,4 +1,5 @@
 import { Node as TsMorphNode, type SourceFile, type Statement } from 'ts-morph';
+import { isDeclarationCompanionFilePath } from '../../common/declaration-companion-paths.ts';
 import type { DeadCodeEliminationSettings } from '../../config/dead-code-elimination-settings.ts';
 import { bindingId, type FileBindingSet } from './binding-id.ts';
 import { collectIdentifierTargets, type DeclarationNodeIndex } from './identifier-target-collector.ts';
@@ -29,7 +30,7 @@ function entryPointExportDeclarationSeeds(
 }
 
 function exportedBindingSeeds(file: FileBindings, isEntry: boolean): readonly string[] {
-    if (!isEntry) {
+    if (!isEntry && !isDeclarationCompanionFilePath(file.sourceFilePath)) {
         return [];
     }
     return file.bindings.flatMap(function (binding) {

--- a/source/packages/packtory.composition.ts
+++ b/source/packages/packtory.composition.ts
@@ -4,12 +4,14 @@ import {
     problemAffectsResolutionKind,
     problemKindInfo
 } from '@arethetypeswrong/core/problems';
+import { RealFileSystemHost } from '@ts-morph/common';
 import { Project } from 'ts-morph';
 import { createCheckRunner, type CheckRunner } from '../checks/check-runner.ts';
 import { createAllRules } from '../checks/rules/registry.ts';
 import { createDeclarationIntegritySummarizer } from '../checks/rules/type-script-declaration-integrity.ts';
 import { createDeclarationProjectFactory } from '../checks/rules/type-script-declaration-project.ts';
 import { createPackageResolutionAnalyzer } from '../checks/rules/type-script-package-resolution.ts';
+import { createFileSystemAdapters } from '../dependency-scanner/typescript-file-host.ts';
 import { createPacktory, type Packtory } from '../packtory/packtory.ts';
 import { createScheduler } from '../packtory/scheduler.ts';
 import type { ProgressBroadcaster } from '../progress/progress-broadcaster.ts';
@@ -23,7 +25,8 @@ export type PacktoryComposition = {
     readonly progressBroadcaster: ProgressBroadcaster;
 };
 
-function buildCheckRunner(): CheckRunner {
+function buildCheckRunner(repositoryFolder: string): CheckRunner {
+    const fileSystemAdapters = createFileSystemAdapters({ fileSystemHost: new RealFileSystemHost() });
     const rules = createAllRules({
         analyzePackageResolution: createPackageResolutionAnalyzer({
             Package,
@@ -33,7 +36,11 @@ function buildCheckRunner(): CheckRunner {
             problemAffectsEntrypointResolution
         }),
         summarizeDeclarationIntegrity: createDeclarationIntegritySummarizer({
-            createDeclarationProjects: createDeclarationProjectFactory({ Project })
+            createDeclarationProjects: createDeclarationProjectFactory({
+                Project,
+                fileSystemHost: fileSystemAdapters.fileSystemHostWithoutFilter,
+                packageResolutionBaseFolder: repositoryFolder
+            })
         })
     });
 
@@ -56,7 +63,7 @@ export function buildPacktoryComposition(options: PackageProcessorCompositionOpt
             fileManager: parts.fileManager,
             repositoryFolder: parts.repositoryFolder,
             versionManager: parts.versionManager,
-            runChecks: buildCheckRunner(),
+            runChecks: buildCheckRunner(parts.repositoryFolder),
             packEmitter: parts.packEmitter,
             vendorMaterializer: parts.vendorMaterializer,
             readCurrentGitHead: parts.readCurrentGitHead,


### PR DESCRIPTION
DCE now treats retained declaration files as declaration graph roots, so shipped `.d.ts` files keep the exported type symbols needed by their type-only imports. The TypeScript declaration integrity project is also mounted under a repo-backed synthetic package path, letting TypeScript resolve valid dependency declarations through installed `node_modules` while still checking the published package files.