### PR TITLE
Batch declaration dependency scans

### DIFF
--- a/source/dependency-scanner/scanner.test.ts
+++ b/source/dependency-scanner/scanner.test.ts
@@ -108,6 +108,45 @@ suite('scanner', function () {
                 }
             });
         });
+
+        test('scanEntries() reuses one analyzed project for all entry points', async function () {
+            const getReferencedModules = fake.returns([]);
+            const analyzeProject = createFakeAnalyzeProject({ getReferencedModules });
+            const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+
+            await dependencyScanner.scanEntries([ '/foo/first.js', '/foo/second.js' ], '/foo', {
+                mainPackageJson: defaultMainPackageJson
+            });
+
+            assert.strictEqual(analyzeProject.callCount, 1);
+            assert.deepStrictEqual(
+                getReferencedModules.getCalls().map(function (call) {
+                    return String(call.firstArg);
+                }),
+                [ '/foo/first.js', '/foo/second.js' ]
+            );
+        });
+
+        test('scanEntries() skips entry points that were already found through another entry point', async function () {
+            const getReferencedModules = stub()
+                .onFirstCall()
+                .returns([ localCode('/foo/second.js') ])
+                .onSecondCall()
+                .returns([]);
+            const analyzeProject = createFakeAnalyzeProject({ getReferencedModules });
+            const dependencyScanner = dependencyScannerFactory({ analyzeProject });
+
+            await dependencyScanner.scanEntries([ '/foo/first.js', '/foo/second.js' ], '/foo', {
+                mainPackageJson: defaultMainPackageJson
+            });
+
+            assert.deepStrictEqual(
+                getReferencedModules.getCalls().map(function (call) {
+                    return String(call.firstArg);
+                }),
+                [ '/foo/first.js', '/foo/second.js' ]
+            );
+        });
     });
 
     suite('source maps', function () {

--- a/source/dependency-scanner/scanner.ts
+++ b/source/dependency-scanner/scanner.ts
@@ -25,6 +25,11 @@ export type DependencyScannerDependencies = {
 
 export type DependencyScanner = {
     scan: (entryPointFile: string, folder: string, options: ScanOptionsInput) => Promise<DependencyGraph>;
+    scanEntries: (
+        entryPointFiles: readonly string[],
+        folder: string,
+        options: ScanOptionsInput
+    ) => Promise<DependencyGraph>;
 };
 
 type ScannableLocalReferenceKinds = {
@@ -140,32 +145,53 @@ export function createDependencyScanner(
         }
     }
 
+    async function scanEntryReferences(
+        entryPointFiles: readonly string[],
+        context: ScanContext
+    ): Promise<void> {
+        for (const entryPointFile of entryPointFiles) {
+            if (!context.graph.isKnown(entryPointFile)) {
+                await scanDependenciesOfReference(
+                    context,
+                    { kind: moduleReferenceKind.localCode, filePath: entryPointFile }
+                );
+            }
+        }
+    }
+
+    async function scanEntries(
+        entryPointFiles: readonly string[],
+        folder: string,
+        options: ScanOptionsInput
+    ): Promise<DependencyGraph> {
+        const { resolveDeclarationFiles = false, includeSourceMapFiles = false, mainPackageJson } = options;
+        const scanOptions = {
+            includeSourceMapFiles,
+            resolveDeclarationFiles,
+            mainPackageJson
+        };
+
+        const graph = createDependencyGraph();
+        const project = typescriptProjectAnalyzer.analyzeProject(folder, {
+            resolveDeclarationFiles: scanOptions.resolveDeclarationFiles,
+            mainPackageJson: scanOptions.mainPackageJson
+        });
+
+        await scanEntryReferences(entryPointFiles, {
+            folder,
+            graph,
+            options: scanOptions,
+            project
+        });
+
+        return graph;
+    }
+
     return {
         async scan(entryPointFile, folder, options) {
-            const { resolveDeclarationFiles = false, includeSourceMapFiles = false, mainPackageJson } = options;
-            const scanOptions = {
-                includeSourceMapFiles,
-                resolveDeclarationFiles,
-                mainPackageJson
-            };
+            return scanEntries([ entryPointFile ], folder, options);
+        },
 
-            const graph = createDependencyGraph();
-            const project = typescriptProjectAnalyzer.analyzeProject(folder, {
-                resolveDeclarationFiles: scanOptions.resolveDeclarationFiles,
-                mainPackageJson: scanOptions.mainPackageJson
-            });
-
-            await scanDependenciesOfReference(
-                {
-                    folder,
-                    graph,
-                    options: scanOptions,
-                    project
-                },
-                { kind: moduleReferenceKind.localCode, filePath: entryPointFile }
-            );
-
-            return graph;
-        }
+        scanEntries
     };
 }

--- a/source/resource-resolver/dependency-resolution-walker.test.ts
+++ b/source/resource-resolver/dependency-resolution-walker.test.ts
@@ -7,7 +7,7 @@ import type { ResourceResolveOptions } from './resource-resolve-options.ts';
 import { resolveDependenciesForAllRoots } from './dependency-resolution-walker.ts';
 
 type ScanCall = {
-    readonly entry: string;
+    readonly entries: readonly string[];
     readonly resolveDeclarationFiles: boolean;
 };
 
@@ -61,7 +61,11 @@ function trackingScanner(): TrackingScanner {
     const calls: ScanCall[] = [];
     const scanner: DependencyScanner = {
         async scan(entry, _sourcesFolder, options) {
-            calls.push({ entry, resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
+            calls.push({ entries: [ entry ], resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
+            return emptyGraph();
+        },
+        async scanEntries(entries, _sourcesFolder, options) {
+            calls.push({ entries, resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
             return emptyGraph();
         }
     };
@@ -71,13 +75,22 @@ function trackingScanner(): TrackingScanner {
     };
 }
 
-function scannerWithGraphs(entries: readonly (readonly [string, DependencyGraph])[]): TrackingScanner {
-    const graphs = new Map(entries);
+function scannerWithGraphs(graphEntries: readonly (readonly [string, DependencyGraph])[]): TrackingScanner {
+    const graphs = new Map(graphEntries);
     const calls: ScanCall[] = [];
     const scanner: DependencyScanner = {
         async scan(entry, _sourcesFolder, options) {
-            calls.push({ entry, resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
+            calls.push({ entries: [ entry ], resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
             return graphs.get(entry) ?? emptyGraph();
+        },
+        async scanEntries(entryFiles, _sourcesFolder, options) {
+            calls.push({ entries: entryFiles, resolveDeclarationFiles: options.resolveDeclarationFiles ?? false });
+            return {
+                ...emptyGraph(),
+                flatten(entry) {
+                    return (graphs.get(entry) ?? emptyGraph()).flatten(entry);
+                }
+            };
         }
     };
     return {
@@ -129,8 +142,8 @@ suite('dependency-resolution-walker', function () {
 
         assert.deepStrictEqual(
             calls
-                .map(function (call) {
-                    return call.entry;
+                .flatMap(function (call) {
+                    return call.entries;
                 })
                 .toSorted(function (left, right) {
                     return left.localeCompare(right);
@@ -147,8 +160,8 @@ suite('dependency-resolution-walker', function () {
         );
 
         assert.deepStrictEqual(calls, [
-            { entry: '/src/index.js', resolveDeclarationFiles: false },
-            { entry: '/src/index.d.ts', resolveDeclarationFiles: true }
+            { entries: [ '/src/index.js' ], resolveDeclarationFiles: false },
+            { entries: [ '/src/index.d.ts' ], resolveDeclarationFiles: true }
         ]);
     });
 
@@ -167,9 +180,8 @@ suite('dependency-resolution-walker', function () {
         });
 
         assert.deepStrictEqual(calls, [
-            { entry: '/src/index.js', resolveDeclarationFiles: false },
-            { entry: '/src/index.d.ts', resolveDeclarationFiles: true },
-            { entry: '/src/internal.d.ts', resolveDeclarationFiles: true }
+            { entries: [ '/src/index.js' ], resolveDeclarationFiles: false },
+            { entries: [ '/src/index.d.ts', '/src/internal.d.ts' ], resolveDeclarationFiles: true }
         ]);
         assert.deepStrictEqual(indexFile?.directDependencies, new Set([ '/src/internal.js' ]));
         const internalDeclarationFile = result.localFiles.find(function (localFile) {
@@ -189,9 +201,9 @@ suite('dependency-resolution-walker', function () {
         );
 
         assert.deepStrictEqual(calls, [
-            { entry: '/src/index.js', resolveDeclarationFiles: false },
-            { entry: '/src/shared.d.ts', resolveDeclarationFiles: true },
-            { entry: '/src/other.js', resolveDeclarationFiles: false }
+            { entries: [ '/src/index.js' ], resolveDeclarationFiles: false },
+            { entries: [ '/src/shared.d.ts' ], resolveDeclarationFiles: true },
+            { entries: [ '/src/other.js' ], resolveDeclarationFiles: false }
         ]);
     });
 
@@ -206,8 +218,8 @@ suite('dependency-resolution-walker', function () {
         );
 
         assert.deepStrictEqual(calls, [
-            { entry: '/src/index.js', resolveDeclarationFiles: false },
-            { entry: '/src/types.d.ts', resolveDeclarationFiles: true }
+            { entries: [ '/src/index.js' ], resolveDeclarationFiles: false },
+            { entries: [ '/src/types.d.ts' ], resolveDeclarationFiles: true }
         ]);
     });
 
@@ -221,7 +233,7 @@ suite('dependency-resolution-walker', function () {
             optionsForRoots({ main: { js: '/src/index.js' } })
         );
 
-        assert.deepStrictEqual(calls, [ { entry: '/src/index.js', resolveDeclarationFiles: false } ]);
+        assert.deepStrictEqual(calls, [ { entries: [ '/src/index.js' ], resolveDeclarationFiles: false } ]);
     });
 
     test('resolveDependenciesForAllRoots scans companions when any root has declarations', async function () {
@@ -239,10 +251,10 @@ suite('dependency-resolution-walker', function () {
         );
 
         assert.deepStrictEqual(calls, [
-            { entry: '/src/index.js', resolveDeclarationFiles: false },
-            { entry: '/src/index.d.ts', resolveDeclarationFiles: true },
-            { entry: '/src/other.js', resolveDeclarationFiles: false },
-            { entry: '/src/internal.d.ts', resolveDeclarationFiles: true }
+            { entries: [ '/src/index.js' ], resolveDeclarationFiles: false },
+            { entries: [ '/src/index.d.ts' ], resolveDeclarationFiles: true },
+            { entries: [ '/src/other.js' ], resolveDeclarationFiles: false },
+            { entries: [ '/src/internal.d.ts' ], resolveDeclarationFiles: true }
         ]);
     });
 });

--- a/source/resource-resolver/dependency-resolution-walker.ts
+++ b/source/resource-resolver/dependency-resolution-walker.ts
@@ -46,27 +46,38 @@ async function findReadableDeclarationCompanion(
 async function scanDeclarationGraph(
     dependencies: DependencyResolutionDependencies,
     options: ResourceResolveOptions,
-    entryFile: string,
+    entryFiles: readonly string[],
     scannedDeclarationFiles: DeclarationScanTracker
 ): Promise<DependencyFiles> {
-    if (scannedDeclarationFiles.has(entryFile)) {
+    const pendingEntryFiles = entryFiles.filter(function (entryFile) {
+        return !scannedDeclarationFiles.has(entryFile);
+    });
+    if (pendingEntryFiles.length === 0) {
         return emptyDependencyFiles();
     }
-    scannedDeclarationFiles.record(entryFile);
-
-    const declarationDependencyGraph = await dependencies.dependencyScanner.scan(entryFile, options.sourcesFolder, {
-        includeSourceMapFiles: options.includeSourceMapFiles,
-        resolveDeclarationFiles: true,
-        mainPackageJson: options.mainPackageJson
+    pendingEntryFiles.forEach(function (entryFile) {
+        scannedDeclarationFiles.record(entryFile);
     });
-    return declarationDependencyGraph.flatten(entryFile);
+
+    const declarationDependencyGraph = await dependencies.dependencyScanner.scanEntries(
+        pendingEntryFiles,
+        options.sourcesFolder,
+        {
+            includeSourceMapFiles: options.includeSourceMapFiles,
+            resolveDeclarationFiles: true,
+            mainPackageJson: options.mainPackageJson
+        }
+    );
+    return pendingEntryFiles.reduce(function (result, entryFile) {
+        return mergeDependencyFiles(result, declarationDependencyGraph.flatten(entryFile));
+    }, emptyDependencyFiles());
 }
 
-async function resolveDeclarationCompanionDependencies(
+async function collectDeclarationCompanionEntries(
     context: RootResolutionContext,
     jsDependencies: DependencyFiles
-): Promise<DependencyFiles> {
-    let result = emptyDependencyFiles();
+): Promise<readonly string[]> {
+    const companions: string[] = [];
     const nonRootLocalFiles = jsDependencies.localFiles.filter(function (localFile) {
         return !context.rootJsSourceFilePaths.has(localFile.filePath);
     });
@@ -76,19 +87,11 @@ async function resolveDeclarationCompanionDependencies(
             localFile.filePath
         );
         if (declarationCompanion !== undefined) {
-            result = mergeDependencyFiles(
-                result,
-                await scanDeclarationGraph(
-                    context.dependencies,
-                    context.options,
-                    declarationCompanion,
-                    context.scannedDeclarationFiles
-                )
-            );
+            companions.push(declarationCompanion);
         }
     }
 
-    return result;
+    return companions;
 }
 
 function createDeclarationScanTracker(): DeclarationScanTracker {
@@ -119,18 +122,22 @@ async function resolveJsDependencies(
 
 async function resolveRootDeclarationDependencies(
     context: RootResolutionContext,
-    root: ResolvedRootsAndSurface['roots'][string]
+    root: ResolvedRootsAndSurface['roots'][string],
+    jsDependencies: DependencyFiles
 ): Promise<DependencyFiles> {
+    const entryFiles: string[] = [];
     if (root.declarationFile !== undefined) {
-        return await scanDeclarationGraph(
-            context.dependencies,
-            context.options,
-            root.declarationFile,
-            context.scannedDeclarationFiles
-        );
+        entryFiles.push(root.declarationFile);
     }
-
-    return emptyDependencyFiles();
+    if (context.packageHasDeclarationRoots) {
+        entryFiles.push(...await collectDeclarationCompanionEntries(context, jsDependencies));
+    }
+    return scanDeclarationGraph(
+        context.dependencies,
+        context.options,
+        entryFiles,
+        context.scannedDeclarationFiles
+    );
 }
 
 async function resolveDependenciesForRoot(
@@ -138,17 +145,8 @@ async function resolveDependenciesForRoot(
     root: ResolvedRootsAndSurface['roots'][string]
 ): Promise<DependencyFiles> {
     const jsDependencies = await resolveJsDependencies(context, root);
-    const declarationDependencies = await resolveRootDeclarationDependencies(context, root);
-    let dependencyFiles = mergeDependencyFiles(jsDependencies, declarationDependencies);
-
-    if (context.packageHasDeclarationRoots) {
-        dependencyFiles = mergeDependencyFiles(
-            dependencyFiles,
-            await resolveDeclarationCompanionDependencies(context, jsDependencies)
-        );
-    }
-
-    return dependencyFiles;
+    const declarationDependencies = await resolveRootDeclarationDependencies(context, root, jsDependencies);
+    return mergeDependencyFiles(jsDependencies, declarationDependencies);
 }
 
 export async function resolveDependenciesForAllRoots(

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -85,6 +85,18 @@ type Overrides = {
 
 function createResolver(overrides: Overrides = {}): ResolverFixture {
     const scan = overrides.scan ?? fake();
+    const scanEntries = fake(async function (
+        entries: readonly string[],
+        sourcesFolder: string,
+        options: Parameters<ResourceResolverDependencies['dependencyScanner']['scanEntries']>[2]
+    ) {
+        const [ entry ] = entries;
+        if (entry === undefined) {
+            throw new Error('Expected at least one scanner entry');
+        }
+        const result: unknown = await scan(entry, sourcesFolder, options);
+        return result as DependencyGraph;
+    });
     const responder = overrides.transferableFileDescriptionResponder ?? createTransferableFile;
     const baseFileManager = createFakeFileManager({
         transferableFileDescriptionResponder(sourceFilePath, targetFilePath) {
@@ -102,7 +114,7 @@ function createResolver(overrides: Overrides = {}): ResolverFixture {
     };
 
     const dependencies: ResourceResolverDependencies = {
-        dependencyScanner: { scan },
+        dependencyScanner: { scan, scanEntries },
         fileManager
     };
 
@@ -133,8 +145,9 @@ function configureScanForJsAndDeclarationGraphs(
 
 function generatedManifestFixture(graph: DependencyGraph): GeneratedManifestFixture {
     const scan = fake.resolves(graph);
+    const scanEntries = fake.resolves(graph);
     const fileDescriptionCalls: FileDescriptionCall[] = [];
-    const dependencyScanner: ResourceResolverDependencies['dependencyScanner'] = { scan };
+    const dependencyScanner: ResourceResolverDependencies['dependencyScanner'] = { scan, scanEntries };
     const fileManager = createFakeFileManager({
         transferableFileDescriptionResponder(sourceFilePath, targetFilePath) {
             if (targetFilePath === 'package.json') {


### PR DESCRIPTION
Declaration companion resolution now scans all pending declaration entries for a root through one `DependencyScanner` project instead of creating a fresh `ts-morph` project per companion. This keeps typed package resolution bounded for large packages while preserving the existing per-entry flattened dependency output.