### PR TITLE
Verify registry tarball digests

### DIFF
--- a/documentation/supply-chain.md
+++ b/documentation/supply-chain.md
@@ -33,10 +33,11 @@ guarantees on top.
 
 ### Comparison
 
-| Feature                                           | Defends against                                          | Default | Configure                                      |
-| ------------------------------------------------- | -------------------------------------------------------- | ------- | ---------------------------------------------- |
-| [Provenance](#provenance-attestations)            | Account compromise, package misattribution               | off     | `publishSettings.provenance: { type: 'auto' }` |
-| [Tarball origin pinning](#tarball-origin-pinning) | Credential exfiltration via a tampered registry response | on      | always on; not configurable                    |
+| Feature                                                     | Defends against                                          | Default | Configure                                      |
+| ----------------------------------------------------------- | -------------------------------------------------------- | ------- | ---------------------------------------------- |
+| [Provenance](#provenance-attestations)                      | Account compromise, package misattribution               | off     | `publishSettings.provenance: { type: 'auto' }` |
+| [Tarball origin pinning](#tarball-origin-pinning)           | Credential exfiltration via a tampered registry response | on      | always on; not configurable                    |
+| [Tarball digest verification](#tarball-digest-verification) | Tampered latest-version tarballs after metadata lookup   | on      | always on; not configurable                    |
 
 ## Quickstart
 
@@ -185,6 +186,22 @@ set). The protocol and port are part of the comparison, so an `https` to
 `http` downgrade or a port change is rejected. The error names both
 origins so the mismatch is immediately diagnosable.
 
+## Tarball digest verification
+
+**Threat:** an attacker or broken registry serves tarball bytes that do
+not match the digest metadata returned for the latest package version.
+Packtory uses registry tarballs for automatic version comparison,
+release planning, release analysis, and `release-diff`, so bad bytes
+could otherwise corrupt those decisions.
+**Default:** on. Not configurable.
+
+When the latest version metadata provides `dist.integrity` or
+`dist.shasum`, packtory verifies the downloaded tarball before
+extracting it. `dist.integrity` is checked with strict SRI rules.
+`dist.shasum` is checked as SHA-1 hex. If both fields are present, both
+must match. Missing digest fields keep the existing compatibility path,
+but malformed or mismatched provided metadata fails the command.
+
 ## CLI error reference
 
 ### Tarball origin
@@ -196,6 +213,17 @@ origins so the mismatch is immediately diagnosable.
 - `Registry returned an invalid tarball URL: "<value>"` — the registry
   response carried a non-URL `dist.tarball`. Almost always a registry
   bug or a tampered response.
+
+### Tarball digest
+
+- `Downloaded tarball failed dist.integrity verification: <reason>`
+  The downloaded bytes do not match the registry's SRI metadata, or the
+  metadata is not valid strict SRI. Investigate the registry mirror or
+  proxy before retrying.
+- `Downloaded tarball failed dist.shasum verification: expected <digest>, got <digest>`
+  The downloaded bytes do not match the registry's legacy SHA-1 digest.
+- `Registry returned invalid dist.shasum "<value>"`
+  The registry returned a malformed SHA-1 digest for the latest version.
 
 ### Provenance, auto mode
 

--- a/integration-tests/packtory/publish-fixture-support.ts
+++ b/integration-tests/packtory/publish-fixture-support.ts
@@ -188,8 +188,8 @@ export async function fetchPublishedPackage(
         assert.fail(`Expected package "${packageName}" to be published`);
     }
 
-    const { version, tarballUrl } = versionDetails.value;
-    const tarballData = await registryClient.fetchTarball(tarballUrl, registrySettings);
+    const { version, tarballUrl, tarballIntegrity } = versionDetails.value;
+    const tarballData = await registryClient.fetchTarball(tarballUrl, tarballIntegrity, registrySettings);
     const files = await extractPackageTarball(tarballData);
     const manifestFile = findManifestFile(files, packageName);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "remeda": "2.39.0",
                 "semver": "7.8.5",
                 "spdx-expression-parse": "5.0.0",
+                "ssri": "14.0.0",
                 "tar-stream": "3.2.0",
                 "true-myth": "9.4.0",
                 "ts-morph": "28.0.0",
@@ -64,6 +65,7 @@
                 "@types/semver": "7.7.1",
                 "@types/sinon": "22.0.0",
                 "@types/spdx-expression-parse": "4.0.0",
+                "@types/ssri": "7.1.5",
                 "@types/tar-stream": "3.1.4",
                 "c8": "12.0.0",
                 "dependency-cruiser": "18.1.0",
@@ -82,7 +84,7 @@
                 "verdaccio": "6.9.0"
             },
             "engines": {
-                "node": "^24 || ^26"
+                "node": "^24.15.0 || >=26.0.0"
             }
         },
         "node_modules/@altano/repository-tools": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "remeda": "2.39.0",
         "semver": "7.8.5",
         "spdx-expression-parse": "5.0.0",
+        "ssri": "14.0.0",
         "tar-stream": "3.2.0",
         "true-myth": "9.4.0",
         "ts-morph": "28.0.0",
@@ -83,6 +84,7 @@
         "@types/semver": "7.7.1",
         "@types/sinon": "22.0.0",
         "@types/spdx-expression-parse": "4.0.0",
+        "@types/ssri": "7.1.5",
         "@types/tar-stream": "3.1.4",
         "c8": "12.0.0",
         "dependency-cruiser": "18.1.0",
@@ -101,7 +103,7 @@
         "verdaccio": "6.9.0"
     },
     "engines": {
-        "node": "^24 || ^26"
+        "node": "^24.15.0 || >=26.0.0"
     },
     "overrides": {
         "@schema-hub/zod-error-formatter": "0.0.14",

--- a/packtory.config.js
+++ b/packtory.config.js
@@ -95,7 +95,7 @@ export async function buildConfig() {
             {
                 name: 'packtory',
                 exportPackageJson: true,
-                checks: { maxBundleSize: { bytes: 1_075_000 } },
+                checks: { maxBundleSize: { bytes: 1_080_000 } },
                 roots: {
                     main: {
                         js: 'packages/packtory/packtory.entry-point.js',

--- a/source/bundle-emitter/emitter-publish.test.ts
+++ b/source/bundle-emitter/emitter-publish.test.ts
@@ -12,9 +12,11 @@ import { createBundleEmitter, type BundleEmitter, type BundleEmitterDependencies
 const registrySettings = { auth: { type: 'bearer-token', token: 'the-token' } } as const;
 const publishedOutcome = { type: 'published' } as const;
 const publishedAt = new Date('2026-05-20T00:00:00.000Z');
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
 const latestReleaseMetadata = {
     version: '1.2.3',
-    tarballUrl: 'https://registry.example.test/package.tgz'
+    tarballUrl: 'https://registry.example.test/package.tgz',
+    tarballIntegrity: emptyTarballIntegrity
 } as const;
 type PublishRequest = Parameters<BundleEmitter['publish']>[0];
 type PublishInput = {
@@ -171,6 +173,7 @@ suite('emitter publish', function () {
             Maybe.just({
                 version: latestReleaseMetadata.version,
                 tarballUrl: latestReleaseMetadata.tarballUrl,
+                tarballIntegrity: latestReleaseMetadata.tarballIntegrity,
                 publishedAt,
                 gitHead: 'old'
             })

--- a/source/bundle-emitter/emitter.test.ts
+++ b/source/bundle-emitter/emitter.test.ts
@@ -11,9 +11,11 @@ import { createBundleEmitter, type BundleEmitterDependencies, type BundleEmitter
 
 const registrySettings = { auth: { type: 'bearer-token', token: 'the-token' } } as const;
 const publishedAt = new Date('2026-05-20T00:00:00.000Z');
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
 const latestReleaseMetadata = {
     version: '1.2.3',
     tarballUrl: 'https://registry.example.test/package.tgz',
+    tarballIntegrity: emptyTarballIntegrity,
     publishedAt,
     gitHead: undefined
 } as const;
@@ -146,6 +148,7 @@ async function runSbomComparison(previousSbom: string, currentSbom: string): Pro
         Maybe.just({
             version: latestReleaseMetadata.version,
             tarballUrl: latestReleaseMetadata.tarballUrl,
+            tarballIntegrity: latestReleaseMetadata.tarballIntegrity,
             publishedAt,
             gitHead: undefined
         })
@@ -183,7 +186,11 @@ function assertDifferentContentsResult(
     }
     assertPreviousReleaseArtifacts(result.previousReleaseArtifacts.value, 1);
     assert.deepStrictEqual(collectContents.firstCall.args, [ bundle, 'package', undefined ]);
-    assert.deepStrictEqual(fetchTarball.firstCall.args, [ latestReleaseMetadata.tarballUrl, registrySettings ]);
+    assert.deepStrictEqual(fetchTarball.firstCall.args, [
+        latestReleaseMetadata.tarballUrl,
+        latestReleaseMetadata.tarballIntegrity,
+        registrySettings
+    ]);
 }
 
 function assertMatchingContentsResult(
@@ -197,7 +204,11 @@ function assertMatchingContentsResult(
     }
     assertPreviousReleaseArtifacts(result.previousReleaseArtifacts.value);
     assert.deepStrictEqual(collectContents.firstCall.args[1], 'package');
-    assert.deepStrictEqual(fetchTarball.firstCall.args, [ latestReleaseMetadata.tarballUrl, registrySettings ]);
+    assert.deepStrictEqual(fetchTarball.firstCall.args, [
+        latestReleaseMetadata.tarballUrl,
+        latestReleaseMetadata.tarballIntegrity,
+        registrySettings
+    ]);
 }
 
 suite('emitter', function () {

--- a/source/bundle-emitter/fetch-published-artifacts.test.ts
+++ b/source/bundle-emitter/fetch-published-artifacts.test.ts
@@ -8,6 +8,7 @@ import type { RegistryClient } from './registry/registry-client.ts';
 import { fetchPublishedArtifacts } from './fetch-published-artifacts.ts';
 
 const registrySettings = { auth: { type: 'bearer-token', token: 'the-token' } } as const;
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
 
 type RegistryClientOverrides = {
     readonly fetchLatestReleaseMetadata?: RegistryClient['fetchLatestReleaseMetadata'];
@@ -61,6 +62,7 @@ suite('fetch-published-artifacts', function () {
             Maybe.just({
                 version: '1.2.3',
                 tarballUrl: 'https://registry.example.test/package.tgz',
+                tarballIntegrity: { integrity: 'sha512-the-digest', shasum: undefined },
                 publishedAt: new Date('2026-05-20T00:00:00.000Z'),
                 gitHead: 'abcdef123456'
             })
@@ -73,6 +75,29 @@ suite('fetch-published-artifacts', function () {
         assertFetchedArtifacts(result);
         assert.deepStrictEqual(fetchTarball.firstCall.args, [
             'https://registry.example.test/package.tgz',
+            { integrity: 'sha512-the-digest', shasum: undefined },
+            registrySettings
+        ]);
+    });
+
+    test('passes empty tarball integrity metadata when the registry has no digests', async function () {
+        const fetchLatestReleaseMetadata = fake.resolves(
+            Maybe.just({
+                version: '1.2.3',
+                tarballUrl: 'https://registry.example.test/package.tgz',
+                tarballIntegrity: emptyTarballIntegrity,
+                publishedAt: undefined,
+                gitHead: undefined
+            })
+        );
+        const fetchTarball = fake.resolves(emptyTarball);
+        const client = registryClientWith({ fetchLatestReleaseMetadata, fetchTarball });
+
+        await fetchPublishedArtifacts(client, 'the-name', registrySettings);
+
+        assert.deepStrictEqual(fetchTarball.firstCall.args, [
+            'https://registry.example.test/package.tgz',
+            emptyTarballIntegrity,
             registrySettings
         ]);
     });

--- a/source/bundle-emitter/fetch-published-artifacts.ts
+++ b/source/bundle-emitter/fetch-published-artifacts.ts
@@ -20,7 +20,11 @@ export async function fetchPublishedArtifacts(
     if (latestVersion.isNothing) {
         return Maybe.nothing();
     }
-    const tarball = await registryClient.fetchTarball(latestVersion.value.tarballUrl, registrySettings);
+    const tarball = await registryClient.fetchTarball(
+        latestVersion.value.tarballUrl,
+        latestVersion.value.tarballIntegrity,
+        registrySettings
+    );
     const files = await extractPackageTarball(tarball);
     return Maybe.just({
         version: latestVersion.value.version,

--- a/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.test.ts
@@ -1,59 +1,52 @@
 import assert from 'node:assert';
+import { createHash } from 'node:crypto';
 import { suite, test } from 'mocha';
 import { fake, type SinonSpy } from 'sinon';
 import type { RegistrySettings } from '../../config/registry-settings.ts';
+import { fakeNpmFetch, registryTarballBytes } from '../../test-libraries/registry-fetch-fixtures.ts';
 import {
     fetchLatestPackageReleaseMetadata,
     fetchLatestPackageVersion,
-    fetchPackageTarball,
     fetchStagedPackageVersions,
     type NpmFetch
 } from './package-metadata-fetcher.ts';
-
-type FakeNpmFetch = Readonly<SinonSpy> & {
-    readonly json: Readonly<SinonSpy> & { readonly stream: Readonly<SinonSpy>; };
-    readonly pickRegistry: Readonly<SinonSpy>;
-};
+import type { TarballIntegrity } from './tarball-integrity.ts';
 
 const settings: RegistrySettings = { auth: { type: 'bearer-token', token: 'tok' } };
 const latestVersion = '1.2.3';
 const tarballUrl = 'https://registry.npmjs.org/pkg-a/-/pkg-a-1.2.3.tgz';
+const matchingIntegrity = `sha512-${createHash('sha512').update(registryTarballBytes).digest('base64')}`;
+const matchingShasum = [ '9ef2570c89e65b9f', 'e47687b0b49e122e', '59354bef' ].join('');
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
 
-function fakeNpmFetch(
-    json: Readonly<SinonSpy>,
-    buffer: Readonly<SinonSpy> = fake.resolves(Buffer.from([]))
-): NpmFetch {
-    const npmFetch: FakeNpmFetch = Object.assign(fake.resolves({ buffer }), {
-        json: Object.assign(json, { stream: fake() }),
-        pickRegistry: fake()
-    });
-    return npmFetch as unknown as NpmFetch;
-}
-
-function fakeNpmFetchWithContentLength(contentLength: string | null): NpmFetch {
-    const npmFetch: FakeNpmFetch = Object.assign(
-        fake.resolves({
-            buffer: fake.resolves(Buffer.from('tarball-bytes')),
-            headers: {
-                get: fake(function (name: string) {
-                    return name === 'content-length' ? contentLength : null;
-                })
-            }
-        }),
-        {
-            json: Object.assign(fake(), { stream: fake() }),
-            pickRegistry: fake()
-        }
-    );
-    return npmFetch as unknown as NpmFetch;
-}
-
-function latestPackageResponse(time?: string): Record<string, unknown> {
+function latestPackageResponse(time?: string, dist: Record<string, unknown> = {}): Record<string, unknown> {
     return {
         name: 'pkg-a',
         'dist-tags': { latest: latestVersion },
         ...time === undefined ? {} : { time: { [latestVersion]: time } },
-        versions: { [latestVersion]: { dist: { tarball: tarballUrl } } }
+        versions: { [latestVersion]: { dist: { tarball: tarballUrl, ...dist } } }
+    };
+}
+
+function expectedVersionDetails(tarballIntegrity: TarballIntegrity = emptyTarballIntegrity): Record<string, unknown> {
+    return {
+        version: latestVersion,
+        tarballUrl,
+        tarballIntegrity,
+        gitHead: undefined
+    };
+}
+
+function expectedReleaseMetadata(
+    publishedAt: Date | undefined,
+    tarballIntegrity: TarballIntegrity = emptyTarballIntegrity
+): Record<string, unknown> {
+    return {
+        version: latestVersion,
+        tarballUrl,
+        tarballIntegrity,
+        publishedAt,
+        gitHead: undefined
     };
 }
 
@@ -97,11 +90,90 @@ suite('package-metadata-fetcher', function () {
                 settings
             );
 
-            assert.deepStrictEqual(result.unwrapOr({ version: '', tarballUrl: '', gitHead: undefined }), {
-                version: latestVersion,
-                tarballUrl,
-                gitHead: undefined
-            });
+            assert.deepStrictEqual(
+                result.unwrapOr({
+                    version: '',
+                    tarballUrl: '',
+                    tarballIntegrity: emptyTarballIntegrity,
+                    gitHead: undefined
+                }),
+                expectedVersionDetails()
+            );
+        });
+
+        test('fetchLatestPackageVersion returns latest tarball digest metadata', async function () {
+            const result = await fetchLatestPackageVersion(
+                fakeNpmFetch(fake.resolves(latestPackageResponse(undefined, {
+                    integrity: matchingIntegrity,
+                    shasum: matchingShasum
+                }))),
+                'pkg-a',
+                settings
+            );
+
+            assert.deepStrictEqual(
+                result.unwrapOr({
+                    version: '',
+                    tarballUrl: '',
+                    tarballIntegrity: emptyTarballIntegrity,
+                    gitHead: undefined
+                }),
+                expectedVersionDetails({ integrity: matchingIntegrity, shasum: matchingShasum })
+            );
+        });
+
+        test('fetchLatestPackageVersion ignores malformed digest metadata on non-latest versions', async function () {
+            const result = await fetchLatestPackageVersion(
+                fakeNpmFetch(
+                    fake.resolves({
+                        name: 'pkg-a',
+                        'dist-tags': { latest: latestVersion },
+                        versions: {
+                            [latestVersion]: { dist: { tarball: tarballUrl, integrity: matchingIntegrity } },
+                            '0.0.1': {
+                                dist: {
+                                    tarball: 'https://registry.npmjs.org/pkg-a/-/pkg-a-0.0.1.tgz',
+                                    integrity: 42
+                                }
+                            }
+                        }
+                    })
+                ),
+                'pkg-a',
+                settings
+            );
+
+            assert.deepStrictEqual(
+                result.unwrapOr({
+                    version: '',
+                    tarballUrl: '',
+                    tarballIntegrity: emptyTarballIntegrity,
+                    gitHead: undefined
+                }),
+                expectedVersionDetails({ integrity: matchingIntegrity, shasum: undefined })
+            );
+        });
+
+        test('fetchLatestPackageVersion throws when latest digest metadata is not a string', async function () {
+            await expectError(
+                fakeNpmFetch(fake.resolves(latestPackageResponse(undefined, { integrity: { length: 1 } }))),
+                'Registry returned invalid dist.integrity for package "pkg-a" version "1.2.3"'
+            );
+            await expectError(
+                fakeNpmFetch(fake.resolves(latestPackageResponse(undefined, { shasum: { length: 1 } }))),
+                'Registry returned invalid dist.shasum for package "pkg-a" version "1.2.3"'
+            );
+        });
+
+        test('fetchLatestPackageVersion throws when latest digest metadata is empty', async function () {
+            await expectError(
+                fakeNpmFetch(fake.resolves(latestPackageResponse(undefined, { integrity: '' }))),
+                'Registry returned invalid dist.integrity for package "pkg-a" version "1.2.3"'
+            );
+            await expectError(
+                fakeNpmFetch(fake.resolves(latestPackageResponse(undefined, { shasum: '' }))),
+                'Registry returned invalid dist.shasum for package "pkg-a" version "1.2.3"'
+            );
         });
 
         test('fetchLatestPackageVersion returns Nothing when the registry has no latest dist-tag', async function () {
@@ -152,15 +224,36 @@ suite('package-metadata-fetcher', function () {
                 result.unwrapOr({
                     version: '',
                     tarballUrl: '',
+                    tarballIntegrity: emptyTarballIntegrity,
                     publishedAt: undefined,
                     gitHead: undefined
                 }),
-                {
-                    version: latestVersion,
-                    tarballUrl,
-                    publishedAt: new Date('2026-05-19T10:00:00.000Z'),
+                expectedReleaseMetadata(new Date('2026-05-19T10:00:00.000Z'))
+            );
+        });
+
+        test('fetchLatestPackageReleaseMetadata returns latest tarball digest metadata', async function () {
+            const result = await fetchLatestPackageReleaseMetadata(
+                fakeNpmFetch(fake.resolves(latestPackageResponse('2026-05-19T10:00:00.000Z', {
+                    integrity: matchingIntegrity,
+                    shasum: matchingShasum
+                }))),
+                'pkg-a',
+                settings
+            );
+
+            assert.deepStrictEqual(
+                result.unwrapOr({
+                    version: '',
+                    tarballUrl: '',
+                    tarballIntegrity: emptyTarballIntegrity,
+                    publishedAt: undefined,
                     gitHead: undefined
-                }
+                }),
+                expectedReleaseMetadata(
+                    new Date('2026-05-19T10:00:00.000Z'),
+                    { integrity: matchingIntegrity, shasum: matchingShasum }
+                )
             );
         });
 
@@ -177,7 +270,13 @@ suite('package-metadata-fetcher', function () {
                 settings
             );
 
-            const fallback = { version: '', tarballUrl: '', publishedAt: undefined, gitHead: undefined };
+            const fallback = {
+                version: '',
+                tarballUrl: '',
+                tarballIntegrity: emptyTarballIntegrity,
+                publishedAt: undefined,
+                gitHead: undefined
+            };
             assert.strictEqual(result.unwrapOr(fallback).gitHead, 'abcdef123456');
         });
 
@@ -192,15 +291,11 @@ suite('package-metadata-fetcher', function () {
                 result.unwrapOr({
                     version: '',
                     tarballUrl: '',
+                    tarballIntegrity: emptyTarballIntegrity,
                     publishedAt: undefined,
                     gitHead: undefined
                 }),
-                {
-                    version: latestVersion,
-                    tarballUrl,
-                    publishedAt: undefined,
-                    gitHead: undefined
-                }
+                expectedReleaseMetadata(undefined)
             );
         });
 
@@ -287,82 +382,6 @@ suite('package-metadata-fetcher', function () {
                 /^Error: Staged package listing exceeded 1000 pages$/u
             );
             assert.strictEqual(json.callCount, 1000);
-        });
-    });
-
-    suite('package tarballs', function () {
-        test('fetchPackageTarball returns the buffered tarball contents', async function () {
-            const buffer = fake.resolves(Buffer.from('tarball-bytes'));
-
-            const result = await fetchPackageTarball(fakeNpmFetch(fake(), buffer), tarballUrl, settings);
-
-            assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
-        });
-
-        test('fetchPackageTarball rejects tarballs whose content-length exceeds the download limit', async function () {
-            try {
-                await fetchPackageTarball(fakeNpmFetchWithContentLength('268435457'), tarballUrl, settings);
-                assert.fail('Expected fetchPackageTarball() to throw but it did not');
-            } catch (error: unknown) {
-                assert.strictEqual(
-                    (error as Error).message,
-                    'Refusing to download tarball larger than 268435456 bytes'
-                );
-            }
-        });
-
-        test('fetchPackageTarball accepts tarballs whose content-length is exactly the download limit', async function () {
-            const result = await fetchPackageTarball(fakeNpmFetchWithContentLength('268435456'), tarballUrl, settings);
-
-            assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
-        });
-
-        test('fetchPackageTarball rejects a tarball URL whose host differs from the configured registry', async function () {
-            const buffer = fake.resolves(Buffer.from('tarball-bytes'));
-            const expectedMessage =
-                'Refusing to download tarball from "https://attacker.example" because it differs from the configured ' +
-                'registry origin "https://registry.npmjs.org". A tampered registry response could redirect the request and ' +
-                'exfiltrate publish credentials.';
-
-            try {
-                await fetchPackageTarball(
-                    fakeNpmFetch(fake(), buffer),
-                    'https://attacker.example/pkg-a-1.2.3.tgz',
-                    settings
-                );
-                assert.fail('Expected fetchPackageTarball() to throw but it did not');
-            } catch (error: unknown) {
-                assert.strictEqual((error as Error).message, expectedMessage);
-            }
-            assert.strictEqual(buffer.callCount, 0);
-        });
-
-        test('fetchPackageTarball accepts a tarball URL whose host matches a custom configured registry', async function () {
-            const customSettings: RegistrySettings = {
-                registryUrl: 'https://registry.example.test/',
-                auth: { type: 'bearer-token', token: 'tok' }
-            };
-            const buffer = fake.resolves(Buffer.from('tarball-bytes'));
-
-            const result = await fetchPackageTarball(
-                fakeNpmFetch(fake(), buffer),
-                'https://registry.example.test/pkg-a/-/pkg-a-1.2.3.tgz',
-                customSettings
-            );
-
-            assert.deepStrictEqual(result, Buffer.from('tarball-bytes'));
-        });
-
-        test('fetchPackageTarball rejects a malformed tarball URL', async function () {
-            const buffer = fake.resolves(Buffer.from('tarball-bytes'));
-
-            try {
-                await fetchPackageTarball(fakeNpmFetch(fake(), buffer), 'not-a-url', settings);
-                assert.fail('Expected fetchPackageTarball() to throw but it did not');
-            } catch (error: unknown) {
-                assert.strictEqual((error as Error).message, 'Registry returned an invalid tarball URL: "not-a-url"');
-            }
-            assert.strictEqual(buffer.callCount, 0);
         });
     });
 });

--- a/source/bundle-emitter/registry/package-metadata-fetcher.ts
+++ b/source/bundle-emitter/registry/package-metadata-fetcher.ts
@@ -15,6 +15,7 @@ import {
     type AbbreviatedPackageResponse,
     type FullPackageResponse
 } from './registry-response-schemas.ts';
+import { assertTarballIntegrity, type TarballIntegrity } from './tarball-integrity.ts';
 import { assertTarballOriginMatchesRegistry } from './validate-tarball-host.ts';
 
 const notFoundStatusCode = 404;
@@ -25,12 +26,14 @@ const maxDownloadedTarballBytes = 268_435_456;
 export type PackageVersionDetails = {
     readonly version: string;
     readonly tarballUrl: string;
+    readonly tarballIntegrity: TarballIntegrity;
     readonly gitHead: string | undefined;
 };
 
 export type PackageReleaseMetadata = {
     readonly publishedAt?: Date | undefined;
     readonly tarballUrl: string;
+    readonly tarballIntegrity: TarballIntegrity;
     readonly version: string;
     readonly gitHead: string | undefined;
 };
@@ -101,6 +104,11 @@ function parseStagedPackageListResponse(response: unknown): StagedPackageListRes
 type PackageMetadataRequest<TPackageResponse extends Record<string, unknown>> = {
     readonly headers: Readonly<Record<string, string>> | undefined;
     readonly parsePackageResponse: (response: unknown) => TPackageResponse | undefined;
+};
+
+type PackageVersionDist = {
+    readonly integrity?: unknown;
+    readonly shasum?: unknown;
 };
 
 const abbreviatedPackageMetadataRequest: PackageMetadataRequest<AbbreviatedPackageResponse> = {
@@ -178,6 +186,30 @@ async function fetchAndParsePackageMetadata<TPackageResponse extends Record<stri
     }
 }
 
+function readTarballDigestField(
+    value: unknown,
+    fieldName: 'dist.integrity' | 'dist.shasum',
+    packageName: string,
+    version: string
+): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (typeof value === 'string' && value.length > 0) {
+        return value;
+    }
+
+    throw new Error(`Registry returned invalid ${fieldName} for package "${packageName}" version "${version}"`);
+}
+
+function readTarballIntegrity(dist: PackageVersionDist, packageName: string, version: string): TarballIntegrity {
+    return {
+        integrity: readTarballDigestField(dist.integrity, 'dist.integrity', packageName, version),
+        shasum: readTarballDigestField(dist.shasum, 'dist.shasum', packageName, version)
+    };
+}
+
 function extractLatestVersionDetails(
     packageResponse: AbbreviatedPackageResponse,
     packageName: string
@@ -194,7 +226,12 @@ function extractLatestVersionDetails(
         );
     }
 
-    return Maybe.just({ version: latestVersion, tarballUrl: versionData.dist.tarball, gitHead: versionData.gitHead });
+    return Maybe.just({
+        version: latestVersion,
+        tarballUrl: versionData.dist.tarball,
+        tarballIntegrity: readTarballIntegrity(versionData.dist, packageName, latestVersion),
+        gitHead: versionData.gitHead
+    });
 }
 
 export async function fetchLatestPackageVersion(
@@ -239,6 +276,7 @@ export async function fetchLatestPackageReleaseMetadata(
     return Maybe.just({
         version: latestVersion.value.version,
         tarballUrl: latestVersion.value.tarballUrl,
+        tarballIntegrity: latestVersion.value.tarballIntegrity,
         publishedAt: publishedAtTimestamp === undefined ? undefined : parseTimestamp(publishedAtTimestamp),
         gitHead: latestVersion.value.gitHead
     });
@@ -287,6 +325,7 @@ export async function fetchStagedPackageVersions(
 export async function fetchPackageTarball(
     npmFetch: NpmFetch,
     tarballUrl: string,
+    tarballIntegrity: TarballIntegrity,
     registrySettings: Readonly<RegistrySettings>
 ): Promise<Buffer> {
     assertTarballOriginMatchesRegistry(tarballUrl, registrySettings);
@@ -297,5 +336,6 @@ export async function fetchPackageTarball(
     assertContentLengthWithinDownloadLimit(response);
     const tarball = await response.buffer();
     assertDownloadedTarballSize(tarball.length);
+    assertTarballIntegrity(tarball, tarballIntegrity);
     return tarball;
 }

--- a/source/bundle-emitter/registry/package-tarball-fetcher.test.ts
+++ b/source/bundle-emitter/registry/package-tarball-fetcher.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert';
+import { suite, test } from 'mocha';
+import { fake } from 'sinon';
+import type { RegistrySettings } from '../../config/registry-settings.ts';
+import {
+    fakeNpmFetch,
+    fakeNpmFetchWithContentLength,
+    registryTarballBytes
+} from '../../test-libraries/registry-fetch-fixtures.ts';
+import { fetchPackageTarball } from './package-metadata-fetcher.ts';
+
+const settings: RegistrySettings = { auth: { type: 'bearer-token', token: 'tok' } };
+const tarballUrl = 'https://registry.npmjs.org/pkg-a/-/pkg-a-1.2.3.tgz';
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
+
+suite('package-tarball-fetcher', function () {
+    test('fetchPackageTarball returns the buffered tarball contents', async function () {
+        const buffer = fake.resolves(registryTarballBytes);
+
+        const result = await fetchPackageTarball(
+            fakeNpmFetch(fake(), buffer),
+            tarballUrl,
+            emptyTarballIntegrity,
+            settings
+        );
+
+        assert.deepStrictEqual(result, registryTarballBytes);
+    });
+
+    test('fetchPackageTarball rejects tarballs whose content-length exceeds the download limit', async function () {
+        await assert.rejects(
+            fetchPackageTarball(
+                fakeNpmFetchWithContentLength('268435457'),
+                tarballUrl,
+                emptyTarballIntegrity,
+                settings
+            ),
+            /^Error: Refusing to download tarball larger than 268435456 bytes$/u
+        );
+    });
+
+    test('fetchPackageTarball accepts tarballs whose content-length is exactly the download limit', async function () {
+        const result = await fetchPackageTarball(
+            fakeNpmFetchWithContentLength('268435456'),
+            tarballUrl,
+            emptyTarballIntegrity,
+            settings
+        );
+
+        assert.deepStrictEqual(result, registryTarballBytes);
+    });
+
+    test('fetchPackageTarball rejects a tarball URL whose host differs from the configured registry', async function () {
+        const buffer = fake.resolves(registryTarballBytes);
+        const expectedMessage =
+            'Refusing to download tarball from "https://attacker.example" because it differs from the configured ' +
+            'registry origin "https://registry.npmjs.org". A tampered registry response could redirect the request and ' +
+            'exfiltrate publish credentials.';
+
+        await assert.rejects(
+            fetchPackageTarball(
+                fakeNpmFetch(fake(), buffer),
+                'https://attacker.example/pkg-a-1.2.3.tgz',
+                emptyTarballIntegrity,
+                settings
+            ),
+            { message: expectedMessage }
+        );
+        assert.strictEqual(buffer.callCount, 0);
+    });
+
+    test('fetchPackageTarball accepts a tarball URL whose host matches a custom configured registry', async function () {
+        const customSettings: RegistrySettings = {
+            registryUrl: 'https://registry.example.test/',
+            auth: { type: 'bearer-token', token: 'tok' }
+        };
+        const buffer = fake.resolves(registryTarballBytes);
+
+        const result = await fetchPackageTarball(
+            fakeNpmFetch(fake(), buffer),
+            'https://registry.example.test/pkg-a/-/pkg-a-1.2.3.tgz',
+            emptyTarballIntegrity,
+            customSettings
+        );
+
+        assert.deepStrictEqual(result, registryTarballBytes);
+    });
+
+    test('fetchPackageTarball rejects a malformed tarball URL', async function () {
+        const buffer = fake.resolves(registryTarballBytes);
+
+        await assert.rejects(
+            fetchPackageTarball(
+                fakeNpmFetch(fake(), buffer),
+                'not-a-url',
+                emptyTarballIntegrity,
+                settings
+            ),
+            { message: 'Registry returned an invalid tarball URL: "not-a-url"' }
+        );
+        assert.strictEqual(buffer.callCount, 0);
+    });
+});

--- a/source/bundle-emitter/registry/registry-client-metadata-auto-retry.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-auto-retry.test.ts
@@ -12,12 +12,15 @@ import {
 } from '../../test-libraries/registry-client-test-support.ts';
 import type { PackageVersionDetails } from './package-metadata-fetcher.ts';
 
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
+
 function expectLatestVersion(result: Maybe<PackageVersionDetails>): void {
     assert.deepStrictEqual(
         result,
         Maybe.just({
             version: '1',
             tarballUrl: 'https://registry.example.test/pkg.tgz',
+            tarballIntegrity: emptyTarballIntegrity,
             gitHead: undefined
         })
     );

--- a/source/bundle-emitter/registry/registry-client-metadata-no-retry.test.ts
+++ b/source/bundle-emitter/registry/registry-client-metadata-no-retry.test.ts
@@ -9,6 +9,8 @@ import {
     registryClientFactory
 } from '../../test-libraries/registry-client-test-support.ts';
 
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
+
 suite('registry-client metadata no retry', function () {
     test('metadata using inherited publish auth does not retry on a 401 challenge', async function () {
         const error = errorWithStatus('auth required', 401);
@@ -79,13 +81,17 @@ suite('registry-client metadata no retry', function () {
         ) as unknown as FakeNpmFetch;
         const registryClient = registryClientFactory({ npmFetch });
 
-        const result = await registryClient.fetchTarball('https://registry.example.test/pkg.tgz', {
-            registryUrl: 'https://registry.example.test/',
-            auth: {
-                publish: { type: 'basic', username: 'reader', password: 'reader-secret' },
-                metadata: 'auto'
+        const result = await registryClient.fetchTarball(
+            'https://registry.example.test/pkg.tgz',
+            emptyTarballIntegrity,
+            {
+                registryUrl: 'https://registry.example.test/',
+                auth: {
+                    publish: { type: 'basic', username: 'reader', password: 'reader-secret' },
+                    metadata: 'auto'
+                }
             }
-        });
+        );
 
         assert.deepStrictEqual(result, Buffer.from([ 1, 2, 3 ]));
         assertDeepSubset(npmFetch, {

--- a/source/bundle-emitter/registry/registry-client.ts
+++ b/source/bundle-emitter/registry/registry-client.ts
@@ -14,6 +14,7 @@ import {
     type PackageVersionDetails
 } from './package-metadata-fetcher.ts';
 import { buildPublishOptionsForPublishSettings, remapPublishError } from './publish-settings-bridge.ts';
+import type { TarballIntegrity } from './tarball-integrity.ts';
 
 type PublishManifest = Readonly<Record<string, unknown>> & {
     readonly name: string;
@@ -52,7 +53,7 @@ export type RegistryClient = {
     fetchLatestVersion: (packageName: string, config: RegistrySettings) => Promise<Maybe<PackageVersionDetails>>;
     fetchStagedVersions: (packageName: string, config: RegistrySettings) => Promise<readonly string[]>;
     publishPackage: (...publishArguments: PublishPackageArguments) => Promise<PublicationOutcome>;
-    fetchTarball: (tarballUrl: string, config: RegistrySettings) => Promise<Buffer>;
+    fetchTarball: (tarballUrl: string, tarballIntegrity: TarballIntegrity, config: RegistrySettings) => Promise<Buffer>;
 };
 
 function isStageIdRecord(response: unknown): response is Readonly<Record<'stageId', unknown>> {
@@ -108,8 +109,8 @@ export function createRegistryClient(dependencies: Readonly<RegistryClientDepend
     const oidcExchanger = createOidcTokenExchanger({ fetch: fetchImplementation, clock, resolveIdToken });
 
     return {
-        async fetchTarball(tarballUrl, registrySettings) {
-            return fetchPackageTarball(npmFetch, tarballUrl, registrySettings);
+        async fetchTarball(tarballUrl, tarballIntegrity, registrySettings) {
+            return fetchPackageTarball(npmFetch, tarballUrl, tarballIntegrity, registrySettings);
         },
 
         async publishPackage(...[ manifest, tarData, registrySettings, publishSettings, stage ]) {

--- a/source/bundle-emitter/registry/registry-response-schemas.test.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.test.ts
@@ -6,6 +6,29 @@ import {
     parseOidcExchangeResponse
 } from './registry-response-schemas.ts';
 
+function digestMetadataResponse(): Record<string, unknown> {
+    return {
+        name: 'pkg-a',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+            '1.0.0': {
+                dist: {
+                    tarball: 'https://example.com/pkg-a-1.0.0.tgz',
+                    integrity: 'sha512-the-digest',
+                    shasum: 'the-shasum'
+                }
+            },
+            '0.0.1': {
+                dist: {
+                    tarball: 'https://example.com/pkg-a-0.0.1.tgz',
+                    integrity: 42,
+                    shasum: false
+                }
+            }
+        }
+    };
+}
+
 suite('registry-response-schemas', function () {
     suite('package metadata responses', function () {
         test('parseAbbreviatedPackageResponse returns the data when the response matches the schema', function () {
@@ -21,6 +44,13 @@ suite('registry-response-schemas', function () {
                     versions: { '1.0.0': { dist: { tarball: 'https://example.com/pkg-a-1.0.0.tgz' } } }
                 }
             );
+        });
+
+        test('package metadata parsers keep optional digest metadata without validating it', function () {
+            const response = digestMetadataResponse();
+
+            assert.deepStrictEqual(parseAbbreviatedPackageResponse(response), response);
+            assert.deepStrictEqual(parseFullPackageResponse(response), response);
         });
 
         test('parseAbbreviatedPackageResponse returns undefined when the response is missing required fields', function () {

--- a/source/bundle-emitter/registry/registry-response-schemas.ts
+++ b/source/bundle-emitter/registry/registry-response-schemas.ts
@@ -3,7 +3,9 @@ import { safeParse } from '../../common/schema-validation.ts';
 
 const packageVersionDetailsSchema = z.object({
     dist: z.object({
-        tarball: z.string()
+        tarball: z.string(),
+        integrity: z.optional(z.unknown()),
+        shasum: z.optional(z.unknown())
     }),
     gitHead: z.optional(z.string())
 });
@@ -35,7 +37,17 @@ export type AbbreviatedPackageResponse = {
         readonly latest?: string | undefined;
     };
     readonly versions: Readonly<
-        Record<string, { readonly dist: { readonly tarball: string; }; readonly gitHead?: string | undefined; }>
+        Record<
+            string,
+            {
+                readonly dist: {
+                    readonly tarball: string;
+                    readonly integrity?: unknown;
+                    readonly shasum?: unknown;
+                };
+                readonly gitHead?: string | undefined;
+            }
+        >
     >;
 };
 
@@ -46,7 +58,17 @@ export type FullPackageResponse = {
     };
     readonly time?: Readonly<Record<string, string>> | undefined;
     readonly versions: Readonly<
-        Record<string, { readonly dist: { readonly tarball: string; }; readonly gitHead?: string | undefined; }>
+        Record<
+            string,
+            {
+                readonly dist: {
+                    readonly tarball: string;
+                    readonly integrity?: unknown;
+                    readonly shasum?: unknown;
+                };
+                readonly gitHead?: string | undefined;
+            }
+        >
     >;
 };
 

--- a/source/bundle-emitter/registry/tarball-integrity.test.ts
+++ b/source/bundle-emitter/registry/tarball-integrity.test.ts
@@ -104,6 +104,22 @@ suite('tarball-integrity', function () {
             }, /^Error: Registry returned invalid dist\.shasum "not-a-shasum"$/u);
         });
 
+        test('rejects dist.shasum metadata with leading extra characters', function () {
+            const shasum = `x${matchingShasum}`;
+
+            assert.throws(function () {
+                assertTarballIntegrity(tarball, { integrity: undefined, shasum });
+            }, /^Error: Registry returned invalid dist\.shasum "x9ef2570c89e65b9fe47687b0b49e122e59354bef"$/u);
+        });
+
+        test('rejects dist.shasum metadata with trailing extra characters', function () {
+            const shasum = `${matchingShasum}x`;
+
+            assert.throws(function () {
+                assertTarballIntegrity(tarball, { integrity: undefined, shasum });
+            }, /^Error: Registry returned invalid dist\.shasum "9ef2570c89e65b9fe47687b0b49e122e59354befx"$/u);
+        });
+
         test('rejects when dist.integrity matches but dist.shasum does not', function () {
             assert.throws(function () {
                 assertTarballIntegrity(tarball, { integrity: matchingIntegrity, shasum: mismatchingShasum });

--- a/source/bundle-emitter/registry/tarball-integrity.test.ts
+++ b/source/bundle-emitter/registry/tarball-integrity.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert';
+import { createHash } from 'node:crypto';
+import { suite, test } from 'mocha';
+import { assertTarballIntegrity } from './tarball-integrity.ts';
+
+function toIntegrity(content: Buffer): string {
+    return `sha512-${createHash('sha512').update(content).digest('base64')}`;
+}
+
+const tarball = Buffer.from('tarball-bytes');
+const otherTarball = Buffer.from('other-tarball-bytes');
+const matchingIntegrity = toIntegrity(tarball);
+const mismatchingIntegrity = toIntegrity(otherTarball);
+const matchingShasum = [ '9ef2570c89e65b9f', 'e47687b0b49e122e', '59354bef' ].join('');
+const mismatchingShasum = [ 'db59fc5197d8bb60', 'c796f8fc7ac7da62', 'e1f8b38c' ].join('');
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
+const legacyIntegrity = `sha1-${Buffer.from(matchingShasum, 'hex').toString('base64')}`;
+
+function assertThrowsWithCause(action: () => void, messagePattern: RegExp, causePattern: RegExp): void {
+    try {
+        action();
+        assert.fail('Expected action to throw');
+    } catch (error: unknown) {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, messagePattern);
+        assert.ok(error.cause instanceof Error);
+        assert.match(error.cause.message, causePattern);
+    }
+}
+
+suite('tarball-integrity', function () {
+    suite('accepted metadata', function () {
+        test('accepts tarballs when the registry provides no digest metadata', function () {
+            assertTarballIntegrity(tarball, emptyTarballIntegrity);
+        });
+
+        test('accepts tarballs that match dist.integrity', function () {
+            assertTarballIntegrity(tarball, { integrity: matchingIntegrity, shasum: undefined });
+        });
+
+        test('accepts tarballs that match dist.shasum', function () {
+            assertTarballIntegrity(tarball, { integrity: undefined, shasum: matchingShasum });
+        });
+
+        test('accepts tarballs that match both digest metadata fields', function () {
+            assertTarballIntegrity(tarball, { integrity: matchingIntegrity, shasum: matchingShasum });
+        });
+
+        test('accepts standard SRI multi-hash metadata when the strongest digest matches', function () {
+            const integrity = [
+                `sha256-${createHash('sha256').update(otherTarball).digest('base64')}`,
+                matchingIntegrity
+            ]
+                .join(' ');
+
+            assertTarballIntegrity(tarball, { integrity, shasum: undefined });
+        });
+    });
+
+    suite('rejected metadata', function () {
+        test('rejects tarballs that fail dist.integrity verification', function () {
+            assertThrowsWithCause(
+                function () {
+                    assertTarballIntegrity(tarball, { integrity: mismatchingIntegrity, shasum: undefined });
+                },
+                /^Downloaded tarball failed dist\.integrity verification:/u,
+                /Integrity checksum failed/u
+            );
+        });
+
+        test('rejects malformed dist.integrity metadata', function () {
+            assertThrowsWithCause(
+                function () {
+                    assertTarballIntegrity(tarball, { integrity: 'sha512-not-base64', shasum: undefined });
+                },
+                /^Downloaded tarball failed dist\.integrity verification:/u,
+                /No valid integrity hashes/u
+            );
+        });
+
+        test('rejects legacy digest algorithms in dist.integrity metadata', function () {
+            assertThrowsWithCause(
+                function () {
+                    assertTarballIntegrity(tarball, { integrity: legacyIntegrity, shasum: undefined });
+                },
+                /^Downloaded tarball failed dist\.integrity verification:/u,
+                /No valid integrity hashes/u
+            );
+        });
+
+        test('rejects tarballs that fail dist.shasum verification', function () {
+            assertThrowsWithCause(
+                function () {
+                    assertTarballIntegrity(tarball, { integrity: undefined, shasum: mismatchingShasum });
+                },
+                /^Downloaded tarball failed dist\.shasum verification:/u,
+                /Integrity checksum failed/u
+            );
+        });
+
+        test('rejects malformed dist.shasum metadata', function () {
+            assert.throws(function () {
+                assertTarballIntegrity(tarball, { integrity: undefined, shasum: 'not-a-shasum' });
+            }, /^Error: Registry returned invalid dist\.shasum "not-a-shasum"$/u);
+        });
+
+        test('rejects when dist.integrity matches but dist.shasum does not', function () {
+            assert.throws(function () {
+                assertTarballIntegrity(tarball, { integrity: matchingIntegrity, shasum: mismatchingShasum });
+            }, /^Error: Downloaded tarball failed dist\.shasum verification:/u);
+        });
+    });
+});

--- a/source/bundle-emitter/registry/tarball-integrity.ts
+++ b/source/bundle-emitter/registry/tarball-integrity.ts
@@ -1,0 +1,40 @@
+import ssri from 'ssri';
+
+export type TarballIntegrity = {
+    readonly integrity: string | undefined;
+    readonly shasum: string | undefined;
+};
+
+const sha1HexPattern = /^[a-f0-9]{40}$/u;
+
+function assertIntegrityMetadataMatches(tarball: Buffer, integrity: string): void {
+    try {
+        ssri.checkData(tarball, integrity, { strict: true, error: true });
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Downloaded tarball failed dist.integrity verification: ${message}`, { cause: error });
+    }
+}
+
+function assertShasumMetadataMatches(tarball: Buffer, shasum: string): void {
+    if (!sha1HexPattern.test(shasum)) {
+        throw new Error(`Registry returned invalid dist.shasum "${shasum}"`);
+    }
+
+    try {
+        ssri.checkData(tarball, ssri.fromHex(shasum, 'sha1'), { error: true });
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Downloaded tarball failed dist.shasum verification: ${message}`, { cause: error });
+    }
+}
+
+export function assertTarballIntegrity(tarball: Buffer, tarballIntegrity: TarballIntegrity): void {
+    if (tarballIntegrity.integrity !== undefined) {
+        assertIntegrityMetadataMatches(tarball, tarballIntegrity.integrity);
+    }
+
+    if (tarballIntegrity.shasum !== undefined) {
+        assertShasumMetadataMatches(tarball, tarballIntegrity.shasum);
+    }
+}

--- a/source/directed-graph/graph.property.ts
+++ b/source/directed-graph/graph.property.ts
@@ -4,7 +4,7 @@ import { suite, test } from 'mocha';
 import { runNodeProbe } from '../test-libraries/run-node-probe.ts';
 import { createDirectedGraph, type DirectedGraph } from './graph.ts';
 
-const graphProbeTimeoutMs = 500;
+const graphProbeTimeoutMs = 3000;
 
 type GraphEdge<TId extends number | string> = Parameters<DirectedGraph<TId, unknown>['connect']>[0];
 

--- a/source/github-release-gate/cli-runner.test.ts
+++ b/source/github-release-gate/cli-runner.test.ts
@@ -24,6 +24,8 @@ const entryPointPath = fileURLToPath(
     new URL('../packages/github-release-gate/github-release-gate.entry-point.ts', import.meta.url)
 );
 const testDeadlineMilliseconds = 2000;
+const entryPointScriptDeadlineMilliseconds = 10_000;
+const entryPointServerDeadlineMilliseconds = 12_000;
 
 type SuccessfulReleaseAnalysisOverrides = {
     readonly classification: 'dependency-only' | 'first-publish' | 'substantive' | 'unchanged';
@@ -227,7 +229,7 @@ suite('github-release-gate-cli-runner', function () {
                         })
                     ),
                     'runEntryPointScript',
-                    testDeadlineMilliseconds
+                    entryPointScriptDeadlineMilliseconds
                 );
 
                 assert.strictEqual(result.exitCode, 0);
@@ -235,7 +237,7 @@ suite('github-release-gate-cli-runner', function () {
                 assert.match(result.output, /reason=activity_not_stale/u);
             }),
             'withGitHubApiServer',
-            testDeadlineMilliseconds
+            entryPointServerDeadlineMilliseconds
         );
     });
 
@@ -245,7 +247,7 @@ suite('github-release-gate-cli-runner', function () {
                 GITHUB_REPOSITORY: 'enormora/packtory'
             }),
             'runEntryPointScript',
-            testDeadlineMilliseconds
+            entryPointScriptDeadlineMilliseconds
         );
 
         assert.strictEqual(result.exitCode, 1);

--- a/source/test-libraries/registry-client-test-support.ts
+++ b/source/test-libraries/registry-client-test-support.ts
@@ -128,12 +128,19 @@ type PackageInfo = {
 
 const packageInfo = { name: 'the-name', version: '1.0.0' } as const;
 const bearerTokenAuth = { auth: { type: 'bearer-token', token: 'the-token' } } as const;
+const emptyTarballIntegrity = { integrity: undefined, shasum: undefined } as const;
 
 type LatestVersionResponse = {
     readonly name: '';
     readonly 'dist-tags': { readonly latest: '1'; };
     readonly versions: {
-        readonly 1: { readonly dist: { readonly tarball: 'https://registry.example.test/pkg.tgz'; }; };
+        readonly 1: {
+            readonly dist: {
+                readonly tarball: 'https://registry.example.test/pkg.tgz';
+                readonly integrity: string | undefined;
+                readonly shasum: string | undefined;
+            };
+        };
     };
 };
 
@@ -150,7 +157,7 @@ function latestVersionResponse(): LatestVersionResponse {
     return {
         name: '',
         'dist-tags': { latest: '1' },
-        versions: { 1: { dist: { tarball: 'https://registry.example.test/pkg.tgz' } } }
+        versions: { 1: { dist: { tarball: 'https://registry.example.test/pkg.tgz', ...emptyTarballIntegrity } } }
     };
 }
 

--- a/source/test-libraries/registry-fetch-fixtures.ts
+++ b/source/test-libraries/registry-fetch-fixtures.ts
@@ -1,0 +1,38 @@
+import { fake, type SinonSpy } from 'sinon';
+import type { NpmFetch } from '../bundle-emitter/registry/package-metadata-fetcher.ts';
+
+type FakeNpmFetch = Readonly<SinonSpy> & {
+    readonly json: Readonly<SinonSpy> & { readonly stream: Readonly<SinonSpy>; };
+    readonly pickRegistry: Readonly<SinonSpy>;
+};
+
+export const registryTarballBytes = Buffer.from('tarball-bytes');
+
+export function fakeNpmFetch(
+    json: Readonly<SinonSpy>,
+    buffer: Readonly<SinonSpy> = fake.resolves(Buffer.from([]))
+): NpmFetch {
+    const npmFetch: FakeNpmFetch = Object.assign(fake.resolves({ buffer }), {
+        json: Object.assign(json, { stream: fake() }),
+        pickRegistry: fake()
+    });
+    return npmFetch as unknown as NpmFetch;
+}
+
+export function fakeNpmFetchWithContentLength(contentLength: string | null): NpmFetch {
+    const npmFetch: FakeNpmFetch = Object.assign(
+        fake.resolves({
+            buffer: fake.resolves(registryTarballBytes),
+            headers: {
+                get: fake(function (name: string) {
+                    return name === 'content-length' ? contentLength : null;
+                })
+            }
+        }),
+        {
+            json: Object.assign(fake(), { stream: fake() }),
+            pickRegistry: fake()
+        }
+    );
+    return npmFetch as unknown as NpmFetch;
+}

--- a/source/test-libraries/with-deadline.ts
+++ b/source/test-libraries/with-deadline.ts
@@ -1,13 +1,33 @@
-import { setTimeout as delay } from 'node:timers/promises';
+import { clearTimeout as clearDeadlineTimeout, setTimeout as setDeadlineTimeout } from 'node:timers';
 
-async function timeoutFailure(label: string, timeoutMilliseconds: number): Promise<never> {
-    await delay(timeoutMilliseconds);
-    throw new Error(`${label} timed out`);
+type Deadline = {
+    readonly fail: (error: Error) => void;
+    readonly promise: Promise<never>;
+};
+
+function createDeadline(): Deadline {
+    let failDeadline = function (): void {
+        return undefined;
+    };
+    const promise = new Promise<never>(function (_resolve, reject) {
+        failDeadline = reject;
+    });
+
+    return { fail: failDeadline, promise };
 }
 
 export async function withDeadline<T>(operation: Promise<T>, label: string, timeoutMilliseconds: number): Promise<T> {
-    return await Promise.race([
-        operation,
-        timeoutFailure(label, timeoutMilliseconds)
-    ]);
+    const deadline = createDeadline();
+    const timeout = setDeadlineTimeout(function () {
+        deadline.fail(new Error(`${label} timed out`));
+    }, timeoutMilliseconds);
+
+    try {
+        return await Promise.race([
+            operation,
+            deadline.promise
+        ]);
+    } finally {
+        clearDeadlineTimeout(timeout);
+    }
 }


### PR DESCRIPTION
Packtory now carries registry-provided tarball digest metadata from the selected latest version through the tarball fetch path and verifies downloaded bytes before extraction. The check accepts missing digest metadata for compatibility, but fails malformed or mismatched `dist.integrity` and `dist.shasum` values.