### PR TITLE
Support bin-only `packageInterface.bins` type surfaces

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -95,7 +95,7 @@ export async function buildConfig() {
             {
                 name: 'packtory',
                 exportPackageJson: true,
-                checks: { maxBundleSize: { bytes: 1_090_000 } },
+                checks: { maxBundleSize: { bytes: 1_095_000 } },
                 roots: {
                     main: {
                         js: 'packages/packtory/packtory.entry-point.js',

--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,7 @@ The configuration for `packtory` is an object with the following properties:
      - A map of root ids to source files, e.g. `{ main: { js: 'file.js', declarationFile: 'file.d.ts' } }`.
      - `js` is required. `declarationFile` is optional.
      - Roots seed scanning, linking, and dead-code analysis. They are internal build anchors, not automatically the full published API.
+     - On bin-only packages, `declarationFile` can describe package-level types for TypeScript annotations such as `import("pkg").Type`; it does not make the bin a runtime module API.
 
    - **`defaultModuleRoot`** (Optional in single-root packages, required in implicit multi-root packages):
      - Selects which root becomes the package root export `"."` when `packageInterface` is not configured.
@@ -285,6 +286,7 @@ The configuration for `packtory` is an object with the following properties:
      - Switches packtory into explicit package-surface mode.
      - `modules` declares the published module exports with `{ root, export }`.
      - `bins` declares published executables with `{ root, name }`.
+     - Packages with `bins` and no `modules` are supported as bin-only packages. If their bin root has a `declarationFile`, packtory emits a type-only `"."` export.
      - If omitted, packtory derives `exports` implicitly from roots and cross-package substitution needs.
 
    - **`includeSourceMapFiles`** (Optional, Boolean, Default: `false`):
@@ -358,6 +360,7 @@ Checks the emitted package contents and generated `package.json`, before publish
 - **Top-level:** `enabled: boolean`, `declarations?: 'all' | 'exports-graph'`.
 - **Per-package:** `{}`.
 - If `declarations` is omitted, packtory checks every packaged declaration file. Use `exports-graph` to check only declaration files reachable from package export declarations.
+- Untyped bin-only packages do not need TypeScript declarations. Typed bin-only packages run declaration integrity checks without runtime package-resolution analysis.
 
 ### `noDuplicatedFiles`
 

--- a/source/checks/rules/type-script-integrity.test.ts
+++ b/source/checks/rules/type-script-integrity.test.ts
@@ -10,6 +10,8 @@ import {
     type TypeScriptIntegrityRule
 } from './type-script-integrity.ts';
 
+type CheckBundle = Parameters<TypeScriptIntegrityRule['run']>[0]['bundles'][number];
+
 type RuleOverrides = {
     readonly analyzePackageResolution?: SinonSpy;
     readonly summarizeDeclarationIntegrity?: SinonSpy;
@@ -56,6 +58,20 @@ async function runRule(options: RunOptions): Promise<readonly string[]> {
     });
 }
 
+async function runRuleForBundles(
+    rule: TypeScriptIntegrityRule,
+    bundles: readonly CheckBundle[],
+    publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>
+): Promise<readonly string[]> {
+    return await rule.run({
+        bundles,
+        publishedPackages,
+        settings: { typeScriptIntegrity: { enabled: true } },
+        perPackageSettings: new Map(),
+        packageConfigs: {}
+    });
+}
+
 function publishedPackagesFor(...names: readonly string[]): ReadonlyMap<string, PublishedPackageWithManifest> {
     return new Map(
         names.map(function (name) {
@@ -64,49 +80,114 @@ function publishedPackagesFor(...names: readonly string[]): ReadonlyMap<string, 
     );
 }
 
+function binOnlyBundle(name: string, hasDeclaration: boolean): CheckBundle {
+    const base = checkBundle(name, hasDeclaration ? [ 'cli.js', 'cli.d.ts' ] : [ 'cli.js' ]);
+    return {
+        ...base,
+        roots: {
+            cli: {
+                js: {
+                    content: '',
+                    isExecutable: true,
+                    sourceFilePath: 'cli.js',
+                    targetFilePath: 'cli.js'
+                },
+                ...hasDeclaration
+                    ? {
+                        declarationFile: {
+                            content: '',
+                            isExecutable: false,
+                            sourceFilePath: 'cli.d.ts',
+                            targetFilePath: 'cli.d.ts'
+                        }
+                    }
+                    : {}
+            }
+        },
+        surface: {
+            mode: 'explicit',
+            packageInterface: { bins: [ { root: 'cli', name } ] }
+        }
+    };
+}
+
+function moduleAndBinBundle(name: string): CheckBundle {
+    const base = checkBundle(name, [ 'index.js', 'cli.js' ]);
+    return {
+        ...base,
+        roots: {
+            main: {
+                js: {
+                    content: '',
+                    isExecutable: false,
+                    sourceFilePath: 'index.js',
+                    targetFilePath: 'index.js'
+                }
+            },
+            cli: {
+                js: {
+                    content: '',
+                    isExecutable: true,
+                    sourceFilePath: 'cli.js',
+                    targetFilePath: 'cli.js'
+                }
+            }
+        },
+        surface: {
+            mode: 'explicit',
+            packageInterface: {
+                modules: [ { root: 'main', export: '.' } ],
+                bins: [ { root: 'cli', name } ]
+            }
+        }
+    };
+}
+
 suite('type-script-integrity', function () {
-    test('exposes the rule name and its schemas', function () {
-        const rule = ruleFor();
+    suite('configuration', function () {
+        test('exposes the rule name and its schemas', function () {
+            const rule = ruleFor();
 
-        assert.strictEqual(rule.name, 'typeScriptIntegrity');
-        assert.deepStrictEqual(rule.globalSchema.safeParse({ enabled: true }).success, true);
-        assert.deepStrictEqual(rule.globalSchema.safeParse({ enabled: true, declarations: 'all' }).success, true);
-        assert.deepStrictEqual(
-            rule.globalSchema.safeParse({ enabled: true, declarations: 'exports-graph' }).success,
-            true
-        );
-        assert.deepStrictEqual(rule.globalSchema.safeParse({ enabled: true, declarations: 'nope' }).success, false);
-        assert.deepStrictEqual(rule.perPackageSchema.safeParse({}).success, true);
-    });
-
-    test('checks nothing when the rule is not configured', async function () {
-        const analyzePackageResolution = fake.resolves(noProblemsReport);
-        const summarizeDeclarationIntegrity = fake.returns([]);
-
-        const issues = await runRule({
-            rule: ruleFor({ analyzePackageResolution, summarizeDeclarationIntegrity }),
-            settings: undefined,
-            publishedPackages: publishedPackagesFor('pkg'),
-            bundleNames: [ 'pkg' ]
+            assert.strictEqual(rule.name, 'typeScriptIntegrity');
+            assert.deepStrictEqual(rule.globalSchema.safeParse({ enabled: true }).success, true);
+            assert.deepStrictEqual(rule.globalSchema.safeParse({ enabled: true, declarations: 'all' }).success, true);
+            assert.deepStrictEqual(
+                rule.globalSchema.safeParse({ enabled: true, declarations: 'exports-graph' }).success,
+                true
+            );
+            assert.deepStrictEqual(rule.globalSchema.safeParse({ enabled: true, declarations: 'nope' }).success, false);
+            assert.deepStrictEqual(rule.perPackageSchema.safeParse({}).success, true);
         });
 
-        assert.deepStrictEqual(issues, []);
-        assert.strictEqual(analyzePackageResolution.callCount, 0);
-        assert.strictEqual(summarizeDeclarationIntegrity.callCount, 0);
-    });
+        test('checks nothing when the rule is not configured', async function () {
+            const analyzePackageResolution = fake.resolves(noProblemsReport);
+            const summarizeDeclarationIntegrity = fake.returns([]);
 
-    test('checks nothing when the rule is disabled', async function () {
-        const analyzePackageResolution = fake.resolves(noProblemsReport);
+            const issues = await runRule({
+                rule: ruleFor({ analyzePackageResolution, summarizeDeclarationIntegrity }),
+                settings: undefined,
+                publishedPackages: publishedPackagesFor('pkg'),
+                bundleNames: [ 'pkg' ]
+            });
 
-        const issues = await runRule({
-            rule: ruleFor({ analyzePackageResolution }),
-            settings: { typeScriptIntegrity: { enabled: false } },
-            publishedPackages: publishedPackagesFor('pkg'),
-            bundleNames: [ 'pkg' ]
+            assert.deepStrictEqual(issues, []);
+            assert.strictEqual(analyzePackageResolution.callCount, 0);
+            assert.strictEqual(summarizeDeclarationIntegrity.callCount, 0);
         });
 
-        assert.deepStrictEqual(issues, []);
-        assert.strictEqual(analyzePackageResolution.callCount, 0);
+        test('checks nothing when the rule is disabled', async function () {
+            const analyzePackageResolution = fake.resolves(noProblemsReport);
+
+            const issues = await runRule({
+                rule: ruleFor({ analyzePackageResolution }),
+                settings: { typeScriptIntegrity: { enabled: false } },
+                publishedPackages: publishedPackagesFor('pkg'),
+                bundleNames: [ 'pkg' ]
+            });
+
+            assert.deepStrictEqual(issues, []);
+            assert.strictEqual(analyzePackageResolution.callCount, 0);
+        });
     });
 
     test('analyzes package resolution for the checked resolution kinds', async function () {
@@ -216,6 +297,105 @@ suite('type-script-integrity', function () {
             'Package "pkg-b" does not expose TypeScript declarations',
             'declaration issue'
         ]);
+    });
+
+    suite('bin-only packages', function () {
+        test('skips package resolution and declaration checks for untyped bin-only packages', async function () {
+            const analyzePackageResolution = fake.resolves({ kind: 'missing-declarations' });
+            const summarizeDeclarationIntegrity = fake.returns([ 'declaration issue' ]);
+
+            const issues = await runRuleForBundles(
+                ruleFor({ analyzePackageResolution, summarizeDeclarationIntegrity }),
+                [ binOnlyBundle('pkg', false) ],
+                new Map([ [ 'pkg', checkPublishedPackage('pkg', '{"bin":{"pkg":"./cli.js"}}', { 'cli.js': '' }) ] ])
+            );
+
+            assert.deepStrictEqual(issues, []);
+            assert.strictEqual(analyzePackageResolution.callCount, 0);
+            assert.strictEqual(summarizeDeclarationIntegrity.callCount, 0);
+        });
+
+        test('runs declaration integrity only for typed bin-only packages', async function () {
+            const analyzePackageResolution = fake.resolves({ kind: 'missing-declarations' });
+            const summarizeDeclarationIntegrity = fake.returns([ 'declaration issue' ]);
+            const publishedPackage = checkPublishedPackage(
+                'pkg',
+                '{"exports":{".":{"types":"./cli.d.ts"}},"bin":{"pkg":"./cli.js"}}',
+                { 'cli.js': '', 'cli.d.ts': 'export {};\n' }
+            );
+
+            const issues = await runRuleForBundles(
+                ruleFor({ analyzePackageResolution, summarizeDeclarationIntegrity }),
+                [ binOnlyBundle('pkg', true) ],
+                new Map([ [ 'pkg', publishedPackage ] ])
+            );
+
+            assert.deepStrictEqual(issues, [ 'declaration issue' ]);
+            assert.strictEqual(analyzePackageResolution.callCount, 0);
+            assert.deepStrictEqual(summarizeDeclarationIntegrity.args, [
+                [ 'pkg', publishedPackage, 'all', new Map([ [ 'pkg', publishedPackage ] ]) ]
+            ]);
+        });
+
+        test('runs declaration integrity when any bin-only root has declarations', async function () {
+            const summarizeDeclarationIntegrity = fake.returns([ 'declaration issue' ]);
+            const bundle = {
+                ...binOnlyBundle('pkg', true),
+                surface: {
+                    mode: 'explicit' as const,
+                    packageInterface: {
+                        bins: [
+                            { root: 'missing', name: 'missing-bin' },
+                            { root: 'cli', name: 'pkg' }
+                        ] as const
+                    }
+                }
+            };
+
+            const issues = await runRuleForBundles(
+                ruleFor({ summarizeDeclarationIntegrity }),
+                [ bundle ],
+                publishedPackagesFor('pkg')
+            );
+
+            assert.deepStrictEqual(issues, [ 'declaration issue' ]);
+        });
+
+        test('skips checks for an explicit package without module or bin entries', async function () {
+            const analyzePackageResolution = fake.resolves({ kind: 'missing-declarations' });
+            const summarizeDeclarationIntegrity = fake.returns([ 'declaration issue' ]);
+            const bundle = {
+                ...binOnlyBundle('pkg', false),
+                surface: {
+                    mode: 'explicit' as const,
+                    packageInterface: {}
+                }
+            };
+
+            const issues = await runRuleForBundles(
+                ruleFor({ analyzePackageResolution, summarizeDeclarationIntegrity }),
+                [ bundle ],
+                publishedPackagesFor('pkg')
+            );
+
+            assert.deepStrictEqual(issues, []);
+            assert.strictEqual(analyzePackageResolution.callCount, 0);
+            assert.strictEqual(summarizeDeclarationIntegrity.callCount, 0);
+        });
+
+        test('checks package resolution normally when a package declares modules and bins', async function () {
+            const analyzePackageResolution = fake.resolves({ kind: 'missing-declarations' });
+            const summarizeDeclarationIntegrity = fake.returns([]);
+
+            const issues = await runRuleForBundles(
+                ruleFor({ analyzePackageResolution, summarizeDeclarationIntegrity }),
+                [ moduleAndBinBundle('pkg') ],
+                new Map([ [ 'pkg', checkPublishedPackage('pkg', '{"exports":{".":"./index.js"}}', {}) ] ])
+            );
+
+            assert.deepStrictEqual(issues, [ 'Package "pkg" does not expose TypeScript declarations' ]);
+            assert.strictEqual(analyzePackageResolution.callCount, 1);
+        });
     });
 
     suite('published packages', function () {

--- a/source/checks/rules/type-script-integrity.ts
+++ b/source/checks/rules/type-script-integrity.ts
@@ -21,6 +21,27 @@ const perPackageSchema = z.strictObject({});
 type GlobalConfig = Readonly<z.infer<typeof globalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof perPackageSchema>>;
 type RunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
+type CheckBundle = RunInput['bundles'][number];
+type BinOnlyBundle = CheckBundle & {
+    readonly surface: Extract<CheckBundle['surface'], { readonly mode: 'explicit'; }> & {
+        readonly packageInterface: {
+            readonly bins?: NonNullable<
+                Extract<
+                    CheckBundle['surface'],
+                    { readonly mode: 'explicit'; }
+                >['packageInterface']['bins']
+            >;
+            readonly modules?: undefined;
+        };
+    };
+};
+type PackageIntegrityInput = {
+    readonly bundle: CheckBundle;
+    readonly packageName: string;
+    readonly publishedPackage: Readonly<PublishedPackageWithManifest>;
+    readonly publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>;
+    readonly declarationMode: DeclarationMode;
+};
 
 export type TypeScriptIntegrityRule = CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig>;
 
@@ -33,6 +54,18 @@ export type TypeScriptIntegrityDependencies = {
     readonly analyzePackageResolution: PackageResolutionAnalyzer;
     readonly summarizeDeclarationIntegrity: DeclarationIntegritySummarizer;
 };
+
+function isBinOnlyPackage(bundle: CheckBundle): bundle is BinOnlyBundle {
+    return bundle.surface.mode === 'explicit' &&
+        bundle.surface.packageInterface.modules === undefined;
+}
+
+function binOnlyPackageHasDeclarations(bundle: BinOnlyBundle): boolean {
+    const binEntries = bundle.surface.packageInterface.bins;
+    return binEntries?.some(function (entry) {
+        return bundle.roots[entry.root]?.declarationFile !== undefined;
+    }) === true;
+}
 
 export function createTypeScriptIntegrityRule(
     dependencies: TypeScriptIntegrityDependencies
@@ -51,12 +84,14 @@ export function createTypeScriptIntegrityRule(
         }
     }
 
-    async function runForPackage(
-        packageName: string,
-        publishedPackage: Readonly<PublishedPackageWithManifest>,
-        publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>,
-        declarationMode: DeclarationMode
-    ): Promise<readonly string[]> {
+    async function runForPackage(input: PackageIntegrityInput): Promise<readonly string[]> {
+        const { bundle, packageName, publishedPackage, publishedPackages, declarationMode } = input;
+        if (isBinOnlyPackage(bundle)) {
+            return binOnlyPackageHasDeclarations(bundle)
+                ? summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode, publishedPackages)
+                : [];
+        }
+
         return [
             ...await summarizePackageResolution(packageName, publishedPackage),
             ...summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode, publishedPackages)
@@ -81,7 +116,13 @@ export function createTypeScriptIntegrityRule(
                     throw new Error(`Published package missing for "${bundle.name}"`);
                 }
 
-                return await runForPackage(bundle.name, publishedPackage, publishedPackages, declarationMode);
+                return await runForPackage({
+                    bundle,
+                    packageName: bundle.name,
+                    publishedPackage,
+                    publishedPackages,
+                    declarationMode
+                });
             })
         );
         return issuesByBundle.flat();

--- a/source/checks/rules/type-script-integrity.ts
+++ b/source/checks/rules/type-script-integrity.ts
@@ -22,25 +22,8 @@ type GlobalConfig = Readonly<z.infer<typeof globalSchema>>;
 type PerPackageConfig = Readonly<z.infer<typeof perPackageSchema>>;
 type RunInput = RuleRunInput<typeof ruleName, GlobalConfig, PerPackageConfig>;
 type CheckBundle = RunInput['bundles'][number];
-type BinOnlyBundle = CheckBundle & {
-    readonly surface: Extract<CheckBundle['surface'], { readonly mode: 'explicit'; }> & {
-        readonly packageInterface: {
-            readonly bins?: NonNullable<
-                Extract<
-                    CheckBundle['surface'],
-                    { readonly mode: 'explicit'; }
-                >['packageInterface']['bins']
-            >;
-            readonly modules?: undefined;
-        };
-    };
-};
-type PackageIntegrityInput = {
-    readonly bundle: CheckBundle;
-    readonly packageName: string;
-    readonly publishedPackage: Readonly<PublishedPackageWithManifest>;
-    readonly publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>;
-    readonly declarationMode: DeclarationMode;
+type ExplicitBundle = CheckBundle & {
+    readonly surface: Extract<CheckBundle['surface'], { readonly mode: 'explicit'; }>;
 };
 
 export type TypeScriptIntegrityRule = CheckRuleDefinition<typeof ruleName, GlobalConfig, PerPackageConfig>;
@@ -55,14 +38,13 @@ export type TypeScriptIntegrityDependencies = {
     readonly summarizeDeclarationIntegrity: DeclarationIntegritySummarizer;
 };
 
-function isBinOnlyPackage(bundle: CheckBundle): bundle is BinOnlyBundle {
+function isBinOnlyPackage(bundle: CheckBundle): bundle is ExplicitBundle {
     return bundle.surface.mode === 'explicit' &&
         bundle.surface.packageInterface.modules === undefined;
 }
 
-function binOnlyPackageHasDeclarations(bundle: BinOnlyBundle): boolean {
-    const binEntries = bundle.surface.packageInterface.bins;
-    return binEntries?.some(function (entry) {
+function hasBinDeclarations(bundle: ExplicitBundle): boolean {
+    return bundle.surface.packageInterface.bins?.some(function (entry) {
         return bundle.roots[entry.root]?.declarationFile !== undefined;
     }) === true;
 }
@@ -84,17 +66,22 @@ export function createTypeScriptIntegrityRule(
         }
     }
 
-    async function runForPackage(input: PackageIntegrityInput): Promise<readonly string[]> {
-        const { bundle, packageName, publishedPackage, publishedPackages, declarationMode } = input;
+    async function runForPackage(
+        bundle: CheckBundle,
+        publishedPackage: Readonly<PublishedPackageWithManifest>,
+        publishedPackages: ReadonlyMap<string, PublishedPackageWithManifest>,
+        declarationMode: DeclarationMode
+    ): Promise<readonly string[]> {
+        const { name } = bundle;
         if (isBinOnlyPackage(bundle)) {
-            return binOnlyPackageHasDeclarations(bundle)
-                ? summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode, publishedPackages)
+            return hasBinDeclarations(bundle)
+                ? summarizeDeclarationIntegrity(name, publishedPackage, declarationMode, publishedPackages)
                 : [];
         }
 
         return [
-            ...await summarizePackageResolution(packageName, publishedPackage),
-            ...summarizeDeclarationIntegrity(packageName, publishedPackage, declarationMode, publishedPackages)
+            ...await summarizePackageResolution(name, publishedPackage),
+            ...summarizeDeclarationIntegrity(name, publishedPackage, declarationMode, publishedPackages)
         ];
     }
 
@@ -116,13 +103,7 @@ export function createTypeScriptIntegrityRule(
                     throw new Error(`Published package missing for "${bundle.name}"`);
                 }
 
-                return await runForPackage({
-                    bundle,
-                    packageName: bundle.name,
-                    publishedPackage,
-                    publishedPackages,
-                    declarationMode
-                });
+                return await runForPackage(bundle, publishedPackage, publishedPackages, declarationMode);
             })
         );
         return issuesByBundle.flat();

--- a/source/package-surface/explicit-exports.test.ts
+++ b/source/package-surface/explicit-exports.test.ts
@@ -52,6 +52,28 @@ suite('explicit-exports', function () {
         assert.deepStrictEqual(buildExplicitExportsField(bundle, surface), {});
     });
 
+    test('returns an empty record when an explicit surface declares no entries', function () {
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: {}
+        };
+
+        assert.deepStrictEqual(buildExplicitExportsField(mainOnlyBundle, surface), {});
+    });
+
+    test('emits a type-only root export when a bin-only package root has a declaration file', function () {
+        const bundle = {
+            name: 'package-a',
+            roots: { cli: rootWithDeclaration('', 'cli.js', '', 'cli.d.ts') }
+        };
+        const surface: ExplicitSurface = {
+            mode: 'explicit',
+            packageInterface: { bins: [ { root: 'cli', name: 'package-a' } ] }
+        };
+
+        assert.deepStrictEqual(buildExplicitExportsField(bundle, surface), { '.': { types: './cli.d.ts' } });
+    });
+
     test('includes the package.json export when exportPackageJson is true', function () {
         const result = buildExplicitExportsField({ ...mainOnlyBundle, exportPackageJson: true }, rootSurface);
 

--- a/source/package-surface/explicit-exports.ts
+++ b/source/package-surface/explicit-exports.ts
@@ -1,5 +1,11 @@
 import { decorateWithPackageJsonExport } from './package-json-export.ts';
-import { buildExportEntry, type BundleLike, type ExplicitSurface, type ExportEntry } from './package-shape.ts';
+import {
+    buildExportEntry,
+    toImportTarget,
+    type BundleLike,
+    type ExplicitSurface,
+    type ExportEntry
+} from './package-shape.ts';
 import { getRoot } from './root-registry.ts';
 
 type ExplicitExportsBundle = Pick<BundleLike, 'exportPackageJson' | 'name' | 'roots'>;
@@ -15,9 +21,24 @@ function buildEntries(
     bundle: ExplicitExportsBundle,
     surface: ExplicitSurface
 ): readonly (readonly [string, ExportEntry])[] {
-    return (surface.packageInterface.modules ?? []).map(function (entry) {
-        return buildExplicitExportEntry(bundle, entry);
-    });
+    const moduleEntries = surface.packageInterface.modules;
+    if (moduleEntries !== undefined) {
+        return moduleEntries.map(function (entry) {
+            return buildExplicitExportEntry(bundle, entry);
+        });
+    }
+
+    const [ binEntry ] = surface.packageInterface.bins ?? [];
+    if (binEntry === undefined) {
+        return [];
+    }
+
+    const { declarationFile } = getRoot(bundle, binEntry.root);
+    if (declarationFile === undefined) {
+        return [];
+    }
+
+    return [ [ '.', { types: toImportTarget(declarationFile.targetFilePath) } ] ];
 }
 
 export function buildExplicitExportsField(


### PR DESCRIPTION
Explicit packages with `bins` and no `modules` now publish as bin-only packages. A bin root `declarationFile` produces a type-only root export for annotation use, while untyped bin-only packages skip TypeScript declaration requirements and typed bin-only packages run declaration integrity only.