### PR TITLE
Extend `typeScriptIntegrity` to validate packed package type resolution against public exports

### DIFF
--- a/integration-tests/checks/declaration-integrity.test.ts
+++ b/integration-tests/checks/declaration-integrity.test.ts
@@ -294,4 +294,116 @@ suite('declaration integrity against the real TypeScript compiler', function () 
 
         assert.deepStrictEqual(issues, []);
     });
+
+    suite('dependency exports', function () {
+        test('rejects generated dependency declaration subpaths hidden by package exports', function () {
+            const producer = publishedPackage(
+                '@scope/core',
+                manifest('@scope/core', {
+                    exports: {
+                        '.': { types: './index.d.ts', import: './index.js' },
+                        './protocol.js': {
+                            types: './protocol.d.ts',
+                            import: './protocol.js'
+                        }
+                    }
+                }),
+                {
+                    'index.js': 'export const value = 1;\n',
+                    'index.d.ts': 'export declare const value: number;\n',
+                    'protocol.js': 'export const protocol = 1;\n',
+                    'protocol.d.ts': 'export type Protocol = string;\n',
+                    'protocol/assertion-reference.d.ts': 'export type CompositeAssertionReference = string;\n'
+                }
+            );
+            const consumer = publishedPackage(
+                'consumer',
+                manifest('consumer', {
+                    types: './index.d.ts',
+                    dependencies: { '@scope/core': '0.0.0' }
+                }),
+                {
+                    'index.js': 'export const value = 1;\n',
+                    'index.d.ts': [
+                        'import type { CompositeAssertionReference } from "@scope/core/protocol/assertion-reference.js";',
+                        'export type ConsumerReference = CompositeAssertionReference;'
+                    ]
+                        .join('\n')
+                }
+            );
+
+            const issues = summarizeDeclarationIntegrity(
+                'consumer',
+                consumer,
+                'all',
+                new Map([
+                    [ '@scope/core', producer ],
+                    [ 'consumer', consumer ]
+                ])
+            );
+
+            assert.deepStrictEqual(issues, [
+                'Package "consumer" failed TypeScript integrity in node16-esm: index.d.ts:1 TS2307: ' +
+                "Cannot find module '@scope/core/protocol/assertion-reference.js' or its corresponding type declarations.",
+                'Package "consumer" failed TypeScript integrity in bundler: index.d.ts:1 TS2307: ' +
+                "Cannot find module '@scope/core/protocol/assertion-reference.js' or its corresponding type declarations."
+            ]);
+        });
+
+        test('rejects generated dependency JavaScript subpaths hidden by package exports', function () {
+            const producer = publishedPackage(
+                '@scope/core',
+                manifest('@scope/core', {
+                    exports: {
+                        '.': { types: './index.d.ts', import: './index.js' },
+                        './protocol.js': {
+                            types: './protocol.d.ts',
+                            import: './protocol.js'
+                        }
+                    }
+                }),
+                {
+                    'index.js': 'export const value = 1;\n',
+                    'index.d.ts': 'export declare const value: number;\n',
+                    'protocol.js': 'export const protocol = 1;\n',
+                    'protocol.d.ts': 'export type Protocol = string;\n',
+                    'protocol/assertion-reference.js': 'export const assertionReference = 1;\n'
+                }
+            );
+            const consumer = publishedPackage(
+                'consumer',
+                manifest('consumer', {
+                    types: './index.d.ts',
+                    dependencies: { '@scope/core': '0.0.0' }
+                }),
+                {
+                    'index.js': [
+                        'import { assertionReference } from "@scope/core/protocol/assertion-reference.js";',
+                        'export const value = assertionReference;'
+                    ]
+                        .join('\n'),
+                    'index.d.ts': 'export declare const value: number;\n'
+                }
+            );
+
+            const issues = summarizeDeclarationIntegrity(
+                'consumer',
+                consumer,
+                'all',
+                new Map([
+                    [ '@scope/core', producer ],
+                    [ 'consumer', consumer ]
+                ])
+            );
+
+            assert.deepStrictEqual(issues, [
+                'Package "consumer" failed TypeScript integrity in node16-esm: ' +
+                '.packtory-javascript-imports.ts:1 TS2882: ' +
+                "Cannot find module or type declarations for side-effect import of '@scope/core/protocol/assertion-reference.js'.",
+                'Package "consumer" failed TypeScript integrity in bundler: ' +
+                '.packtory-javascript-imports.ts:1 TS2882: ' +
+                "Cannot find module or type declarations for side-effect import of '@scope/core/protocol/assertion-reference.js'."
+            ]);
+        });
+    });
 });

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -95,7 +95,7 @@ export async function buildConfig() {
             {
                 name: 'packtory',
                 exportPackageJson: true,
-                checks: { maxBundleSize: { bytes: 1_070_000 } },
+                checks: { maxBundleSize: { bytes: 1_075_000 } },
                 roots: {
                     main: {
                         js: 'packages/packtory/packtory.entry-point.js',

--- a/source/checks/rules/type-script-declaration-integrity.test.ts
+++ b/source/checks/rules/type-script-declaration-integrity.test.ts
@@ -12,11 +12,13 @@ type FakeProjectParts = {
     readonly modeLabel: string;
     readonly diagnostics: readonly DeclarationDiagnostic[];
     readonly specifiers: Readonly<Record<string, readonly string[]>>;
+    readonly publicEntrypointPaths: readonly string[];
 };
 
 function fakeProject(parts: FakeProjectParts): DeclarationProject {
     return {
         modeLabel: parts.modeLabel,
+        publicEntrypointPaths: parts.publicEntrypointPaths,
         moduleSpecifiersOf(declarationPath) {
             return parts.specifiers[declarationPath] ?? [];
         },
@@ -33,6 +35,14 @@ function diagnostic(declarationPath: string): DeclarationDiagnostic {
         code: 2305,
         message: "Module '\"./internal.js\"' has no exported member 'Missing'."
     };
+}
+
+function projectWith(
+    modeLabel: string,
+    diagnostics: readonly DeclarationDiagnostic[],
+    specifiers: Readonly<Record<string, readonly string[]>> = {}
+): DeclarationProject {
+    return fakeProject({ modeLabel, diagnostics, specifiers, publicEntrypointPaths: [] });
 }
 
 type SummarizeOptions = {
@@ -111,8 +121,8 @@ suite('type-script-declaration-integrity', function () {
             manifestContent: '{"types":"./index.d.ts"}',
             files: brokenIndexFiles,
             projects: [
-                fakeProject({ modeLabel: 'node16-esm', diagnostics: [ diagnostic('index.d.ts') ], specifiers: {} }),
-                fakeProject({ modeLabel: 'bundler', diagnostics: [ diagnostic('index.d.ts') ], specifiers: {} })
+                projectWith('node16-esm', [ diagnostic('index.d.ts') ]),
+                projectWith('bundler', [ diagnostic('index.d.ts') ])
             ],
             declarationMode: 'all'
         });
@@ -135,7 +145,8 @@ suite('type-script-declaration-integrity', function () {
                     diagnostics: [
                         { declarationPath: 'index.d.ts', line: 7, code: 2430, message: 'incompatible\n  details' }
                     ],
-                    specifiers: {}
+                    specifiers: {},
+                    publicEntrypointPaths: []
                 })
             ],
             declarationMode: 'all'
@@ -153,8 +164,9 @@ suite('type-script-declaration-integrity', function () {
             projects: [
                 fakeProject({
                     modeLabel: 'node16-esm',
-                    diagnostics: [ diagnostic('../../typescript/lib/lib.es5.d.ts'), diagnostic('index.js') ],
-                    specifiers: {}
+                    diagnostics: [ diagnostic('../../typescript/lib/lib.es5.d.ts'), diagnostic('package.json') ],
+                    specifiers: {},
+                    publicEntrypointPaths: []
                 })
             ],
             declarationMode: 'all'
@@ -168,7 +180,7 @@ suite('type-script-declaration-integrity', function () {
             manifestContent: '{"types":"./index.d.ts"}',
             files: brokenIndexFiles,
             projects: [
-                fakeProject({ modeLabel: 'node16-esm', diagnostics: [ diagnostic('internal.d.ts') ], specifiers: {} })
+                projectWith('node16-esm', [ diagnostic('internal.d.ts') ])
             ],
             declarationMode: 'all'
         });
@@ -188,7 +200,7 @@ suite('type-script-declaration-integrity', function () {
                 'internal.d.ts': 'export declare const present: string;\n'
             },
             projects: [
-                fakeProject({ modeLabel: 'node16-esm', diagnostics: [ diagnostic('private.d.ts') ], specifiers: {} })
+                projectWith('node16-esm', [ diagnostic('private.d.ts') ])
             ],
             declarationMode: 'exports-graph'
         });
@@ -208,7 +220,8 @@ suite('type-script-declaration-integrity', function () {
                 fakeProject({
                     modeLabel: 'node16-esm',
                     diagnostics: [ diagnostic('reachable.d.ts') ],
-                    specifiers: { 'index.d.ts': [ './reachable.js' ] }
+                    specifiers: { 'index.d.ts': [ './reachable.js' ] },
+                    publicEntrypointPaths: []
                 })
             ],
             declarationMode: 'exports-graph'
@@ -216,6 +229,27 @@ suite('type-script-declaration-integrity', function () {
 
         assert.deepStrictEqual(issues, [
             'Package "pkg" failed TypeScript integrity in node16-esm: reachable.d.ts:1 TS2305: ' +
+            "Module '\"./internal.js\"' has no exported member 'Missing'."
+        ]);
+    });
+
+    test('reports generated public consumer entrypoint diagnostics in the "exports-graph" mode', function () {
+        const issues = summarize({
+            manifestContent: '{"exports":{".":{"types":"./index.d.ts"}}}',
+            files: { 'index.d.ts': 'export declare const value: number;\n' },
+            projects: [
+                fakeProject({
+                    modeLabel: 'node16-esm',
+                    diagnostics: [ diagnostic('.packtory-consumer-entrypoints.ts') ],
+                    specifiers: {},
+                    publicEntrypointPaths: [ '.packtory-consumer-entrypoints.ts' ]
+                })
+            ],
+            declarationMode: 'exports-graph'
+        });
+
+        assert.deepStrictEqual(issues, [
+            'Package "pkg" failed TypeScript integrity in node16-esm: .packtory-consumer-entrypoints.ts:1 TS2305: ' +
             "Module '\"./internal.js\"' has no exported member 'Missing'."
         ]);
     });

--- a/source/checks/rules/type-script-declaration-integrity.ts
+++ b/source/checks/rules/type-script-declaration-integrity.ts
@@ -23,6 +23,13 @@ export type DeclarationIntegrityDependencies = {
     readonly createDeclarationProjects: DeclarationProjectsFactory;
 };
 
+type CheckedDeclarationPathInput = {
+    readonly project: DeclarationProject;
+    readonly declarationPaths: ReadonlySet<string>;
+    readonly rootPaths: ReadonlySet<string>;
+    readonly declarationMode: DeclarationMode;
+};
+
 function collectPackageFiles(publishedPackage: Readonly<PublishedPackageWithManifest>): readonly PackageFile[] {
     return [
         {
@@ -65,21 +72,21 @@ function collectResolutionPackageFiles(
         });
 }
 
-function checkedDeclarationPaths(
-    project: DeclarationProject,
-    declarationPaths: ReadonlySet<string>,
-    rootPaths: ReadonlySet<string>,
-    declarationMode: DeclarationMode
-): ReadonlySet<string> {
+function checkedDeclarationPaths(input: CheckedDeclarationPathInput): ReadonlySet<string> {
+    const { project, declarationPaths, rootPaths, declarationMode } = input;
+    const { publicEntrypointPaths } = project;
     if (declarationMode === 'all') {
-        return declarationPaths;
+        return new Set([ ...declarationPaths, ...publicEntrypointPaths ]);
     }
 
-    return reachableDeclarationPaths({
-        declarationPaths,
-        rootPaths,
-        moduleSpecifiersOf: project.moduleSpecifiersOf
-    });
+    return new Set([
+        ...reachableDeclarationPaths({
+            declarationPaths,
+            rootPaths,
+            moduleSpecifiersOf: project.moduleSpecifiersOf
+        }),
+        ...publicEntrypointPaths
+    ]);
 }
 
 function formatDeclarationDiagnostic(
@@ -105,7 +112,12 @@ export function createDeclarationIntegritySummarizer(
         const resolutionPackageFiles = collectResolutionPackageFiles(packageName, resolutionPackages);
 
         return createDeclarationProjects(packageName, packageFiles, resolutionPackageFiles).flatMap(function (project) {
-            const checkedPaths = checkedDeclarationPaths(project, declarationPaths, rootPaths, declarationMode);
+            const checkedPaths = checkedDeclarationPaths({
+                project,
+                declarationPaths,
+                rootPaths,
+                declarationMode
+            });
 
             return project
                 .listDiagnostics()

--- a/source/checks/rules/type-script-declaration-project.test.ts
+++ b/source/checks/rules/type-script-declaration-project.test.ts
@@ -115,6 +115,40 @@ const commonCompilerOptions = {
     target: ScriptTarget.ESNext
 };
 
+const consumerEntrypointFilePath =
+    '/workspace/.packtory-type-integrity/node_modules/pkg/.packtory-consumer-entrypoints.ts';
+const javaScriptImportFilePath = '/workspace/.packtory-type-integrity/node_modules/pkg/.packtory-javascript-imports.ts';
+
+function createdSourceFiles(createSourceFile: SinonSpy, expectedFilePath: string): readonly unknown[][] {
+    return createSourceFile.args.filter(function ([ filePath ]) {
+        return filePath === expectedFilePath;
+    });
+}
+
+function assertConsumerEntrypointSources(createSourceFile: SinonSpy, sources: readonly string[]): void {
+    assert.deepStrictEqual(
+        createdSourceFiles(createSourceFile, consumerEntrypointFilePath),
+        sources.flatMap(function (source) {
+            return [
+                [ consumerEntrypointFilePath, source ],
+                [ consumerEntrypointFilePath, source ]
+            ];
+        })
+    );
+}
+
+function assertJavaScriptImportSources(createSourceFile: SinonSpy, sources: readonly string[]): void {
+    assert.deepStrictEqual(
+        createdSourceFiles(createSourceFile, javaScriptImportFilePath),
+        sources.flatMap(function (source) {
+            return [
+                [ javaScriptImportFilePath, source ],
+                [ javaScriptImportFilePath, source ]
+            ];
+        })
+    );
+}
+
 suite('type-script-declaration-project', function () {
     test('creates one project per checked compiler mode', function () {
         const TSMorphProject = createFakeProjectConstructor();
@@ -265,6 +299,181 @@ suite('type-script-declaration-project', function () {
                 { scriptKind: ScriptKind.JSON }
             ]
         ]);
+    });
+
+    suite('public consumer entrypoints', function () {
+        test('adds a public consumer import file for root package types', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            const projects = declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"types":"./index.d.ts"}' },
+                { filePath: 'index.d.ts', content: 'export declare const value: number;' }
+            ]);
+
+            assert.deepStrictEqual(firstProject(projects).publicEntrypointPaths, [
+                '.packtory-consumer-entrypoints.ts'
+            ]);
+            assertConsumerEntrypointSources(createSourceFile, [ 'import "pkg";\n' ]);
+        });
+
+        test('adds public consumer imports for explicit package exports', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            declarationProjectsFor(TSMorphProject, [
+                {
+                    filePath: 'package.json',
+                    content: JSON.stringify({
+                        exports: {
+                            '.': { types: './index.d.ts', import: './index.js' },
+                            './feature.js': { types: './feature.d.ts', import: './feature.js' },
+                            './private/*.js': { types: './private/*.d.ts', import: './private/*.js' },
+                            './blocked.js': null
+                        }
+                    })
+                }
+            ]);
+
+            assertConsumerEntrypointSources(createSourceFile, [
+                [
+                    'import "pkg";',
+                    'import "pkg/feature.js";',
+                    ''
+                ]
+                    .join('\n')
+            ]);
+        });
+
+        test('adds a public consumer import file for string package exports', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"exports":"./index.js"}' }
+            ]);
+
+            assertConsumerEntrypointSources(createSourceFile, [ 'import "pkg";\n' ]);
+        });
+
+        test('adds a public consumer import file for array package exports', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"exports":["./index.js"]}' }
+            ]);
+
+            assertConsumerEntrypointSources(createSourceFile, [ 'import "pkg";\n' ]);
+        });
+
+        test('adds a public consumer import file for conditional root exports', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"exports":{"types":"./index.d.ts","import":"./index.js"}}' }
+            ]);
+
+            assertConsumerEntrypointSources(createSourceFile, [ 'import "pkg";\n' ]);
+        });
+
+        test('adds public consumer imports for each legacy package root field', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"typings":"./index.d.ts"}' }
+            ]);
+            declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"main":"./index.js"}' }
+            ]);
+
+            assertConsumerEntrypointSources(createSourceFile, [
+                'import "pkg";\n',
+                'import "pkg";\n'
+            ]);
+        });
+
+        test('finds the manifest by file name', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            declarationProjectsFor(TSMorphProject, [
+                { filePath: 'index.d.ts', content: 'export declare const value: number;' },
+                { filePath: 'nested/package.json', content: '{"types":"./wrong.d.ts"}' },
+                { filePath: 'package.json', content: '{"types":"./index.d.ts"}' }
+            ]);
+
+            assertConsumerEntrypointSources(createSourceFile, [ 'import "pkg";\n' ]);
+        });
+
+        test('does not add a public consumer import file without public entrypoints', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            const checkedProjects = [
+                declarationProjectsFor(TSMorphProject, []),
+                declarationProjectsFor(TSMorphProject, [ { filePath: 'package.json', content: 'null' } ]),
+                declarationProjectsFor(TSMorphProject, [ { filePath: 'package.json', content: '{"exports":{}}' } ]),
+                declarationProjectsFor(TSMorphProject, [
+                    { filePath: 'package.json', content: '{"exports":{".":null,"./blocked.js":null}}' }
+                ]),
+                declarationProjectsFor(TSMorphProject, [
+                    {
+                        filePath: 'package.json',
+                        content: '{"exports":{"import":"./index.js","./private/*.js":"./private/*.js"}}'
+                    }
+                ])
+            ];
+
+            assert.deepStrictEqual(
+                checkedProjects.map(function (projects) {
+                    return firstProject(projects).publicEntrypointPaths;
+                }),
+                [ [], [], [], [], [] ]
+            );
+            assert.deepStrictEqual(createdSourceFiles(createSourceFile, consumerEntrypointFilePath), []);
+        });
+
+        test('adds public consumer imports for package specifiers used by JavaScript files', function () {
+            const createSourceFile = fake();
+            const TSMorphProject = createFakeProjectConstructor({ createSourceFile });
+
+            const projects = declarationProjectsFor(TSMorphProject, [
+                { filePath: 'package.json', content: '{"types":"./index.d.ts"}' },
+                {
+                    filePath: 'index.js',
+                    content: [
+                        'import "@scope/core/public.js";',
+                        'import "@scope/core/public.js";',
+                        'import "./local.js";',
+                        'import "../parent.js";',
+                        'import "/absolute.js";',
+                        'import "#internal";',
+                        'import "node:path";',
+                        'export { value } from "dependency";',
+                        'export const value = 1;'
+                    ]
+                        .join('\n')
+                },
+                { filePath: 'index.d.ts', content: 'import "declaration-only";\n' },
+                { filePath: 'index.js.map', content: 'import "source-map-only";\n' }
+            ]);
+
+            assert.deepStrictEqual(firstProject(projects).publicEntrypointPaths, [
+                '.packtory-consumer-entrypoints.ts',
+                '.packtory-javascript-imports.ts'
+            ]);
+            assertJavaScriptImportSources(createSourceFile, [
+                [
+                    'import "@scope/core/public.js";',
+                    'import "dependency";',
+                    ''
+                ]
+                    .join('\n')
+            ]);
+        });
     });
 
     test('moduleSpecifiersOf() reads import and export specifiers of the installed declaration', function () {

--- a/source/checks/rules/type-script-declaration-project.ts
+++ b/source/checks/rules/type-script-declaration-project.ts
@@ -10,6 +10,7 @@ import {
     type Project as TSMorphProject,
     type SourceFile
 } from 'ts-morph';
+import { isPackageManifestRecord, parsePackageManifest } from './type-script-declaration-roots.ts';
 
 export type PackageFile = {
     readonly filePath: string;
@@ -30,6 +31,7 @@ export type DeclarationDiagnostic = {
 
 export type DeclarationProject = {
     readonly modeLabel: string;
+    readonly publicEntrypointPaths: readonly string[];
     readonly moduleSpecifiersOf: (declarationPath: string) => readonly string[];
     readonly listDiagnostics: () => readonly DeclarationDiagnostic[];
 };
@@ -70,6 +72,93 @@ function declarationCompilerModes(): readonly DeclarationCompilerMode[] {
             moduleResolution: ModuleResolutionKind.Bundler
         }
     ];
+}
+
+function isPackageExportKey(key: string): boolean {
+    return key === '.' || key.startsWith('./');
+}
+
+function hasConditionalRootExports(exportKeys: readonly string[]): boolean {
+    return exportKeys.length > 0 && !exportKeys.some(isPackageExportKey);
+}
+
+function publicExportSubpaths(exportsField: unknown): readonly string[] {
+    if (typeof exportsField === 'string' || Array.isArray(exportsField)) {
+        return [ '.' ];
+    }
+
+    if (!isPackageManifestRecord(exportsField)) {
+        return [];
+    }
+
+    const exportKeys = Object.keys(exportsField);
+    const subpaths = exportKeys.filter(function (key) {
+        return isPackageExportKey(key) && !key.includes('*') && exportsField[key] !== null;
+    });
+    if (subpaths.length > 0) {
+        return subpaths;
+    }
+
+    return hasConditionalRootExports(exportKeys) ? [ '.' ] : [];
+}
+
+function publicEntrypointSpecifiers(packageName: string, manifestContent: string): readonly string[] {
+    const manifest = parsePackageManifest(manifestContent);
+    const exportSubpaths = publicExportSubpaths(manifest.exports);
+    if (exportSubpaths.length > 0) {
+        return exportSubpaths.map(function (subpath) {
+            return subpath === '.' ? packageName : `${packageName}/${subpath.slice('./'.length)}`;
+        });
+    }
+
+    return manifest.types !== undefined || manifest.typings !== undefined || manifest.main !== undefined
+        ? [ packageName ]
+        : [];
+}
+
+function importSource(specifiers: Iterable<string>): string {
+    return Array
+        .from(new Set(specifiers), function (specifier) {
+            return `import ${JSON.stringify(specifier)};`;
+        })
+        .join('\n');
+}
+
+function publicEntrypointSource(packageName: string, packageFiles: readonly PackageFile[]): string {
+    const manifestFile = packageFiles.find(function (packageFile) {
+        return packageFile.filePath === 'package.json';
+    });
+    const specifiers = manifestFile === undefined ? [] : publicEntrypointSpecifiers(packageName, manifestFile.content);
+
+    return importSource(specifiers);
+}
+
+function isJavaScriptPath(filePath: string): boolean {
+    return /\.(?:cjs|js|mjs)$/u.test(filePath);
+}
+
+function isPackageImportSpecifier(specifier: string): boolean {
+    return !specifier.startsWith('./') &&
+        !specifier.startsWith('../') &&
+        !specifier.startsWith('/') &&
+        !specifier.startsWith('#') &&
+        !specifier.startsWith('node:');
+}
+
+function javaScriptPackageImportSource(packageFiles: readonly PackageFile[]): string {
+    const specifiers = packageFiles
+        .filter(function (packageFile) {
+            return isJavaScriptPath(packageFile.filePath);
+        })
+        .flatMap(function (packageFile) {
+            return typescript.preProcessFile(packageFile.content).importedFiles;
+        })
+        .map(function (importedFile) {
+            return importedFile.fileName;
+        })
+        .filter(isPackageImportSpecifier);
+
+    return importSource(specifiers);
 }
 
 function moduleSpecifiersIn(sourceFile: Readonly<SourceFile>): readonly string[] {
@@ -122,10 +211,12 @@ function isDeclarationDiagnostic(diagnostic: DeclarationDiagnostic | undefined):
 function createModeProject(
     project: Readonly<TSMorphProject>,
     packageFolder: string,
-    modeLabel: string
+    modeLabel: string,
+    publicEntrypointPaths: readonly string[]
 ): DeclarationProject {
     return {
         modeLabel,
+        publicEntrypointPaths,
 
         moduleSpecifiersOf(declarationPath) {
             return moduleSpecifiersIn(
@@ -169,14 +260,8 @@ export function createDeclarationProjectFactory(
         }
     }
 
-    function createProjectForMode(
-        packageName: string,
-        packageFiles: readonly PackageFile[],
-        resolutionPackages: readonly ResolutionPackageFiles[],
-        compilerMode: DeclarationCompilerMode
-    ): DeclarationProject {
-        const packageFolder = declarationProjectPackageFolder(packageResolutionBaseFolder, packageName);
-        const project = new Project({
+    function createCompilerProject(compilerMode: DeclarationCompilerMode): TSMorphProject {
+        return new Project({
             fileSystem: fileSystemHost,
             skipAddingFilesFromTsConfig: true,
             compilerOptions: {
@@ -189,9 +274,50 @@ export function createDeclarationProjectFactory(
                 target: ScriptTarget.ESNext
             }
         });
+    }
+
+    function addGeneratedFile(
+        project: TSMorphProject,
+        packageFolder: string,
+        filePath: string,
+        source: string
+    ): readonly string[] {
+        if (source.length === 0) {
+            return [];
+        }
+
+        project.createSourceFile(
+            declarationProjectPackageFilePath(packageFolder, filePath),
+            `${source}\n`
+        );
+        return [ filePath ];
+    }
+
+    function createProjectForMode(
+        packageName: string,
+        packageFiles: readonly PackageFile[],
+        resolutionPackages: readonly ResolutionPackageFiles[],
+        compilerMode: DeclarationCompilerMode
+    ): DeclarationProject {
+        const packageFolder = declarationProjectPackageFolder(packageResolutionBaseFolder, packageName);
+        const project = createCompilerProject(compilerMode);
         const createdFilePaths = new Set<string>();
 
         addPackageFiles(project, packageName, packageFiles, createdFilePaths);
+        const publicEntrypointPaths = [
+            ...addGeneratedFile(
+                project,
+                packageFolder,
+                '.packtory-consumer-entrypoints.ts',
+                publicEntrypointSource(packageName, packageFiles)
+            ),
+            ...addGeneratedFile(
+                project,
+                packageFolder,
+                '.packtory-javascript-imports.ts',
+                javaScriptPackageImportSource(packageFiles)
+            )
+        ];
         for (const resolutionPackage of resolutionPackages) {
             addPackageFiles(
                 project,
@@ -201,7 +327,7 @@ export function createDeclarationProjectFactory(
             );
         }
 
-        return createModeProject(project, packageFolder, compilerMode.label);
+        return createModeProject(project, packageFolder, compilerMode.label, publicEntrypointPaths);
     }
 
     return function createDeclarationProjects(packageName, packageFiles, resolutionPackages) {

--- a/source/checks/rules/type-script-declaration-roots.ts
+++ b/source/checks/rules/type-script-declaration-roots.ts
@@ -1,13 +1,20 @@
-const relativeSpecifierPrefix = './';
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+export function isPackageManifestRecord(value: unknown): value is Readonly<Record<string, unknown>> {
     return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+export function parsePackageManifest(manifestContent: string): Readonly<Record<string, unknown>> {
+    const manifest: unknown = JSON.parse(manifestContent);
+    if (!isPackageManifestRecord(manifest)) {
+        return {};
+    }
+
+    return manifest;
 }
 
 function packagePathsIn(value: unknown): readonly string[] {
     if (typeof value === 'string') {
-        return value.startsWith(relativeSpecifierPrefix)
-            ? [ value.slice(relativeSpecifierPrefix.length) ]
+        return value.startsWith('./')
+            ? [ value.slice('./'.length) ]
             : [ value ];
     }
 
@@ -18,17 +25,8 @@ function packagePathsIn(value: unknown): readonly string[] {
     return [];
 }
 
-function parseManifestContent(manifestContent: string): Readonly<Record<string, unknown>> {
-    const manifest: unknown = JSON.parse(manifestContent);
-    if (!isRecord(manifest)) {
-        return {};
-    }
-
-    return manifest;
-}
-
 export function declarationRootsFromManifest(manifestContent: string): ReadonlySet<string> {
-    const manifest = parseManifestContent(manifestContent);
+    const manifest = parsePackageManifest(manifestContent);
     return new Set([
         ...packagePathsIn(manifest.exports),
         ...packagePathsIn(manifest.types),


### PR DESCRIPTION
`typeScriptIntegrity` now builds a consumer-like TypeScript project around packed package output, including generated imports for public entrypoints and installed sibling packages. This makes declaration and JavaScript module-resolution failures surface when a packed package imports dependency subpaths that exist on disk but are hidden by the dependency package `exports` map.