### PR TITLE
Fix `typeScriptIntegrity` declaration graph checks

### DIFF
--- a/integration-tests/checks/declaration-integrity.test.ts
+++ b/integration-tests/checks/declaration-integrity.test.ts
@@ -25,13 +25,15 @@ function checkDeclarations(
     files: Readonly<Record<string, string>>,
     declarationMode: DeclarationMode
 ): readonly string[] {
+    const packageUnderCheck = publishedPackage(packageName, manifest(packageName, manifestFields), {
+        'index.js': 'export const value = 1;\n',
+        ...files
+    });
     return summarizeDeclarationIntegrity(
         packageName,
-        publishedPackage(packageName, manifest(packageName, manifestFields), {
-            'index.js': 'export const value = 1;\n',
-            ...files
-        }),
-        declarationMode
+        packageUnderCheck,
+        declarationMode,
+        new Map([ [ packageName, packageUnderCheck ] ])
     );
 }
 
@@ -235,6 +237,59 @@ suite('declaration integrity against the real TypeScript compiler', function () 
                     .join('\n')
             },
             'all'
+        );
+
+        assert.deepStrictEqual(issues, []);
+    });
+
+    test('resolves generated dependency declaration subpaths imported by shipped declarations', function () {
+        const producer = publishedPackage(
+            '@scope/core',
+            manifest('@scope/core', {
+                exports: {
+                    '.': { types: './index.d.ts', import: './index.js' },
+                    './lib/version-number.js': {
+                        types: './lib/version-number.d.ts',
+                        import: './lib/version-number.js'
+                    },
+                    './lib/type-only.d.ts': {
+                        types: './lib/type-only.d.ts'
+                    }
+                }
+            }),
+            {
+                'index.js': 'export const value = 1;\n',
+                'index.d.ts': 'export declare const value: number;\n',
+                'lib/version-number.js': 'export const version = "1.0.0";\n',
+                'lib/version-number.d.ts': 'export type VersionNumber = string;\n',
+                'lib/type-only.d.ts': 'export type TypeOnly = number;\n'
+            }
+        );
+        const consumer = publishedPackage(
+            'consumer',
+            manifest('consumer', {
+                types: './index.d.ts',
+                dependencies: { '@scope/core': '0.0.0' }
+            }),
+            {
+                'index.js': 'export const value = 1;\n',
+                'index.d.ts': [
+                    'import type { VersionNumber } from "@scope/core/lib/version-number.js";',
+                    'import type { TypeOnly } from "@scope/core/lib/type-only.d.ts";',
+                    'export type ConsumerVersion = VersionNumber | TypeOnly;'
+                ]
+                    .join('\n')
+            }
+        );
+
+        const issues = summarizeDeclarationIntegrity(
+            'consumer',
+            consumer,
+            'all',
+            new Map([
+                [ '@scope/core', producer ],
+                [ 'consumer', consumer ]
+            ])
         );
 
         assert.deepStrictEqual(issues, []);

--- a/integration-tests/packtory/publish-fixture-expectations.ts
+++ b/integration-tests/packtory/publish-fixture-expectations.ts
@@ -11,6 +11,9 @@ export const expectedFirstPackageVersion = {
                         import: './entry1.js',
                         types: './entry1.d.ts'
                     },
+                    './foo.d.ts': {
+                        types: './foo.d.ts'
+                    },
                     './qux.js': {
                         import: './qux.js',
                         types: './qux.d.ts'

--- a/source/checks/rules/type-script-declaration-integrity.test.ts
+++ b/source/checks/rules/type-script-declaration-integrity.test.ts
@@ -50,7 +50,8 @@ function summarize(options: SummarizeOptions): readonly string[] {
     return summarizeDeclarationIntegrity(
         'pkg',
         checkPublishedPackage('pkg', options.manifestContent, options.files),
-        options.declarationMode
+        options.declarationMode,
+        new Map()
     );
 }
 
@@ -70,7 +71,21 @@ suite('type-script-declaration-integrity', function () {
         summarizeDeclarationIntegrity(
             'pkg',
             checkPublishedPackage('pkg', '{"types":"./index.d.ts"}', { 'index.d.ts': 'export {};\n' }),
-            'all'
+            'all',
+            new Map([
+                [
+                    'pkg',
+                    checkPublishedPackage('pkg', '{"types":"./index.d.ts"}', {
+                        'index.d.ts': 'export {};\n'
+                    })
+                ],
+                [
+                    'dependency',
+                    checkPublishedPackage('dependency', '{"types":"./index.d.ts"}', {
+                        'index.d.ts': 'export type Dependency = string;\n'
+                    })
+                ]
+            ])
         );
 
         assert.deepStrictEqual(createDeclarationProjects.args, [ [
@@ -78,6 +93,15 @@ suite('type-script-declaration-integrity', function () {
             [
                 { filePath: 'package.json', content: '{"types":"./index.d.ts"}' },
                 { filePath: 'index.d.ts', content: 'export {};\n' }
+            ],
+            [
+                {
+                    packageName: 'dependency',
+                    packageFiles: [
+                        { filePath: 'package.json', content: '{"types":"./index.d.ts"}' },
+                        { filePath: 'index.d.ts', content: 'export type Dependency = string;\n' }
+                    ]
+                }
             ]
         ] ]);
     });

--- a/source/checks/rules/type-script-declaration-integrity.ts
+++ b/source/checks/rules/type-script-declaration-integrity.ts
@@ -4,7 +4,8 @@ import type {
     DeclarationDiagnostic,
     DeclarationProject,
     DeclarationProjectsFactory,
-    PackageFile
+    PackageFile,
+    ResolutionPackageFiles
 } from './type-script-declaration-project.ts';
 import { reachableDeclarationPaths } from './type-script-declaration-reachability.ts';
 import { declarationRootsFromManifest } from './type-script-declaration-roots.ts';
@@ -14,7 +15,8 @@ export type DeclarationMode = 'all' | 'exports-graph';
 export type DeclarationIntegritySummarizer = (
     packageName: string,
     publishedPackage: Readonly<PublishedPackageWithManifest>,
-    declarationMode: DeclarationMode
+    declarationMode: DeclarationMode,
+    resolutionPackages: ReadonlyMap<string, PublishedPackageWithManifest>
 ) => readonly string[];
 
 export type DeclarationIntegrityDependencies = {
@@ -44,6 +46,23 @@ function collectDeclarationPaths(packageFiles: readonly PackageFile[]): Readonly
             })
             .filter(isDeclarationPath)
     );
+}
+
+function collectResolutionPackageFiles(
+    packageName: string,
+    publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>
+): readonly ResolutionPackageFiles[] {
+    return Array
+        .from(publishedPackages)
+        .filter(function ([ candidateName ]) {
+            return candidateName !== packageName;
+        })
+        .map(function ([ candidateName, publishedPackage ]) {
+            return {
+                packageName: candidateName,
+                packageFiles: collectPackageFiles(publishedPackage)
+            };
+        });
 }
 
 function checkedDeclarationPaths(
@@ -79,12 +98,13 @@ export function createDeclarationIntegritySummarizer(
 ): DeclarationIntegritySummarizer {
     const { createDeclarationProjects } = dependencies;
 
-    return function summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode) {
+    return function summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode, resolutionPackages) {
         const packageFiles = collectPackageFiles(publishedPackage);
         const declarationPaths = collectDeclarationPaths(packageFiles);
         const rootPaths = declarationRootsFromManifest(publishedPackage.manifestFile.content);
+        const resolutionPackageFiles = collectResolutionPackageFiles(packageName, resolutionPackages);
 
-        return createDeclarationProjects(packageName, packageFiles).flatMap(function (project) {
+        return createDeclarationProjects(packageName, packageFiles, resolutionPackageFiles).flatMap(function (project) {
             const checkedPaths = checkedDeclarationPaths(project, declarationPaths, rootPaths, declarationMode);
 
             return project

--- a/source/checks/rules/type-script-declaration-project.test.ts
+++ b/source/checks/rules/type-script-declaration-project.test.ts
@@ -6,7 +6,8 @@ import { assertDeepSubset } from '../../test-libraries/deep-subset-assertion.ts'
 import {
     createDeclarationProjectFactory,
     type DeclarationProject,
-    type DeclarationProjectDependencies
+    type DeclarationProjectDependencies,
+    type ResolutionPackageFiles
 } from './type-script-declaration-project.ts';
 
 type FakeModuleSpecifier = {
@@ -87,7 +88,8 @@ function createFakeProjectConstructor(overrides: FakeProjectOverrides = {}): Sin
 
 function declarationProjectsFor(
     projectConstructor: SinonStub,
-    packageFiles: readonly { readonly filePath: string; readonly content: string; }[] = []
+    packageFiles: readonly { readonly filePath: string; readonly content: string; }[] = [],
+    resolutionPackages: readonly ResolutionPackageFiles[] = []
 ): readonly DeclarationProject[] {
     const fileSystemHost = {};
     const fakeDependencies = {
@@ -95,7 +97,7 @@ function declarationProjectsFor(
         fileSystemHost,
         packageResolutionBaseFolder: '/workspace'
     } as unknown as DeclarationProjectDependencies;
-    return createDeclarationProjectFactory(fakeDependencies)('pkg', packageFiles);
+    return createDeclarationProjectFactory(fakeDependencies)('pkg', packageFiles, resolutionPackages);
 }
 
 function firstProject(projects: readonly DeclarationProject[]): DeclarationProject {
@@ -185,6 +187,82 @@ suite('type-script-declaration-project', function () {
             [
                 '/workspace/.packtory-type-integrity/node_modules/pkg/nested/index.d.ts',
                 'export declare const value: number;'
+            ]
+        ]);
+    });
+
+    test('adds resolution package files below their installed package folders', function () {
+        const createSourceFile = fake();
+        const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+        declarationProjectsFor(
+            TSMorphProject,
+            [ { filePath: 'package.json', content: '{"name":"pkg"}' } ],
+            [
+                {
+                    packageName: '@scope/dependency',
+                    packageFiles: [
+                        { filePath: 'package.json', content: '{"name":"@scope/dependency"}' },
+                        { filePath: 'lib/index.d.ts', content: 'export type Dependency = string;' }
+                    ]
+                }
+            ]
+        );
+
+        assert.deepStrictEqual(createSourceFile.args, [
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/package.json',
+                '{"name":"pkg"}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/@scope/dependency/package.json',
+                '{"name":"@scope/dependency"}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/@scope/dependency/lib/index.d.ts',
+                'export type Dependency = string;'
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/package.json',
+                '{"name":"pkg"}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/@scope/dependency/package.json',
+                '{"name":"@scope/dependency"}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/@scope/dependency/lib/index.d.ts',
+                'export type Dependency = string;'
+            ]
+        ]);
+    });
+
+    test('adds each virtual package file once per project', function () {
+        const createSourceFile = fake();
+        const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+        declarationProjectsFor(
+            TSMorphProject,
+            [
+                { filePath: 'package.json', content: '{"name":"pkg"}' },
+                { filePath: 'package.json', content: '{"name":"pkg"}' }
+            ]
+        );
+
+        assert.deepStrictEqual(createSourceFile.args, [
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/package.json',
+                '{"name":"pkg"}',
+                { scriptKind: ScriptKind.JSON }
+            ],
+            [
+                '/workspace/.packtory-type-integrity/node_modules/pkg/package.json',
+                '{"name":"pkg"}',
+                { scriptKind: ScriptKind.JSON }
             ]
         ]);
     });

--- a/source/checks/rules/type-script-declaration-project.ts
+++ b/source/checks/rules/type-script-declaration-project.ts
@@ -16,6 +16,11 @@ export type PackageFile = {
     readonly content: string;
 };
 
+export type ResolutionPackageFiles = {
+    readonly packageName: string;
+    readonly packageFiles: readonly PackageFile[];
+};
+
 export type DeclarationDiagnostic = {
     readonly declarationPath: string;
     readonly line: number;
@@ -31,7 +36,8 @@ export type DeclarationProject = {
 
 export type DeclarationProjectsFactory = (
     packageName: string,
-    packageFiles: readonly PackageFile[]
+    packageFiles: readonly PackageFile[],
+    resolutionPackages: readonly ResolutionPackageFiles[]
 ) => readonly DeclarationProject[];
 
 export type DeclarationProjectDependencies = {
@@ -44,6 +50,11 @@ type DeclarationCompilerMode = {
     readonly label: string;
     readonly module: ModuleKind;
     readonly moduleResolution: ModuleResolutionKind;
+};
+
+type CreatedFilePathSet = {
+    readonly add: (filePath: string) => unknown;
+    readonly has: (filePath: string) => boolean;
 };
 
 function declarationCompilerModes(): readonly DeclarationCompilerMode[] {
@@ -138,9 +149,30 @@ export function createDeclarationProjectFactory(
 ): DeclarationProjectsFactory {
     const { Project, fileSystemHost, packageResolutionBaseFolder } = dependencies;
 
+    function addPackageFiles(
+        project: TSMorphProject,
+        packageName: string,
+        packageFiles: readonly PackageFile[],
+        createdFilePaths: CreatedFilePathSet
+    ): void {
+        const packageFolder = declarationProjectPackageFolder(packageResolutionBaseFolder, packageName);
+        for (const packageFile of packageFiles) {
+            const filePath = declarationProjectPackageFilePath(packageFolder, packageFile.filePath);
+            if (!createdFilePaths.has(filePath)) {
+                createdFilePaths.add(filePath);
+                if (path.basename(packageFile.filePath) === 'package.json') {
+                    project.createSourceFile(filePath, packageFile.content, { scriptKind: ScriptKind.JSON });
+                } else {
+                    project.createSourceFile(filePath, packageFile.content);
+                }
+            }
+        }
+    }
+
     function createProjectForMode(
         packageName: string,
         packageFiles: readonly PackageFile[],
+        resolutionPackages: readonly ResolutionPackageFiles[],
         compilerMode: DeclarationCompilerMode
     ): DeclarationProject {
         const packageFolder = declarationProjectPackageFolder(packageResolutionBaseFolder, packageName);
@@ -157,22 +189,24 @@ export function createDeclarationProjectFactory(
                 target: ScriptTarget.ESNext
             }
         });
+        const createdFilePaths = new Set<string>();
 
-        for (const packageFile of packageFiles) {
-            const filePath = declarationProjectPackageFilePath(packageFolder, packageFile.filePath);
-            if (path.basename(packageFile.filePath) === 'package.json') {
-                project.createSourceFile(filePath, packageFile.content, { scriptKind: ScriptKind.JSON });
-            } else {
-                project.createSourceFile(filePath, packageFile.content);
-            }
+        addPackageFiles(project, packageName, packageFiles, createdFilePaths);
+        for (const resolutionPackage of resolutionPackages) {
+            addPackageFiles(
+                project,
+                resolutionPackage.packageName,
+                resolutionPackage.packageFiles,
+                createdFilePaths
+            );
         }
 
         return createModeProject(project, packageFolder, compilerMode.label);
     }
 
-    return function createDeclarationProjects(packageName, packageFiles) {
+    return function createDeclarationProjects(packageName, packageFiles, resolutionPackages) {
         return declarationCompilerModes().map(function (compilerMode) {
-            return createProjectForMode(packageName, packageFiles, compilerMode);
+            return createProjectForMode(packageName, packageFiles, resolutionPackages, compilerMode);
         });
     };
 }

--- a/source/checks/rules/type-script-integrity.test.ts
+++ b/source/checks/rules/type-script-integrity.test.ts
@@ -179,7 +179,7 @@ suite('type-script-integrity', function () {
         });
 
         assert.deepStrictEqual(summarizeDeclarationIntegrity.args, [
-            [ 'pkg', publishedPackages.get('pkg'), 'all' ]
+            [ 'pkg', publishedPackages.get('pkg'), 'all', publishedPackages ]
         ]);
     });
 
@@ -195,7 +195,7 @@ suite('type-script-integrity', function () {
         });
 
         assert.deepStrictEqual(summarizeDeclarationIntegrity.args, [
-            [ 'pkg', publishedPackages.get('pkg'), 'exports-graph' ]
+            [ 'pkg', publishedPackages.get('pkg'), 'exports-graph', publishedPackages ]
         ]);
     });
 
@@ -218,17 +218,33 @@ suite('type-script-integrity', function () {
         ]);
     });
 
-    test('throws when the rule is enabled but a bundle has no emitted package', async function () {
-        await assert.rejects(
-            async function () {
-                await runRule({
-                    rule: ruleFor(),
-                    settings: { typeScriptIntegrity: { enabled: true } },
-                    publishedPackages: undefined,
-                    bundleNames: [ 'pkg' ]
-                });
-            },
-            /Published package missing for "pkg"/u
-        );
+    suite('published packages', function () {
+        test('throws when the rule is enabled but no emitted packages are present', async function () {
+            await assert.rejects(
+                async function () {
+                    await runRule({
+                        rule: ruleFor(),
+                        settings: { typeScriptIntegrity: { enabled: true } },
+                        publishedPackages: undefined,
+                        bundleNames: [ 'pkg' ]
+                    });
+                },
+                /Published packages missing for TypeScript integrity/u
+            );
+        });
+
+        test('throws when one checked bundle has no emitted package', async function () {
+            await assert.rejects(
+                async function () {
+                    await runRule({
+                        rule: ruleFor(),
+                        settings: { typeScriptIntegrity: { enabled: true } },
+                        publishedPackages: publishedPackagesFor('pkg-a'),
+                        bundleNames: [ 'pkg-a', 'pkg-b' ]
+                    });
+                },
+                /Published package missing for "pkg-b"/u
+            );
+        });
     });
 });

--- a/source/checks/rules/type-script-integrity.ts
+++ b/source/checks/rules/type-script-integrity.ts
@@ -54,11 +54,12 @@ export function createTypeScriptIntegrityRule(
     async function runForPackage(
         packageName: string,
         publishedPackage: Readonly<PublishedPackageWithManifest>,
+        publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>,
         declarationMode: DeclarationMode
     ): Promise<readonly string[]> {
         return [
             ...await summarizePackageResolution(packageName, publishedPackage),
-            ...summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode)
+            ...summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode, publishedPackages)
         ];
     }
 
@@ -69,14 +70,18 @@ export function createTypeScriptIntegrityRule(
         }
 
         const declarationMode = globalConfig.declarations ?? defaultDeclarationMode;
+        const { publishedPackages } = params;
+        if (publishedPackages === undefined) {
+            throw new Error('Published packages missing for TypeScript integrity');
+        }
         const issuesByBundle = await Promise.all(
             params.bundles.map(async function (bundle) {
-                const publishedPackage = params.publishedPackages?.get(bundle.name);
+                const publishedPackage = publishedPackages.get(bundle.name);
                 if (publishedPackage === undefined) {
                     throw new Error(`Published package missing for "${bundle.name}"`);
                 }
 
-                return await runForPackage(bundle.name, publishedPackage, declarationMode);
+                return await runForPackage(bundle.name, publishedPackage, publishedPackages, declarationMode);
             })
         );
         return issuesByBundle.flat();

--- a/source/linker/replacement-lookup.test.ts
+++ b/source/linker/replacement-lookup.test.ts
@@ -41,6 +41,21 @@ suite('replacement-lookup', function () {
         assert.deepStrictEqual(result.bundleDependencies, [ 'pkg-b' ]);
     });
 
+    test('findAllPathReplacements maps declaration companions to the JavaScript package subpath', function () {
+        const bundle = linkedBundle({
+            name: 'pkg-b',
+            contents: [
+                analyzedBundleResource('/b/helpers.js', { targetFilePath: 'helpers.js' }),
+                analyzedBundleResource('/b/helpers.d.ts', { targetFilePath: 'helpers.d.ts' })
+            ]
+        });
+
+        const result = findAllPathReplacements([ '/b/helpers.d.ts' ], [ bundle ]);
+
+        assert.strictEqual(result.importPathReplacements.get('/b/helpers.d.ts'), 'pkg-b/helpers.js');
+        assert.deepStrictEqual(result.bundleDependencies, [ 'pkg-b' ]);
+    });
+
     test('findAllPathReplacements throws when a bundle owns the file but does not expose it', function () {
         const bundle = linkedBundle({
             name: 'pkg-b',

--- a/source/package-surface/package-surface-index.test.ts
+++ b/source/package-surface/package-surface-index.test.ts
@@ -177,6 +177,23 @@ suite('package-surface-index', function () {
             assertImplicitDuplicateMappings(index);
         });
 
+        test('indexPublicModules maps declaration companions to their JavaScript package specifier', function () {
+            const index = indexPublicModules({
+                name: 'package-a',
+                roots: { main: rootWithSource('/src/index.js', 'index.js') },
+                contents: [
+                    content('/src/feature.js', 'feature.js'),
+                    content('/src/feature.d.ts', 'feature.d.ts'),
+                    content('/src/types.d.ts', 'types.d.ts')
+                ],
+                surface: { mode: 'implicit', defaultModuleRoot: 'main' }
+            });
+
+            assert.strictEqual(index.specifierBySourceFilePath.get('/src/feature.d.ts'), 'package-a/feature.js');
+            assert.strictEqual(index.specifierBySourceFilePath.get('/src/types.d.ts'), 'package-a/types.d.ts');
+            assert.strictEqual(index.sourceFilePathBySpecifier.get('package-a/feature.js'), '/src/feature.js');
+        });
+
         test('indexPublicModules keeps the first same-length explicit specifier', function () {
             const index = indexPublicModules({
                 name: 'package-a',

--- a/source/package-surface/package-surface-index.ts
+++ b/source/package-surface/package-surface-index.ts
@@ -1,3 +1,6 @@
+import {
+    declarationCompanionCandidates
+} from '../common/declaration-companion-paths.ts';
 import type { BundleLike, ExplicitSurface, ImplicitSurface, RootFileDescription } from './package-shape.ts';
 import { getEntryRootIds, getRoot } from './root-registry.ts';
 import { toPackageSpecifier } from './specifier-syntax.ts';
@@ -161,10 +164,19 @@ function indexExplicitPublicModules(bundle: ExplicitModuleBundle): PublicModuleI
     return publicModuleIndex.build();
 }
 
-function indexImplicitPublicModules(bundle: ImplicitModuleBundle): PublicModuleIndex {
-    const publicModuleIndex = createPublicModuleIndexBuilder();
-    const defaultRoot = getRoot(bundle, bundle.surface.defaultModuleRoot);
+function declarationCompanionSpecifier(bundle: ImplicitModuleBundle, targetFilePath: string): string | undefined {
+    const companion = bundle.contents.find(function (entry) {
+        const candidatePaths = declarationCompanionCandidates(entry.fileDescription.targetFilePath);
+        return candidatePaths.includes(targetFilePath);
+    });
+    if (companion === undefined) {
+        return undefined;
+    }
+    return toPackageSpecifier(bundle.name, `./${companion.fileDescription.targetFilePath}`);
+}
 
+function recordImplicitRootModules(bundle: ImplicitModuleBundle, publicModuleIndex: PublicModuleIndexBuilder): void {
+    const defaultRoot = getRoot(bundle, bundle.surface.defaultModuleRoot);
     publicModuleIndex.recordFirstIndexedPublicSpecifier({
         publicSourceFilePath: defaultRoot.js.sourceFilePath,
         sourceFilePaths: rootSourceFilePaths(defaultRoot),
@@ -179,12 +191,35 @@ function indexImplicitPublicModules(bundle: ImplicitModuleBundle): PublicModuleI
             });
         }
     }
-    for (const entry of bundle.contents) {
+}
+
+function recordImplicitContentModule(
+    bundle: ImplicitModuleBundle,
+    publicModuleIndex: PublicModuleIndexBuilder,
+    entry: ImplicitModuleBundle['contents'][number]
+): void {
+    const companionSpecifier = declarationCompanionSpecifier(bundle, entry.fileDescription.targetFilePath);
+    if (companionSpecifier === undefined) {
         publicModuleIndex.recordFirstIndexedPublicSpecifier({
             publicSourceFilePath: entry.fileDescription.sourceFilePath,
             sourceFilePaths: [ entry.fileDescription.sourceFilePath ],
             specifier: toPackageSpecifier(bundle.name, `./${entry.fileDescription.targetFilePath}`)
         });
+    } else {
+        publicModuleIndex.recordFirstIndexedPublicSpecifier({
+            publicSourceFilePath: undefined,
+            sourceFilePaths: [ entry.fileDescription.sourceFilePath ],
+            specifier: companionSpecifier
+        });
+    }
+}
+
+function indexImplicitPublicModules(bundle: ImplicitModuleBundle): PublicModuleIndex {
+    const publicModuleIndex = createPublicModuleIndexBuilder();
+
+    recordImplicitRootModules(bundle, publicModuleIndex);
+    for (const entry of bundle.contents) {
+        recordImplicitContentModule(bundle, publicModuleIndex, entry);
     }
 
     return publicModuleIndex.build();

--- a/source/package-surface/substitution-exports.test.ts
+++ b/source/package-surface/substitution-exports.test.ts
@@ -230,7 +230,7 @@ suite('substitution-exports', function () {
             assert.deepStrictEqual(result['./data.json'], { import: './data.json' });
         });
 
-        test('omits a substitution whose target is a .d.ts declaration', function () {
+        test('exposes a substitution whose target is a .d.ts declaration as types-only', function () {
             const result = collectSubstitutionExports(
                 {
                     name: 'package-a',
@@ -240,10 +240,10 @@ suite('substitution-exports', function () {
                 new Set([ '/src/types.d.ts' ])
             );
 
-            assert.deepStrictEqual(result, {});
+            assert.deepStrictEqual(result['./types.d.ts'], { types: './types.d.ts' });
         });
 
-        test('omits a substitution whose target is a .d.mts declaration', function () {
+        test('exposes a substitution whose target is a .d.mts declaration as types-only', function () {
             const result = collectSubstitutionExports(
                 {
                     name: 'package-a',
@@ -253,10 +253,10 @@ suite('substitution-exports', function () {
                 new Set([ '/src/types.d.mts' ])
             );
 
-            assert.deepStrictEqual(result, {});
+            assert.deepStrictEqual(result['./types.d.mts'], { types: './types.d.mts' });
         });
 
-        test('omits a substitution whose target is a .d.cts declaration', function () {
+        test('exposes a substitution whose target is a .d.cts declaration as types-only', function () {
             const result = collectSubstitutionExports(
                 {
                     name: 'package-a',
@@ -266,7 +266,7 @@ suite('substitution-exports', function () {
                 new Set([ '/src/types.d.cts' ])
             );
 
-            assert.deepStrictEqual(result, {});
+            assert.deepStrictEqual(result['./types.d.cts'], { types: './types.d.cts' });
         });
 
         test('skips a substitution path that matches one root js source path among multiple roots', function () {

--- a/source/package-surface/substitution-exports.ts
+++ b/source/package-surface/substitution-exports.ts
@@ -75,17 +75,6 @@ function findBundleContent(
     return content;
 }
 
-function declarationCompanionTargetPaths(
-    targetFilePath: string
-): readonly string[] | null | undefined {
-    if (isDeclarationCompanionFilePath(targetFilePath)) {
-        return null;
-    }
-
-    const candidates = declarationCompanionCandidates(targetFilePath);
-    return candidates.length === 0 ? undefined : candidates;
-}
-
 function findDeclarationCompanionTargetPath(
     targetFilePaths: ReadonlySet<string>,
     candidatePaths: readonly string[]
@@ -130,12 +119,9 @@ function declarationTargetFilePathFor(
     bundleName: string,
     lookups: SubstitutionBundleLookups,
     jsTargetFilePath: string
-): string | null | undefined {
-    const declarationCandidates = declarationCompanionTargetPaths(jsTargetFilePath);
-    if (declarationCandidates === null) {
-        return null;
-    }
-    if (declarationCandidates === undefined) {
+): string | undefined {
+    const declarationCandidates = declarationCompanionCandidates(jsTargetFilePath);
+    if (declarationCandidates.length === 0) {
         return undefined;
     }
 
@@ -153,10 +139,13 @@ function buildSubstitutionExportEntry(
 
     const content = findBundleContent(bundleName, lookups.contentBySourceFilePath, sourceFilePath);
     const jsTargetFilePath = content.fileDescription.targetFilePath;
-    const declarationTargetFilePath = declarationTargetFilePathFor(bundleName, lookups, jsTargetFilePath);
-    if (declarationTargetFilePath === null) {
-        return undefined;
+    if (isDeclarationCompanionFilePath(jsTargetFilePath)) {
+        return [
+            `./${jsTargetFilePath}`,
+            { types: toImportTarget(jsTargetFilePath) }
+        ];
     }
+    const declarationTargetFilePath = declarationTargetFilePathFor(bundleName, lookups, jsTargetFilePath);
     return [
         `./${jsTargetFilePath}`,
         pickBy(


### PR DESCRIPTION
Packtory now keeps generated declaration graphs resolvable when `declarations` is set to `all` and retained declaration companions import substituted bundle dependency subpaths.

The change maps declaration companions to the shipped JavaScript package subpath when present, emits types-only exports for declaration-only substitutions, and mounts generated sibling packages in the TypeScript integrity project so package subpath imports resolve like they do from the published package.