### PR TITLE
Replace owned abbreviated identifiers

### DIFF
--- a/integration-tests/github-api/changelog-git-repository.ts
+++ b/integration-tests/github-api/changelog-git-repository.ts
@@ -5,9 +5,9 @@ import path from 'node:path';
 
 const gitExecutable = '/usr/bin/git';
 
-async function git(workingDirectory: string, args: readonly string[]): Promise<void> {
+async function git(workingDirectory: string, commandArguments: readonly string[]): Promise<void> {
     await new Promise<void>(function (resolve, reject) {
-        execFile(gitExecutable, args, {
+        execFile(gitExecutable, commandArguments, {
             cwd: workingDirectory,
             timeout: 5000
         }, function (error) {

--- a/integration-tests/package-processor/package-json-imports.test.ts
+++ b/integration-tests/package-processor/package-json-imports.test.ts
@@ -10,7 +10,7 @@ type ImportsPackageJson = {
     readonly imports: Readonly<Record<string, string>>;
 };
 
-type BuildPackageParams = {
+type BuildPackageInput = {
     readonly sourcesFolder: string;
     readonly mainPackageJson: ImportsPackageJson;
     readonly name: string;
@@ -19,16 +19,16 @@ type BuildPackageParams = {
     readonly bundleDependencies: readonly BuiltPackage[];
 };
 
-async function buildPackage(params: BuildPackageParams): Promise<BuiltPackage> {
+async function buildPackage(input: BuildPackageInput): Promise<BuiltPackage> {
     return packageProcessor.build({
-        name: params.name,
-        version: params.version,
-        sourcesFolder: params.sourcesFolder,
-        roots: { main: { js: path.join(params.sourcesFolder, params.entryFileName) } },
-        mainPackageJson: params.mainPackageJson,
+        name: input.name,
+        version: input.version,
+        sourcesFolder: input.sourcesFolder,
+        roots: { main: { js: path.join(input.sourcesFolder, input.entryFileName) } },
+        mainPackageJson: input.mainPackageJson,
         includeSourceMapFiles: false,
         additionalFiles: [],
-        bundleDependencies: params.bundleDependencies,
+        bundleDependencies: input.bundleDependencies,
         bundlePeerDependencies: [],
         additionalPackageJsonAttributes: {},
         allowMutableSpecifiers: [],

--- a/integration-tests/packtory/dead-code-elimination.test.ts
+++ b/integration-tests/packtory/dead-code-elimination.test.ts
@@ -76,14 +76,14 @@ function findPackage(packages: readonly ResolvedPackage[], name: string): Resolv
 }
 
 function findResource(
-    pkg: ResolvedPackage,
+    resolvedPackage: ResolvedPackage,
     targetFilePath: string
 ): ResolvedPackage['analyzedBundle']['contents'][number] {
-    const match = pkg.analyzedBundle.contents.find(function (resource) {
+    const match = resolvedPackage.analyzedBundle.contents.find(function (resource) {
         return resource.fileDescription.targetFilePath === targetFilePath;
     });
     if (match === undefined) {
-        assert.fail(`Expected to find target file "${targetFilePath}" in bundle "${pkg.name}"`);
+        assert.fail(`Expected to find target file "${targetFilePath}" in bundle "${resolvedPackage.name}"`);
     }
     return match;
 }
@@ -112,8 +112,8 @@ suite('dead-code-elimination', function () {
         const config = await singlePackageConfig(fixturePath);
         const result = await resolveAndLinkAll(config);
         const packages = expectOk(result);
-        const pkg = findPackage(packages, 'pkg');
-        const helpers = findResource(pkg, 'shared/helpers.js');
+        const resolvedPackage = findPackage(packages, 'pkg');
+        const helpers = findResource(resolvedPackage, 'shared/helpers.js');
 
         assert.ok(helpers.fileDescription.content.includes('used'), 'used() should remain');
         assert.strictEqual(
@@ -128,14 +128,14 @@ suite('dead-code-elimination', function () {
         const config = await singlePackageConfig(fixturePath);
         const result = await resolveAndLinkAll(config);
         const packages = expectOk(result);
-        const pkg = findPackage(packages, 'pkg');
-        const entry = findResource(pkg, 'pkg/index.js');
+        const resolvedPackage = findPackage(packages, 'pkg');
+        const entry = findResource(resolvedPackage, 'pkg/index.js');
 
         assert.ok(
             entry.fileDescription.content.includes('unusedHelper'),
             'unusedHelper must be kept because the file has top-level side effects'
         );
-        assert.deepStrictEqual(pkg.analyzedBundle.sideEffectsField, [ './pkg/index.js' ]);
+        assert.deepStrictEqual(resolvedPackage.analyzedBundle.sideEffectsField, [ './pkg/index.js' ]);
     });
 
     test('preserves a binding in pkg-producer that pkg-consumer imports across bundles', async function () {

--- a/integration-tests/packtory/publish-fixture-support.ts
+++ b/integration-tests/packtory/publish-fixture-support.ts
@@ -47,14 +47,14 @@ type PublishConfig = PacktoryConfig & {
         readonly mainPackageJson: NonNullable<CommonPackageSettings['mainPackageJson']>;
     };
 };
-type CreatePublishConfigParams = {
+type CreatePublishConfigInput = {
     readonly fixturePath: string;
     readonly registryDetails: RegistryDetails;
     readonly packages: PackageConfigList;
     readonly commonPackageSettings?: Partial<CommonPackageSettings>;
     readonly mainPackageJsonOverrides?: Partial<NonNullable<CommonPackageSettings['mainPackageJson']>>;
 };
-type PublishFixturePackagesParams = {
+type PublishFixturePackagesInput = {
     readonly fixturePath: string;
     readonly registryDetails: RegistryDetails;
     readonly packages?: PackageConfigList;
@@ -65,7 +65,7 @@ type PublishFixturePackagesParams = {
 
 function createRegistrySettings(
     registryDetails: RegistryDetails,
-    authMode: PublishFixturePackagesParams['authMode'] = 'bearer'
+    authMode: PublishFixturePackagesInput['authMode'] = 'bearer'
 ): NonNullable<PublishConfig['registrySettings']> {
     if (authMode === 'basic') {
         return {
@@ -125,8 +125,8 @@ export function getFixturePath(name: string): string {
     return path.join(process.cwd(), `integration-tests/fixtures/${name}`);
 }
 
-async function createPublishConfig(params: CreatePublishConfigParams): Promise<PublishConfig> {
-    const { fixturePath, registryDetails, packages, commonPackageSettings, mainPackageJsonOverrides } = params;
+async function createPublishConfig(input: CreatePublishConfigInput): Promise<PublishConfig> {
+    const { fixturePath, registryDetails, packages, commonPackageSettings, mainPackageJsonOverrides } = input;
     const baseMainPackageJson = await loadPackageJson(fixturePath);
     const mergedMainPackageJson = { ...baseMainPackageJson, ...mainPackageJsonOverrides };
     const mergedCommonPackageSettings: PublishConfig['commonPackageSettings'] = {
@@ -144,18 +144,18 @@ async function createPublishConfig(params: CreatePublishConfigParams): Promise<P
     };
 }
 
-export async function publishFixturePackages(params: PublishFixturePackagesParams): Promise<PublishAllResult> {
-    const configParams = {
-        fixturePath: params.fixturePath,
-        registryDetails: params.registryDetails,
-        packages: params.packages ?? standardFixturePackages(params.fixturePath),
-        ...params.commonPackageSettings === undefined ? {} : { commonPackageSettings: params.commonPackageSettings },
-        ...params.mainPackageJsonOverrides === undefined ? {} : {
-            mainPackageJsonOverrides: params.mainPackageJsonOverrides
+export async function publishFixturePackages(input: PublishFixturePackagesInput): Promise<PublishAllResult> {
+    const configInput = {
+        fixturePath: input.fixturePath,
+        registryDetails: input.registryDetails,
+        packages: input.packages ?? standardFixturePackages(input.fixturePath),
+        ...input.commonPackageSettings === undefined ? {} : { commonPackageSettings: input.commonPackageSettings },
+        ...input.mainPackageJsonOverrides === undefined ? {} : {
+            mainPackageJsonOverrides: input.mainPackageJsonOverrides
         }
     };
-    const config = await createPublishConfig(configParams);
-    const registrySettings = createRegistrySettings(params.registryDetails, params.authMode ?? 'basic');
+    const config = await createPublishConfig(configInput);
+    const registrySettings = createRegistrySettings(input.registryDetails, input.authMode ?? 'basic');
 
     const outcome = await buildAndPublishAll({ ...config, registrySettings }, { dryRun: false, stage: false });
     return outcome.result;

--- a/source/artifacts/artifacts-builder.test.ts
+++ b/source/artifacts/artifacts-builder.test.ts
@@ -322,8 +322,8 @@ suite('artifacts-builder', function () {
                 ]
             );
 
-            const args = tarballBuilder.build.firstCall.args as readonly unknown[];
-            const vendorArgs = args[1];
+            const buildArguments = tarballBuilder.build.firstCall.args as readonly unknown[];
+            const vendorArgs = buildArguments[1];
             assert.deepStrictEqual(vendorArgs, [
                 {
                     sourceAbsolutePath: '/host/node_modules/pkg/index.js',

--- a/source/bootstrap-npm-package/web-login.ts
+++ b/source/bootstrap-npm-package/web-login.ts
@@ -15,7 +15,7 @@ type LoginWebOptions = {
     readonly authType: 'web';
 };
 
-type LoginWebFunction = (opener: LoginWebOpener, opts: LoginWebOptions) => Promise<WebLoginResult>;
+type LoginWebFunction = (opener: LoginWebOpener, options: LoginWebOptions) => Promise<WebLoginResult>;
 type OpenInBrowser = (loginUrl: string) => Promise<void>;
 
 export type WebLoginDependencies = {

--- a/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
+++ b/source/build-support/mutation-timeout/mutation-timeout-cli-runner.test.ts
@@ -38,13 +38,13 @@ async function withDefaultReport<T>(report: unknown, action: (directory: string)
 }
 
 async function runCheckerCli(
-    args: readonly string[],
+    extraArguments: readonly string[],
     cwd: string
 ): Promise<{ readonly exitCode: number; readonly standardError: string; }> {
     return new Promise(function (resolve) {
         execFile(
             process.execPath,
-            [ '--experimental-strip-types', '--enable-source-maps', checkerScriptPath, ...args ],
+            [ '--experimental-strip-types', '--enable-source-maps', checkerScriptPath, ...extraArguments ],
             { cwd, encoding: 'utf8' },
             function (error, _standardOutput, standardError) {
                 resolve({

--- a/source/bundle-emitter/emitter-publish.test.ts
+++ b/source/bundle-emitter/emitter-publish.test.ts
@@ -17,7 +17,7 @@ const latestReleaseMetadata = {
     tarballUrl: 'https://registry.example.test/package.tgz'
 } as const;
 type PublishRequest = Parameters<BundleEmitter['publish']>[0];
-type PublishParams = {
+type PublishInput = {
     readonly bundle?: PublishRequest['bundle'];
     readonly publishSettings: PublishRequest['publishSettings'];
     readonly stage?: boolean;
@@ -87,18 +87,18 @@ function emitterFactory(overrides: Overrides = {}): BundleEmitter {
     return createBundleEmitter(dependencies);
 }
 
-function publishRequest(params: PublishParams): PublishRequest {
+function publishRequest(input: PublishInput): PublishRequest {
     return {
         registrySettings,
-        bundle: params.bundle ?? namedBundle(),
-        publishSettings: params.publishSettings,
-        stage: params.stage ?? false,
-        ...params.extraFiles === undefined ? {} : { extraFiles: params.extraFiles }
+        bundle: input.bundle ?? namedBundle(),
+        publishSettings: input.publishSettings,
+        stage: input.stage ?? false,
+        ...input.extraFiles === undefined ? {} : { extraFiles: input.extraFiles }
     };
 }
 
-async function publishBundle(emitter: BundleEmitter, params: PublishParams): Promise<void> {
-    await emitter.publish(publishRequest(params));
+async function publishBundle(emitter: BundleEmitter, input: PublishInput): Promise<void> {
+    await emitter.publish(publishRequest(input));
 }
 
 function createPublishScenario(ciRepositoryUrl: string | undefined): PublishScenario {

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -19,7 +19,7 @@ const latestReleaseMetadata = {
 } as const;
 type CurrentVersionRequest = Parameters<BundleEmitter['determineCurrentVersion']>[0];
 type BundlePublishedCheckResult = Awaited<ReturnType<BundleEmitter['checkBundleAlreadyPublished']>>;
-type CurrentVersionParams = {
+type CurrentVersionInput = {
     readonly stage: boolean;
     readonly versioning: CurrentVersionRequest['versioning'];
     readonly registrySettings?: CurrentVersionRequest['registrySettings'];
@@ -94,36 +94,36 @@ function emitterFactory(overrides: Overrides = {}): BundleEmitter {
     return createBundleEmitter(dependencies);
 }
 
-function currentVersionRequest(params: CurrentVersionParams): CurrentVersionRequest {
+function currentVersionRequest(input: CurrentVersionInput): CurrentVersionRequest {
     return {
         name: 'the-name',
-        registrySettings: params.registrySettings ?? registrySettings,
-        stage: params.stage,
-        versioning: params.versioning
+        registrySettings: input.registrySettings ?? registrySettings,
+        stage: input.stage,
+        versioning: input.versioning
     };
 }
 
 async function determineCurrentVersion(
     emitter: BundleEmitter,
-    params: CurrentVersionParams
+    input: CurrentVersionInput
 ): Promise<Maybe<string>> {
-    return emitter.determineCurrentVersion(currentVersionRequest(params));
+    return emitter.determineCurrentVersion(currentVersionRequest(input));
 }
 
 async function expectCurrentVersionFailure(
     emitter: BundleEmitter,
-    params: CurrentVersionParams,
+    input: CurrentVersionInput,
     matcher: RegExp
 ): Promise<void> {
     await assert.rejects(async function () {
-        await determineCurrentVersion(emitter, params);
+        await determineCurrentVersion(emitter, input);
     }, matcher);
 }
 
-function buildSbomWithDependency(params: SbomDependency): string {
+function buildSbomWithDependency(input: SbomDependency): string {
     return buildSbomFixtureContent({
-        packtoryVersion: params.packtoryVersion,
-        dependencyComponents: [ { name: params.dependencyName, version: params.dependencyVersion } ]
+        packtoryVersion: input.packtoryVersion,
+        dependencyComponents: [ { name: input.dependencyName, version: input.dependencyVersion } ]
     });
 }
 

--- a/source/bundle-emitter/registry/registry-client.ts
+++ b/source/bundle-emitter/registry/registry-client.ts
@@ -51,7 +51,7 @@ export type RegistryClient = {
     ) => Promise<Maybe<PackageReleaseMetadata>>;
     fetchLatestVersion: (packageName: string, config: RegistrySettings) => Promise<Maybe<PackageVersionDetails>>;
     fetchStagedVersions: (packageName: string, config: RegistrySettings) => Promise<readonly string[]>;
-    publishPackage: (...args: PublishPackageArguments) => Promise<PublicationOutcome>;
+    publishPackage: (...publishArguments: PublishPackageArguments) => Promise<PublicationOutcome>;
     fetchTarball: (tarballUrl: string, config: RegistrySettings) => Promise<Buffer>;
 };
 

--- a/source/bundle-emitter/repository-coherence.test.ts
+++ b/source/bundle-emitter/repository-coherence.test.ts
@@ -189,73 +189,73 @@ suite('repository-coherence', function () {
 
     suite('CI repository urls', function () {
         test('getCiRepositoryUrl() returns undefined when no env vars are set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: undefined,
                 githubRepository: undefined,
                 gitlabProjectUrl: undefined
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), undefined);
+            assert.strictEqual(getCiRepositoryUrl(environment), undefined);
         });
 
         test('getCiRepositoryUrl() returns the GitHub Actions repository url when both GHA env vars are set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: 'https://github.com',
                 githubRepository: 'enormora/packtory',
                 gitlabProjectUrl: undefined
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), 'https://github.com/enormora/packtory');
+            assert.strictEqual(getCiRepositoryUrl(environment), 'https://github.com/enormora/packtory');
         });
 
         test('getCiRepositoryUrl() returns the GitLab CI repository url when only the GitLab var is set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: undefined,
                 githubRepository: undefined,
                 gitlabProjectUrl: 'https://gitlab.com/enormora/packtory'
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), 'https://gitlab.com/enormora/packtory');
+            assert.strictEqual(getCiRepositoryUrl(environment), 'https://gitlab.com/enormora/packtory');
         });
 
         test('getCiRepositoryUrl() prefers GitHub Actions over GitLab when both are set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: 'https://github.com',
                 githubRepository: 'enormora/packtory',
                 gitlabProjectUrl: 'https://gitlab.com/some/other'
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), 'https://github.com/enormora/packtory');
+            assert.strictEqual(getCiRepositoryUrl(environment), 'https://github.com/enormora/packtory');
         });
 
         test('getCiRepositoryUrl() returns undefined when only GITHUB_SERVER_URL is set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: 'https://github.com',
                 githubRepository: undefined,
                 gitlabProjectUrl: undefined
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), undefined);
+            assert.strictEqual(getCiRepositoryUrl(environment), undefined);
         });
 
         test('getCiRepositoryUrl() returns undefined when only GITHUB_REPOSITORY is set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: undefined,
                 githubRepository: 'enormora/packtory',
                 gitlabProjectUrl: undefined
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), undefined);
+            assert.strictEqual(getCiRepositoryUrl(environment), undefined);
         });
 
         test('getCiRepositoryUrl() treats empty env values as not set', function () {
-            const env: CiEnvironment = {
+            const environment: CiEnvironment = {
                 githubServerUrl: '',
                 githubRepository: '',
                 gitlabProjectUrl: ''
             };
 
-            assert.strictEqual(getCiRepositoryUrl(env), undefined);
+            assert.strictEqual(getCiRepositoryUrl(environment), undefined);
         });
     });
 
@@ -333,13 +333,13 @@ suite('repository-coherence', function () {
 
     suite('CI environment reads', function () {
         test('readCiEnvironment() reads GitHub Actions, GitLab CI, and missing env vars from the given env', function () {
-            const env: CiEnvironment = readCiEnvironment({
+            const environment: CiEnvironment = readCiEnvironment({
                 GITHUB_SERVER_URL: 'https://github.com',
                 GITHUB_REPOSITORY: 'enormora/packtory',
                 CI_PROJECT_URL: 'https://gitlab.com/some/other'
             });
 
-            assert.deepStrictEqual(env, {
+            assert.deepStrictEqual(environment, {
                 githubServerUrl: 'https://github.com',
                 githubRepository: 'enormora/packtory',
                 gitlabProjectUrl: 'https://gitlab.com/some/other'
@@ -347,9 +347,9 @@ suite('repository-coherence', function () {
         });
 
         test('readCiEnvironment() returns undefined values when env vars are absent', function () {
-            const env: CiEnvironment = readCiEnvironment({});
+            const environment: CiEnvironment = readCiEnvironment({});
 
-            assert.deepStrictEqual(env, {
+            assert.deepStrictEqual(environment, {
                 githubServerUrl: undefined,
                 githubRepository: undefined,
                 gitlabProjectUrl: undefined

--- a/source/bundle-emitter/repository-coherence.ts
+++ b/source/bundle-emitter/repository-coherence.ts
@@ -6,11 +6,11 @@ export type CiEnvironment = {
     readonly gitlabProjectUrl: string | undefined;
 };
 
-export function readCiEnvironment(env: Readonly<Record<string, string | undefined>>): CiEnvironment {
+export function readCiEnvironment(environment: Readonly<Record<string, string | undefined>>): CiEnvironment {
     return {
-        githubServerUrl: env.GITHUB_SERVER_URL,
-        githubRepository: env.GITHUB_REPOSITORY,
-        gitlabProjectUrl: env.CI_PROJECT_URL
+        githubServerUrl: environment.GITHUB_SERVER_URL,
+        githubRepository: environment.GITHUB_REPOSITORY,
+        gitlabProjectUrl: environment.CI_PROJECT_URL
     };
 }
 
@@ -18,13 +18,13 @@ function isDefinedValue(value: string | undefined): value is string {
     return value !== undefined && value !== '';
 }
 
-export function getCiRepositoryUrl(env: CiEnvironment): string | undefined {
-    if (isDefinedValue(env.githubServerUrl) && isDefinedValue(env.githubRepository)) {
-        return `${env.githubServerUrl}/${env.githubRepository}`;
+export function getCiRepositoryUrl(environment: CiEnvironment): string | undefined {
+    if (isDefinedValue(environment.githubServerUrl) && isDefinedValue(environment.githubRepository)) {
+        return `${environment.githubServerUrl}/${environment.githubRepository}`;
     }
 
-    if (isDefinedValue(env.gitlabProjectUrl)) {
-        return env.gitlabProjectUrl;
+    if (isDefinedValue(environment.gitlabProjectUrl)) {
+        return environment.gitlabProjectUrl;
     }
 
     return undefined;

--- a/source/checks/check-runner.test.ts
+++ b/source/checks/check-runner.test.ts
@@ -3,9 +3,9 @@ import { suite, test } from 'mocha';
 import { checkBundle, fakeCheckRules } from '../test-libraries/check-fixtures.ts';
 import { createCheckRunner, type CheckRunner } from './check-runner.ts';
 
-type CheckRunnerParams = Parameters<CheckRunner>[0];
+type CheckRunnerInput = Parameters<CheckRunner>[0];
 
-function checkParams(overrides: Partial<CheckRunnerParams> = {}): CheckRunnerParams {
+function checkInput(overrides: Partial<CheckRunnerInput> = {}): CheckRunnerInput {
     return {
         settings: {},
         publishedPackages: undefined,
@@ -18,14 +18,14 @@ function checkParams(overrides: Partial<CheckRunnerParams> = {}): CheckRunnerPar
 
 suite('check-runner', function () {
     test('does not invoke any rule when settings are empty', async function () {
-        const issues = await createCheckRunner({ rules: fakeCheckRules() })(checkParams());
+        const issues = await createCheckRunner({ rules: fakeCheckRules() })(checkInput());
 
         assert.deepStrictEqual(issues, []);
     });
 
     test('dispatches an enabled rule with the provided bundles and aggregates its issues', async function () {
         const issues = await createCheckRunner({ rules: fakeCheckRules() })(
-            checkParams({ settings: { noDuplicatedFiles: { enabled: true } } })
+            checkInput({ settings: { noDuplicatedFiles: { enabled: true } } })
         );
 
         assert.deepStrictEqual(issues, [ 'File "shared.ts" is included in multiple packages: a, b' ]);
@@ -34,7 +34,7 @@ suite('check-runner', function () {
     test('threads per-package settings through to the rule for cross-package consent decisions', async function () {
         const consent = { noDuplicatedFiles: { allowList: [ 'shared.ts' ] } };
         const issues = await createCheckRunner({ rules: fakeCheckRules() })(
-            checkParams({
+            checkInput({
                 settings: { noDuplicatedFiles: { enabled: true } },
                 perPackageSettings: new Map([
                     [ 'a', consent ],
@@ -48,7 +48,7 @@ suite('check-runner', function () {
 
     test('aggregates the issues of every configured rule', async function () {
         const issues = await createCheckRunner({ rules: fakeCheckRules() })(
-            checkParams({
+            checkInput({
                 settings: {
                     noDuplicatedFiles: { enabled: true },
                     requiredFiles: { enabled: true, files: [ 'readme.md' ] }

--- a/source/checks/check-runner.ts
+++ b/source/checks/check-runner.ts
@@ -7,7 +7,7 @@ export type CheckRunnerDependencies = {
     readonly rules: AllCheckRules;
 };
 
-type CheckRunnerParams = {
+type CheckRunnerInput = {
     readonly bundles: readonly AnalyzedBundle[];
     readonly publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest> | undefined;
     readonly settings: ChecksSettings | undefined;
@@ -15,13 +15,13 @@ type CheckRunnerParams = {
     readonly packageConfigs: PackageConfigsByName;
 };
 
-export type CheckRunner = (params: CheckRunnerParams) => Promise<readonly string[]>;
+export type CheckRunner = (input: CheckRunnerInput) => Promise<readonly string[]>;
 
 export function createCheckRunner(dependencies: CheckRunnerDependencies): CheckRunner {
-    return async function runChecks(params) {
+    return async function runChecks(input) {
         const issues = await Promise.all(
             dependencies.rules.map(async function (rule) {
-                return await rule.run(params);
+                return await rule.run(input);
             })
         );
         return issues.flat();

--- a/source/checks/rule.ts
+++ b/source/checks/rule.ts
@@ -33,7 +33,7 @@ export type RulePackageConfig = {
     readonly mainPackageJson?: MainPackageJsonShape | undefined;
 };
 
-export type RuleRunParams<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {
+export type RuleRunInput<TName extends string, TGlobal extends RuleGlobalConfig, TPerPackage> = {
     readonly bundles: readonly AnalyzedBundle[];
     readonly publishedPackages?: ReadonlyMap<string, PublishedPackageWithManifest> | undefined;
     readonly settings: Readonly<Partial<Readonly<Record<TName, TGlobal | undefined>>>> | undefined;
@@ -48,5 +48,5 @@ export type CheckRuleDefinition<TName extends string, TGlobal extends RuleGlobal
     readonly name: TName;
     readonly globalSchema: ZodMiniType<TGlobal>;
     readonly perPackageSchema: ZodMiniType<TPerPackage>;
-    readonly run: (params: RuleRunParams<TName, TGlobal, TPerPackage>) => Promise<readonly string[]>;
+    readonly run: (input: RuleRunInput<TName, TGlobal, TPerPackage>) => Promise<readonly string[]>;
 };

--- a/source/checks/rules/max-bundle-size.ts
+++ b/source/checks/rules/max-bundle-size.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/mini';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
-import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+import type { CheckRuleDefinition, RuleRunInput } from '../rule.ts';
 
 function ruleName(): 'maxBundleSize' {
     return 'maxBundleSize';
@@ -25,7 +25,7 @@ function perPackageSchema(): z.ZodMiniType<PerPackageConfig> {
     });
 }
 
-type RunParams = RuleRunParams<RuleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<RuleName, GlobalConfig, PerPackageConfig>;
 
 function bundleSizeBytes(bundle: AnalyzedBundle): number {
     let total = 0;
@@ -46,14 +46,14 @@ function checkBundle(bundle: AnalyzedBundle, threshold: number | undefined): rea
     return [ `Package "${bundle.name}" exceeds the maximum bundle size: ${size} bytes (limit: ${threshold} bytes)` ];
 }
 
-async function run(params: RunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.maxBundleSize;
+async function run(input: RunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.maxBundleSize;
     if (globalConfig?.enabled !== true) {
         return [];
     }
 
-    return params.bundles.flatMap(function (bundle) {
-        const override = params.perPackageSettings.get(bundle.name)?.maxBundleSize?.bytes;
+    return input.bundles.flatMap(function (bundle) {
+        const override = input.perPackageSettings.get(bundle.name)?.maxBundleSize?.bytes;
         return checkBundle(bundle, override ?? globalConfig.bytes);
     });
 }

--- a/source/checks/rules/no-dev-dependency-imports.test.ts
+++ b/source/checks/rules/no-dev-dependency-imports.test.ts
@@ -9,8 +9,8 @@ function bundleWithExternals(name: string, externals: readonly string[]): Analyz
     return analyzedBundle({
         name,
         externalDependencies: new Map<string, ExternalDependency>(
-            externals.map(function (dep) {
-                return [ dep, { name: dep, referencedFrom: [ `/${name}/index.js` ] } ];
+            externals.map(function (dependencyName) {
+                return [ dependencyName, { name: dependencyName, referencedFrom: [ `/${name}/index.js` ] } ];
             })
         )
     });

--- a/source/checks/rules/no-dev-dependency-imports.ts
+++ b/source/checks/rules/no-dev-dependency-imports.ts
@@ -5,7 +5,7 @@ import {
     emptyPerPackageSchema,
     enabledOnlyGlobalSchema,
     type RulePackageConfig,
-    type RuleRunParams
+    type RuleRunInput
 } from '../rule.ts';
 
 function ruleName(): 'noDevDependencyImports' {
@@ -23,7 +23,7 @@ function perPackageSchema(): typeof emptyPerPackageSchema {
 type RuleName = ReturnType<typeof ruleName>;
 type GlobalConfig = Readonly<z.infer<ReturnType<typeof globalSchema>>>;
 type PerPackageConfig = Readonly<z.infer<ReturnType<typeof perPackageSchema>>>;
-type RunParams = RuleRunParams<RuleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<RuleName, GlobalConfig, PerPackageConfig>;
 
 function findLeakedDevDependencies(
     bundle: AnalyzedBundle,
@@ -50,14 +50,14 @@ function findLeakedDevDependencies(
         });
 }
 
-async function run(params: RunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.noDevDependencyImports;
+async function run(input: RunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.noDevDependencyImports;
     if (globalConfig?.enabled !== true) {
         return [];
     }
 
-    return params.bundles.flatMap(function (bundle) {
-        return findLeakedDevDependencies(bundle, params.packageConfigs?.[bundle.name]);
+    return input.bundles.flatMap(function (bundle) {
+        return findLeakedDevDependencies(bundle, input.packageConfigs?.[bundle.name]);
     });
 }
 

--- a/source/checks/rules/no-duplicated-files.test.ts
+++ b/source/checks/rules/no-duplicated-files.test.ts
@@ -75,8 +75,8 @@ function consentMap(
     );
 }
 
-async function runRule(args: DuplicateRuleRunArgs): Promise<readonly string[]> {
-    return await noDuplicatedFilesRule.run(args);
+async function runRule(input: DuplicateRuleRunArgs): Promise<readonly string[]> {
+    return await noDuplicatedFilesRule.run(input);
 }
 
 async function runWithConsent(

--- a/source/checks/rules/no-duplicated-files.ts
+++ b/source/checks/rules/no-duplicated-files.ts
@@ -4,7 +4,7 @@ import {
     type CheckRuleDefinition,
     pathAllowListGlobalSchema,
     pathAllowListPerPackageSchema,
-    type RuleRunParams
+    type RuleRunInput
 } from '../rule.ts';
 import { duplicateMessage, hasMultipleOwners } from './duplicate-detection.ts';
 import { collectFileOwnership, type OwnerInfo } from './file-ownership.ts';
@@ -24,12 +24,12 @@ function perPackageSchema(): typeof pathAllowListPerPackageSchema {
 type RuleName = ReturnType<typeof ruleName>;
 type GlobalConfig = Readonly<z.infer<ReturnType<typeof globalSchema>>>;
 type PerPackageConfig = Readonly<z.infer<ReturnType<typeof perPackageSchema>>>;
-type RunParams = RuleRunParams<RuleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<RuleName, GlobalConfig, PerPackageConfig>;
 
 function everyOwnerConsents(
     filePath: string,
     owners: readonly OwnerInfo[],
-    perPackageSettings: RunParams['perPackageSettings']
+    perPackageSettings: RunInput['perPackageSettings']
 ): boolean {
     return owners.every(function (owner) {
         const allowList = perPackageSettings.get(owner.bundleName)?.noDuplicatedFiles?.allowList;
@@ -39,7 +39,7 @@ function everyOwnerConsents(
 
 function findDuplicateIssues(
     bundles: readonly AnalyzedBundle[],
-    perPackageSettings: RunParams['perPackageSettings'],
+    perPackageSettings: RunInput['perPackageSettings'],
     globalConfig: GlobalConfig
 ): readonly string[] {
     const globallyAllowed = new Set(globalConfig.allowList);
@@ -58,12 +58,12 @@ function findDuplicateIssues(
     });
 }
 
-async function run(params: RunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.noDuplicatedFiles;
+async function run(input: RunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.noDuplicatedFiles;
     if (globalConfig?.enabled !== true) {
         return [];
     }
-    return findDuplicateIssues(params.bundles, params.perPackageSettings, globalConfig);
+    return findDuplicateIssues(input.bundles, input.perPackageSettings, globalConfig);
 }
 
 export const noDuplicatedFilesRule: CheckRuleDefinition<RuleName, GlobalConfig, PerPackageConfig> = {

--- a/source/checks/rules/no-side-effects.test.ts
+++ b/source/checks/rules/no-side-effects.test.ts
@@ -5,7 +5,7 @@ import { safeParse } from '../../common/schema-validation.ts';
 import type { PackageChecksSettings } from '../../config/config.ts';
 import type { AnalyzedBundle, AnalyzedBundleResource } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import { analyzedBundle, analyzedBundleResource } from '../../test-libraries/bundle-fixtures.ts';
-import type { RuleRunParams } from '../rule.ts';
+import type { RuleRunInput } from '../rule.ts';
 import { noSideEffectsRule } from './no-side-effects.ts';
 
 type NoSideEffectsGlobalConfig = {
@@ -15,7 +15,7 @@ type NoSideEffectsGlobalConfig = {
 type NoSideEffectsPerPackageConfig = {
     readonly allowList?: readonly string[] | undefined;
 };
-type NoSideEffectsRunParams = RuleRunParams<
+type NoSideEffectsRunInput = RuleRunInput<
     'noSideEffects',
     NoSideEffectsGlobalConfig,
     NoSideEffectsPerPackageConfig
@@ -52,7 +52,7 @@ function consentMap(
 }
 
 async function runWithInitSideEffect(
-    settings: NoSideEffectsRunParams['settings'],
+    settings: NoSideEffectsRunInput['settings'],
     perPackageSettings: ReadonlyMap<string, PackageChecksSettings>
 ): Promise<readonly string[]> {
     return await noSideEffectsRule.run({

--- a/source/checks/rules/no-side-effects.ts
+++ b/source/checks/rules/no-side-effects.ts
@@ -4,7 +4,7 @@ import {
     pathAllowListGlobalSchema,
     pathAllowListPerPackageSchema,
     type CheckRuleDefinition,
-    type RuleRunParams
+    type RuleRunInput
 } from '../rule.ts';
 
 const ruleName = 'noSideEffects';
@@ -14,7 +14,7 @@ const perPackageSchema = pathAllowListPerPackageSchema;
 
 type GlobalConfig = Readonly<z.infer<typeof globalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof perPackageSchema>>;
-type NoSideEffectsRunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type NoSideEffectsRunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 type SideEffectStatement = {
     readonly line: number;
@@ -29,7 +29,7 @@ function isAllowedFor(
     sourceFilePath: string,
     bundleName: string,
     globalAllowList: ReadonlySet<string>,
-    perPackageSettings: NoSideEffectsRunParams['perPackageSettings']
+    perPackageSettings: NoSideEffectsRunInput['perPackageSettings']
 ): boolean {
     if (globalAllowList.has(sourceFilePath)) {
         return true;
@@ -51,7 +51,7 @@ function reportResource(bundleName: string, resource: AnalyzedBundleResource): s
 function findSideEffectsInBundle(
     bundle: AnalyzedBundle,
     globalAllowList: ReadonlySet<string>,
-    perPackageSettings: NoSideEffectsRunParams['perPackageSettings']
+    perPackageSettings: NoSideEffectsRunInput['perPackageSettings']
 ): readonly string[] {
     return bundle.contents.flatMap(function (resource) {
         if (resource.analysis.sideEffectStatements.length === 0) {
@@ -64,14 +64,14 @@ function findSideEffectsInBundle(
     });
 }
 
-async function run(params: NoSideEffectsRunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.noSideEffects;
+async function run(input: NoSideEffectsRunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.noSideEffects;
     if (globalConfig?.enabled !== true) {
         return [];
     }
     const globalAllowList = new Set(globalConfig.allowList);
-    return params.bundles.flatMap(function (bundle) {
-        return findSideEffectsInBundle(bundle, globalAllowList, params.perPackageSettings);
+    return input.bundles.flatMap(function (bundle) {
+        return findSideEffectsInBundle(bundle, globalAllowList, input.perPackageSettings);
     });
 }
 

--- a/source/checks/rules/no-unused-bundle-dependencies.ts
+++ b/source/checks/rules/no-unused-bundle-dependencies.ts
@@ -6,14 +6,14 @@ import {
     enabledOnlyGlobalSchema,
     type CheckRuleDefinition,
     type RulePackageConfig,
-    type RuleRunParams
+    type RuleRunInput
 } from '../rule.ts';
 
 const ruleName = 'noUnusedBundleDependencies';
 
 type GlobalConfig = Readonly<z.infer<typeof enabledOnlyGlobalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof emptyPerPackageSchema>>;
-type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
 function checkBundle(bundle: AnalyzedBundle, packageConfig: RulePackageConfig | undefined): readonly string[] {
     const issues: string[] = [];
 
@@ -31,14 +31,14 @@ function checkBundle(bundle: AnalyzedBundle, packageConfig: RulePackageConfig | 
     return issues;
 }
 
-async function run(params: RunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.noUnusedBundleDependencies;
+async function run(input: RunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.noUnusedBundleDependencies;
     if (globalConfig?.enabled !== true) {
         return [];
     }
 
-    return params.bundles.flatMap(function (bundle) {
-        return checkBundle(bundle, params.packageConfigs?.[bundle.name]);
+    return input.bundles.flatMap(function (bundle) {
+        return checkBundle(bundle, input.packageConfigs?.[bundle.name]);
     });
 }
 

--- a/source/checks/rules/required-files.ts
+++ b/source/checks/rules/required-files.ts
@@ -2,7 +2,7 @@ import { unique } from 'remeda';
 import { z } from 'zod/mini';
 import type { AnalyzedBundle } from '../../dead-code-eliminator/analyzed-bundle.ts';
 import { nonEmptyStringSchema } from '../../config/base-validations.ts';
-import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+import type { CheckRuleDefinition, RuleRunInput } from '../rule.ts';
 
 const ruleName = 'requiredFiles';
 
@@ -19,7 +19,7 @@ const perPackageSchema = z.strictObject({
 
 type GlobalConfig = Readonly<z.infer<typeof globalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof perPackageSchema>>;
-type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 function effectiveRequiredFiles(
     globalConfig: GlobalConfig,
@@ -39,16 +39,16 @@ function findMissingFiles(bundle: AnalyzedBundle, requiredFiles: readonly string
     });
 }
 
-async function run(params: RunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.requiredFiles;
+async function run(input: RunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.requiredFiles;
     if (globalConfig?.enabled !== true) {
         return [];
     }
 
-    return params.bundles.flatMap(function (bundle) {
+    return input.bundles.flatMap(function (bundle) {
         const requiredFiles = effectiveRequiredFiles(
             globalConfig,
-            params.perPackageSettings.get(bundle.name)?.requiredFiles
+            input.perPackageSettings.get(bundle.name)?.requiredFiles
         );
         return findMissingFiles(bundle, requiredFiles).map(function (file) {
             return `Package "${bundle.name}" is missing required file "${file}"`;

--- a/source/checks/rules/type-script-integrity.ts
+++ b/source/checks/rules/type-script-integrity.ts
@@ -1,7 +1,7 @@
 import type { ResolutionKind } from '@arethetypeswrong/core';
 import { z } from 'zod/mini';
 import type { PublishedPackageWithManifest } from '../../published-package/published-package.ts';
-import type { CheckRuleDefinition, RuleRunParams } from '../rule.ts';
+import type { CheckRuleDefinition, RuleRunInput } from '../rule.ts';
 import type { DeclarationIntegritySummarizer, DeclarationMode } from './type-script-declaration-integrity.ts';
 import type { PackageResolutionAnalyzer } from './type-script-package-resolution.ts';
 import { summarizeResolutionReport } from './type-script-resolution-summary.ts';
@@ -20,7 +20,7 @@ const perPackageSchema = z.strictObject({});
 
 type GlobalConfig = Readonly<z.infer<typeof globalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof perPackageSchema>>;
-type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 export type TypeScriptIntegrityRule = CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
@@ -63,19 +63,19 @@ export function createTypeScriptIntegrityRule(
         ];
     }
 
-    async function run(params: RunParams): Promise<readonly string[]> {
-        const globalConfig = params.settings?.typeScriptIntegrity;
+    async function run(input: RunInput): Promise<readonly string[]> {
+        const globalConfig = input.settings?.typeScriptIntegrity;
         if (globalConfig?.enabled !== true) {
             return [];
         }
 
         const declarationMode = globalConfig.declarations ?? defaultDeclarationMode;
-        const { publishedPackages } = params;
+        const { publishedPackages } = input;
         if (publishedPackages === undefined) {
             throw new Error('Published packages missing for TypeScript integrity');
         }
         const issuesByBundle = await Promise.all(
-            params.bundles.map(async function (bundle) {
+            input.bundles.map(async function (bundle) {
                 const publishedPackage = publishedPackages.get(bundle.name);
                 if (publishedPackage === undefined) {
                     throw new Error(`Published package missing for "${bundle.name}"`);

--- a/source/checks/rules/unique-target-paths.ts
+++ b/source/checks/rules/unique-target-paths.ts
@@ -5,14 +5,14 @@ import {
     emptyPerPackageSchema,
     enabledOnlyGlobalSchema,
     type CheckRuleDefinition,
-    type RuleRunParams
+    type RuleRunInput
 } from '../rule.ts';
 
 const ruleName = 'uniqueTargetPaths';
 
 type GlobalConfig = Readonly<z.infer<typeof enabledOnlyGlobalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof emptyPerPackageSchema>>;
-type RunParams = RuleRunParams<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type RunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
 function findCollidingTargetPaths(bundle: AnalyzedBundle): readonly string[] {
     const sourcesByTarget = groupBy(bundle.contents, function (resource) {
@@ -34,13 +34,13 @@ function findCollidingTargetPaths(bundle: AnalyzedBundle): readonly string[] {
     });
 }
 
-async function run(params: RunParams): Promise<readonly string[]> {
-    const globalConfig = params.settings?.uniqueTargetPaths;
+async function run(input: RunInput): Promise<readonly string[]> {
+    const globalConfig = input.settings?.uniqueTargetPaths;
     if (globalConfig?.enabled !== true) {
         return [];
     }
 
-    return params.bundles.flatMap(findCollidingTargetPaths);
+    return input.bundles.flatMap(findCollidingTargetPaths);
 }
 
 export const uniqueTargetPathsRule: CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig> = {

--- a/source/command-line-interface/config-loader.ts
+++ b/source/command-line-interface/config-loader.ts
@@ -10,7 +10,7 @@ export type ConfigLoader = {
     load: () => Promise<unknown>;
 };
 
-type UnknownFunction = (...args: readonly unknown[]) => unknown;
+type UnknownFunction = (...inputArguments: readonly unknown[]) => unknown;
 
 function isFunction(value: unknown): value is UnknownFunction {
     return typeof value === 'function';

--- a/source/command-line-interface/preview-io/preview-io-shared.test.ts
+++ b/source/command-line-interface/preview-io/preview-io-shared.test.ts
@@ -7,7 +7,7 @@ import type { SpawnedProcess, SpawnOptions } from './preview-spawn.ts';
 
 type FakeSpawnResult = {
     readonly command: string;
-    readonly args: readonly string[];
+    readonly commandArguments: readonly string[];
     readonly options: SpawnOptions;
     readonly child: FakeSpawnedProcess;
 };
@@ -102,9 +102,9 @@ function previewIoFactory(overrides: PreviewIoFactoryOverrides = {}): PreviewIoF
             openedFiles.push(filePath);
             await openFile(filePath);
         },
-        spawnProcess(command, args, options) {
+        spawnProcess(command, commandArguments, options) {
             const child = createFakeSpawnedProcess(overrides.stdinMode);
-            const result = { command, args, options, child };
+            const result = { command, commandArguments, options, child };
             calls.push(result);
             overrides.spawnHook?.(result);
             return child;
@@ -173,7 +173,7 @@ suite('preview-io-shared', function () {
             );
             assert.deepStrictEqual(
                 calls.map(function (call) {
-                    return [ call.command, call.args ];
+                    return [ call.command, call.commandArguments ];
                 }),
                 [ [ 'sh', [ '-lc', 'bat' ] ] ]
             );
@@ -201,7 +201,7 @@ suite('preview-io-shared', function () {
             assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'pager fallback'), true);
             assert.deepStrictEqual(
                 calls.map(function (call) {
-                    return [ call.command, call.args ];
+                    return [ call.command, call.commandArguments ];
                 }),
                 [
                     [ '/bin/bash', [ '-lc', 'bat' ] ],
@@ -216,7 +216,7 @@ suite('preview-io-shared', function () {
             assert.strictEqual(await withPromiseDeadline(io.pagePreviewOutput('content'), 'default less pager'), true);
             assert.deepStrictEqual(
                 calls.map(function (call) {
-                    return [ call.command, call.args ];
+                    return [ call.command, call.commandArguments ];
                 }),
                 [ [ 'sh', [ '-lc', 'less -R' ] ] ]
             );
@@ -231,7 +231,7 @@ suite('preview-io-shared', function () {
             );
             assert.deepStrictEqual(
                 calls.map(function (call) {
-                    return call.args;
+                    return call.commandArguments;
                 }),
                 [ [ '-lc', 'less -R' ] ]
             );

--- a/source/command-line-interface/preview-io/preview-spawn.ts
+++ b/source/command-line-interface/preview-io/preview-spawn.ts
@@ -14,10 +14,18 @@ export type SpawnOptions = {
     readonly detached?: boolean;
 };
 
-export type SpawnFunction = (command: string, args: readonly string[], options: SpawnOptions) => SpawnedProcess;
+export type SpawnFunction = (
+    command: string,
+    commandArguments: readonly string[],
+    options: SpawnOptions
+) => SpawnedProcess;
 
-export function defaultSpawnProcess(command: string, args: readonly string[], options: SpawnOptions): SpawnedProcess {
-    return spawn(command, Array.from(args), {
+export function defaultSpawnProcess(
+    command: string,
+    commandArguments: readonly string[],
+    options: SpawnOptions
+): SpawnedProcess {
+    return spawn(command, Array.from(commandArguments), {
         ...options,
         stdio: options.stdio === 'ignore' ? 'ignore' : Array.from(options.stdio)
     });
@@ -26,11 +34,11 @@ export function defaultSpawnProcess(command: string, args: readonly string[], op
 export async function spawnForCompletion(
     spawnProcess: SpawnFunction,
     command: string,
-    args: readonly string[],
+    commandArguments: readonly string[],
     content: string
 ): Promise<boolean> {
     return new Promise<boolean>(function (resolve) {
-        const child = spawnProcess(command, args, { stdio: [ 'pipe', 'inherit', 'inherit' ] });
+        const child = spawnProcess(command, commandArguments, { stdio: [ 'pipe', 'inherit', 'inherit' ] });
         if (child.stdin === null) {
             resolve(false);
             return;

--- a/source/command-line-interface/runner/changelog-handler.test.ts
+++ b/source/command-line-interface/runner/changelog-handler.test.ts
@@ -80,8 +80,10 @@ type PartialFailureOutcomeSpec = {
     readonly failures: readonly Error[];
 };
 
-function partialFailureOutcome(spec: PartialFailureOutcomeSpec): ReleasePlanOutcome {
-    return releasePlanOutcomeFrom(Result.err({ type: 'partial', succeeded: spec.succeeded, failures: spec.failures }));
+function partialFailureOutcome(input: PartialFailureOutcomeSpec): ReleasePlanOutcome {
+    return releasePlanOutcomeFrom(
+        Result.err({ type: 'partial', succeeded: input.succeeded, failures: input.failures })
+    );
 }
 
 type PullRequestFilterInput = {
@@ -162,27 +164,27 @@ type ChangelogHandlerDependenciesSpec = {
     readonly readEnvironmentVariable?: (name: 'GH_TOKEN' | 'GITHUB_TOKEN') => string | undefined;
 };
 
-function dependenciesWith(spec: ChangelogHandlerDependenciesSpec): ChangelogHandlerDependencies {
+function dependenciesWith(input: ChangelogHandlerDependenciesSpec): ChangelogHandlerDependencies {
     return {
         log(message) {
-            spec.spies.log(message);
+            input.spies.log(message);
         },
-        pageOutput: spec.spies.pageOutput,
+        pageOutput: input.spies.pageOutput,
         packtory: {
-            planReleaseAgainstLatestPublished: spec.spies.planReleaseAgainstLatestPublished
+            planReleaseAgainstLatestPublished: input.spies.planReleaseAgainstLatestPublished
         } as unknown as Packtory,
-        fileManager: spec.fileManager ?? createFakeFileManager(),
-        spinnerRenderer: spinnerRendererCapturing(spec.spies.stopAll),
-        configLoader: spec.configLoader ?? configLoaderReturning(validConfig),
-        createPrLogEngine: spec.spies.createPrLogEngine,
+        fileManager: input.fileManager ?? createFakeFileManager(),
+        spinnerRenderer: spinnerRendererCapturing(input.spies.stopAll),
+        configLoader: input.configLoader ?? configLoaderReturning(validConfig),
+        createPrLogEngine: input.spies.createPrLogEngine,
         currentDate() {
             return new Date('2026-06-13T00:00:00.000Z');
         },
-        readEnvironmentVariable: spec.readEnvironmentVariable ??
+        readEnvironmentVariable: input.readEnvironmentVariable ??
             function (name) {
                 return name === 'GH_TOKEN' ? 'gh-token' : undefined;
             },
-        readPackageInfo: spec.readPackageInfo ??
+        readPackageInfo: input.readPackageInfo ??
             async function () {
                 return { repository: { url: 'git+https://github.com/Owner/Repo.git' } };
             },
@@ -219,15 +221,15 @@ type ReleasePlanFailureLogSpec = {
     readonly expectedLog: string;
 };
 
-async function assertReleasePlanFailureLogged(spec: ReleasePlanFailureLogSpec): Promise<void> {
-    const spies = makeSpies(createEngine(), spec.releasePlanOutcome);
+async function assertReleasePlanFailureLogged(input: ReleasePlanFailureLogSpec): Promise<void> {
+    const spies = makeSpies(createEngine(), input.releasePlanOutcome);
 
     const code = await runChangelogHandler(dependenciesWith({ spies }));
 
     assert.strictEqual(code, 1);
     assert.deepStrictEqual(
         { createPrLogEngine: spies.createPrLogEngine.callCount, logArgs: spies.log.firstCall.args },
-        { createPrLogEngine: 0, logArgs: [ spec.expectedLog ] }
+        { createPrLogEngine: 0, logArgs: [ input.expectedLog ] }
     );
 }
 

--- a/source/command-line-interface/runner/pack-handler.test.ts
+++ b/source/command-line-interface/runner/pack-handler.test.ts
@@ -23,8 +23,8 @@ function spinnerRendererCapturing(stopAll: SinonSpy): TerminalSpinnerRenderer {
 
 function packtoryStub(outcome: Readonly<PackOutcome>, spy: SinonSpy): Packtory {
     return {
-        async packPackage(...args: readonly unknown[]) {
-            spy(...args);
+        async packPackage(...packageArguments: readonly unknown[]) {
+            spy(...packageArguments);
             return outcome;
         }
     } as unknown as Packtory;
@@ -91,8 +91,8 @@ suite('pack-handler', function () {
         await runPackHandler(dependencies);
 
         assert.strictEqual(packPackageSpy.callCount, 1);
-        const args = packPackageSpy.firstCall.args as readonly unknown[];
-        const options = args[1];
+        const packageArguments = packPackageSpy.firstCall.args as readonly unknown[];
+        const options = packageArguments[1];
         assert.deepStrictEqual(options, {
             packageName: 'pkg-b',
             format: 'tar',

--- a/source/command-line-interface/runner/release-preparation.test.ts
+++ b/source/command-line-interface/runner/release-preparation.test.ts
@@ -81,11 +81,11 @@ function createReleasePackage(overrides: Partial<ReleasePlanPackage> = {}): Rele
     };
 }
 
-function createEngine(spec: EngineSpec): PrLogEngine {
+function createEngine(input: EngineSpec): PrLogEngine {
     return {
-        collectMergedPullRequests: fake.resolves(spec.pullRequests),
+        collectMergedPullRequests: fake.resolves(input.pullRequests),
         filterPullRequestsByTargetFiles: fake(function () {
-            return spec.pullRequests;
+            return input.pullRequests;
         }),
         readPullRequestChangedFiles: fake.resolves(
             new Map([ [ 1, [ pullRequestChangedFileFactory.build({ path: 'src/pkg-a/index.ts' }) ] ] ])
@@ -95,14 +95,14 @@ function createEngine(spec: EngineSpec): PrLogEngine {
             throw new Error('unexpected changelog section extraction');
         }),
         renderChangelog: fake.returns(''),
-        renderGroupedTargetChangelog: fake.returns(spec.renderedMarkdown),
-        renderTargetChangelog: fake.returns(spec.renderedMarkdown),
+        renderGroupedTargetChangelog: fake.returns(input.renderedMarkdown),
+        renderTargetChangelog: fake.returns(input.renderedMarkdown),
         resolveChangelogBaseRef: fake.resolves({ ref: 'old-head' }),
         resolveLatestSemverChangelogBaseRef: fake.resolves({ ref: 'latest-semver' }),
-        resolvePullRequestLabels: fake.resolves(spec.labeledPullRequests),
+        resolvePullRequestLabels: fake.resolves(input.labeledPullRequests),
         resolveVersionNumber: fake.returns('1.0.1'),
-        updateChangelog: fake(function (input: ChangelogUpdateInput) {
-            return `updated:\n${input.generatedChangelogMarkdown}`;
+        updateChangelog: fake(function (changelogUpdate: ChangelogUpdateInput) {
+            return `updated:\n${changelogUpdate.generatedChangelogMarkdown}`;
         })
     };
 }
@@ -155,28 +155,28 @@ function mergeDependencySpec(overrides: Partial<DependencySpec>): DependencySpec
 }
 
 function createDependencies(overrides: Partial<DependencySpec> = {}): CreatedReleasePreparationDependencies {
-    const spec = mergeDependencySpec(overrides);
+    const input = mergeDependencySpec(overrides);
 
     return {
-        createPrLogEngine: spec.createPrLogEngine,
+        createPrLogEngine: input.createPrLogEngine,
         currentDate() {
             return new Date('2026-06-13T00:00:00.000Z');
         },
-        fileManager: spec.fileManager,
-        log: spec.log,
-        packtory: spec.packtory,
-        readEnvironmentVariable: spec.readEnvironmentVariable,
+        fileManager: input.fileManager,
+        log: input.log,
+        packtory: input.packtory,
+        readEnvironmentVariable: input.readEnvironmentVariable,
         async readPackageInfo() {
             return { repository: { url: 'https://github.com/owner/repo' } };
         },
         spinnerRenderer: {
             stopAll() {
-                spec.stopAll();
+                input.stopAll();
             }
         },
         configLoader: { load: fake.resolves(validConfig) },
         workingDirectory: '/repo',
-        stopAll: spec.stopAll
+        stopAll: input.stopAll
     };
 }
 

--- a/source/command-line-interface/runner/release-pull-request-handler.ts
+++ b/source/command-line-interface/runner/release-pull-request-handler.ts
@@ -129,11 +129,14 @@ function readGitHubToken(
 function parseGitHubRepositoryName(repositoryName: string): GitHubRepositoryNameParts {
     const ownerSeparatorIndex = repositoryName.indexOf('/');
     const owner = repositoryName.slice(0, ownerSeparatorIndex);
-    const repo = repositoryName.slice(ownerSeparatorIndex + 1);
-    if (!repositoryName.includes('/') || owner.length === 0 || repo.length === 0 || repo.includes('/')) {
+    const repositoryPathSegment = repositoryName.slice(ownerSeparatorIndex + 1);
+    if (
+        !repositoryName.includes('/') || owner.length === 0 || repositoryPathSegment.length === 0 ||
+        repositoryPathSegment.includes('/')
+    ) {
         throw new Error('GITHUB_REPOSITORY must use owner/repo format');
     }
-    return { owner, repo };
+    return { owner, repo: repositoryPathSegment };
 }
 
 async function readGitHubRepository(
@@ -141,8 +144,8 @@ async function readGitHubRepository(
 ): Promise<GitHubRepository> {
     const repositoryName = dependencies.readEnvironmentVariable('GITHUB_REPOSITORY');
     if (repositoryName !== undefined) {
-        const { owner, repo } = parseGitHubRepositoryName(repositoryName);
-        return { name: repositoryName, owner, repo };
+        const { owner, repo: repositoryPathSegment } = parseGitHubRepositoryName(repositoryName);
+        return { name: repositoryName, owner, repo: repositoryPathSegment };
     }
     const packageInfo = await dependencies.readPackageInfo();
     const repository = parseGitHubRepositoryParts(packageInfo);

--- a/source/command-line-interface/spinner/spinner-shared-state.test.ts
+++ b/source/command-line-interface/spinner/spinner-shared-state.test.ts
@@ -62,7 +62,7 @@ type ControlledAtomicsOverrides = {
         index: number,
         realLoad: SpinnerSharedAtomics['load']
     ) => number;
-    readonly wait?: (args: ControlledWaitArgs) => WaitResult;
+    readonly wait?: (input: ControlledWaitArgs) => WaitResult;
 };
 type ControlledWaitArgs = {
     readonly typedArray: Int32Array;

--- a/source/command-line-interface/spinner/spinner-shared-state.ts
+++ b/source/command-line-interface/spinner/spinner-shared-state.ts
@@ -192,19 +192,19 @@ function getRenderedMutationWaitAttemptBudget(timeoutMs: number): number {
     return Math.min(maximumRenderedMutationWaitAttempts, Math.max(Math.ceil(timeoutMs), 1));
 }
 
-function waitForRenderedMutationStep(args: RenderedMutationWaitStepArgs): RenderedMutationWaitStep {
-    const waitStatus = args.atomics.wait(
-        args.headerInt32,
+function waitForRenderedMutationStep(input: RenderedMutationWaitStepArgs): RenderedMutationWaitStep {
+    const waitStatus = input.atomics.wait(
+        input.headerInt32,
         headerRenderedMutationIndex,
-        args.expectedMutation,
-        args.timeoutMs
+        input.expectedMutation,
+        input.timeoutMs
     );
-    const current = args.atomics.load(args.headerInt32, headerRenderedMutationIndex);
+    const current = input.atomics.load(input.headerInt32, headerRenderedMutationIndex);
 
     return {
         current,
-        remainingMs: args.deadline - args.now(),
-        timedOutWithoutProgress: waitStatus === 'timed-out' && current === args.expectedMutation
+        remainingMs: input.deadline - input.now(),
+        timedOutWithoutProgress: waitStatus === 'timed-out' && current === input.expectedMutation
     };
 }
 
@@ -272,68 +272,68 @@ type FinishedRenderedMutationBudget = {
 type RenderedMutationBudget = FinishedRenderedMutationBudget | PendingRenderedMutationBudget;
 
 function initialRenderedMutationWaitState(
-    args: WaitForRenderedMutationWithinBudgetArgs,
+    input: WaitForRenderedMutationWithinBudgetArgs,
     deadline: number
 ): RenderedMutationWaitState {
     return Float64Array.of(
-        args.atomics.load(args.headerInt32, headerRenderedMutationIndex),
-        deadline - args.now()
+        input.atomics.load(input.headerInt32, headerRenderedMutationIndex),
+        deadline - input.now()
     );
 }
 
-function advanceRenderedMutationWait(args: AdvanceRenderedMutationWaitArgs): RenderedMutationWaitIteration {
-    const currentResult = getRenderedMutationWaitResult(args.current, args.remainingMs, args.mutation);
+function advanceRenderedMutationWait(input: AdvanceRenderedMutationWaitArgs): RenderedMutationWaitIteration {
+    const currentResult = getRenderedMutationWaitResult(input.current, input.remainingMs, input.mutation);
     if (currentResult !== undefined) {
         return { result: currentResult };
     }
 
     const step = waitForRenderedMutationStep({
-        atomics: args.atomics,
-        headerInt32: args.headerInt32,
-        now: args.now,
-        deadline: args.deadline,
-        expectedMutation: args.current,
-        timeoutMs: Math.min(args.remainingMs, args.timeoutMs)
+        atomics: input.atomics,
+        headerInt32: input.headerInt32,
+        now: input.now,
+        deadline: input.deadline,
+        expectedMutation: input.current,
+        timeoutMs: Math.min(input.remainingMs, input.timeoutMs)
     });
-    const stepResult = getRenderedMutationWaitStepResult(args.current, args.remainingMs, step, args.mutation);
+    const stepResult = getRenderedMutationWaitStepResult(input.current, input.remainingMs, step, input.mutation);
     if (stepResult !== undefined) {
         return { result: stepResult };
     }
 
     return {
-        nextCurrent: args.atomics.load(args.headerInt32, headerRenderedMutationIndex),
+        nextCurrent: input.atomics.load(input.headerInt32, headerRenderedMutationIndex),
         nextRemainingMs: step.remainingMs
     };
 }
 
-function waitForRenderedMutationWithinBudget(args: WaitForRenderedMutationWithinBudgetArgs): boolean {
-    const deadline = args.now() + args.timeoutMs;
-    const maximumAttempts = getRenderedMutationWaitAttemptBudget(args.timeoutMs);
+function waitForRenderedMutationWithinBudget(input: WaitForRenderedMutationWithinBudgetArgs): boolean {
+    const deadline = input.now() + input.timeoutMs;
+    const maximumAttempts = getRenderedMutationWaitAttemptBudget(input.timeoutMs);
 
     const budget = Array.from({ length: maximumAttempts }).reduce<RenderedMutationBudget>(function (currentBudget) {
         if (currentBudget.type !== 'pending') {
             return currentBudget;
         }
         const iteration = advanceRenderedMutationWait({
-            atomics: args.atomics,
-            headerInt32: args.headerInt32,
-            now: args.now,
+            atomics: input.atomics,
+            headerInt32: input.headerInt32,
+            now: input.now,
             deadline,
-            mutation: args.mutation,
+            mutation: input.mutation,
             current: Number(currentBudget.state[0]),
             remainingMs: Number(currentBudget.state[1]),
-            timeoutMs: args.timeoutMs
+            timeoutMs: input.timeoutMs
         });
         if (!isPendingRenderedMutationWaitIteration(iteration)) {
             return { type: 'finished', result: renderedMutationWaitIterationResult(iteration) };
         }
         return { type: 'pending', state: Float64Array.of(iteration.nextCurrent, iteration.nextRemainingMs) };
-    }, { type: 'pending', state: initialRenderedMutationWaitState(args, deadline) });
+    }, { type: 'pending', state: initialRenderedMutationWaitState(input, deadline) });
 
     if (budget.type === 'finished') {
         return budget.result;
     }
-    return getRenderedMutationWaitResult(Number(budget.state[0]), Number(budget.state[1]), args.mutation) ?? false;
+    return getRenderedMutationWaitResult(Number(budget.state[0]), Number(budget.state[1]), input.mutation) ?? false;
 }
 
 function writeStringIntoSlot(views: Views, slotIndex: number, slice: SlotStringSlice, value: string): void {

--- a/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
+++ b/source/command-line-interface/spinner/terminal-spinner-renderer.test.ts
@@ -15,9 +15,9 @@ type BackendOverrides = {
     readonly shutdown?: SinonSpy;
 };
 
-function wrapVoid(spy: SinonSpy): (...args: readonly unknown[]) => void {
-    return function (...args: readonly unknown[]): void {
-        spy(...args);
+function wrapVoid(spy: SinonSpy): (...callArguments: readonly unknown[]) => void {
+    return function (...callArguments: readonly unknown[]): void {
+        spy(...callArguments);
     };
 }
 

--- a/source/common/clock.ts
+++ b/source/common/clock.ts
@@ -3,9 +3,9 @@ import { clearTimeout as clearTimer, setTimeout as setTimer } from 'node:timers'
 export type Clock = {
     readonly getCurrentTimeInMilliseconds: () => number;
     readonly setTimeout: <Arguments extends readonly unknown[]>(
-        handler: (...args: Arguments) => void,
+        handler: (...timerArguments: Arguments) => void,
         delayInMilliseconds: number,
-        ...args: Arguments
+        ...timerArguments: Arguments
     ) => ReturnType<typeof globalThis.setTimeout>;
     readonly clearTimeout: (id: ReturnType<typeof globalThis.setTimeout>) => void;
 };

--- a/source/config/pre-graph-validation.test.ts
+++ b/source/config/pre-graph-validation.test.ts
@@ -4,26 +4,26 @@ import { packageConfigFixture, publicPublishSettings } from '../test-libraries/c
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { collectPreGraphIssues, packageListToRecord } from './pre-graph-validation.ts';
 
-const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
+const packageConfig: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 suite('pre-graph-validation', function () {
     test('packageListToRecord indexes packages by name', function () {
-        const packageA = pkg({ name: 'a' });
-        const packageB = pkg({ name: 'b' });
+        const packageA = packageConfig({ name: 'a' });
+        const packageB = packageConfig({ name: 'b' });
 
         assert.deepStrictEqual(packageListToRecord([ packageA, packageB ]), { a: packageA, b: packageB });
     });
 
     test('collectPreGraphIssues returns no issues for a well-formed single-package config with publishSettings on the package', function () {
         const config: PacktoryConfigWithoutRegistry = {
-            packages: [ pkg({ publishSettings: publicPublishSettings }) ]
+            packages: [ packageConfig({ publishSettings: publicPublishSettings }) ]
         };
 
         assert.deepStrictEqual(collectPreGraphIssues(config), []);
     });
 
     test('collectPreGraphIssues reports a missing publishSettings placement', function () {
-        const config: PacktoryConfigWithoutRegistry = { packages: [ pkg({}) ] };
+        const config: PacktoryConfigWithoutRegistry = { packages: [ packageConfig({}) ] };
 
         assert.ok(
             collectPreGraphIssues(config).includes(
@@ -35,7 +35,7 @@ suite('pre-graph-validation', function () {
     test('collectPreGraphIssues reports a missing bundle dependency target', function () {
         const config = {
             packages: [
-                pkg({
+                packageConfig({
                     publishSettings: publicPublishSettings,
                     bundleDependencies: [ 'missing' ]
                 })
@@ -50,7 +50,7 @@ suite('pre-graph-validation', function () {
     test('collectPreGraphIssues reports a root configuration violation', function () {
         const config = {
             packages: [
-                pkg({
+                packageConfig({
                     publishSettings: publicPublishSettings,
                     roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } }
                 })

--- a/source/config/root-config-validation.test.ts
+++ b/source/config/root-config-validation.test.ts
@@ -3,7 +3,7 @@ import { suite, test } from 'mocha';
 import type { PackageConfig, PackageConfigsByName } from './config.ts';
 import { validatePackageSurfaceRules } from './root-config-validation.ts';
 
-function pkg(overrides: Partial<PackageConfig>): PackageConfig {
+function packageConfig(overrides: Partial<PackageConfig>): PackageConfig {
     return {
         name: 'pkg-a',
         roots: { main: { js: 'index.js' } },
@@ -13,19 +13,19 @@ function pkg(overrides: Partial<PackageConfig>): PackageConfig {
 }
 
 function configs(...packages: readonly PackageConfig[]): PackageConfigsByName {
-    return Object.fromEntries(packages.map(function (packageConfig) {
-        return [ packageConfig.name, packageConfig ];
+    return Object.fromEntries(packages.map(function (packageEntry) {
+        return [ packageEntry.name, packageEntry ];
     }));
 }
 
 suite('root-config-validation', function () {
     test('validatePackageSurfaceRules returns no issues for a single-root implicit package', function () {
-        assert.deepStrictEqual(validatePackageSurfaceRules(configs(pkg({}))), []);
+        assert.deepStrictEqual(validatePackageSurfaceRules(configs(packageConfig({}))), []);
     });
 
     test('validatePackageSurfaceRules requires defaultModuleRoot when an implicit package has multiple roots', function () {
         const result = validatePackageSurfaceRules(
-            configs(pkg({ roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } } }))
+            configs(packageConfig({ roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } } }))
         );
 
         assert.deepStrictEqual(result, [ 'Package "pkg-a" must define defaultModuleRoot when multiple roots exist' ]);
@@ -33,7 +33,7 @@ suite('root-config-validation', function () {
 
     test('validatePackageSurfaceRules reports an unknown defaultModuleRoot for an implicit package', function () {
         const result = validatePackageSurfaceRules(
-            configs(pkg({ roots: { main: { js: 'index.js' } }, defaultModuleRoot: 'missing' }))
+            configs(packageConfig({ roots: { main: { js: 'index.js' } }, defaultModuleRoot: 'missing' }))
         );
 
         assert.deepStrictEqual(result, [ 'Package "pkg-a" references unknown defaultModuleRoot "missing"' ]);
@@ -41,7 +41,7 @@ suite('root-config-validation', function () {
 
     test('validatePackageSurfaceRules reports duplicate javascript targets across roots', function () {
         const result = validatePackageSurfaceRules(
-            configs(pkg({ roots: { a: { js: 'index.js' }, b: { js: 'index.js' } } }))
+            configs(packageConfig({ roots: { a: { js: 'index.js' }, b: { js: 'index.js' } } }))
         );
 
         assert.ok(result.includes('Package "pkg-a" maps both root "a" and "b" to "index.js"'));
@@ -50,7 +50,7 @@ suite('root-config-validation', function () {
     test('validatePackageSurfaceRules reports explicit module exports that reference unknown roots', function () {
         const result = validatePackageSurfaceRules(
             configs(
-                pkg({
+                packageConfig({
                     roots: { main: { js: 'index.js' } },
                     packageInterface: { modules: [ { root: 'missing', export: '.' } ] }
                 })
@@ -69,7 +69,7 @@ suite('root-config-validation', function () {
     test('validatePackageSurfaceRules reports duplicate explicit export keys', function () {
         const result = validatePackageSurfaceRules(
             configs(
-                pkg({
+                packageConfig({
                     roots: { main: { js: 'index.js' }, extra: { js: 'extra.js' } },
                     packageInterface: {
                         modules: [
@@ -89,7 +89,7 @@ suite('root-config-validation', function () {
     test('validatePackageSurfaceRules reports an unused root in explicit mode', function () {
         const result = validatePackageSurfaceRules(
             configs(
-                pkg({
+                packageConfig({
                     roots: { main: { js: 'index.js' }, unused: { js: 'unused.js' } },
                     packageInterface: { modules: [ { root: 'main', export: '.' } ] }
                 })
@@ -104,7 +104,7 @@ suite('root-config-validation', function () {
     test('validatePackageSurfaceRules rejects mixing defaultModuleRoot with packageInterface', function () {
         const result = validatePackageSurfaceRules(
             configs(
-                pkg({
+                packageConfig({
                     defaultModuleRoot: 'main',
                     packageInterface: { modules: [ { root: 'main', export: '.' } ] }
                 } as never)
@@ -119,7 +119,7 @@ suite('root-config-validation', function () {
     test('validatePackageSurfaceRules reports a private root that conflicts with a public export', function () {
         const result = validatePackageSurfaceRules(
             configs(
-                pkg({
+                packageConfig({
                     roots: { main: { js: 'index.js' } },
                     packageInterface: {
                         modules: [ { root: 'main', export: '.' } ],

--- a/source/config/settings-validation.test.ts
+++ b/source/config/settings-validation.test.ts
@@ -8,7 +8,7 @@ import {
 import type { PackageConfig, PacktoryConfigWithoutRegistry } from './config.ts';
 import { validateAllowScriptsConsistency, validatePublishSettingsArePlaced } from './settings-validation.ts';
 
-const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
+const packageConfig: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 function config(overrides: Partial<PacktoryConfigWithoutRegistry>): PacktoryConfigWithoutRegistry {
     return { packages: [], ...overrides };
@@ -19,7 +19,7 @@ suite('settings-validation', function () {
         const result = validatePublishSettingsArePlaced(
             config({
                 commonPackageSettings: { publishSettings: publicPublishSettings },
-                packages: [ pkg({}) ]
+                packages: [ packageConfig({}) ]
             })
         );
 
@@ -30,8 +30,8 @@ suite('settings-validation', function () {
         const result = validatePublishSettingsArePlaced(
             config({
                 packages: [
-                    pkg({ publishSettings: publicPublishSettings }),
-                    pkg({ name: 'pkg-b', publishSettings: publicPublishSettings })
+                    packageConfig({ publishSettings: publicPublishSettings }),
+                    packageConfig({ name: 'pkg-b', publishSettings: publicPublishSettings })
                 ]
             })
         );
@@ -42,7 +42,10 @@ suite('settings-validation', function () {
     test('validatePublishSettingsArePlaced reports when publishSettings is missing from a package and from commonPackageSettings', function () {
         const result = validatePublishSettingsArePlaced(
             config({
-                packages: [ pkg({ publishSettings: publicPublishSettings }), pkg({ name: 'pkg-b' }) ]
+                packages: [
+                    packageConfig({ publishSettings: publicPublishSettings }),
+                    packageConfig({ name: 'pkg-b' })
+                ]
             })
         );
 
@@ -50,7 +53,7 @@ suite('settings-validation', function () {
     });
 
     test('validateAllowScriptsConsistency returns no issues when no package contributes a scripts attribute', function () {
-        const result = validateAllowScriptsConsistency(config({ packages: [ pkg({}) ] }));
+        const result = validateAllowScriptsConsistency(config({ packages: [ packageConfig({}) ] }));
 
         assert.deepStrictEqual(result, []);
     });
@@ -59,7 +62,7 @@ suite('settings-validation', function () {
         const result = validateAllowScriptsConsistency(
             config({
                 packages: [
-                    pkg({
+                    packageConfig({
                         additionalPackageJsonAttributes: { scripts: { build: 'tsc' } },
                         publishSettings: publicPublishSettings
                     })
@@ -76,7 +79,7 @@ suite('settings-validation', function () {
         const result = validateAllowScriptsConsistency(
             config({
                 packages: [
-                    pkg({
+                    packageConfig({
                         additionalPackageJsonAttributes: { scripts: { build: 'tsc' } },
                         publishSettings: publicPublishSettingsAllowingScripts
                     })
@@ -93,7 +96,7 @@ suite('settings-validation', function () {
                 commonPackageSettings: {
                     publishSettings: publicPublishSettingsAllowingScripts
                 },
-                packages: [ pkg({ additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } }) ]
+                packages: [ packageConfig({ additionalPackageJsonAttributes: { scripts: { build: 'tsc' } } }) ]
             })
         );
 

--- a/source/dependency-scanner/scanner.ts
+++ b/source/dependency-scanner/scanner.ts
@@ -67,15 +67,15 @@ export function createDependencyScanner(
 ): DependencyScanner {
     const { sourceMapFileLocator, typescriptProjectAnalyzer } = dependencyScannerDependencies;
 
-    async function getDependencyNodeData(args: DependencyNodeDataInput): Promise<DependencyGraphNodeData> {
-        const sourceMapFilePath = args.options.includeSourceMapFiles && isCodeFile(args.sourceFilePath)
-            ? await sourceMapFileLocator.locate(args.sourceFilePath, args.sourcesFolder)
+    async function getDependencyNodeData(input: DependencyNodeDataInput): Promise<DependencyGraphNodeData> {
+        const sourceMapFilePath = input.options.includeSourceMapFiles && isCodeFile(input.sourceFilePath)
+            ? await sourceMapFileLocator.locate(input.sourceFilePath, input.sourcesFolder)
             : Maybe.nothing<string>();
 
         return {
             sourceMapFilePath,
-            externalDependencies: args.externalDependencies,
-            project: args.project
+            externalDependencies: input.externalDependencies,
+            project: input.project
         };
     }
 

--- a/source/dependency-scanner/source-file-references.import-meta.test.ts
+++ b/source/dependency-scanner/source-file-references.import-meta.test.ts
@@ -113,16 +113,16 @@ suite('source-file-references import.meta and package assets', function () {
     });
 
     suite('import.meta.resolve references', function () {
-        function expectImportMetaResolveReferences(args: ImportMetaResolveExpectation): void {
+        function expectImportMetaResolveReferences(expectation: ImportMetaResolveExpectation): void {
             const project = createProject({
-                withFiles: [ { filePath: 'main.ts', content: args.mainContent } ]
+                withFiles: [ { filePath: 'main.ts', content: expectation.mainContent } ]
             });
-            const extraFiles = args.extraFiles ?? [];
+            const extraFiles = expectation.extraFiles ?? [];
             for (const file of extraFiles) {
                 project.createSourceFile(file.filePath, file.content);
             }
             const result = getReferencedModules(project.getSourceFileOrThrow('main.ts'), packageJsonPath);
-            assert.deepStrictEqual(result, args.expected);
+            assert.deepStrictEqual(result, expectation.expected);
         }
 
         suite('resolved references', function () {

--- a/source/dependency-scanner/typescript-project-analyzer.test.ts
+++ b/source/dependency-scanner/typescript-project-analyzer.test.ts
@@ -75,12 +75,12 @@ function typescriptProjectAnalyzerFactory(overrides: Overrides = {}): Typescript
     return createTypescriptProjectAnalyzer(fakeDependencies);
 }
 
-function expectedProjectConstruction(args: ExpectedProjectConstructionArgs): unknown[] {
+function expectedProjectConstruction(input: ExpectedProjectConstructionArgs): unknown[] {
     return [
         {
             compilerOptions: {
                 allowJs: true,
-                module: args.module,
+                module: input.module,
                 esModuleInterop: true,
                 maxNodeModuleJsDepth: 1,
                 noEmit: true,
@@ -89,9 +89,9 @@ function expectedProjectConstruction(args: ExpectedProjectConstructionArgs): unk
                 resolveJsonModule: true,
                 skipLibCheck: true,
                 resolvePackageJsonImports: true,
-                ...args.extra
+                ...input.extra
             },
-            fileSystem: args.fileSystem
+            fileSystem: input.fileSystem
         }
     ];
 }

--- a/source/git/current-git-head.test.ts
+++ b/source/git/current-git-head.test.ts
@@ -6,9 +6,9 @@ suite('current-git-head', function () {
     test('reads and trims the current git head', async function () {
         const reader = createCurrentGitHeadReader({
             repositoryFolder: '/repo',
-            async runGitCommand(command, args) {
+            async runGitCommand(command, commandArguments) {
                 assert.strictEqual(command, 'git');
-                assert.deepStrictEqual(args, [ '-C', '/repo', 'rev-parse', '--verify', 'HEAD' ]);
+                assert.deepStrictEqual(commandArguments, [ '-C', '/repo', 'rev-parse', '--verify', 'HEAD' ]);
                 return { stdout: 'abcdef123456\n', stderr: '' };
             }
         });

--- a/source/git/current-git-head.ts
+++ b/source/git/current-git-head.ts
@@ -1,6 +1,6 @@
 type GitCommandRunner = (
     command: string,
-    args: readonly string[]
+    commandArguments: readonly string[]
 ) => Promise<{ readonly stdout: string; readonly stderr: string; }>;
 
 export type CurrentGitHeadReader = () => Promise<string | undefined>;

--- a/source/git/git-command.test.ts
+++ b/source/git/git-command.test.ts
@@ -26,9 +26,9 @@ function createFakeGitCommandChildProcess(
 
 suite('git-command', function () {
     test('createGitCommandRunner resolves stdout and stderr from the executor', async function () {
-        const runner = createGitCommandRunner(async function (command, args) {
+        const runner = createGitCommandRunner(async function (command, commandArguments) {
             assert.strictEqual(command, 'git');
-            assert.deepStrictEqual(args, [ 'status', '--short' ]);
+            assert.deepStrictEqual(commandArguments, [ 'status', '--short' ]);
             return { stdout: Buffer.from('stdout'), stderr: 'stderr' };
         });
 
@@ -41,8 +41,8 @@ suite('git-command', function () {
     test('createGitCommandRunner copies readonly args before calling execFile', async function () {
         const sourceArgs = [ 'rev-parse', 'HEAD' ] as const;
         let receivedArgs: readonly string[] = [];
-        const runner = createGitCommandRunner(async function (_command, args) {
-            receivedArgs = args;
+        const runner = createGitCommandRunner(async function (_command, commandArguments) {
+            receivedArgs = commandArguments;
             return { stdout: '', stderr: '' };
         });
 
@@ -72,10 +72,10 @@ suite('git-command', function () {
 
     test('createChildProcessGitCommandExecutor resolves stdout and stderr from the child callback', async function () {
         const sourceArgs = [ 'status', '--short' ] as const;
-        const executeGitCommand = createChildProcessGitCommandExecutor(function (command, args, callback) {
+        const executeGitCommand = createChildProcessGitCommandExecutor(function (command, commandArguments, callback) {
             assert.strictEqual(command, 'git');
-            assert.deepStrictEqual(args, [ 'status', '--short' ]);
-            assert.notStrictEqual(args, sourceArgs);
+            assert.deepStrictEqual(commandArguments, [ 'status', '--short' ]);
+            assert.notStrictEqual(commandArguments, sourceArgs);
             callback(null, 'stdout', 'stderr');
             return createFakeGitCommandChildProcess(function (listener) {
                 assert.strictEqual(typeof listener, 'function');

--- a/source/git/git-command.ts
+++ b/source/git/git-command.ts
@@ -6,12 +6,12 @@ type GitCommandResult = {
     readonly stdout: string;
     readonly stderr: string;
 };
-export type GitCommandRunner = (command: string, args: readonly string[]) => Promise<GitCommandResult>;
+export type GitCommandRunner = (command: string, commandArguments: readonly string[]) => Promise<GitCommandResult>;
 type GitCommandExecutorResult = {
     readonly stdout: Readonly<Buffer> | string;
     readonly stderr: Readonly<Buffer> | string;
 };
-type GitCommandExecutor = (command: string, args: readonly string[]) => Promise<GitCommandExecutorResult>;
+type GitCommandExecutor = (command: string, commandArguments: readonly string[]) => Promise<GitCommandExecutorResult>;
 type GitCommandChildProcess = {
     readonly once: (eventName: 'close', listener: () => void) => GitCommandChildProcess;
 };
@@ -22,7 +22,7 @@ type ExecFileCallback = (
 ) => void;
 type SpawnGitCommand = (
     command: string,
-    args: readonly string[],
+    commandArguments: readonly string[],
     callback: ExecFileCallback
 ) => GitCommandChildProcess;
 type Deferred<T> = {
@@ -41,9 +41,9 @@ function toGitCommandResult(result: GitCommandExecutorResult): GitCommandResult 
 }
 
 export function createGitCommandRunner(executeGitCommand: GitCommandExecutor): GitCommandRunner {
-    return async function (command, args) {
+    return async function (command, commandArguments) {
         try {
-            return toGitCommandResult(await executeGitCommand(command, Array.from(args)));
+            return toGitCommandResult(await executeGitCommand(command, Array.from(commandArguments)));
         } catch (error: unknown) {
             throw toGitCommandError(error);
         }
@@ -79,7 +79,7 @@ async function runUntilOutputOrClose(
 }
 
 export function createChildProcessGitCommandExecutor(spawnGitCommand: SpawnGitCommand): GitCommandExecutor {
-    return async function (command, args) {
+    return async function (command, commandArguments) {
         const output = Promise.withResolvers<GitCommandExecutorResult>();
         const closed = Promise.withResolvers<never>();
         const callback: ExecFileCallback = function (error, stdout, stderr) {
@@ -89,7 +89,7 @@ export function createChildProcessGitCommandExecutor(spawnGitCommand: SpawnGitCo
             undefined,
             new Error('Child process closed before reporting output')
         );
-        const childProcess = spawnGitCommand(command, Array.from(args), callback);
+        const childProcess = spawnGitCommand(command, Array.from(commandArguments), callback);
         childProcess.once('close', rejectClosedChildProcess);
         return await runUntilOutputOrClose(output, closed);
     };
@@ -97,8 +97,8 @@ export function createChildProcessGitCommandExecutor(spawnGitCommand: SpawnGitCo
 
 export function spawnChildProcessGitCommand(
     command: string,
-    args: readonly string[],
+    commandArguments: readonly string[],
     callback: ExecFileCallback
 ): GitCommandChildProcess {
-    return execFile(command, Array.from(args), callback);
+    return execFile(command, Array.from(commandArguments), callback);
 }

--- a/source/github-release-gate/cli-runner.test.ts
+++ b/source/github-release-gate/cli-runner.test.ts
@@ -60,18 +60,18 @@ function minutesBefore(timestamp: number, minutes: number): string {
     return date.toISOString();
 }
 
-async function expectReleaseAnalysisFailure(spec: ReleaseAnalysisFailureExpectation): Promise<void> {
+async function expectReleaseAnalysisFailure(input: ReleaseAnalysisFailureExpectation): Promise<void> {
     await assert.rejects(async function () {
         await runGitHubReleaseGate({
             analyzeReleaseAgainstLatestPublished: fake.resolves({
                 getReport: fake(),
-                result: spec.result
+                result: input.result
             }),
             fetch,
             fileManager: createFakeFileManager(),
             getEnvironmentVariable: createEnvironmentVariableReader(
                 createBaseEnvironment({
-                    GITHUB_API_BASE_URL: spec.apiBaseUrl,
+                    GITHUB_API_BASE_URL: input.apiBaseUrl,
                     QUIET_PERIOD_MINUTES: '0'
                 })
             ),
@@ -83,7 +83,7 @@ async function expectReleaseAnalysisFailure(spec: ReleaseAnalysisFailureExpectat
                 return undefined;
             }
         });
-    }, spec.expectedError);
+    }, input.expectedError);
 }
 
 suite('github-release-gate-cli-runner', function () {

--- a/source/github-release-gate/test-support.test.ts
+++ b/source/github-release-gate/test-support.test.ts
@@ -18,7 +18,7 @@ import { withDeadline } from '../test-libraries/with-deadline.ts';
 
 type EntryPointScriptCall = {
     readonly execFile: {
-        readonly args: readonly string[];
+        readonly commandArguments: readonly string[];
         readonly cwd: string;
         readonly encoding: 'utf8';
         readonly file: string;
@@ -197,10 +197,10 @@ suite('github-release-gate-test-support', function () {
         let calls: EntryPointScriptCall | null = null;
         const dependencies: EntryPointScriptDependencies = {
             cwd: '/workspace',
-            execFile(file, args, options, callback) {
+            execFile(file, commandArguments, options, callback) {
                 calls = {
                     execFile: {
-                        args,
+                        commandArguments,
                         cwd: options.cwd,
                         encoding: options.encoding,
                         file,
@@ -238,7 +238,7 @@ suite('github-release-gate-test-support', function () {
         assert.deepStrictEqual(observedReadFile, { encoding: 'utf8', path: scriptOutputPath });
         assert.deepStrictEqual(calls, {
             execFile: {
-                args: [ '--experimental-strip-types', '--enable-source-maps', '/entry.ts' ],
+                commandArguments: [ '--experimental-strip-types', '--enable-source-maps', '/entry.ts' ],
                 cwd: '/workspace',
                 encoding: 'utf8',
                 file: '/node',

--- a/source/packages/bootstrap-npm-package/bootstrap-npm-package.entry-point.ts
+++ b/source/packages/bootstrap-npm-package/bootstrap-npm-package.entry-point.ts
@@ -32,7 +32,7 @@ declare module 'npm-profile' {
         opener: (url: string) => Promise<void>,
         authUrl: string,
         doneUrl: string,
-        opts: WebAuthOpenerOptions
+        options: WebAuthOpenerOptions
     ): Promise<WebAuthOpenerResult>;
 }
 
@@ -105,9 +105,9 @@ const bootstrapCommand = command({
     args: {
         packageName: positional({ type: string, displayName: 'package-name' })
     },
-    async handler(args) {
+    async handler(commandInput) {
         const runner = createComposedRunner();
-        const input: BootstrapInput = { packageName: args.packageName, hostname: os.hostname() };
+        const input: BootstrapInput = { packageName: commandInput.packageName, hostname: os.hostname() };
         await runner.run(input);
     }
 });

--- a/source/packages/github-release-gate/github-release-gate.entry-point.ts
+++ b/source/packages/github-release-gate/github-release-gate.entry-point.ts
@@ -9,7 +9,7 @@ import {
     type GitHubReleaseGateRunnerDependencies
 } from '../../github-release-gate/cli-runner.ts';
 
-type UnknownFunction = (...args: readonly unknown[]) => unknown;
+type UnknownFunction = (...inputArguments: readonly unknown[]) => unknown;
 
 type ConfigModule = Readonly<Record<PropertyKey, unknown>>;
 

--- a/source/packages/packtory/packtory.type-test.ts
+++ b/source/packages/packtory/packtory.type-test.ts
@@ -48,7 +48,7 @@ type ConfigWithVersioning<TVersioning> = {
     };
     readonly packages: readonly [
         {
-            readonly name: 'pkg';
+            readonly name: 'package-a';
             readonly roots: { readonly main: { readonly js: 'index.js'; }; };
             readonly versioning: TVersioning;
         }
@@ -143,7 +143,7 @@ describe('PacktoryConfig - accepted shapes', function () {
                 readonly auth: { readonly type: 'bearer-token'; readonly token: 'any-token'; };
             };
             readonly packages: readonly [
-                { readonly name: 'pkg'; readonly roots: { readonly main: { readonly js: 'index.js'; }; }; }
+                { readonly name: 'package-a'; readonly roots: { readonly main: { readonly js: 'index.js'; }; }; }
             ];
         }>();
     });
@@ -183,16 +183,16 @@ describe('PacktoryConfig - accepted shapes', function () {
                     { readonly kind: 'repository-file'; readonly path: 'CHANGELOG.md'; },
                     {
                         readonly kind: 'package-file';
-                        readonly paths: { readonly pkg: 'packages/pkg/CHANGELOG.md'; };
+                        readonly paths: { readonly 'package-a': 'packages/package-a/CHANGELOG.md'; };
                     }
                 ];
-                readonly packageTagFormat: 'pkg/{packageName}/v{version}';
+                readonly packageTagFormat: 'package/{packageName}/v{version}';
                 readonly targetScopedLabelPattern: 'scope:{targetName}:{label}';
             };
             readonly commonPackageSettings: { readonly sourcesFolder: 'src'; readonly includeSourceMapFiles: true; };
             readonly packages: readonly [
                 {
-                    readonly name: 'pkg';
+                    readonly name: 'package-a';
                     readonly roots: {
                         readonly main: {
                             readonly js: 'index.js';
@@ -229,7 +229,9 @@ describe('PacktoryConfig - accepted shapes', function () {
 describe('PacktoryConfig - rejected shapes', function () {
     test('accepts a configuration without registrySettings (read-only ops do not require auth)', function () {
         expect<{
-            readonly packages: readonly [{ readonly name: 'pkg'; readonly roots: Readonly<Record<string, never>>; }];
+            readonly packages: readonly [
+                { readonly name: 'package-a'; readonly roots: Readonly<Record<string, never>>; }
+            ];
         }>()
             .type
             .toBeAssignableTo<PacktoryConfig>();
@@ -246,7 +248,9 @@ describe('PacktoryConfig - rejected shapes', function () {
     test('accepts a registrySettings without auth (publish fails fast at runtime instead)', function () {
         expect<{
             readonly registrySettings: { readonly registryUrl: 'https://registry.example'; };
-            readonly packages: readonly [{ readonly name: 'pkg'; readonly roots: Readonly<Record<string, never>>; }];
+            readonly packages: readonly [
+                { readonly name: 'package-a'; readonly roots: Readonly<Record<string, never>>; }
+            ];
         }>()
             .type
             .toBeAssignableTo<PacktoryConfig>();
@@ -263,7 +267,7 @@ describe('PacktoryConfig - rejected shapes', function () {
             readonly registrySettings: {
                 readonly auth: { readonly type: 'bearer-token'; readonly token: 'tok'; };
             };
-            readonly packages: readonly [{ readonly name: 'pkg'; }];
+            readonly packages: readonly [{ readonly name: 'package-a'; }];
         }>();
     });
 });

--- a/source/packtory/options/bundle-dependency-resolution.test.ts
+++ b/source/packtory/options/bundle-dependency-resolution.test.ts
@@ -4,11 +4,11 @@ import type { PackageConfig } from '../../config/config.ts';
 import { packageConfigFixture } from '../../test-libraries/config-fixtures.ts';
 import { resolveBundleDependencies } from './bundle-dependency-resolution.ts';
 
-const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
+const packageConfig: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 suite('bundle-dependency-resolution', function () {
     test('resolveBundleDependencies returns empty lists when the package has no declared dependencies', function () {
-        assert.deepStrictEqual(resolveBundleDependencies(pkg({}), []), {
+        assert.deepStrictEqual(resolveBundleDependencies(packageConfig({}), []), {
             bundleDependencies: [],
             bundlePeerDependencies: []
         });
@@ -18,7 +18,7 @@ suite('bundle-dependency-resolution', function () {
         const bundleA = { name: 'pkg-b', payload: 'b' };
         const bundleB = { name: 'pkg-c', payload: 'c' };
 
-        const result = resolveBundleDependencies(pkg({ bundleDependencies: [ 'pkg-b', 'pkg-c' ] }), [
+        const result = resolveBundleDependencies(packageConfig({ bundleDependencies: [ 'pkg-b', 'pkg-c' ] }), [
             bundleA,
             bundleB
         ]);
@@ -29,14 +29,14 @@ suite('bundle-dependency-resolution', function () {
     test('resolveBundleDependencies maps each declared peer dependency name to the matching bundle', function () {
         const peer = { name: 'pkg-peer', payload: 'p' };
 
-        const result = resolveBundleDependencies(pkg({ bundlePeerDependencies: [ 'pkg-peer' ] }), [ peer ]);
+        const result = resolveBundleDependencies(packageConfig({ bundlePeerDependencies: [ 'pkg-peer' ] }), [ peer ]);
 
         assert.deepStrictEqual(result.bundlePeerDependencies, [ peer ]);
     });
 
     test('resolveBundleDependencies throws when a declared dependency has no matching bundle', function () {
         try {
-            resolveBundleDependencies(pkg({ bundleDependencies: [ 'missing' ] }), []);
+            resolveBundleDependencies(packageConfig({ bundleDependencies: [ 'missing' ] }), []);
             assert.fail('Expected resolveBundleDependencies() to throw but it did not');
         } catch (error: unknown) {
             assert.strictEqual((error as Error).message, 'Dependent bundle "missing" not found');

--- a/source/packtory/options/dead-code-elimination-resolution.test.ts
+++ b/source/packtory/options/dead-code-elimination-resolution.test.ts
@@ -19,10 +19,10 @@ function validated(
 ): ValidConfigWithoutRegistryResult {
     return validConfigWithoutRegistryFixture({
         commonPackageSettings: common === undefined ? undefined : { deadCodeElimination: common },
-        packages: packages.map(function (pkg) {
+        packages: packages.map(function (packageEntry) {
             return packageConfigFixture({
-                name: pkg.name,
-                deadCodeElimination: pkg.enabled === undefined ? undefined : { enabled: pkg.enabled }
+                name: packageEntry.name,
+                deadCodeElimination: packageEntry.enabled === undefined ? undefined : { enabled: packageEntry.enabled }
             });
         })
     });

--- a/source/packtory/options/setting-resolvers.test.ts
+++ b/source/packtory/options/setting-resolvers.test.ts
@@ -12,7 +12,7 @@ import {
     resolveSourcesFolder
 } from './setting-resolvers.ts';
 
-function pkg(overrides: Partial<PackageConfig>): PackageConfig {
+function packageConfig(overrides: Partial<PackageConfig>): PackageConfig {
     return { name: 'pkg-a', roots: {}, ...overrides };
 }
 
@@ -25,7 +25,7 @@ const baseMain: MainPackageJson = { type: 'module' };
 function registerRequiredSettingTests(): void {
     test('resolveSourcesFolder prefers the package-level sourcesFolder over commonPackageSettings', function () {
         const result = resolveSourcesFolder(
-            pkg({ sourcesFolder: 'pkg-src' }),
+            packageConfig({ sourcesFolder: 'pkg-src' }),
             config({ commonPackageSettings: { sourcesFolder: 'common-src' } })
         );
         assert.strictEqual(result, 'pkg-src');
@@ -33,7 +33,7 @@ function registerRequiredSettingTests(): void {
 
     test('resolveSourcesFolder falls back to commonPackageSettings when the package omits sourcesFolder', function () {
         const result = resolveSourcesFolder(
-            pkg({}),
+            packageConfig({}),
             config({ commonPackageSettings: { sourcesFolder: 'common-src' } })
         );
         assert.strictEqual(result, 'common-src');
@@ -41,7 +41,7 @@ function registerRequiredSettingTests(): void {
 
     test('resolveSourcesFolder throws when no source folder is configured anywhere', function () {
         try {
-            resolveSourcesFolder(pkg({}), config());
+            resolveSourcesFolder(packageConfig({}), config());
             assert.fail('Expected resolveSourcesFolder() to throw but it did not');
         } catch (error: unknown) {
             assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing the sources folder');
@@ -49,13 +49,13 @@ function registerRequiredSettingTests(): void {
     });
 
     test('resolveMainPackageJson returns the package-level mainPackageJson when defined', function () {
-        const result = resolveMainPackageJson(pkg({ mainPackageJson: baseMain }), config());
+        const result = resolveMainPackageJson(packageConfig({ mainPackageJson: baseMain }), config());
         assert.deepStrictEqual(result, baseMain);
     });
 
     test('resolveMainPackageJson throws when no main package.json is configured anywhere', function () {
         try {
-            resolveMainPackageJson(pkg({}), config());
+            resolveMainPackageJson(packageConfig({}), config());
             assert.fail('Expected resolveMainPackageJson() to throw but it did not');
         } catch (error: unknown) {
             assert.strictEqual(
@@ -67,7 +67,7 @@ function registerRequiredSettingTests(): void {
 
     test('resolvePublishSettings throws when no publish settings are configured', function () {
         try {
-            resolvePublishSettings(pkg({}), config());
+            resolvePublishSettings(packageConfig({}), config());
             assert.fail('Expected resolvePublishSettings() to throw but it did not');
         } catch (error: unknown) {
             assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing publish settings');
@@ -77,12 +77,12 @@ function registerRequiredSettingTests(): void {
 
 function registerOptionalSettingTests(): void {
     test('resolveAllowMutableSpecifiers returns an empty array when no dependency policy is configured', function () {
-        assert.deepStrictEqual(resolveAllowMutableSpecifiers(pkg({}), config()), []);
+        assert.deepStrictEqual(resolveAllowMutableSpecifiers(packageConfig({}), config()), []);
     });
 
     test('resolveAllowMutableSpecifiers prefers package-level dependency policy over commonPackageSettings', function () {
         const result = resolveAllowMutableSpecifiers(
-            pkg({ dependencyPolicy: { allowMutableSpecifiers: [ 'react' ] } }),
+            packageConfig({ dependencyPolicy: { allowMutableSpecifiers: [ 'react' ] } }),
             config({ commonPackageSettings: { dependencyPolicy: { allowMutableSpecifiers: [ 'lodash' ] } } })
         );
         assert.deepStrictEqual(result, [ 'react' ]);
@@ -90,7 +90,7 @@ function registerOptionalSettingTests(): void {
 
     test('resolveAdditionalChangelogSourceFiles keeps common and package paths separate', function () {
         const result = resolveAdditionalChangelogSourceFiles(
-            pkg({ additionalChangelogSourceFiles: [ 'packages/pkg/package.json' ] }),
+            packageConfig({ additionalChangelogSourceFiles: [ 'packages/pkg/package.json' ] }),
             config({ commonPackageSettings: { additionalChangelogSourceFiles: [ 'package-lock.json' ] } })
         );
         assert.deepStrictEqual(result, {
@@ -100,7 +100,7 @@ function registerOptionalSettingTests(): void {
     });
 
     test('resolveAdditionalChangelogSourceFiles defaults absent common and package paths to empty lists', function () {
-        const result = resolveAdditionalChangelogSourceFiles(pkg({}), config());
+        const result = resolveAdditionalChangelogSourceFiles(packageConfig({}), config());
 
         assert.deepStrictEqual(result, {
             packageFiles: [],
@@ -110,7 +110,7 @@ function registerOptionalSettingTests(): void {
 
     test('buildAdditionalPackageJsonAttributes merges common attributes with package-level overrides', function () {
         const result = buildAdditionalPackageJsonAttributes(
-            pkg({ additionalPackageJsonAttributes: { keywords: [ 'custom' ], scripts: { build: 'tsc' } } }),
+            packageConfig({ additionalPackageJsonAttributes: { keywords: [ 'custom' ], scripts: { build: 'tsc' } } }),
             config({ commonPackageSettings: { additionalPackageJsonAttributes: { keywords: [ 'shared' ] } } })
         );
 
@@ -118,12 +118,12 @@ function registerOptionalSettingTests(): void {
     });
 
     test('resolveIncludeSourceMapFiles defaults to false when neither level configures it', function () {
-        assert.strictEqual(resolveIncludeSourceMapFiles(pkg({}), config()), false);
+        assert.strictEqual(resolveIncludeSourceMapFiles(packageConfig({}), config()), false);
     });
 
     test('resolveIncludeSourceMapFiles prefers the package-level setting over commonPackageSettings', function () {
         const result = resolveIncludeSourceMapFiles(
-            pkg({ includeSourceMapFiles: true }),
+            packageConfig({ includeSourceMapFiles: true }),
             config({ commonPackageSettings: { includeSourceMapFiles: false } })
         );
         assert.strictEqual(result, true);

--- a/source/packtory/options/surface-resolution.test.ts
+++ b/source/packtory/options/surface-resolution.test.ts
@@ -5,11 +5,11 @@ import type { PackageInterface } from '../../config/package-interface.ts';
 import { packageConfigFixture } from '../../test-libraries/config-fixtures.ts';
 import { resolveSurface } from './surface-resolution.ts';
 
-const pkg: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
+const packageConfig: (overrides: Partial<PackageConfig>) => PackageConfig = packageConfigFixture;
 
 suite('surface-resolution', function () {
     test('resolveSurface returns an implicit surface using the only root when there is a single root', function () {
-        const surface = resolveSurface([ 'main' ], pkg({}));
+        const surface = resolveSurface([ 'main' ], packageConfig({}));
 
         if (surface.mode !== 'implicit') {
             assert.fail('expected implicit surface');
@@ -18,7 +18,7 @@ suite('surface-resolution', function () {
     });
 
     test('resolveSurface returns an implicit surface honouring defaultModuleRoot when multiple roots exist', function () {
-        const surface = resolveSurface([ 'main', 'feature' ], pkg({ defaultModuleRoot: 'feature' }));
+        const surface = resolveSurface([ 'main', 'feature' ], packageConfig({ defaultModuleRoot: 'feature' }));
 
         if (surface.mode !== 'implicit') {
             assert.fail('expected implicit surface');
@@ -28,7 +28,7 @@ suite('surface-resolution', function () {
 
     test('resolveSurface throws when multiple roots exist without a defaultModuleRoot', function () {
         try {
-            resolveSurface([ 'main', 'feature' ], pkg({}));
+            resolveSurface([ 'main', 'feature' ], packageConfig({}));
             assert.fail('Expected resolveSurface() to throw but it did not');
         } catch (error: unknown) {
             assert.strictEqual((error as Error).message, 'Config for package "pkg-a" is missing defaultModuleRoot');
@@ -39,7 +39,7 @@ suite('surface-resolution', function () {
         const packageInterface: PackageInterface = { modules: [ { root: 'main', export: '.' } ] };
         const surface = resolveSurface(
             [ 'main' ],
-            pkg({ packageInterface })
+            packageConfig({ packageInterface })
         );
 
         assert.strictEqual(surface.mode, 'explicit');

--- a/source/packtory/package-processor-build.test.ts
+++ b/source/packtory/package-processor-build.test.ts
@@ -110,8 +110,8 @@ function createPipelineDependencies(
             linkBundle: spies.linkBundle
         },
         progressBroadcaster: {
-            emit(...args: EmitArguments) {
-                spies.emit(...args);
+            emit(...emitArguments: EmitArguments) {
+                spies.emit(...emitArguments);
             },
             hasSubscribers: fake(function (eventName: string) {
                 return eventName === 'scanCompleted' || eventName === 'linkingCompleted';

--- a/source/packtory/package-processor-publish.ts
+++ b/source/packtory/package-processor-publish.ts
@@ -344,15 +344,15 @@ export function createPublishOperations(dependencies: PublishDependencies): Publ
         return { versionedBundle, currentVersion, version };
     }
 
-    function emitVersionDetermined(args: VersionDeterminedInput): void {
+    function emitVersionDetermined(input: VersionDeterminedInput): void {
         if (!dependencies.progressBroadcaster.hasSubscribers('versionDetermined')) {
             return;
         }
         dependencies.progressBroadcaster.emit('versionDetermined', {
-            packageName: args.options.name,
-            previousVersion: args.currentVersion.isJust ? args.currentVersion.value : undefined,
-            chosenVersion: args.chosenVersion,
-            trigger: inferVersionTrigger(args.currentVersion, args.options, args.didBump)
+            packageName: input.options.name,
+            previousVersion: input.currentVersion.isJust ? input.currentVersion.value : undefined,
+            chosenVersion: input.chosenVersion,
+            trigger: inferVersionTrigger(input.currentVersion, input.options, input.didBump)
         });
     }
 

--- a/source/packtory/package-processor.test.ts
+++ b/source/packtory/package-processor.test.ts
@@ -89,7 +89,7 @@ suite('package-processor', function () {
             {
                 bundle: { ...linkedBundle, contents: [], sideEffectsField: undefined },
                 version: '3.4.5',
-                mainPackageJson: { type: 'module', dependencies: { dep: '^1.0.0' } },
+                mainPackageJson: { type: 'module', dependencies: { dependency: '^1.0.0' } },
                 bundleDependencies: [ createVersionedBundle('bundle-dependency', '1.0.0') ],
                 bundlePeerDependencies: [ createVersionedBundle('peer-dependency', '2.0.0') ],
                 additionalPackageJsonAttributes: { publishConfig: { access: 'public' } },

--- a/source/packtory/packtory-pack.ts
+++ b/source/packtory/packtory-pack.ts
@@ -99,9 +99,9 @@ function collectBundleDependencies(
         pendingDependencyNames: createWorklist(target.analyzedBundle.linkedBundleDependencies.keys())
     };
 
-    function appendBundleDependency(pkg: ResolvedPackage): void {
-        const versioned = buildVersionedBundle(versionManager, pkg, fallbackVersion);
-        closure.packageNames.add(pkg.name);
+    function appendBundleDependency(resolvedPackage: ResolvedPackage): void {
+        const versioned = buildVersionedBundle(versionManager, resolvedPackage, fallbackVersion);
+        closure.packageNames.add(resolvedPackage.name);
         closure.extraFiles.push({
             filePath: bundledInstalledDependencyPath(versioned.name, versioned.manifestFile.filePath),
             content: versioned.manifestFile.content,
@@ -114,8 +114,8 @@ function collectBundleDependencies(
                 isExecutable: entry.fileDescription.isExecutable
             });
         }
-        closure.peerRequirements.set(pkg.name, Object.keys(versioned.peerDependencies));
-        closure.pendingDependencyNames.scheduleAll(pkg.analyzedBundle.linkedBundleDependencies.keys());
+        closure.peerRequirements.set(resolvedPackage.name, Object.keys(versioned.peerDependencies));
+        closure.pendingDependencyNames.scheduleAll(resolvedPackage.analyzedBundle.linkedBundleDependencies.keys());
     }
 
     for (
@@ -123,9 +123,11 @@ function collectBundleDependencies(
         dependencyName !== undefined;
         dependencyName = closure.pendingDependencyNames.takeNext()
     ) {
-        const pkg = closure.packageNames.has(dependencyName) ? undefined : resolvedByName.get(dependencyName);
-        if (pkg !== undefined) {
-            appendBundleDependency(pkg);
+        const resolvedPackage = closure.packageNames.has(dependencyName)
+            ? undefined
+            : resolvedByName.get(dependencyName);
+        if (resolvedPackage !== undefined) {
+            appendBundleDependency(resolvedPackage);
         }
     }
 

--- a/source/packtory/packtory-release-analysis.test.ts
+++ b/source/packtory/packtory-release-analysis.test.ts
@@ -49,8 +49,8 @@ type PartialFailureMarker = {
 };
 type ReleaseAnalysisPartialFailure = Extract<ReleaseAnalysisFailure, PartialFailureMarker>;
 
-function createAnalyzer(spec: AnalyzerSpec): ReleaseAnalyzer {
-    return createAnalyzeReleaseAgainstLatestPublishedValidated(createReleaseTestDependencies(spec));
+function createAnalyzer(input: AnalyzerSpec): ReleaseAnalyzer {
+    return createAnalyzeReleaseAgainstLatestPublishedValidated(createReleaseTestDependencies(input));
 }
 
 function expectPartialFailure(result: ReleaseAnalysisResult): ReleaseAnalysisPartialFailure {
@@ -73,11 +73,11 @@ function publishedBuildResultFor(status: BuildAndPublishResult['status'] = 'new-
     });
 }
 
-async function analyzePublishedBuildResult(spec: AnalyzePublishedBuildResultSpec): Promise<ReleaseAnalysisResult> {
+async function analyzePublishedBuildResult(input: AnalyzePublishedBuildResultSpec): Promise<ReleaseAnalysisResult> {
     const analyze = createAnalyzer({
         packageNames: [ 'pkg-a' ],
-        buildResults: [ publishedBuildResultFor(spec.status) ],
-        collectContents: spec.collectContents
+        buildResults: [ publishedBuildResultFor(input.status) ],
+        collectContents: input.collectContents
     });
     const validated = validatedReleaseConfigFor([ 'pkg-a' ]);
 

--- a/source/packtory/packtory-release-diff.test.ts
+++ b/source/packtory/packtory-release-diff.test.ts
@@ -34,7 +34,7 @@ type ScheduledPackageContext = {
     readonly config: unknown;
 };
 
-type ScheduledPackageParams = {
+type ScheduledPackageInput = {
     readonly config: ScheduledPackageConfig;
     readonly createOptions: (context: ScheduledPackageContext) => unknown;
     readonly execute: (options: unknown) => Promise<unknown>;
@@ -109,19 +109,19 @@ function staged<TFirst, TSecond>(
 function publishThenRunStage(succeededPublish: readonly BuildAndPublishResult[]): PackageScheduler {
     let invocations = 0;
     return {
-        async runForEachScheduledPackage(params: ScheduledPackageParams) {
+        async runForEachScheduledPackage(input: ScheduledPackageInput) {
             invocations += 1;
             if (invocations === 1) {
                 return Result.ok(succeededPublish);
             }
             const stageResults: unknown[] = [];
-            for (const pkg of params.config.packtoryConfig.packages) {
-                const options = params.createOptions({
-                    packageName: pkg.name,
+            for (const packageConfig of input.config.packtoryConfig.packages) {
+                const options = input.createOptions({
+                    packageName: packageConfig.name,
                     existing: [],
-                    config: params.config
+                    config: input.config
                 });
-                const result = await params.execute(options);
+                const result = await input.execute(options);
                 if (result !== undefined) {
                     stageResults.push(result);
                 }
@@ -131,8 +131,8 @@ function publishThenRunStage(succeededPublish: readonly BuildAndPublishResult[])
     } as unknown as PackageScheduler;
 }
 
-async function assertDerivedTransition(spec: DerivedTransitionSpec): Promise<void> {
-    const diff = createDiff(publishThenRunStage([ spec.buildResult ]));
+async function assertDerivedTransition(input: DerivedTransitionSpec): Promise<void> {
+    const diff = createDiff(publishThenRunStage([ input.buildResult ]));
 
     const result = await diff(configFor([ 'pkg-a' ]), okResolve);
 
@@ -144,9 +144,9 @@ async function assertDerivedTransition(spec: DerivedTransitionSpec): Promise<voi
         assert.fail('expected a release diff entry');
     }
     assert.partialDeepStrictEqual(entry, {
-        state: spec.expectedState,
-        versionTransition: spec.expectedVersionTransition,
-        previousVersionLabel: spec.expectedPreviousVersionLabel
+        state: input.expectedState,
+        versionTransition: input.expectedVersionTransition,
+        previousVersionLabel: input.expectedPreviousVersionLabel
     });
 }
 

--- a/source/packtory/packtory-release-plan.test.ts
+++ b/source/packtory/packtory-release-plan.test.ts
@@ -205,8 +205,8 @@ function registerMetadataTests(): void {
             }
         });
 
-        const pkg = expectFirstPackage(result);
-        assert.partialDeepStrictEqual(pkg, {
+        const packagePlan = expectFirstPackage(result);
+        assert.partialDeepStrictEqual(packagePlan, {
             previousGitHead: 'old-head',
             currentGitHead: 'current-head',
             latestRegistryMetadata: {
@@ -238,8 +238,8 @@ function registerDependencyAttributionTests(): void {
             }
         });
 
-        const pkg = expectFirstPackage(result);
-        assert.partialDeepStrictEqual(pkg, {
+        const packagePlan = expectFirstPackage(result);
+        assert.partialDeepStrictEqual(packagePlan, {
             changelogDependencyNames: [ 'react' ],
             changelogDependencyUpdates: [ { name: 'react', version: '^19.0.0' } ],
             releaseClassification: 'dependency-only',
@@ -270,8 +270,8 @@ function registerDependencyAttributionTests(): void {
             }
         });
 
-        const pkg = expectFirstPackage(result);
-        assert.partialDeepStrictEqual(pkg, {
+        const packagePlan = expectFirstPackage(result);
+        assert.partialDeepStrictEqual(packagePlan, {
             changedArtifactFiles: [ 'package.json' ],
             changelogDependencyNames: [ 'react' ],
             releaseClassification: 'dependency-only',
@@ -429,11 +429,11 @@ function registerSourceFileTests(): void {
             }
         });
 
-        const pkg = expectFirstPackage(result);
+        const packagePlan = expectFirstPackage(result);
         assert.deepStrictEqual(
             {
-                releaseClassification: pkg.releaseClassification,
-                changelogSourceFiles: pkg.changelogSourceFiles
+                releaseClassification: packagePlan.releaseClassification,
+                changelogSourceFiles: packagePlan.changelogSourceFiles
             },
             {
                 releaseClassification: 'substantive',

--- a/source/packtory/packtory-release-plan.ts
+++ b/source/packtory/packtory-release-plan.ts
@@ -62,22 +62,22 @@ type CreatePackagePlanInput = {
     readonly resolvedPackagesByName: ReadonlyMap<string, ResolvedPackage>;
 };
 
-async function createPackagePlan(args: CreatePackagePlanInput): Promise<ReleasePlanPackage> {
-    const packageName = args.buildResult.bundle.name;
-    const resolvedPackage = args.resolvedPackagesByName.get(packageName);
+async function createPackagePlan(input: CreatePackagePlanInput): Promise<ReleasePlanPackage> {
+    const packageName = input.buildResult.bundle.name;
+    const resolvedPackage = input.resolvedPackagesByName.get(packageName);
     if (resolvedPackage === undefined) {
         throw new Error(`Resolved package "${packageName}" is missing`);
     }
-    const releaseArtifactFiles = args.artifactsBuilder.collectContents(
-        args.buildResult.bundle,
+    const releaseArtifactFiles = input.artifactsBuilder.collectContents(
+        input.buildResult.bundle,
         'package',
-        args.buildResult.extraFiles
+        input.buildResult.extraFiles
     );
-    return createReleasePlanPackage(args, resolvedPackage.analyzedBundle, args.buildResult, {
+    return createReleasePlanPackage(input, resolvedPackage.analyzedBundle, input.buildResult, {
         changelogSourceOptions: resolvedPackage.resolveOptions,
-        currentGitHead: args.currentGitHead,
+        currentGitHead: input.currentGitHead,
         releaseArtifactFiles,
-        releaseClassification: classifyPackageRelease(args.buildResult, releaseArtifactFiles).classification
+        releaseClassification: classifyPackageRelease(input.buildResult, releaseArtifactFiles).classification
     });
 }
 

--- a/source/packtory/packtory.test.ts
+++ b/source/packtory/packtory.test.ts
@@ -131,19 +131,19 @@ function createConfigWithRegistry(overrides: Record<string, unknown> = {}): Reco
     };
 }
 
-type CreateProgressEvent = (params: ProgressEventInput) => ProgressEvent;
+type CreateProgressEvent = (input: ProgressEventInput) => ProgressEvent;
 
-type StageParams = {
+type StageInput = {
     readonly createOptions: (context: StageCreateOptionsInput) => unknown;
     readonly execute: (options: unknown) => Promise<unknown>;
-    readonly selectNext: (params: SelectNextInput) => unknown;
+    readonly selectNext: (input: SelectNextInput) => unknown;
     readonly createProgressEvent?: CreateProgressEvent | undefined;
     readonly config: SchedulerConfig;
 };
 
 type SchedulerOverrides = {
-    readonly resolveStage?: (params: StageParams) => Promise<Result<readonly unknown[], unknown>>;
-    readonly publishStage?: (params: StageParams) => Promise<Result<readonly unknown[], unknown>>;
+    readonly resolveStage?: (input: StageInput) => Promise<Result<readonly unknown[], unknown>>;
+    readonly publishStage?: (input: StageInput) => Promise<Result<readonly unknown[], unknown>>;
 };
 
 type PacktoryFactoryOverrides = SchedulerOverrides & {
@@ -156,11 +156,11 @@ type PacktoryFactoryOverrides = SchedulerOverrides & {
     readonly versionManagerAddVersion?: SinonSpy;
 };
 
-type ScheduledStageParams = StageParams & {
+type ScheduledStageInput = StageInput & {
     readonly emitScheduledEvents?: boolean;
 };
 
-type DefaultRunStage = (params: StageParams) => Promise<Result<unknown[], never>>;
+type DefaultRunStage = (input: StageInput) => Promise<Result<unknown[], never>>;
 
 type PacktoryUnderTest = {
     readonly packtory: Packtory;
@@ -218,19 +218,19 @@ function createBuildAndPublishSpy(): SinonSpy {
 }
 
 function createDefaultRunStage(): DefaultRunStage {
-    return async function (params: StageParams): Promise<Result<unknown[], never>> {
+    return async function (input: StageInput): Promise<Result<unknown[], never>> {
         const existing: unknown[] = [];
         const results: unknown[] = [];
 
-        for (const packageConfig of params.config.packtoryConfig.packages) {
-            const options = params.createOptions({
+        for (const packageConfig of input.config.packtoryConfig.packages) {
+            const options = input.createOptions({
                 packageName: packageConfig.name,
                 existing,
-                config: params.config
+                config: input.config
             });
-            const result = await params.execute(options);
-            params.createProgressEvent?.({ packageName: packageConfig.name, result, options });
-            existing.push(params.selectNext({ result, options }));
+            const result = await input.execute(options);
+            input.createProgressEvent?.({ packageName: packageConfig.name, result, options });
+            existing.push(input.selectNext({ result, options }));
             results.push(result);
         }
 
@@ -239,14 +239,14 @@ function createDefaultRunStage(): DefaultRunStage {
 }
 
 async function runScheduledStage(
-    params: ScheduledStageParams,
+    input: ScheduledStageInput,
     overrides: SchedulerOverrides,
     defaultRunStage: DefaultRunStage
 ): Promise<Result<readonly unknown[], unknown>> {
-    if (params.emitScheduledEvents === false) {
-        return overrides.publishStage === undefined ? defaultRunStage(params) : overrides.publishStage(params);
+    if (input.emitScheduledEvents === false) {
+        return overrides.publishStage === undefined ? defaultRunStage(input) : overrides.publishStage(input);
     }
-    return overrides.resolveStage === undefined ? defaultRunStage(params) : overrides.resolveStage(params);
+    return overrides.resolveStage === undefined ? defaultRunStage(input) : overrides.resolveStage(input);
 }
 
 function createPacktoryUnderTest(overrides: PacktoryFactoryOverrides = {}): PacktoryUnderTest {
@@ -257,8 +257,8 @@ function createPacktoryUnderTest(overrides: PacktoryFactoryOverrides = {}): Pack
 
     const scheduler = {
         runForEachScheduledPackage: fake(
-            async function (params: ScheduledStageParams) {
-                return runScheduledStage(params, overrides, defaultRunStage);
+            async function (input: ScheduledStageInput) {
+                return runScheduledStage(input, overrides, defaultRunStage);
             }
         )
     };

--- a/source/packtory/packtory.ts
+++ b/source/packtory/packtory.ts
@@ -149,23 +149,23 @@ type ReportedOperationArgs<TValidated, TResult, TReport, TOutcome> = {
 };
 
 async function createReportedOutcome<TValidated, TResult, TReport, TOutcome>(
-    args: ReportedOperationArgs<TValidated, TResult, TReport, TOutcome>,
+    operation: ReportedOperationArgs<TValidated, TResult, TReport, TOutcome>,
     getReport: () => TReport
 ): Promise<TOutcome> {
-    const validation = args.validate(args.config);
+    const validation = operation.validate(operation.config);
     const result = validation.isErr
-        ? args.createValidationErrorResult(validation.error)
-        : await args.runValidated(validation.value);
+        ? operation.createValidationErrorResult(validation.error)
+        : await operation.runValidated(validation.value);
 
-    return args.createOutcome(result, getReport);
+    return operation.createOutcome(result, getReport);
 }
 
 async function runReportedOperation<TValidated, TResult, TReport, TOutcome>(
-    args: ReportedOperationArgs<TValidated, TResult, TReport, TOutcome>
+    operation: ReportedOperationArgs<TValidated, TResult, TReport, TOutcome>
 ): Promise<TOutcome> {
-    const reporting = args.attachReporting();
+    const reporting = operation.attachReporting();
     try {
-        return await createReportedOutcome(args, reporting.getReport);
+        return await createReportedOutcome(operation, reporting.getReport);
     } finally {
         reporting.dispose();
     }

--- a/source/packtory/scheduler.test.ts
+++ b/source/packtory/scheduler.test.ts
@@ -29,10 +29,10 @@ type PackageExecutionSnapshots = {
     readonly createOptions: SinonSpy;
     readonly execute: SinonSpy;
 };
-type SelectStringResultParams = {
+type SelectStringResultInput = {
     readonly result: string;
 };
-type SelectPackageNameResultParams = {
+type SelectPackageNameResultInput = {
     readonly result: PackageNameResult;
 };
 
@@ -108,8 +108,8 @@ suite('scheduler', function () {
             config,
             createOptions,
             execute,
-            selectNext(params: SelectStringResultParams) {
-                return params.result;
+            selectNext(input: SelectStringResultInput) {
+                return input.result;
             }
         });
 
@@ -136,14 +136,14 @@ suite('scheduler', function () {
             async execute(packageName) {
                 return { packageName };
             },
-            selectNext(params) {
-                return params.result.packageName;
+            selectNext(input) {
+                return input.result.packageName;
             },
             emitScheduledEvents: false,
-            createProgressEvent(params) {
+            createProgressEvent(input) {
                 return {
                     version: '1.0.0',
-                    status: params.result.packageName === 'package-a' ? 'initial-version' : 'new-version',
+                    status: input.result.packageName === 'package-a' ? 'initial-version' : 'new-version',
                     publication: noPublication
                 };
             }
@@ -178,12 +178,12 @@ suite('scheduler', function () {
                 return { packageName: context.packageName };
             },
             execute,
-            selectNext(params) {
-                return params.result;
+            selectNext(input) {
+                return input.result;
             },
-            createProgressEvent(params) {
+            createProgressEvent(input) {
                 return {
-                    version: params.result,
+                    version: input.result,
                     status: 'new-version',
                     publication: noPublication
                 };
@@ -238,8 +238,8 @@ suite('scheduler', function () {
             async execute() {
                 return rejectWithNonError('not-an-error');
             },
-            selectNext(params: SelectPackageNameResultParams) {
-                return params.result;
+            selectNext(input: SelectPackageNameResultInput) {
+                return input.result;
             }
         });
 

--- a/source/packtory/scheduler.ts
+++ b/source/packtory/scheduler.ts
@@ -17,7 +17,7 @@ export type Scheduler = {
         TOptions,
         TConfig extends { readonly packages: readonly PackageConfig[]; }
     >(
-        params: RunForEachScheduledPackageParams<TResult, TNext, TOptions, TConfig>
+        input: RunForEachScheduledPackageInput<TResult, TNext, TOptions, TConfig>
     ) => Promise<Result<readonly TResult[], PartialError<TResult>>>;
 };
 
@@ -105,10 +105,10 @@ type ProgressEventInput<TResult, TOptions> = {
 };
 
 type CreateProgressEvent<TResult, TOptions> = (
-    params: ProgressEventInput<TResult, TOptions>
+    input: ProgressEventInput<TResult, TOptions>
 ) => ProgressEventReturnValue;
 
-type RunForEachScheduledPackageParams<
+type RunForEachScheduledPackageInput<
     TResult,
     TNext,
     TOptions,
@@ -117,7 +117,7 @@ type RunForEachScheduledPackageParams<
     readonly config: ConfigWithGraph<TConfig>;
     readonly createOptions: (context: PackageExecutionContext<TNext, TConfig>) => TOptions;
     readonly execute: (options: TOptions) => Promise<TResult>;
-    readonly selectNext: (params: SelectNextInput<TResult, TOptions>) => TNext;
+    readonly selectNext: (input: SelectNextInput<TResult, TOptions>) => TNext;
     readonly createProgressEvent?: CreateProgressEvent<TResult, TOptions> | undefined;
     readonly emitScheduledEvents?: boolean;
 };
@@ -147,12 +147,12 @@ export function createScheduler(dependencies: SchedulerDependencies): Scheduler 
         packageNames: readonly string[],
         config: ConfigWithGraph<TConfig>,
         existingItems: readonly TNext[],
-        params: RunForEachScheduledPackageParams<TResult, TNext, TOptions, TConfig>
+        input: RunForEachScheduledPackageInput<TResult, TNext, TOptions, TConfig>
     ): Promise<Result<readonly PackageSuccess<TResult, TOptions>[], PartialError<TResult>>> {
         const executePackage = async function (packageName: string): Promise<PackageSuccess<TResult, TOptions>> {
-            const options = params.createOptions({ packageName, existing: existingItems, config });
-            const result = await executeAndReportError(packageName, options, params.execute);
-            const progressEvent = params.createProgressEvent?.({ packageName, result, options });
+            const options = input.createOptions({ packageName, existing: existingItems, config });
+            const result = await executeAndReportError(packageName, options, input.execute);
+            const progressEvent = input.createProgressEvent?.({ packageName, result, options });
             if (progressEvent !== undefined) {
                 progressBroadcastProvider.emit('done', { packageName, ...progressEvent });
             }
@@ -196,7 +196,7 @@ export function createScheduler(dependencies: SchedulerDependencies): Scheduler 
         nextItems: ResultCollector<TNext>,
         succeededResults: ResultCollector<TResult>,
         succeeded: readonly PackageSuccess<TResult, TOptions>[],
-        selectNext: (params: SelectNextInput<TResult, TOptions>) => TNext
+        selectNext: (input: SelectNextInput<TResult, TOptions>) => TNext
     ): void {
         for (const entry of succeeded) {
             nextItems.push(selectNext({ result: entry.result, options: entry.options }));
@@ -211,18 +211,18 @@ export function createScheduler(dependencies: SchedulerDependencies): Scheduler 
         TConfig extends { readonly packages: readonly PackageConfig[]; }
     >(
         config: ConfigWithGraph<TConfig>,
-        params: RunForEachScheduledPackageParams<TResult, TNext, TOptions, TConfig>
+        input: RunForEachScheduledPackageInput<TResult, TNext, TOptions, TConfig>
     ): Promise<Result<readonly TResult[], PartialError<TResult>>> {
         const nextItems: TNext[] = [];
         const succeededResults: TResult[] = [];
 
         for (const generation of getExecutionPlan(config)) {
-            const generationResult = await runForGeneration(generation, config, nextItems, params);
+            const generationResult = await runForGeneration(generation, config, nextItems, input);
             if (generationResult.isErr) {
                 return failGeneration(succeededResults, generationResult.error);
             }
 
-            appendGenerationSuccesses(nextItems, succeededResults, generationResult.value, params.selectNext);
+            appendGenerationSuccesses(nextItems, succeededResults, generationResult.value, input.selectNext);
         }
 
         return Result.ok(succeededResults);
@@ -234,13 +234,13 @@ export function createScheduler(dependencies: SchedulerDependencies): Scheduler 
             TNext,
             TOptions,
             TConfig extends { readonly packages: readonly PackageConfig[]; }
-        >(params: RunForEachScheduledPackageParams<TResult, TNext, TOptions, TConfig>) {
-            const { config } = params;
-            if (shouldEmitScheduledEvents(params.emitScheduledEvents)) {
+        >(input: RunForEachScheduledPackageInput<TResult, TNext, TOptions, TConfig>) {
+            const { config } = input;
+            if (shouldEmitScheduledEvents(input.emitScheduledEvents)) {
                 emitScheduledEventForAllPackages(config);
             }
 
-            return runExecutionPlan(config, params);
+            return runExecutionPlan(config, input);
         }
     };
 }

--- a/source/packtory/stages/package-analysis-stage.test.ts
+++ b/source/packtory/stages/package-analysis-stage.test.ts
@@ -19,10 +19,10 @@ function configWithPackages(
     ...packages: readonly { readonly name: string; readonly enabled?: boolean; }[]
 ): ValidConfigWithoutRegistryResult {
     return validConfigWithoutRegistryFixture({
-        packages: packages.map(function (pkg) {
+        packages: packages.map(function (packageEntry) {
             return packageConfigFixture({
-                name: pkg.name,
-                ...pkg.enabled === undefined ? {} : { deadCodeElimination: { enabled: pkg.enabled } }
+                name: packageEntry.name,
+                ...packageEntry.enabled === undefined ? {} : { deadCodeElimination: { enabled: packageEntry.enabled } }
             });
         })
     });

--- a/source/packtory/stages/package-resolution-stage.ts
+++ b/source/packtory/stages/package-resolution-stage.ts
@@ -76,8 +76,8 @@ export async function resolvePackages(
                 };
             }
         ),
-        selectNext(params) {
-            return params.result.linkedBundle;
+        selectNext(input) {
+            return input.result.linkedBundle;
         },
         emitScheduledEvents: true
     });

--- a/source/packtory/stages/publish-stage.ts
+++ b/source/packtory/stages/publish-stage.ts
@@ -97,15 +97,15 @@ export async function determineVersionAndPublishAll(
                 return dependencies.packageProcessor.buildAndPublish(processorOptions);
             }
         ),
-        selectNext(params) {
-            return params.result.bundle;
+        selectNext(input) {
+            return input.result.bundle;
         },
         emitScheduledEvents: false,
-        createProgressEvent(params) {
+        createProgressEvent(input) {
             return {
-                version: params.result.bundle.packageJson.version,
-                status: params.result.status,
-                publication: params.result.publication
+                version: input.result.bundle.packageJson.version,
+                status: input.result.status,
+                publication: input.result.publication
             };
         }
     });

--- a/source/packtory/stages/release-diff-stage.ts
+++ b/source/packtory/stages/release-diff-stage.ts
@@ -134,8 +134,8 @@ export async function runReleaseDiffStage(
             }
             return classifyDiff(dependencies.artifactsBuilder, options.packageName, options.buildResult);
         },
-        selectNext(params) {
-            return params.options.packageName;
+        selectNext(input) {
+            return input.options.packageName;
         },
         emitScheduledEvents: false
     });

--- a/source/published-package/published-package.ts
+++ b/source/published-package/published-package.ts
@@ -52,12 +52,14 @@ export type ArtifactPublishPackage = Pick<
     'binField' | 'contents' | 'manifestFile' | 'name' | 'packageJson'
 >;
 
-export function explicitBinTargetPaths(pkg: Pick<ArtifactSourcePackage, 'binField'>): ReadonlySet<string> {
-    if (pkg.binField === undefined) {
+export function explicitBinTargetPaths(sourcePackage: Pick<ArtifactSourcePackage, 'binField'>): ReadonlySet<string> {
+    if (sourcePackage.binField === undefined) {
         return new Set<string>();
     }
 
-    const targets = isString(pkg.binField) ? [ pkg.binField ] : Object.values(pkg.binField).filter(isString);
+    const targets = isString(sourcePackage.binField)
+        ? [ sourcePackage.binField ]
+        : Object.values(sourcePackage.binField).filter(isString);
     return new Set(
         targets.map(function (target) {
             return target.replace(/^\.\//u, '');

--- a/source/report/aggregator/report-aggregator.test.ts
+++ b/source/report/aggregator/report-aggregator.test.ts
@@ -133,13 +133,13 @@ function registerLifecycleTests(): void {
 
         broadcaster.provider.emit('stageTimed', { packageName: 'pkg-a', stage: 'build', durationMs: 5 });
 
-        const pkg = aggregator.build().packages['pkg-a'];
-        if (pkg === undefined) {
+        const packageReport = aggregator.build().packages['pkg-a'];
+        if (packageReport === undefined) {
             assert.fail('expected pkg-a in report');
         }
-        assert.strictEqual(Object.hasOwn(pkg, 'inputs'), false);
-        assert.strictEqual(Object.hasOwn(pkg, 'outputs'), false);
-        assert.strictEqual(Object.hasOwn(pkg, 'failure'), false);
+        assert.strictEqual(Object.hasOwn(packageReport, 'inputs'), false);
+        assert.strictEqual(Object.hasOwn(packageReport, 'outputs'), false);
+        assert.strictEqual(Object.hasOwn(packageReport, 'failure'), false);
     });
 
     test('build() reports schemaVersion 1 on an empty aggregator', function () {

--- a/source/report/html-renderer/diagnostics-renderer.ts
+++ b/source/report/html-renderer/diagnostics-renderer.ts
@@ -19,19 +19,19 @@ function sectionForRecord(title: string, value: Readonly<Record<string, unknown>
     return hasEntries(value) ? [ { title, value } ] : [];
 }
 
-function diagnosticSections(pkg: PreviewPackage): readonly DiagnosticSection[] {
+function diagnosticSections(previewPackage: PreviewPackage): readonly DiagnosticSection[] {
     return [
-        ...sectionForDefinedValue('Inputs', pkg.diagnostics.inputs),
-        ...sectionForRecord('Decisions', pkg.diagnostics.decisions),
-        ...sectionForDefinedValue('Outputs', pkg.diagnostics.outputs),
-        ...sectionForDefinedValue('Publication', pkg.diagnostics.publication),
-        ...sectionForRecord('Timings (ms)', pkg.diagnostics.timings),
-        ...sectionForDefinedValue('Failure', pkg.diagnostics.failure)
+        ...sectionForDefinedValue('Inputs', previewPackage.diagnostics.inputs),
+        ...sectionForRecord('Decisions', previewPackage.diagnostics.decisions),
+        ...sectionForDefinedValue('Outputs', previewPackage.diagnostics.outputs),
+        ...sectionForDefinedValue('Publication', previewPackage.diagnostics.publication),
+        ...sectionForRecord('Timings (ms)', previewPackage.diagnostics.timings),
+        ...sectionForDefinedValue('Failure', previewPackage.diagnostics.failure)
     ];
 }
 
-export function renderDiagnostics(pkg: PreviewPackage): string {
-    const sections = diagnosticSections(pkg)
+export function renderDiagnostics(previewPackage: PreviewPackage): string {
+    const sections = diagnosticSections(previewPackage)
         .map(function (section) {
             return renderCollapsibleSection(section.title, section.value);
         })
@@ -42,11 +42,11 @@ export function renderDiagnostics(pkg: PreviewPackage): string {
     return `<section class="package-block diagnostics"><h3>Diagnostics</h3>${sections}</section>`;
 }
 
-export function renderFailureBanner(pkg: PreviewPackage): string {
-    if (pkg.failure === undefined) {
+export function renderFailureBanner(previewPackage: PreviewPackage): string {
+    if (previewPackage.failure === undefined) {
         return '';
     }
-    return `<p class="failure">Failed in stage <strong>${escapeHtml(pkg.failure.stage)}</strong>: ${
-        escapeHtml(pkg.failure.message)
+    return `<p class="failure">Failed in stage <strong>${escapeHtml(previewPackage.failure.stage)}</strong>: ${
+        escapeHtml(previewPackage.failure.message)
     }</p>`;
 }

--- a/source/report/html-renderer/diff-renderer.ts
+++ b/source/report/html-renderer/diff-renderer.ts
@@ -22,12 +22,12 @@ function renderArtifactDiff(artifact: ChangedPreviewArtifact): string {
     return `<details class="diff" open><summary>${escapeHtml(artifact.path)}</summary>${hunks}</details>`;
 }
 
-export function renderPackageDiffs(pkg: PreviewPackage): string {
-    if (pkg.changedArtifacts.length === 0) {
+export function renderPackageDiffs(previewPackage: PreviewPackage): string {
+    if (previewPackage.changedArtifacts.length === 0) {
         return '';
     }
     let sections = '';
-    for (const artifact of pkg.changedArtifacts) {
+    for (const artifact of previewPackage.changedArtifacts) {
         sections += renderArtifactDiff(artifact);
     }
     return `<section class="package-block"><h3>Changed files</h3>${sections}</section>`;

--- a/source/report/html-renderer/eliminated-files-renderer.ts
+++ b/source/report/html-renderer/eliminated-files-renderer.ts
@@ -2,12 +2,12 @@ import type { PreviewPackage } from '../preview/preview-document.ts';
 import { escapeHtml } from './html-escaping.ts';
 import { formatBytes } from './html-primitives.ts';
 
-export function renderEliminatedFiles(pkg: PreviewPackage): string {
-    if (pkg.eliminatedSourceFiles.length === 0) {
+export function renderEliminatedFiles(previewPackage: PreviewPackage): string {
+    if (previewPackage.eliminatedSourceFiles.length === 0) {
         return '';
     }
     let items = '';
-    for (const file of pkg.eliminatedSourceFiles) {
+    for (const file of previewPackage.eliminatedSourceFiles) {
         items += `<li><code>${escapeHtml(file.path)}</code> <span class="tree-meta">${
             escapeHtml(formatBytes(file.sourceBytes))
         }</span></li>`;

--- a/source/report/html-renderer/html-renderer.ts
+++ b/source/report/html-renderer/html-renderer.ts
@@ -17,8 +17,8 @@ function renderIssues(document: PreviewDocument): string {
 
 function renderPackages(document: PreviewDocument): string {
     let result = '';
-    for (const pkg of document.packages) {
-        result += renderPackage(pkg);
+    for (const previewPackage of document.packages) {
+        result += renderPackage(previewPackage);
     }
     return result;
 }

--- a/source/report/html-renderer/package-renderer.ts
+++ b/source/report/html-renderer/package-renderer.ts
@@ -6,28 +6,33 @@ import { renderEliminatedFiles } from './eliminated-files-renderer.ts';
 import { escapeHtml } from './html-escaping.ts';
 import { renderBadge } from './html-primitives.ts';
 
-function renderPackageBadges(pkg: PreviewPackage): string {
+function renderPackageBadges(previewPackage: PreviewPackage): string {
     return [
-        renderBadge(pkg.hasChanges ? 'changed' : 'unchanged', pkg.hasChanges ? 'status-changed' : 'status-unchanged'),
-        ...pkg.versionTransition === undefined ? [] : [ renderBadge(pkg.versionTransition, 'secondary') ]
+        renderBadge(
+            previewPackage.hasChanges ? 'changed' : 'unchanged',
+            previewPackage.hasChanges ? 'status-changed' : 'status-unchanged'
+        ),
+        ...previewPackage.versionTransition === undefined
+            ? []
+            : [ renderBadge(previewPackage.versionTransition, 'secondary') ]
     ]
         .join('');
 }
 
-export function renderPackage(pkg: PreviewPackage): string {
-    const badges = renderPackageBadges(pkg);
-    const summary = `<span class="package-title">${escapeHtml(pkg.name)}</span>` +
+export function renderPackage(previewPackage: PreviewPackage): string {
+    const badges = renderPackageBadges(previewPackage);
+    const summary = `<span class="package-title">${escapeHtml(previewPackage.name)}</span>` +
         `<span class="package-summary">${badges}</span>`;
 
-    return `<details class="package"${pkg.openByDefault ? ' open' : ''}>
+    return `<details class="package"${previewPackage.openByDefault ? ' open' : ''}>
         <summary>${summary}</summary>
-        ${renderFailureBanner(pkg)}
+        ${renderFailureBanner(previewPackage)}
         <section class="package-block">
             <h3>Artifacts</h3>
-            <ul class="tree">${pkg.tree.map(renderArtifactNode).join('')}</ul>
+            <ul class="tree">${previewPackage.tree.map(renderArtifactNode).join('')}</ul>
         </section>
-        ${renderEliminatedFiles(pkg)}
-        ${renderPackageDiffs(pkg)}
-        ${renderDiagnostics(pkg)}
+        ${renderEliminatedFiles(previewPackage)}
+        ${renderPackageDiffs(previewPackage)}
+        ${renderDiagnostics(previewPackage)}
     </details>`;
 }

--- a/source/report/preview/preview-document-package-state.test.ts
+++ b/source/report/preview/preview-document-package-state.test.ts
@@ -29,10 +29,10 @@ suite('preview-document package state', function () {
                 })
             });
 
-            const pkg = requireSinglePackage(document);
-            assert.deepStrictEqual(pkg.eliminatedSourceFiles, [ eliminatedUnusedFile ]);
+            const previewPackage = requireSinglePackage(document);
+            assert.deepStrictEqual(previewPackage.eliminatedSourceFiles, [ eliminatedUnusedFile ]);
             assert.strictEqual(
-                pkg.tree.some(function (entry) {
+                previewPackage.tree.some(function (entry) {
                     return entry.path === eliminatedUnusedFile.path;
                 }),
                 false
@@ -141,11 +141,11 @@ suite('preview-document package state', function () {
             });
 
             assert.strictEqual(document.modeLabel, 'Publish');
-            const pkg = requireSinglePackage(document);
-            if (pkg.failure === undefined) {
+            const previewPackage = requireSinglePackage(document);
+            if (previewPackage.failure === undefined) {
                 assert.fail('expected package failure');
             }
-            assert.partialDeepStrictEqual(pkg, {
+            assert.partialDeepStrictEqual(previewPackage, {
                 failure: {
                     message: 'boom'
                 },

--- a/source/report/preview/preview-document.test.ts
+++ b/source/report/preview/preview-document.test.ts
@@ -45,8 +45,8 @@ suite('preview-document', function () {
         });
 
         assert.deepStrictEqual(
-            document.packages.map(function (pkg) {
-                return [ pkg.name, pkg.versionTransition ];
+            document.packages.map(function (previewPackage) {
+                return [ previewPackage.name, previewPackage.versionTransition ];
             }),
             [
                 [ 'pkg-a', '1.0.0 -> 1.0.1' ],
@@ -69,10 +69,10 @@ suite('preview-document', function () {
             )
         });
 
-        const pkg = requireSinglePackage(document);
+        const previewPackage = requireSinglePackage(document);
         assert.strictEqual(requireTreeNodeAt(document, 0, 0).path, 'package.json');
         assert.deepStrictEqual(
-            pkg
+            previewPackage
                 .tree
                 .filter(function (entry) {
                     return entry.type === 'file' && entry.artifact.diff !== undefined;

--- a/source/report/preview/preview-document.ts
+++ b/source/report/preview/preview-document.ts
@@ -48,7 +48,7 @@ export type PreviewDocument = {
     readonly report: BuildReport;
 };
 
-type PreviewDocumentParams = {
+type PreviewDocumentInput = {
     readonly report: BuildReport;
     readonly result: PublishAllResult;
     readonly dryRun: boolean;
@@ -129,24 +129,24 @@ async function buildPreviewPackage(
     };
 }
 
-export async function buildPreviewDocument(params: PreviewDocumentParams): Promise<PreviewDocument> {
-    const readWorkspaceFile = params.fileManager.readFile;
-    const bundleArtifactIndex = buildBundleArtifactIndex(getSucceededResults(params.result));
+export async function buildPreviewDocument(input: PreviewDocumentInput): Promise<PreviewDocument> {
+    const readWorkspaceFile = input.fileManager.readFile;
+    const bundleArtifactIndex = buildBundleArtifactIndex(getSucceededResults(input.result));
     const packages = await Promise.all(
-        Object.entries(params.report.packages).map(async function ([ packageName, packageReport ]) {
+        Object.entries(input.report.packages).map(async function ([ packageName, packageReport ]) {
             return buildPreviewPackage(packageName, packageReport, bundleArtifactIndex, readWorkspaceFile);
         })
     );
 
     return {
         title: 'Packtory preview',
-        modeLabel: params.dryRun ? 'Dry run' : 'Publish',
-        previewable: isPreviewableResult(params.result),
-        resultType: getResultType(params.result),
+        modeLabel: input.dryRun ? 'Dry run' : 'Publish',
+        previewable: isPreviewableResult(input.result),
+        resultType: getResultType(input.result),
         summary: summarizePackages(packages),
         packages,
-        issues: getIssues(params.result),
-        report: params.report
+        issues: getIssues(input.result),
+        report: input.report
     };
 }
 

--- a/source/report/preview/preview-summary.ts
+++ b/source/report/preview/preview-summary.ts
@@ -34,15 +34,16 @@ function createPreviewSummary(totalPackages: number): PreviewSummary {
 
 export function summarizePackages(packages: readonly PackageForSummary[]): PreviewSummary {
     return packages.reduce(
-        function (summary, pkg) {
+        function (summary, previewPackage) {
             return {
                 totalPackages: summary.totalPackages,
-                changedPackages: summary.changedPackages + (pkg.hasChanges ? 1 : 0),
-                unchangedPackages: summary.unchangedPackages + (!pkg.hasChanges && pkg.failure === undefined ? 1 : 0),
-                failedPackages: summary.failedPackages + (pkg.failure === undefined ? 0 : 1),
-                emittedArtifacts: summary.emittedArtifacts + pkg.artifactCounts.emitted,
-                changedArtifacts: summary.changedArtifacts + pkg.artifactCounts.changed,
-                eliminatedSourceFiles: summary.eliminatedSourceFiles + pkg.eliminatedSourceFiles.length
+                changedPackages: summary.changedPackages + (previewPackage.hasChanges ? 1 : 0),
+                unchangedPackages: summary.unchangedPackages +
+                    (!previewPackage.hasChanges && previewPackage.failure === undefined ? 1 : 0),
+                failedPackages: summary.failedPackages + (previewPackage.failure === undefined ? 0 : 1),
+                emittedArtifacts: summary.emittedArtifacts + previewPackage.artifactCounts.emitted,
+                changedArtifacts: summary.changedArtifacts + previewPackage.artifactCounts.changed,
+                eliminatedSourceFiles: summary.eliminatedSourceFiles + previewPackage.eliminatedSourceFiles.length
             };
         },
         createPreviewSummary(packages.length)

--- a/source/report/release-diff/release-diff-document.test.ts
+++ b/source/report/release-diff/release-diff-document.test.ts
@@ -54,13 +54,13 @@ suite('release-diff-document', function () {
     });
 
     test('forwards the package list into the document verbatim', function () {
-        const pkg = releaseDiffPackage({ name: 'pkg-x', state: 'first-publish' });
+        const packageDiff = releaseDiffPackage({ name: 'pkg-x', state: 'first-publish' });
         const document = buildReleaseDiffDocument({
             report: buildReport(),
             result: successResult,
-            packages: [ pkg ]
+            packages: [ packageDiff ]
         });
         assert.strictEqual(document.packages.length, 1);
-        assert.strictEqual(document.packages[0], pkg);
+        assert.strictEqual(document.packages[0], packageDiff);
     });
 });

--- a/source/report/release-diff/release-diff-document.ts
+++ b/source/report/release-diff/release-diff-document.ts
@@ -20,7 +20,7 @@ export type ReleaseDiffDocument = {
     readonly report: BuildReport;
 };
 
-type ReleaseDiffDocumentParams = {
+type ReleaseDiffDocumentInput = {
     readonly report: BuildReport;
     readonly result: ReleaseDiffAllResult;
     readonly packages: readonly PackageReleaseDiff[];
@@ -29,8 +29,8 @@ type ReleaseDiffDocumentParams = {
 function countFailedPackages(report: BuildReport): number {
     let failedPackages = 0;
 
-    for (const pkg of Object.values(report.packages)) {
-        if (pkg.failure !== undefined) {
+    for (const packageReport of Object.values(report.packages)) {
+        if (packageReport.failure !== undefined) {
             failedPackages += 1;
         }
     }
@@ -38,8 +38,8 @@ function countFailedPackages(report: BuildReport): number {
     return failedPackages;
 }
 
-export function buildReleaseDiffDocument(params: ReleaseDiffDocumentParams): ReleaseDiffDocument {
-    const { report, result, packages } = params;
+export function buildReleaseDiffDocument(input: ReleaseDiffDocumentInput): ReleaseDiffDocument {
+    const { report, result, packages } = input;
     const failedPackages = countFailedPackages(report);
     return {
         title: 'Packtory release diff',

--- a/source/report/release-diff/release-diff-summary.ts
+++ b/source/report/release-diff/release-diff-summary.ts
@@ -27,10 +27,10 @@ function classifyStateCounts(packages: readonly PackageReleaseDiffStateView[]): 
     let changedPackages = 0;
     let firstPublishPackages = 0;
     let unchangedPackages = 0;
-    for (const pkg of packages) {
-        if (pkg.state === packageReleaseDiffState.changed) {
+    for (const packageDiff of packages) {
+        if (packageDiff.state === packageReleaseDiffState.changed) {
             changedPackages += 1;
-        } else if (pkg.state === packageReleaseDiffState.firstPublish) {
+        } else if (packageDiff.state === packageReleaseDiffState.firstPublish) {
             firstPublishPackages += 1;
         } else {
             unchangedPackages += 1;
@@ -43,10 +43,10 @@ function aggregateFileCounts(packages: readonly PackageReleaseDiffStateView[]): 
     let addedFiles = 0;
     let removedFiles = 0;
     let modifiedFiles = 0;
-    for (const pkg of packages) {
-        addedFiles += pkg.files.added.length;
-        removedFiles += pkg.files.removed.length;
-        modifiedFiles += pkg.files.modified.length;
+    for (const packageDiff of packages) {
+        addedFiles += packageDiff.files.added.length;
+        removedFiles += packageDiff.files.removed.length;
+        modifiedFiles += packageDiff.files.modified.length;
     }
     return { addedFiles, removedFiles, modifiedFiles };
 }

--- a/source/report/terminal-renderer/terminal-package-renderer.ts
+++ b/source/report/terminal-renderer/terminal-package-renderer.ts
@@ -6,22 +6,22 @@ type EliminatedSourceFile = PreviewPackage['eliminatedSourceFiles'][number];
 type ChangedArtifact = PreviewPackage['changedArtifacts'][number];
 type DiffHunk = ChangedArtifact['diff'][number];
 
-function renderPackageHeader(pkg: PreviewPackage, colors: Colors): string {
-    if (pkg.versionTransition === undefined) {
-        return colors.bold(pkg.name);
+function renderPackageHeader(previewPackage: PreviewPackage, colors: Colors): string {
+    if (previewPackage.versionTransition === undefined) {
+        return colors.bold(previewPackage.name);
     }
-    return `${colors.bold(pkg.name)} ${colors.dim(pkg.versionTransition)}`;
+    return `${colors.bold(previewPackage.name)} ${colors.dim(previewPackage.versionTransition)}`;
 }
 
-function renderFailureLine(pkg: PreviewPackage, colors: Colors): string | undefined {
-    if (pkg.failure === undefined) {
+function renderFailureLine(previewPackage: PreviewPackage, colors: Colors): string | undefined {
+    if (previewPackage.failure === undefined) {
         return undefined;
     }
-    return `${colors.red('  failure')} ${pkg.failure.stage}: ${pkg.failure.message}`;
+    return `${colors.red('  failure')} ${previewPackage.failure.stage}: ${previewPackage.failure.message}`;
 }
 
-function renderTreeLines(pkg: PreviewPackage, colors: Colors): readonly string[] {
-    return pkg.tree.map(function (node) {
+function renderTreeLines(previewPackage: PreviewPackage, colors: Colors): readonly string[] {
+    return previewPackage.tree.map(function (node) {
         return renderArtifactNode(node, colors);
     });
 }
@@ -31,13 +31,13 @@ function renderEliminatedSourceFile(file: EliminatedSourceFile, colors: Colors):
     return `    - ${file.path} ${size}`;
 }
 
-function renderEliminatedSourceFiles(pkg: PreviewPackage, colors: Colors): readonly string[] {
-    if (pkg.eliminatedSourceFiles.length === 0) {
+function renderEliminatedSourceFiles(previewPackage: PreviewPackage, colors: Colors): readonly string[] {
+    if (previewPackage.eliminatedSourceFiles.length === 0) {
         return [];
     }
     return [
         `  ${colors.bold('Eliminated source files')}`,
-        ...pkg.eliminatedSourceFiles.map(function (file) {
+        ...previewPackage.eliminatedSourceFiles.map(function (file) {
             return renderEliminatedSourceFile(file, colors);
         })
     ];
@@ -61,25 +61,25 @@ function renderChangedArtifact(artifact: ChangedArtifact, colors: Colors): reado
     ];
 }
 
-function renderChangedArtifacts(pkg: PreviewPackage, colors: Colors): readonly string[] {
-    if (pkg.changedArtifacts.length === 0) {
+function renderChangedArtifacts(previewPackage: PreviewPackage, colors: Colors): readonly string[] {
+    if (previewPackage.changedArtifacts.length === 0) {
         return [];
     }
     return [
         `  ${colors.bold('Diffs')}`,
-        ...pkg.changedArtifacts.flatMap(function (artifact) {
+        ...previewPackage.changedArtifacts.flatMap(function (artifact) {
             return renderChangedArtifact(artifact, colors);
         })
     ];
 }
 
-export function renderPackage(pkg: PreviewPackage, colors: Colors): string {
+export function renderPackage(previewPackage: PreviewPackage, colors: Colors): string {
     const lines = [
-        renderPackageHeader(pkg, colors),
-        renderFailureLine(pkg, colors),
-        ...renderTreeLines(pkg, colors),
-        ...renderEliminatedSourceFiles(pkg, colors),
-        ...renderChangedArtifacts(pkg, colors)
+        renderPackageHeader(previewPackage, colors),
+        renderFailureLine(previewPackage, colors),
+        ...renderTreeLines(previewPackage, colors),
+        ...renderEliminatedSourceFiles(previewPackage, colors),
+        ...renderChangedArtifacts(previewPackage, colors)
     ]
         .filter(function (line): line is string {
             return line !== undefined;

--- a/source/report/terminal-renderer/terminal-preview-renderer.ts
+++ b/source/report/terminal-renderer/terminal-preview-renderer.ts
@@ -37,8 +37,8 @@ export function renderTerminalPreview(document: PreviewDocument, options: Termin
         renderTitle(document, colors),
         colors.dim(renderSummary(document)),
         renderIssues(document.issues, colors),
-        ...document.packages.map(function (pkg) {
-            return renderPackage(pkg, colors);
+        ...document.packages.map(function (previewPackage) {
+            return renderPackage(previewPackage, colors);
         })
     ]
         .filter(function (section): section is string {
@@ -52,11 +52,13 @@ export function renderFailureOnlyTerminalPreview(
     options: TerminalPreviewRendererOptions = {}
 ): string {
     const colors = createColors(options.color);
-    const failedPackageLines = document.packages.flatMap(function (pkg): readonly string[] {
-        if (pkg.failure === undefined) {
+    const failedPackageLines = document.packages.flatMap(function (previewPackage): readonly string[] {
+        if (previewPackage.failure === undefined) {
             return [];
         }
-        return [ `${colors.bold(pkg.name)} ${pkg.failure.stage}: ${pkg.failure.message}` ];
+        return [
+            `${colors.bold(previewPackage.name)} ${previewPackage.failure.stage}: ${previewPackage.failure.message}`
+        ];
     });
     const lines = [
         ...renderFailureDocumentHeader(document, colors),

--- a/source/report/terminal-renderer/terminal-release-diff-package-renderer.ts
+++ b/source/report/terminal-renderer/terminal-release-diff-package-renderer.ts
@@ -159,56 +159,56 @@ function renderHeaderSummary(files: FileSetDiff, unchangedCount: number): string
     return parts.join(', ');
 }
 
-function renderUnchangedPackage(pkg: PackageReleaseDiff, colors: Colors): string {
-    const packageName = colors.bold(pkg.name);
-    return colors.dim(`${packageName}  ${pkg.previousVersionLabel}  ·  no changes`);
+function renderUnchangedPackage(packageDiff: PackageReleaseDiff, colors: Colors): string {
+    const packageName = colors.bold(packageDiff.name);
+    return colors.dim(`${packageName}  ${packageDiff.previousVersionLabel}  ·  no changes`);
 }
 
-function renderFirstPublishPackageLines(pkg: PackageReleaseDiff, colors: Colors): readonly string[] {
+function renderFirstPublishPackageLines(packageDiff: PackageReleaseDiff, colors: Colors): readonly string[] {
     return [
-        `${colors.bold(pkg.name)}  ${colors.dim(pkg.versionTransition)}`,
+        `${colors.bold(packageDiff.name)}  ${colors.dim(packageDiff.versionTransition)}`,
         `  ${colors.yellow('[first publish]')}  ${colors.dim('showing all bundled files as added')}`,
         ...renderTreeGroup(
-            { title: 'Added', files: pkg.files.added, renderFileLines: renderAddedFileLines },
+            { title: 'Added', files: packageDiff.files.added, renderFileLines: renderAddedFileLines },
             colors
         )
     ];
 }
 
-function renderChangedPackageLines(pkg: PackageReleaseDiff, colors: Colors): readonly string[] {
-    const summary = renderHeaderSummary(pkg.files, pkg.files.unchanged.length);
-    const packageName = colors.bold(pkg.name);
-    const versionTransition = colors.dim(pkg.versionTransition);
+function renderChangedPackageLines(packageDiff: PackageReleaseDiff, colors: Colors): readonly string[] {
+    const summary = renderHeaderSummary(packageDiff.files, packageDiff.files.unchanged.length);
+    const packageName = colors.bold(packageDiff.name);
+    const versionTransition = colors.dim(packageDiff.versionTransition);
     const summaryLabel = colors.dim(`·  ${summary}`);
     return [
         `${packageName}  ${versionTransition}  ${summaryLabel}`,
         ...renderTreeGroup(
-            { title: 'Added', files: pkg.files.added, renderFileLines: renderAddedFileLines },
+            { title: 'Added', files: packageDiff.files.added, renderFileLines: renderAddedFileLines },
             colors
         ),
         ...renderTreeGroup(
-            { title: 'Removed', files: pkg.files.removed, renderFileLines: renderRemovedFileLines },
+            { title: 'Removed', files: packageDiff.files.removed, renderFileLines: renderRemovedFileLines },
             colors
         ),
         ...renderTreeGroup(
-            { title: 'Modified', files: pkg.files.modified, renderFileLines: renderModifiedFileLines },
+            { title: 'Modified', files: packageDiff.files.modified, renderFileLines: renderModifiedFileLines },
             colors
         )
     ];
 }
 
-function renderPackageLines(pkg: PackageReleaseDiff, colors: Colors): readonly string[] {
-    if (pkg.state === packageReleaseDiffState.unchanged) {
-        return [ renderUnchangedPackage(pkg, colors) ];
+function renderPackageLines(packageDiff: PackageReleaseDiff, colors: Colors): readonly string[] {
+    if (packageDiff.state === packageReleaseDiffState.unchanged) {
+        return [ renderUnchangedPackage(packageDiff, colors) ];
     }
 
-    if (pkg.state === packageReleaseDiffState.firstPublish) {
-        return renderFirstPublishPackageLines(pkg, colors);
+    if (packageDiff.state === packageReleaseDiffState.firstPublish) {
+        return renderFirstPublishPackageLines(packageDiff, colors);
     }
 
-    return renderChangedPackageLines(pkg, colors);
+    return renderChangedPackageLines(packageDiff, colors);
 }
 
-export function renderReleaseDiffPackage(pkg: PackageReleaseDiff, colors: Colors): string {
-    return renderPackageLines(pkg, colors).join('\n');
+export function renderReleaseDiffPackage(packageDiff: PackageReleaseDiff, colors: Colors): string {
+    return renderPackageLines(packageDiff, colors).join('\n');
 }

--- a/source/report/terminal-renderer/terminal-release-diff-renderer.test.ts
+++ b/source/report/terminal-renderer/terminal-release-diff-renderer.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import { suite, test } from 'mocha';
-import { createPackageReleaseDiff as pkg } from '../../test-libraries/release-diff-fixtures.ts';
+import { createPackageReleaseDiff } from '../../test-libraries/release-diff-fixtures.ts';
 import type { ReleaseDiffDocument } from '../release-diff/release-diff-document.ts';
 import { renderFailureOnlyTerminalReleaseDiff, renderTerminalReleaseDiff } from './terminal-release-diff-renderer.ts';
 
@@ -118,7 +118,10 @@ suite('terminal-release-diff-renderer', function () {
     test('renderTerminalReleaseDiff renders each package section in order separated by blank lines', function () {
         const output = renderTerminalReleaseDiff(
             document({
-                packages: [ pkg({ name: 'pkg-a', state: 'unchanged' }), pkg({ name: 'pkg-b', state: 'unchanged' }) ]
+                packages: [
+                    createPackageReleaseDiff({ name: 'pkg-a', state: 'unchanged' }),
+                    createPackageReleaseDiff({ name: 'pkg-b', state: 'unchanged' })
+                ]
             }),
             { color: false }
         );

--- a/source/report/terminal-renderer/terminal-release-diff-renderer.ts
+++ b/source/report/terminal-renderer/terminal-release-diff-renderer.ts
@@ -50,8 +50,8 @@ export function renderTerminalReleaseDiff(
     if (issuesSection !== undefined) {
         sections.push(issuesSection);
     }
-    for (const pkg of document.packages) {
-        sections.push(renderReleaseDiffPackage(pkg, colors));
+    for (const packageDiff of document.packages) {
+        sections.push(renderReleaseDiffPackage(packageDiff, colors));
     }
 
     return `${sections.join('\n\n')}\n`;

--- a/source/resource-resolver/resource-resolver.test.ts
+++ b/source/resource-resolver/resource-resolver.test.ts
@@ -17,7 +17,7 @@ type TransferableFile = {
     readonly content: string;
     readonly isExecutable: boolean;
 };
-type GraphParams = {
+type GraphInput = {
     readonly rootFile: string;
     readonly additionalLocalFiles?: readonly string[];
     readonly externalDependencyName?: string;
@@ -47,8 +47,8 @@ function createTransferableFile(sourceFilePath: string, targetFilePath = sourceF
     };
 }
 
-function createGraph(params: GraphParams): DependencyGraph {
-    const { rootFile, additionalLocalFiles = [], externalDependencyName } = params;
+function createGraph(input: GraphInput): DependencyGraph {
+    const { rootFile, additionalLocalFiles = [], externalDependencyName } = input;
     const graph = createDependencyGraph();
     const project = {
         getProject() {

--- a/source/test-libraries/eliminator-test-support.ts
+++ b/source/test-libraries/eliminator-test-support.ts
@@ -19,22 +19,22 @@ type CodeFileSpec = {
     readonly extraResources?: readonly LinkedBundleResource[];
 };
 
-export function bundleForCodeFile(spec: CodeFileSpec): LinkedBundle {
+export function bundleForCodeFile(input: CodeFileSpec): LinkedBundle {
     const root = {
         js: {
-            content: spec.content,
+            content: input.content,
             isExecutable: false,
-            sourceFilePath: spec.sourceFilePath,
-            targetFilePath: spec.targetFilePath
+            sourceFilePath: input.sourceFilePath,
+            targetFilePath: input.targetFilePath
         }
     } as const;
     const codeResource = {
-        ...bundleResource(spec.sourceFilePath, { content: spec.content, targetFilePath: spec.targetFilePath }),
+        ...bundleResource(input.sourceFilePath, { content: input.content, targetFilePath: input.targetFilePath }),
         isSubstituted: false
     };
     return linkedBundle({
-        name: spec.name,
-        contents: [ codeResource, ...spec.extraResources ?? [] ],
+        name: input.name,
+        contents: [ codeResource, ...input.extraResources ?? [] ],
         roots: { main: root },
         surface: { mode: 'implicit', defaultModuleRoot: 'main' }
     });

--- a/source/test-libraries/fake-clock.ts
+++ b/source/test-libraries/fake-clock.ts
@@ -37,9 +37,9 @@ export function createFakeClock(options: FakeClockOptions = {}): FakeClock {
         },
 
         setTimeout<Arguments extends readonly unknown[]>(
-            handler: (...args: Arguments) => void,
+            handler: (...timerArguments: Arguments) => void,
             delayInMilliseconds: number,
-            ...args: Arguments
+            ...timerArguments: Arguments
         ) {
             if (delayInMilliseconds < 0) {
                 throw new Error(`Invalid delay ${delayInMilliseconds}, must be greater than or equal to 0`);
@@ -54,7 +54,7 @@ export function createFakeClock(options: FakeClockOptions = {}): FakeClock {
             handlers.set(currentHandlerIndex, {
                 executionTimestamp,
                 handler() {
-                    handler(...args);
+                    handler(...timerArguments);
                 }
             });
 

--- a/source/test-libraries/github-release-gate-test-support.ts
+++ b/source/test-libraries/github-release-gate-test-support.ts
@@ -40,7 +40,7 @@ type EntryPointScriptExecFileError = {
 };
 type EntryPointScriptExecFile = (
     file: string,
-    args: readonly string[],
+    commandArguments: readonly string[],
     options: EntryPointScriptExecFileOptions,
     callback: (error: EntryPointScriptExecFileError | null, stdout: string, stderr: string) => void
 ) => void;
@@ -210,8 +210,8 @@ export async function runEntryPointScript(
     environmentVariables: FakeEnvironment,
     dependencies: Readonly<EntryPointScriptDependencies> = {
         cwd: process.cwd(),
-        execFile(file, args, options, callback) {
-            execFile(file, args, options, callback);
+        execFile(file, commandArguments, options, callback) {
+            execFile(file, commandArguments, options, callback);
         },
         async mkdtemp(prefix) {
             return await mkdtemp(prefix);

--- a/source/test-libraries/iterating-scheduler.ts
+++ b/source/test-libraries/iterating-scheduler.ts
@@ -1,12 +1,12 @@
 import { Result } from 'true-myth';
 import type { Scheduler as PackageScheduler } from '../packtory/scheduler.ts';
 
-type IterateParams = {
+type IterateInput = {
     readonly config: IteratingSchedulerConfig;
     readonly createOptions: (context: unknown) => unknown;
     readonly execute: (options: unknown) => Promise<unknown>;
-    readonly selectNext: (params: SelectNextInput) => unknown;
-    readonly createProgressEvent?: (params: ProgressEventInput) => unknown;
+    readonly selectNext: (input: SelectNextInput) => unknown;
+    readonly createProgressEvent?: (input: ProgressEventInput) => unknown;
 };
 
 type IteratingSchedulerConfig = {
@@ -32,7 +32,7 @@ export type IteratingSchedulerCapture = {
     readonly emitScheduledEvents?: boolean | undefined;
 };
 
-type IterateRunParams = IterateParams & { readonly emitScheduledEvents?: boolean; };
+type IterateRunInput = IterateInput & { readonly emitScheduledEvents?: boolean; };
 
 function createUnknownList(): unknown[] {
     return [];
@@ -62,27 +62,27 @@ export function createIteratingScheduler(
     capture?: IteratingSchedulerCapture
 ): PackageScheduler {
     const value = {
-        async runForEachScheduledPackage(params: IterateRunParams) {
+        async runForEachScheduledPackage(input: IterateRunInput) {
             const state = {
                 existing: createUnknownList(),
                 failures: createErrorList(),
                 results: createUnknownList()
             };
             if (capture !== undefined) {
-                Object.assign(capture, { emitScheduledEvents: params.emitScheduledEvents });
+                Object.assign(capture, { emitScheduledEvents: input.emitScheduledEvents });
             }
             function recordPackageSuccess(packageName: string, options: unknown, result: unknown): void {
                 state.results.push(result);
-                const selected = params.selectNext({ result, options });
+                const selected = input.selectNext({ result, options });
                 state.existing.push(selected);
                 recordCapturedSelection(capture, selected);
-                const event = params.createProgressEvent?.({ packageName, result, options });
+                const event = input.createProgressEvent?.({ packageName, result, options });
                 recordCapturedEvent(capture, event);
             }
             const runPackage = async function (packageName: string): Promise<void> {
-                const options = params.createOptions({ packageName, existing: state.existing, config: params.config });
+                const options = input.createOptions({ packageName, existing: state.existing, config: input.config });
                 try {
-                    const result = await params.execute(options);
+                    const result = await input.execute(options);
                     recordPackageSuccess(packageName, options, result);
                 } catch (error) {
                     state.failures.push(error as Error);

--- a/source/test-libraries/package-processor-test-support.ts
+++ b/source/test-libraries/package-processor-test-support.ts
@@ -222,7 +222,7 @@ export function createResolveOptions(): ResolveAndLinkOptions {
         roots: { main: { js: '/src/index.js' } } as const,
         includeSourceMapFiles: true,
         additionalFiles: [ { sourceFilePath: '/src/readme.md', targetFilePath: 'readme.md' } ],
-        mainPackageJson: { type: 'module' as const, dependencies: { dep: '^1.0.0' } },
+        mainPackageJson: { type: 'module' as const, dependencies: { dependency: '^1.0.0' } },
         additionalChangelogSourceFiles: { packageFiles: [], sharedFiles: [] },
         additionalPackageJsonAttributes: { publishConfig: { access: 'public' } },
         allowMutableSpecifiers: [],

--- a/source/test-libraries/preview-document-test-support.ts
+++ b/source/test-libraries/preview-document-test-support.ts
@@ -171,19 +171,19 @@ export function workspaceFileManager(readFile: (filePath: string) => Promise<str
 }
 
 export function requireSinglePackage(document: PreviewDocument): PreviewPackage {
-    const [ pkg ] = document.packages;
-    if (pkg === undefined) {
+    const [ previewPackage ] = document.packages;
+    if (previewPackage === undefined) {
         assert.fail('expected preview package');
     }
-    return pkg;
+    return previewPackage;
 }
 
 export function requirePackageAt(document: PreviewDocument, index: number): PreviewPackage {
-    const pkg = document.packages[index];
-    if (pkg === undefined) {
+    const previewPackage = document.packages[index];
+    if (previewPackage === undefined) {
         assert.fail(`expected preview package at index ${String(index)}`);
     }
-    return pkg;
+    return previewPackage;
 }
 
 export function requireTreeNodeAt(

--- a/source/test-libraries/release-orchestrator-fixtures.ts
+++ b/source/test-libraries/release-orchestrator-fixtures.ts
@@ -194,32 +194,32 @@ export function packageProcessorCheckingStage(expectedStage: boolean): PackagePr
 }
 
 export function previousReleaseArtifactsFor(
-    spec: PreviousReleaseArtifactsSpec
+    input: PreviousReleaseArtifactsSpec
 ): BuildAndPublishResult['previousReleaseArtifacts'] {
     return Maybe.just({
-        version: spec.version,
-        publishedAt: spec.publishedAt,
-        gitHead: spec.gitHead,
-        files: spec.files
+        version: input.version,
+        publishedAt: input.publishedAt,
+        gitHead: input.gitHead,
+        files: input.files
     });
 }
 
-export function createReleaseTestDependencies(spec: ReleaseTestDependencySpec): ReleaseTestDependencies {
+export function createReleaseTestDependencies(input: ReleaseTestDependencySpec): ReleaseTestDependencies {
     return {
         artifactsBuilder: {
-            collectContents: spec.collectContents ??
+            collectContents: input.collectContents ??
                 function () {
                     return [];
                 }
         },
-        fileManager: spec.fileManager ?? defaultReleasePlanFileReader,
-        packageProcessor: spec.packageProcessor ?? packageProcessorWith(spec.buildResults ?? []),
+        fileManager: input.fileManager ?? defaultReleasePlanFileReader,
+        packageProcessor: input.packageProcessor ?? packageProcessorWith(input.buildResults ?? []),
         progressBroadcaster: releaseProgressBroadcaster,
         async readCurrentGitHead() {
-            return spec.currentGitHead;
+            return input.currentGitHead;
         },
-        repositoryFolder: spec.repositoryFolder ?? '/',
-        scheduler: createIteratingScheduler(spec.packageNames)
+        repositoryFolder: input.repositoryFolder ?? '/',
+        scheduler: createIteratingScheduler(input.packageNames)
     };
 }
 

--- a/source/test-libraries/release-plan-test-support.ts
+++ b/source/test-libraries/release-plan-test-support.ts
@@ -53,8 +53,8 @@ export type ReleaseArtifactDescription = {
 };
 type ReleasePlanPartialFailure = Extract<ReleasePlanFailure, { readonly type: typeof partialFailureType; }>;
 
-export function createPlanner(spec: ReleasePlannerSpec): ReleasePlanner {
-    return createPlanReleaseAgainstLatestPublishedValidated(createReleaseTestDependencies(spec));
+export function createPlanner(input: ReleasePlannerSpec): ReleasePlanner {
+    return createPlanReleaseAgainstLatestPublishedValidated(createReleaseTestDependencies(input));
 }
 
 export function resolvedPackagesFor(
@@ -69,20 +69,20 @@ export function resolvedPackagesFor(
     });
 }
 
-export async function planFor(spec: ReleasePlanSpec): Promise<ReleasePlanResult> {
-    const validated = validatedReleaseConfigFor(spec.packageNames);
+export async function planFor(input: ReleasePlanSpec): Promise<ReleasePlanResult> {
+    const validated = validatedReleaseConfigFor(input.packageNames);
     const plan = createPlanner({
-        packageNames: spec.packageNames,
-        buildResults: spec.buildResults,
-        collectContents: spec.collectContents,
-        currentGitHead: spec.currentGitHead,
-        fileManager: spec.fileManager,
-        repositoryFolder: spec.repositoryFolder
+        packageNames: input.packageNames,
+        buildResults: input.buildResults,
+        collectContents: input.collectContents,
+        currentGitHead: input.currentGitHead,
+        fileManager: input.fileManager,
+        repositoryFolder: input.repositoryFolder
     });
 
     return plan(validated, async function () {
         return Result.ok<readonly ResolvedPackage[], ResolveAndLinkFailure>(
-            resolvedPackagesFor(validated, spec.bundleContents)
+            resolvedPackagesFor(validated, input.bundleContents)
         );
     });
 }
@@ -119,9 +119,9 @@ export function expectPartialFailure(result: ReleasePlanResult): ReleasePlanPart
 }
 
 export function expectFirstPackage(result: ReleasePlanResult): ReleasePlanPackage {
-    const [ pkg ] = expectPlan(result).packages;
-    if (pkg === undefined) {
+    const [ packagePlan ] = expectPlan(result).packages;
+    if (packagePlan === undefined) {
         assert.fail('Expected a package plan');
     }
-    return pkg;
+    return packagePlan;
 }

--- a/source/test-libraries/runner-test-support.ts
+++ b/source/test-libraries/runner-test-support.ts
@@ -61,14 +61,14 @@ function createSpinnerRenderer(
     const stopAll = overrides.stopAll ?? fake();
 
     return {
-        add(...args) {
-            add(...args);
+        add(...commandArguments) {
+            add(...commandArguments);
         },
-        stop(...args) {
-            stop(...args);
+        stop(...commandArguments) {
+            stop(...commandArguments);
         },
-        updateMessage(...args) {
-            updateMessage(...args);
+        updateMessage(...commandArguments) {
+            updateMessage(...commandArguments);
         },
         stopAll() {
             stopAll();
@@ -254,12 +254,12 @@ export async function expectCommandLoadsConfig(command: 'preview' | 'publish'): 
     assert.strictEqual(buildAndPublishAll.firstCall.args[0], 'the-config');
 }
 
-export async function expectHelp(args: readonly string[]): Promise<string> {
+export async function expectHelp(commandArguments: readonly string[]): Promise<string> {
     const log = fake();
     const buildAndPublishAll = fake.resolves(toOutcome(Result.ok([])));
     const runner = createRunner({ buildAndPublishAll, log });
 
-    const exitCode = await runner.run([ 'foo', 'bar', ...args ]);
+    const exitCode = await runner.run([ 'foo', 'bar', ...commandArguments ]);
 
     assert.strictEqual(exitCode, 0);
     return String(log.firstCall.args[0]);

--- a/source/vendor-materializer/vendor-materializer.test.ts
+++ b/source/vendor-materializer/vendor-materializer.test.ts
@@ -116,7 +116,7 @@ function registerMaterializationTests(): void {
             ],
             realPaths: [
                 { value: '/repo/node_modules/root' },
-                { value: '/repo/node_modules/dep' },
+                { value: '/repo/node_modules/dependency' },
                 { value: '/repo/node_modules/peer' }
             ],
             listings: [
@@ -125,7 +125,12 @@ function registerMaterializationTests(): void {
                 { value: [ { name: 'peer.js', isDirectory: false, isSymbolicLink: false } ] }
             ],
             fileReads: [
-                { value: JSON.stringify({ dependencies: { dep: '1.0.0' }, peerDependencies: { peer: '1.0.0' } }) },
+                {
+                    value: JSON.stringify({
+                        dependencies: { dependency: '1.0.0' },
+                        peerDependencies: { peer: '1.0.0' }
+                    })
+                },
                 { value: '{}' },
                 { value: '{}' }
             ]
@@ -139,10 +144,10 @@ function registerMaterializationTests(): void {
             })
         );
 
-        assert.deepStrictEqual(result.packageNames, [ 'root', 'dep', 'peer' ]);
+        assert.deepStrictEqual(result.packageNames, [ 'root', 'dependency', 'peer' ]);
         assert.deepStrictEqual(targetRelativePaths(result), [
             'node_modules/root/index.js',
-            'node_modules/dep/lib.js',
+            'node_modules/dependency/lib.js',
             'node_modules/peer/peer.js'
         ]);
     });
@@ -161,8 +166,8 @@ function registerMaterializationTests(): void {
                     { value: '/repo/node_modules/root' },
                     { value: '/repo/node_modules/1dep' },
                     { value: '/repo/node_modules/a1dep' },
-                    { value: '/repo/node_modules/@a1scope/dep' },
-                    { value: '/repo/node_modules/@1scope/dep' }
+                    { value: '/repo/node_modules/@a1scope/dependency' },
+                    { value: '/repo/node_modules/@1scope/dependency' }
                 ],
                 listings: [
                     { value: [ { name: 'index.js', isDirectory: false, isSymbolicLink: false } ] },
@@ -177,8 +182,8 @@ function registerMaterializationTests(): void {
                             dependencies: {
                                 '1dep': '1.0.0',
                                 a1dep: '1.0.0',
-                                '@a1scope/dep': '1.0.0',
-                                '@1scope/dep': '1.0.0'
+                                '@a1scope/dependency': '1.0.0',
+                                '@1scope/dependency': '1.0.0'
                             }
                         })
                     },
@@ -191,7 +196,13 @@ function registerMaterializationTests(): void {
             { initialDependencyNames: [ 'root' ], projectFolder: '/repo' }
         );
 
-        assert.deepStrictEqual(result.packageNames, [ 'root', '1dep', 'a1dep', '@a1scope/dep', '@1scope/dep' ]);
+        assert.deepStrictEqual(result.packageNames, [
+            'root',
+            '1dep',
+            'a1dep',
+            '@a1scope/dependency',
+            '@1scope/dependency'
+        ]);
     });
 
     test('skips nested node_modules when walking files (nested packages are visited as separate closure entries instead)', async function () {

--- a/source/version-manager/manager.test.ts
+++ b/source/version-manager/manager.test.ts
@@ -39,7 +39,7 @@ suite('manager', function () {
                 versionedBundle({
                     name: 'bundle-dependency',
                     version: '4.5.6',
-                    mainFile: { sourceFilePath: '/src/dep.js', targetFilePath: 'dep.js' }
+                    mainFile: { sourceFilePath: '/src/dependency.js', targetFilePath: 'dependency.js' }
                 })
             ],
             bundlePeerDependencies: [],
@@ -103,7 +103,7 @@ suite('manager', function () {
 
         const result = manager.increaseVersion(
             standardVersionedBundle({
-                dependencies: { dep: '^1.0.0' },
+                dependencies: { dependency: '^1.0.0' },
                 peerDependencies: { react: '^19.0.0' }
             })
         );
@@ -120,7 +120,7 @@ suite('manager', function () {
                     }
                 },
                 type: 'module',
-                dependencies: { dep: '^1.0.0' },
+                dependencies: { dependency: '^1.0.0' },
                 peerDependencies: { react: '^19.0.0' }
             },
             manifestFile: {
@@ -129,7 +129,7 @@ suite('manager', function () {
                 content: [
                     '{',
                     '    "dependencies": {',
-                    '        "dep": "^1.0.0"',
+                    '        "dependency": "^1.0.0"',
                     '    },',
                     '    "exports": {',
                     '        ".": {',

--- a/source/version-manager/optional-bundle-fields.ts
+++ b/source/version-manager/optional-bundle-fields.ts
@@ -15,8 +15,8 @@ type OptionalVersionedBundleFieldsInput = {
     readonly typesMainFile: FileDescription | TransferableFileDescription | undefined;
 };
 
-export function buildOptionalVersionedBundleFields(params: OptionalVersionedBundleFieldsInput): OptionalFields {
-    const { importsField, binField, typesMainFile } = params;
+export function buildOptionalVersionedBundleFields(input: OptionalVersionedBundleFieldsInput): OptionalFields {
+    const { importsField, binField, typesMainFile } = input;
 
     return pickBy({ importsField, binField, typesMainFile }, isDefined);
 }


### PR DESCRIPTION
Renames owned local variables, helper inputs, and test fixture names that used abbreviations such as `pkg`, `dep`, `args`, `params`, `spec`, and `opts`. External API names and established environment/authentication fields are left unchanged.