### PR TITLE
Wait for stale release CI cancellation

### DIFF
--- a/integration-tests/github-api/release-pull-request-ci.test.ts
+++ b/integration-tests/github-api/release-pull-request-ci.test.ts
@@ -77,12 +77,19 @@ function workflowRunsBody(requests: readonly DeterministicGitHubApiRequest[]): R
         status: 'in_progress',
         workflow_id: 101
     };
-    if (workflowRunsAfterDispatch(requests) < 2) {
+    const canceledOldRun = { ...oldRun, conclusion: 'cancelled', status: 'completed' };
+    if (countRequests(requests, 'POST', staleRunCancelPath) === 0) {
         return { workflow_runs: [ oldRun ] };
+    }
+    if (dispatchIndex(requests) === -1) {
+        return { workflow_runs: [ canceledOldRun ] };
+    }
+    if (workflowRunsAfterDispatch(requests) < 2) {
+        return { workflow_runs: [ canceledOldRun ] };
     }
     return {
         workflow_runs: [
-            oldRun,
+            canceledOldRun,
             {
                 database_id: 8,
                 event: 'workflow_dispatch',
@@ -373,7 +380,7 @@ suite('release-pull-request-ci GitHub API integration', function () {
 
             assert.strictEqual(countRequests(server.requests(), 'POST', staleRunCancelPath), 1);
             assert.strictEqual(countRequests(server.requests(), 'POST', dispatchPath), 1);
-            assert.strictEqual(countRequests(server.requests(), 'GET', workflowRunsPath), 4);
+            assert.strictEqual(countRequests(server.requests(), 'GET', workflowRunsPath), 5);
             assert.deepStrictEqual(
                 statusesFor(server.requests(), 'Node.js v24.x').map(function (status) {
                     return {

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,7 @@ npx packtory release --publish --tag --push --github-release --no-dry-run
 
 Release PR commits are authored through the GitHub credential from `GH_TOKEN` or `GITHUB_TOKEN`, so GitHub can mark them verified when the credential supports signed API commits. This allows release PRs to merge into branches that require signed commits without local Git signing setup.
 
-The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory dispatches the configured workflow on the release branch, waits for the fresh run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch update already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human update, or another CI system.
+The optional `releasePullRequest.githubActionsCi` config enables the GitHub Actions `GITHUB_TOKEN` workaround: Packtory cancels stale dispatched runs, dispatches the configured workflow on the release branch, waits for the fresh run, and mirrors the configured job names back as commit statuses. Leave it unset when your release branch update already triggers normal PR or push workflows, for example through a GitHub App token, a PAT, a human update, or another CI system.
 
 For more details about the CLI application have a look at the [full documentation](./source/packages/command-line-interface/readme.md).
 

--- a/source/command-line-interface/runner/release-pr-github-client.ts
+++ b/source/command-line-interface/runner/release-pr-github-client.ts
@@ -105,7 +105,9 @@ type ReleasePullRequestUpdateInput = {
     readonly title: string;
 };
 export type ReleasePullRequestGitHubClient = {
-    readonly cancelActiveDispatchedWorkflowRuns: (input: CancelActiveDispatchedWorkflowRunsInput) => Promise<void>;
+    readonly cancelActiveDispatchedWorkflowRuns: (
+        input: CancelActiveDispatchedWorkflowRunsInput
+    ) => Promise<readonly number[]>;
     readonly closeOpenReleasePullRequests: (input: CloseOpenReleasePullRequestsInput) => Promise<void>;
     readonly createCommitOnBranch: (input: CreateCommitOnBranchInput) => Promise<string>;
     readonly createOrUpdateReleasePullRequest: (input: CreateOrUpdateReleasePullRequestInput) => Promise<number>;
@@ -304,7 +306,7 @@ export function createReleasePullRequestGitHubClient(context: GitHubClientContex
     return {
         async cancelActiveDispatchedWorkflowRuns(input) {
             const workflow = await resolveRawWorkflow(input.workflowFile);
-            await cancelActiveDispatchedWorkflowRuns({
+            return cancelActiveDispatchedWorkflowRuns({
                 branch: input.branch,
                 cancelWorkflowRun: octokit.rest.actions.cancelWorkflowRun,
                 listWorkflowRuns: octokit.rest.actions.listWorkflowRuns,

--- a/source/command-line-interface/runner/release-pr-workflow-run-cancellation.test.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-run-cancellation.test.ts
@@ -46,11 +46,12 @@ suite('release-pr-workflow-run-cancellation', function () {
             )
         );
 
-        await client.cancelActiveDispatchedWorkflowRuns({
+        const activeRunIds = await client.cancelActiveDispatchedWorkflowRuns({
             branch: 'release/packtory',
             workflowFile: 'ci.yml'
         });
 
+        assert.deepStrictEqual(activeRunIds, [ 21, 22, 23, 24, 25 ]);
         assert.deepStrictEqual(
             records
                 .filter(function (record) {

--- a/source/command-line-interface/runner/release-pr-workflow-run-cancellation.ts
+++ b/source/command-line-interface/runner/release-pr-workflow-run-cancellation.ts
@@ -77,7 +77,7 @@ function releasePullRequestRunNeedsApproval(run: RawWorkflowRun, headSha: string
 
 export async function cancelActiveDispatchedWorkflowRuns(
     input: CancelActiveDispatchedWorkflowRunsInput
-): Promise<void> {
+): Promise<readonly number[]> {
     const response = await resolveGitHubResponse(
         input.listWorkflowRuns({
             ...input.requestContext,
@@ -101,6 +101,7 @@ export async function cancelActiveDispatchedWorkflowRuns(
             })
         );
     }
+    return activeRunIds;
 }
 
 export async function deleteActionRequiredPullRequestRuns(

--- a/source/command-line-interface/runner/release-pull-request-ci-workflow-cancellation.test.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci-workflow-cancellation.test.ts
@@ -4,6 +4,16 @@ import { fake } from 'sinon';
 import { createReleasePullRequestClient } from '../../test-libraries/runner-test-support.ts';
 import { runConfiguredGitHubActionsCi } from './release-pull-request-ci.ts';
 import type { ReleasePullRequestConfig } from './release-pull-request-config.ts';
+import type { ReleasePullRequestGitHubClient } from './release-pr-github-client.ts';
+
+type DelayedCancellationRun = {
+    readonly cancelActiveDispatchedWorkflowRuns: ReturnType<typeof fake>;
+    readonly client: ReleasePullRequestGitHubClient;
+    readonly createStatus: ReturnType<typeof fake>;
+    readonly dispatchWorkflow: ReturnType<typeof fake>;
+    readonly sleep: (milliseconds: number) => Promise<void>;
+    readonly sleepSpy: ReturnType<typeof fake>;
+};
 
 function createConfig(): ReleasePullRequestConfig {
     return {
@@ -22,9 +32,44 @@ function createConfig(): ReleasePullRequestConfig {
     };
 }
 
+function createDelayedCancellationRun(
+    activeRunIdsByRead: readonly (readonly number[])[] = [ [ 7 ], [ 7 ], [] ]
+): DelayedCancellationRun {
+    let cancellationReadIndex = 0;
+    const cancelActiveDispatchedWorkflowRuns = fake(async function () {
+        const runIds = activeRunIdsByRead[cancellationReadIndex] ?? [];
+        cancellationReadIndex += 1;
+        return runIds;
+    });
+    const createStatus = fake.resolves(undefined);
+    const dispatchWorkflow = fake.resolves(undefined);
+    const sleepSpy = fake();
+    async function sleep(milliseconds: number): Promise<void> {
+        sleepSpy(milliseconds);
+    }
+    const findDispatchedWorkflowRun = fake(async function () {
+        return dispatchWorkflow.callCount === 0
+            ? { event: 'workflow_dispatch' as const, observedRunIds: [ 7 ], runId: 7 }
+            : { event: 'workflow_dispatch' as const, observedRunIds: [ 7, 8 ], runId: 8 };
+    });
+    const client = createReleasePullRequestClient({
+        cancelActiveDispatchedWorkflowRuns,
+        createStatus,
+        dispatchWorkflow,
+        findDispatchedWorkflowRun,
+        readWorkflowRunResult: fake.resolves({
+            conclusion: 'success',
+            databaseId: 8,
+            jobs: [ { conclusion: 'success', name: 'Node.js', url: 'https://run/node' } ],
+            url: 'https://github.com/enormora/packtory/actions/runs/8'
+        })
+    });
+    return { cancelActiveDispatchedWorkflowRuns, client, createStatus, dispatchWorkflow, sleep, sleepSpy };
+}
+
 suite('release-pull-request-ci workflow cancellation', function () {
     test('cancels active dispatched runs for the configured release workflow before dispatch', async function () {
-        const cancelActiveDispatchedWorkflowRuns = fake.resolves(undefined);
+        const cancelActiveDispatchedWorkflowRuns = fake.resolves([]);
         const dispatchWorkflow = fake.resolves(undefined);
         const findDispatchedWorkflowRun = fake(async function () {
             return dispatchWorkflow.callCount === 0
@@ -59,5 +104,89 @@ suite('release-pull-request-ci workflow cancellation', function () {
         });
         assert.strictEqual(cancelActiveDispatchedWorkflowRuns.calledBefore(findDispatchedWorkflowRun), true);
         assert.strictEqual(cancelActiveDispatchedWorkflowRuns.calledBefore(dispatchWorkflow), true);
+    });
+
+    test('waits for active dispatched runs to cancel before dispatch', async function () {
+        const { cancelActiveDispatchedWorkflowRuns, client, createStatus, dispatchWorkflow, sleep, sleepSpy } =
+            createDelayedCancellationRun();
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client,
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep
+            }),
+            true
+        );
+
+        assert.strictEqual(cancelActiveDispatchedWorkflowRuns.callCount, 3);
+        assert.strictEqual(sleepSpy.callCount, 2);
+        assert.strictEqual(dispatchWorkflow.calledAfter(cancelActiveDispatchedWorkflowRuns), true);
+        assert.strictEqual(createStatus.calledAfter(cancelActiveDispatchedWorkflowRuns), true);
+    });
+
+    test('dispatches when active runs clear on the final cancellation check', async function () {
+        const activeRunIdsByRead = [
+            ...Array.from({ length: 29 }, function () {
+                return [ 7 ];
+            }),
+            []
+        ];
+        const delayedCancellationRun = createDelayedCancellationRun(activeRunIdsByRead);
+
+        assert.strictEqual(
+            await runConfiguredGitHubActionsCi({
+                client: delayedCancellationRun.client,
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep: delayedCancellationRun.sleep
+            }),
+            true
+        );
+
+        assert.deepStrictEqual({
+            cancellationCalls: delayedCancellationRun.cancelActiveDispatchedWorkflowRuns.callCount,
+            dispatchCalls: delayedCancellationRun.dispatchWorkflow.callCount
+        }, {
+            cancellationCalls: 30,
+            dispatchCalls: 1
+        });
+        assert.deepStrictEqual(delayedCancellationRun.cancelActiveDispatchedWorkflowRuns.lastCall.args[0], {
+            branch: 'release/packtory',
+            workflowFile: 'ci.yml'
+        });
+    });
+
+    test('fails release statuses when active dispatched runs do not cancel', async function () {
+        const cancelActiveDispatchedWorkflowRuns = fake.resolves([ 7 ]);
+        const createStatus = fake.resolves(undefined);
+        const dispatchWorkflow = fake.resolves(undefined);
+        const sleep = fake.resolves(undefined);
+        const client = createReleasePullRequestClient({
+            cancelActiveDispatchedWorkflowRuns,
+            createStatus,
+            dispatchWorkflow
+        });
+
+        await assert.rejects(
+            runConfiguredGitHubActionsCi({
+                client,
+                config: createConfig(),
+                headSha: 'release-head',
+                sleep
+            }),
+            { message: 'Active release workflow runs did not cancel: 7' }
+        );
+
+        assert.strictEqual(cancelActiveDispatchedWorkflowRuns.callCount, 30);
+        assert.strictEqual(dispatchWorkflow.callCount, 0);
+        assert.deepStrictEqual(createStatus.firstCall.args[0], {
+            commitSha: 'release-head',
+            context: 'Node.js',
+            description: 'Dispatched release CI did not start.',
+            state: 'error',
+            targetUrl: undefined
+        });
     });
 });

--- a/source/command-line-interface/runner/release-pull-request-ci.ts
+++ b/source/command-line-interface/runner/release-pull-request-ci.ts
@@ -66,6 +66,7 @@ type RunConfiguredGitHubActionsCiInput = {
 
 const workflowRunLookupAttempts = 30;
 const workflowRunCompletionAttempts = 120;
+const staleWorkflowRunCancellationAttempts = 30;
 const workflowPollIntervalMilliseconds = 10_000;
 
 function createRetryAttempts(count: number): readonly number[] {
@@ -303,13 +304,26 @@ async function createFailedWorkflowStatuses(input: FailedWorkflowStatusesInput):
     }
 }
 
+async function waitForActiveDispatchedWorkflowRunsToCancel(input: WaitForDispatchedWorkflowRunInput): Promise<void> {
+    for (const attempt of createRetryAttempts(staleWorkflowRunCancellationAttempts)) {
+        const activeRunIds = await input.client.cancelActiveDispatchedWorkflowRuns({
+            branch: input.config.branch,
+            workflowFile: input.ciConfig.workflowFile
+        });
+        if (activeRunIds.length === 0) {
+            return;
+        }
+        if (isLastAttempt(attempt, staleWorkflowRunCancellationAttempts)) {
+            throw new Error(`Active release workflow runs did not cancel: ${formatObservedRunIds(activeRunIds)}`);
+        }
+        await input.sleep(workflowPollIntervalMilliseconds);
+    }
+}
+
 async function dispatchWorkflowRun(input: WaitForDispatchedWorkflowRunInput): Promise<number> {
-    await createPendingWorkflowStatuses(input);
-    await input.client.cancelActiveDispatchedWorkflowRuns({
-        branch: input.config.branch,
-        workflowFile: input.ciConfig.workflowFile
-    });
+    await waitForActiveDispatchedWorkflowRunsToCancel(input);
     const baseline = await findDispatchedWorkflowRun(input);
+    await createPendingWorkflowStatuses(input);
     await input.client.dispatchWorkflow({
         ref: input.config.branch,
         workflowFile: input.ciConfig.workflowFile

--- a/source/packages/command-line-interface/readme.md
+++ b/source/packages/command-line-interface/readme.md
@@ -99,7 +99,7 @@ packtory <command> [options]
 - The release PR policy derives allowed files from `changelog.outputs`. Repository and package changelog files are allowed. GitHub Release outputs are ignored because they do not write repository files.
 - `release-pr validate` accepts normal PRs without a release label. Release-labeled PRs must match the configured branch, title, author, commit subject, base head, and allowed files. Merge groups must not batch release PRs with other PRs.
 - `release-pr authorize-publish` writes GitHub step outputs when `$GITHUB_OUTPUT` exists, otherwise it prints them. Normal commits get `should_publish=false`. A merged valid release PR gets `should_publish=true`, `publish_commit_sha`, `release_commit_sha`, and `release_pull_request_number`.
-- Set `releasePullRequest.githubActionsCi` only for the GitHub Actions `GITHUB_TOKEN` workaround. With `trigger: 'workflow-dispatch'`, `workflowFile`, and `requiredStatusContexts`, `maintain` dispatches fresh CI for the release branch, waits for that release commit run, and mirrors the configured job names as commit statuses.
+- Set `releasePullRequest.githubActionsCi` only for the GitHub Actions `GITHUB_TOKEN` workaround. With `trigger: 'workflow-dispatch'`, `workflowFile`, and `requiredStatusContexts`, `maintain` cancels stale dispatched runs, dispatches fresh CI for the release branch, waits for that release commit run, and mirrors the configured job names as commit statuses.
 - Leave `githubActionsCi` unset when the release branch update already triggers normal CI, such as with a GitHub App token, PAT, human update, external automation, or non-GitHub CI.
 
 **Pack behavior:**

--- a/source/test-libraries/runner-test-support.ts
+++ b/source/test-libraries/runner-test-support.ts
@@ -101,7 +101,7 @@ function createReleasePullRequestClientFixture(
 ): ReleasePullRequestGitHubClientFixture {
     let workflowRunLookupCount = 0;
     return {
-        cancelActiveDispatchedWorkflowRuns: fake.resolves(undefined),
+        cancelActiveDispatchedWorkflowRuns: fake.resolves([]),
         closeOpenReleasePullRequests: fake.resolves(undefined),
         createCommitOnBranch: fake.resolves('signed-release-head'),
         createOrUpdateReleasePullRequest: fake.resolves(1),


### PR DESCRIPTION
Release PR CI cancellation is asynchronous in GitHub Actions. This waits until stale dispatched runs leave the active state before creating pending statuses and dispatching the fresh run, so older runs cannot keep the workflow concurrency group occupied and leave mirrored statuses pending.