### PR TITLE
Print recursive CLI partial failure causes

### DIFF
--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -306,7 +306,10 @@ suite('changelog-handler', function () {
         test('returns 1 and still renders succeeded changed packages for partial release-plan failures', async function () {
             const releasePlanOutcome = partialFailureOutcome({
                 succeeded: [ releasePackage() ],
-                failures: [ new Error('pkg-b failed'), new Error('pkg-c failed') ]
+                failures: [
+                    new Error('pkg-b failed', { cause: new Error('source map failed') }),
+                    new Error('pkg-c failed')
+                ]
             });
             const spies = makeSpies(createEngine(), releasePlanOutcome);
 
@@ -315,7 +318,7 @@ suite('changelog-handler', function () {
             assert.strictEqual(code, 1);
             assert.deepStrictEqual(
                 { pageOutput: spies.pageOutput.callCount, logArgs: spies.log.firstCall.args },
-                { pageOutput: 1, logArgs: [ 'pkg-b failed\npkg-c failed' ] }
+                { pageOutput: 1, logArgs: [ '- pkg-b failed\n  Caused by: source map failed\n- pkg-c failed' ] }
             );
         });
     });

--- a/source/command-line-interface/runner/failure-printing.test.ts
+++ b/source/command-line-interface/runner/failure-printing.test.ts
@@ -60,7 +60,7 @@ suite('failure-printing', function () {
         assert.match(message, /- check X/u);
     });
 
-    test('printPublishFailure summarises partial failures when type is partial', function () {
+    test('printPublishFailure summarises partial failures with recursive cause messages when type is partial', function () {
         const sink = captureLogger();
         const failure: PublishFailure = {
             type: 'partial',
@@ -68,13 +68,19 @@ suite('failure-printing', function () {
                 { bundle: { name: 'pkg-a', version: '1.0.0' }, publication: stagedForApproval('stage-a') },
                 { bundle: { name: 'pkg-b', version: '1.0.0' }, publication: noPublication }
             ] as never,
-            failures: [ { message: 'pkg-c failed' } ] as never
+            failures: [
+                new Error('pkg-c failed', {
+                    cause: new Error('registry failed', { cause: new Error('connection reset') })
+                })
+            ] as never
         };
 
         printPublishFailure(sink.log, failure, true);
 
         assert.ok((sink.messages[0] ?? '').includes('package(s) failed'));
         assert.ok((sink.messages[0] ?? '').includes('- pkg-c failed'));
+        assert.ok((sink.messages[0] ?? '').includes('  Caused by: registry failed'));
+        assert.ok((sink.messages[0] ?? '').includes('    Caused by: connection reset'));
         assert.deepStrictEqual(sink.messages[1], 'Staged packages:\n- pkg-a@1.0.0: stage-a');
     });
 

--- a/source/command-line-interface/runner/failure-printing.ts
+++ b/source/command-line-interface/runner/failure-printing.ts
@@ -8,9 +8,9 @@ import {
     type PublishFailure
 } from '../../packtory/packtory-results.ts';
 import type { BuildAndPublishResult } from '../../packtory/package-processor.ts';
-import { partialFailureMessages } from '../../packtory/partial-result.ts';
 import type { PartialError } from '../../packtory/scheduler.ts';
 import { getErrorSymbol, getSuccessSymbol, getWarningSymbol } from './runner-symbols.ts';
+import { formatTerminalErrorBullet } from './terminal-error-chain.ts';
 
 type PublishPartialError = PartialError<BuildAndPublishResult>;
 type StagedResult = BuildAndPublishResult & {
@@ -90,9 +90,7 @@ function printPartialErrorSummary(log: Logger, error: PublishPartialError, stage
     const successCount = green(String(error.succeeded.length));
     const summary = `${getErrorSymbol()} ${failureCount} from ${bold(String(total))} package(s) failed; ` +
         `${successCount} succeeded`;
-    const details = partialFailureMessages(error).map(function (message) {
-        return `- ${message}`;
-    });
+    const details = error.failures.map(formatTerminalErrorBullet);
     log([ summary, ...details ].join('\n'));
     if (stage) {
         printStagedPackageList(log, error.succeeded);

--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -203,13 +203,22 @@ suite('pack-handler', function () {
             );
         });
 
-        test('summarises partial resolve failures with one line per failure', async function () {
+        test('summarises partial resolve failures with recursive cause messages', async function () {
             await expectFailure(
                 {
                     type: 'partial',
-                    error: { succeeded: [], failures: [ new Error('resolve A'), new Error('resolve B') ] }
+                    error: {
+                        succeeded: [],
+                        failures: [
+                            new Error('resolve A', { cause: new Error('read failed') }),
+                            new Error('resolve B')
+                        ]
+                    }
                 },
-                [ /2 package\(s\) failed to resolve/u, /- resolve A\n- resolve B/u ]
+                [
+                    /2 package\(s\) failed to resolve/u,
+                    /- resolve A\n {2}Caused by: read failed\n- resolve B/u
+                ]
             );
         });
     });

--- a/source/command-line-interface/runner/pack-handler.ts
+++ b/source/command-line-interface/runner/pack-handler.ts
@@ -1,5 +1,4 @@
 import type { PackOutcome, Packtory } from '../../packtory/packtory.ts';
-import { partialFailureMessages } from '../../packtory/partial-result.ts';
 import {
     checksErrorType,
     configErrorType,
@@ -10,6 +9,7 @@ import {
 import type { ConfigLoader } from '../config-loader.ts';
 import type { TerminalSpinnerRenderer } from '../spinner/terminal-spinner-renderer.ts';
 import { getErrorSymbol, getSuccessSymbol } from './runner-symbols.ts';
+import { formatTerminalErrorBullet } from './terminal-error-chain.ts';
 
 type Logger = (message: string) => void;
 const issuePrefixByType = {
@@ -73,9 +73,7 @@ function formatBulletedLines(header: string, details: readonly string[]): string
 function formatPartialResolveFailure(error: PartialPackFailure): string {
     return formatBulletedLines(
         `${getErrorSymbol()} ${error.error.failures.length} package(s) failed to resolve`,
-        partialFailureMessages(error.error).map(function (message) {
-            return `- ${message}`;
-        })
+        error.error.failures.map(formatTerminalErrorBullet)
     );
 }
 

--- a/source/command-line-interface/runner/release-plan-result-printing.ts
+++ b/source/command-line-interface/runner/release-plan-result-printing.ts
@@ -1,4 +1,3 @@
-import { partialFailureMessages } from '../../packtory/partial-result.ts';
 import type { ReleasePlanPackage, ReleasePlanResult } from '../../packtory/packtory.ts';
 import {
     checksErrorType,
@@ -6,6 +5,7 @@ import {
     partialFailureType,
     type ReleasePlanFailure
 } from '../../packtory/packtory-results.ts';
+import { formatTerminalErrorBullet } from './terminal-error-chain.ts';
 
 type Logger = (message: string) => void;
 
@@ -22,7 +22,7 @@ export function printReleasePlanFailure(log: Logger, error: ReleasePlanFailure):
         printIssueFailure(log, 'Check issues', error.issues);
         return;
     }
-    log(partialFailureMessages(error).join('\n'));
+    log(error.failures.map(formatTerminalErrorBullet).join('\n'));
 }
 
 export function collectReleasePlanPackages(result: ReleasePlanResult): readonly ReleasePlanPackage[] {

--- a/source/command-line-interface/runner/terminal-error-chain.test.ts
+++ b/source/command-line-interface/runner/terminal-error-chain.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { formatTerminalErrorBullet } from './terminal-error-chain.ts';
+
+function createCauseChain(errorCount: number): Error {
+    let error = new Error(`failure ${errorCount - 1}`);
+    for (let index = errorCount - 2; index >= 0; index -= 1) {
+        error = new Error(`failure ${index}`, { cause: error });
+    }
+
+    return error;
+}
+
+suite('terminal-error-chain', function () {
+    suite('formatting', function () {
+        test('formats a plain error message', function () {
+            assert.strictEqual(formatTerminalErrorBullet(new Error('failed')), '- failed');
+        });
+
+        test('formats one cause level', function () {
+            const error = new Error('failed', { cause: new Error('inner failure') });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed\n  Caused by: inner failure');
+        });
+
+        test('formats recursive cause messages', function () {
+            const error = new Error('failed', {
+                cause: new Error('middle failure', { cause: new Error('inner failure') })
+            });
+
+            assert.strictEqual(
+                formatTerminalErrorBullet(error),
+                '- failed\n  Caused by: middle failure\n    Caused by: inner failure'
+            );
+        });
+
+        test('formats error-like causes', function () {
+            const error = new Error('failed', { cause: { message: 'library failure' } });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed\n  Caused by: library failure');
+        });
+
+        test('indents multiline messages under the same failure', function () {
+            const error = new Error('failed\nwith details', {
+                cause: new Error('inner failure\nwith inner details')
+            });
+
+            assert.strictEqual(
+                formatTerminalErrorBullet(error),
+                '- failed\n  with details\n  Caused by: inner failure\n    with inner details'
+            );
+        });
+    });
+
+    suite('ignored causes', function () {
+        test('ignores causes without a message', function () {
+            const error = new Error('failed', { cause: { reason: 'hidden' } });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed');
+        });
+
+        test('ignores null causes', function () {
+            const error = new Error('failed', { cause: null });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed');
+        });
+
+        test('ignores causes with non-string messages', function () {
+            const error = new Error('failed', { cause: { message: 42 } });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed');
+        });
+    });
+
+    suite('depth limits', function () {
+        test('stops at circular cause chains', function () {
+            const error = new Error('failed');
+            Object.defineProperty(error, 'cause', { value: error });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed');
+        });
+
+        test('stops at two-node circular cause chains', function () {
+            const error = new Error('failed');
+            const cause = new Error('inner failure');
+            Object.defineProperty(error, 'cause', { value: cause });
+            Object.defineProperty(cause, 'cause', { value: error });
+
+            assert.strictEqual(formatTerminalErrorBullet(error), '- failed\n  Caused by: inner failure');
+        });
+
+        test('stops after the maximum cause depth', function () {
+            const message = formatTerminalErrorBullet(createCauseChain(102));
+            const causeMatches = message.match(/Caused by:/gu);
+
+            assert.strictEqual(causeMatches === null ? 0 : causeMatches.length, 100);
+            assert.ok(message.includes('failure 100'));
+            assert.ok(!message.includes('failure 101'));
+        });
+    });
+});

--- a/source/command-line-interface/runner/terminal-error-chain.ts
+++ b/source/command-line-interface/runner/terminal-error-chain.ts
@@ -1,0 +1,87 @@
+const indent = '  ';
+const maximumCauseDepth = 100;
+
+type MessageCarrier = {
+    readonly message: string;
+};
+
+type CauseFormattingState = {
+    readonly cause: unknown;
+    readonly depth: number;
+    readonly lines: readonly string[];
+    readonly visitedCauses: ReadonlySet<unknown>;
+};
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+    return typeof value === 'object' && value !== null;
+}
+
+function hasMessage(value: unknown): value is MessageCarrier {
+    return (
+        isRecord(value) &&
+        Object.hasOwn(value, 'message') &&
+        typeof Reflect.get(value, 'message') === 'string'
+    );
+}
+
+function readCause(value: MessageCarrier): unknown {
+    return Reflect.get(value, 'cause');
+}
+
+function formatMessageLines(
+    firstLinePrefix: string,
+    message: string,
+    continuationIndent: string
+): readonly string[] {
+    return message.split('\n').map(function (line, index) {
+        if (index === 0) {
+            return `${firstLinePrefix}${line}`;
+        }
+
+        return `${continuationIndent}${line}`;
+    });
+}
+
+function formatCauseMessageLines(cause: MessageCarrier, depth: number): readonly string[] {
+    const causeIndent = indent.repeat(depth);
+    return formatMessageLines(`${causeIndent}Caused by: `, cause.message, `${causeIndent}${indent}`);
+}
+
+function advanceCauseFormatting(state: CauseFormattingState): CauseFormattingState {
+    const { cause, visitedCauses } = state;
+    if (!hasMessage(cause) || visitedCauses.has(cause)) {
+        return state;
+    }
+
+    return {
+        cause: readCause(cause),
+        depth: state.depth + 1,
+        lines: [ ...state.lines, ...formatCauseMessageLines(cause, state.depth) ],
+        visitedCauses: new Set<unknown>([ ...visitedCauses, cause ])
+    };
+}
+
+function formatCauseLines(error: MessageCarrier): readonly string[] {
+    const initialState: CauseFormattingState = {
+        cause: readCause(error),
+        depth: 1,
+        lines: [],
+        visitedCauses: new Set<unknown>([ error ])
+    };
+    return Array
+        .from({ length: maximumCauseDepth })
+        .reduce(advanceCauseFormatting, initialState)
+        .lines;
+}
+
+function formatErrorChain(error: Error, firstLinePrefix: string): string {
+    return [
+        ...formatMessageLines(firstLinePrefix, error.message, indent),
+        ...formatCauseLines(error)
+    ]
+        .join('\n');
+}
+
+export function formatTerminalErrorBullet(error: Error): string {
+    return formatErrorChain(error, '- ');
+}


### PR DESCRIPTION
Partial package failures now render their full terminal error chain after spinners stop, preserving each failure as one bullet with indented `cause.message` entries. Preview and report issue extraction keeps the existing plain-message behavior so structured report output does not change.